### PR TITLE
Make whisper BaseDomain and ModelId configurable (eg. so it can be used with groq.com)

### DIFF
--- a/CognitiveSupport/CognitiveSupport.csproj
+++ b/CognitiveSupport/CognitiveSupport.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Betalgo.OpenAI" Version="7.4.3" />
+    <PackageReference Include="Betalgo.OpenAI" Version="8.5.1" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.Vision.ComputerVision" Version="7.0.1" />
     <PackageReference Include="NAudio" Version="2.2.1" />
     <PackageReference Include="NAudio.Lame" Version="2.1.0" />

--- a/CognitiveSupport/Settings.cs
+++ b/CognitiveSupport/Settings.cs
@@ -39,6 +39,8 @@ public class SpeetchToTextSettings
 {
 	public string SpeechToTextHotKey { get; set; }
 	public string ApiKey { get; set; }
+	public string BaseDomain { get; set; }
+	public string ModelId { get; set; }
 	public string TempDirectory { get; set; }
 	public string SpeechToTextPrompt { get; set; }
 

--- a/CognitiveSupport/SpeechToTextService.cs
+++ b/CognitiveSupport/SpeechToTextService.cs
@@ -8,20 +8,28 @@ namespace CognitiveSupport
 {
 	public class SpeechToTextService
 	{
-		private readonly string ApiKey;
-		private readonly string Endpoint;
+		private readonly string _apiKey;
+		private readonly string _modelId;
+		private readonly string _baseDomain;
 		private readonly object _lock = new object();
 		private readonly IOpenAIService _openAIService;
 
 
 		public SpeechToTextService(
-			string apiKey)
+			string apiKey,
+			string baseDomain,
+			string modelId)
 		{
-			ApiKey = apiKey ?? throw new ArgumentNullException(nameof(apiKey));
+			_apiKey = apiKey ?? throw new ArgumentNullException(nameof(apiKey));
+			_baseDomain = baseDomain?.Trim();
+			if (_baseDomain == "")
+				_baseDomain = null;
+			_modelId = modelId ?? throw new ArgumentNullException(nameof(modelId), "Check your Whisper API provider's documentation for supported modelIds. On OpenAI, it's something like 'whisper-1'. On Groq, it's something like 'whisper-large-v3'.");
 
 			OpenAiOptions options = new OpenAiOptions
 			{
 				ApiKey = apiKey,
+				BaseDomain = _baseDomain,
 			};
 			HttpClient httpClient = new HttpClient();
 			httpClient.Timeout = TimeSpan.FromSeconds(30);
@@ -38,7 +46,7 @@ namespace CognitiveSupport
 				Prompt = speechToTextPrompt,
 				FileName = Path.GetFileName(audioffilePath),
 				File = audioBytes,
-				Model = Models.WhisperV1,
+				Model = _modelId,
 				ResponseFormat = StaticValues.AudioStatics.ResponseFormat.VerboseJson
 			});
 			if (response.Successful)

--- a/Mutation/MutationForm.cs
+++ b/Mutation/MutationForm.cs
@@ -66,7 +66,9 @@ namespace Mutation
 
 			OcrService = new OcrService(Settings.AzureComputerVisionSettings.ApiKey, Settings.AzureComputerVisionSettings.Endpoint);
 			SpeechToTextService = new SpeechToTextService(
-				Settings.SpeetchToTextSettings.ApiKey);
+				Settings.SpeetchToTextSettings.ApiKey,
+				Settings.SpeetchToTextSettings.BaseDomain,
+				Settings.SpeetchToTextSettings.ModelId);
 			LlmService = new LlmService(
 				Settings.LlmSettings.ApiKey,
 				Settings.LlmSettings.ResourceName,

--- a/README.md
+++ b/README.md
@@ -44,12 +44,29 @@ The free tier is quite sufficient for daily use by a single person.
 - Save the JSON file and restart Mutation.
 
 #### Speech to text
-Whisper is an incredibly capable speech-to-text model developed by OpenAI. This application uses the OpenAI API to allow you to transcribe your voice at random in any application into text onto the clipboard with the press of a hotkey. The resulting text can then be pasted into the application of your choice. Whisper also supports many different languages. Check out the OpenAI site for more information.
+Whisper is an incredibly capable speech-to-text model developed by OpenAI.
+Seem more at: https://platform.openai.com/overview
+This application uses an OpenAI compatible API to allow you to transcribe your voice at random in any application into text onto the clipboard with the press of a hotkey. The resulting text can then be pasted into the application of your choice. Whisper also supports many different languages. Check out the OpenAI site for more information.
+It also has the capability of injecting the transcribed text into any input box in any application that currently has the focus once the transcription completes. 
 
-If you want to use the speech-to-text functionality, you will need to create an OpenAI API account, add a credit card, configure a budget, generate API keys for the Whisper API, and configure the key in Mutation.json under OpenAiSettings, ApiKey.
-Unfortunately, this only has a limited free credit, but in my experience it is fairly cheap even with quite aggressive daily use.
-https://platform.openai.com/overview
-Currently, in Mutation.json, the OpenAiSettings.Endpoint value is not used and can be left unpopulated. For now, the application will use the default Whisper endpoint.
+If you want to use the speech-to-text functionality, you will need to create an account with a provider that hosts a whisper API that is compatible with that of OpenAI. 
+
+1. To use OpenAI Proper
+Create an OpenAI API account, add a credit card, configure a budget, generate API keys for the Whisper API, and configure the following in Mutation.json under SpeetchToTextSettings:
+    "ApiKey" : "<your API key>",
+    "BaseDomain" : "https://api.groq.com/openai/",
+    "ModelId": "whisper-large-v3",
+
+2. Groq.com
+Create a Groq account, generate an API key, and configure the following in Mutation.json under SpeetchToTextSettings:
+    "ApiKey" : "<your API key>",
+    "BaseDomain" : "https://api.openai.com/",
+    "ModelId": "whisper-1",
+
+Of course, as things stand now, Groq is much faster because of the inference chip they use, and they have a generous daily free quota. 
+
+3. There are probably other providers with compatible APIs that can be used as well. 
+
 
 
 #### Review transcript with ChatGPT API


### PR DESCRIPTION
There are various providers that now host Whisper under APIs that is compatible with that of OpenAI. 
For example: groq.com.
This change allows the base domain and the model ID to be configured so that these other providers can be used instead of only OpenAI.