### PR TITLE
Feature/ocr retry

### DIFF
--- a/CognitiveSupport/DeepgramSpeechToTextService.cs
+++ b/CognitiveSupport/DeepgramSpeechToTextService.cs
@@ -1,4 +1,5 @@
-﻿using Deepgram.Models.Listen.v1.REST;
+﻿using CognitiveSupport.Extensions;
+using Deepgram.Models.Listen.v1.REST;
 using Polly;
 using Polly.Contrib.WaitAndRetry;
 using Polly.Timeout;
@@ -50,9 +51,7 @@ public class DeepgramSpeechToTextService : ISpeechToTextService
 			var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5 * attempt));
 
 			if (attempt > 0)
-#pragma warning disable CA1416 // Validate platform compatibility
-				Console.Beep(400 + (100 * attempt), 100);
-#pragma warning restore CA1416 // Validate platform compatibility
+				this.Beep(attempt);
 
 			return await TranscribeViaDeepgram(keywords, audioBytes, cts).ConfigureAwait(false);
 		}, context, new CancellationTokenSource().Token).ConfigureAwait(false);

--- a/CognitiveSupport/Extensions/ObjectExtensions.cs
+++ b/CognitiveSupport/Extensions/ObjectExtensions.cs
@@ -1,0 +1,14 @@
+﻿namespace CognitiveSupport.Extensions;
+
+public static class ObjectExtensions
+{
+	public static void Beep(
+		this object caller,
+		int attempt)
+	{
+#pragma warning disable CA1416 // Validate platform compatibility
+		Console.Beep(400 + (100 * attempt), 100);
+#pragma warning restore CA1416 // Validate platform compatibility
+	}
+
+}

--- a/CognitiveSupport/Extensions/StringExtensions.cs
+++ b/CognitiveSupport/Extensions/StringExtensions.cs
@@ -1,27 +1,26 @@
-﻿namespace CognitiveSupport.Extensions
+﻿namespace CognitiveSupport.Extensions;
+
+public static class StringExtensions
 {
-	public static class StringExtensions
+	/// <summary>
+	/// Converts any partial new lines and carriage returns in the given string to the system's new line representation.
+	/// If the input string contains only '\n' or '\r', they are replaced with the appropriate new line string for the system.
+	/// If a correct new line for the system already exists, it remains unchanged.
+	/// </summary>
+	/// <param name="text">The input string that may contain partial new lines or carriage returns.</param>
+	/// <returns>A new string with all partial new lines and carriage returns replaced by the system's new line representation, or null if the input is null.</returns>
+	public static string FixNewLines(
+		this string text)
 	{
-		/// <summary>
-		/// Converts any partial new lines and carriage returns in the given string to the system's new line representation.
-		/// If the input string contains only '\n' or '\r', they are replaced with the appropriate new line string for the system.
-		/// If a correct new line for the system already exists, it remains unchanged.
-		/// </summary>
-		/// <param name="text">The input string that may contain partial new lines or carriage returns.</param>
-		/// <returns>A new string with all partial new lines and carriage returns replaced by the system's new line representation, or null if the input is null.</returns>
-		public static string FixNewLines(
-			this string text)
-		{
-			if (text is null) return text;
+		if (text is null) return text;
 
-			// Replace isolated "\r" with "\n"
-			text = text.Replace("\r\n", "\n");
-			text = text.Replace("\r", "\n");
+		// Replace isolated "\r" with "\n"
+		text = text.Replace("\r\n", "\n");
+		text = text.Replace("\r", "\n");
 
-			text = text.Replace("\n", Environment.NewLine);
+		text = text.Replace("\n", Environment.NewLine);
 
-			return text;
-		}
-
+		return text;
 	}
+
 }

--- a/CognitiveSupport/OcrService.cs
+++ b/CognitiveSupport/OcrService.cs
@@ -66,7 +66,7 @@ public class OcrService : IOcrService
 		string response = await retryPolicy.ExecuteAsync(async (context, token) =>
 		{
 			int attempt = context.ContainsKey(AttemptKey) ? (int)context[AttemptKey] : 1;
-			var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5 * attempt));
+			var cts = new CancellationTokenSource(TimeSpan.FromSeconds(7.5 * attempt));
 
 			if (attempt > 0)
 				this.Beep(attempt);

--- a/CognitiveSupport/OcrService.cs
+++ b/CognitiveSupport/OcrService.cs
@@ -67,11 +67,13 @@ public class OcrService : IOcrService
 		{
 			int attempt = context.ContainsKey(AttemptKey) ? (int)context[AttemptKey] : 1;
 			var cts = new CancellationTokenSource(TimeSpan.FromSeconds(7.5 * attempt));
+			using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(token, cts.Token);
 
 			if (attempt > 0)
 				this.Beep(attempt);
 
-			return await ReadFileInternal(imageStream, cts.Token).ConfigureAwait(false);
+			return await ReadFileInternal(imageStream, linkedCts.Token).ConfigureAwait(false);
+
 		}, context, new CancellationTokenSource().Token).ConfigureAwait(false);
 
 		return response;

--- a/CognitiveSupport/WhisperSpeechToTextService.cs
+++ b/CognitiveSupport/WhisperSpeechToTextService.cs
@@ -50,11 +50,12 @@ public class WhisperSpeechToTextService : ISpeechToTextService
 		{
 			int attempt = context.ContainsKey(AttemptKey) ? (int)context[AttemptKey] : 1;
 			var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5 * attempt));
+			using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(token, cts.Token);
 
 			if (attempt > 0)
 				this.Beep(attempt);
 
-			return await TranscribeViaWhisper(speechToTextPrompt, audioffilePath, audioBytes, cts.Token).ConfigureAwait(false);
+			return await TranscribeViaWhisper(speechToTextPrompt, audioffilePath, audioBytes, linkedCts.Token).ConfigureAwait(false);
 		}, context, new CancellationTokenSource().Token).ConfigureAwait(false);
 
 		if (response.Successful)

--- a/CognitiveSupport/WhisperSpeechToTextService.cs
+++ b/CognitiveSupport/WhisperSpeechToTextService.cs
@@ -1,4 +1,5 @@
-﻿using OpenAI.Interfaces;
+﻿using CognitiveSupport.Extensions;
+using OpenAI.Interfaces;
 using OpenAI.ObjectModels;
 using OpenAI.ObjectModels.RequestModels;
 using Polly;
@@ -44,15 +45,14 @@ public class WhisperSpeechToTextService : ISpeechToTextService
 
 		var context = new Context();
 		context[AttemptKey] = 1;
+		
 		var response = await retryPolicy.ExecuteAsync(async (context, token) =>
 		{
 			int attempt = context.ContainsKey(AttemptKey) ? (int)context[AttemptKey] : 1;
 			var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5 * attempt));
 
 			if (attempt > 0)
-#pragma warning disable CA1416 // Validate platform compatibility
-				Console.Beep(400 + (100 * attempt), 100);
-#pragma warning restore CA1416 // Validate platform compatibility
+				this.Beep(attempt);
 
 			return await TranscribeViaWhisper(speechToTextPrompt, audioffilePath, audioBytes, cts.Token).ConfigureAwait(false);
 		}, context, new CancellationTokenSource().Token).ConfigureAwait(false);

--- a/Mutation/MutationForm.cs
+++ b/Mutation/MutationForm.cs
@@ -9,8 +9,6 @@ using ScreenCapturing;
 using StringExtensionLibrary;
 using System.ComponentModel;
 using System.Drawing.Imaging;
-using System.Globalization;
-using System.Runtime;
 
 namespace Mutation
 {
@@ -406,7 +404,7 @@ The model may also leave out common filler words in the audio. If you want to ke
 
 				if (image is null)
 					// Sometimes we are too quick for the image to have shown up on the clipboard, so, waita  short while and try again.
-					await Task.Delay(100);
+					await Task.Delay(200);
 
 				if (image is not null)
 				{
@@ -415,24 +413,16 @@ The model may also leave out common filler words in the audio. If you want to ke
 					imageStream.Seek(0, SeekOrigin.Begin);
 					string text = await this._ocrService.ExtractText(imageStream).ConfigureAwait(true);
 
-					//MessageBox.Show(text, "OCR", MessageBoxButtons.OK, MessageBoxIcon.Information, MessageBoxDefaultButton.Button1);
-
 					SetTextToClipboard(text);
 					txtOcr.Text = $"Converted text is on clipboard:{Environment.NewLine}{text}";
 
 					BeepSuccess();
-
-					//using MessageForm msgForm = new MessageForm();
-					//msgForm.Show();
-					//msgForm.Activate();
 				}
 				else
 				{
 					BeepFail();
 
 					txtOcr.Text = "No image found on the clipboard.";
-					//this.Activate();
-					//MessageBox.Show("No image found on the clipboard.");
 				}
 			}
 			catch (Exception ex)
@@ -440,10 +430,9 @@ The model may also leave out common filler words in the audio. If you want to ke
 				string msg = $"Failed to extract text via OCR: {ex.Message}{Environment.NewLine}{ex.GetType().FullName}{Environment.NewLine}{ex.StackTrace}";
 				txtOcr.Text = msg;
 
-				BeepFail();
 
-				//this.Activate();
-				//MessageBox.Show(this, msg, "Unexpected error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+				BeepFail();
+				SetTextToClipboard(msg);
 			}
 		}
 


### PR DESCRIPTION
Add an exponential back-off retry mechanism to OCR, where the first attempt will wait for 7.5 seconds, and subsequent retries will have progressively longer delays.

Additionally, for Deepgram, Whisper, and the OCR service, combine the retry policy cancellation token source with the external cancellation token source into a linked cancellation token source.

