### PR TITLE
**Multi-Service Speech-to-Text: Auto-Migration, UI Selector & Expanded Integrations**

### DIFF
--- a/CognitiveSupport/CognitiveSupport.csproj
+++ b/CognitiveSupport/CognitiveSupport.csproj
@@ -5,8 +5,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Betalgo.OpenAI" Version="8.5.1" />
-    <PackageReference Include="Deepgram" Version="4.1.0" />
+    <PackageReference Include="Betalgo.OpenAI" Version="8.7.2" />
+    <PackageReference Include="Deepgram" Version="5.1.2" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.Vision.ComputerVision" Version="7.0.1" />
     <PackageReference Include="NAudio" Version="2.2.1" />
     <PackageReference Include="NAudio.Lame" Version="2.1.0" />

--- a/CognitiveSupport/DeepgramSpeechToTextService.cs
+++ b/CognitiveSupport/DeepgramSpeechToTextService.cs
@@ -9,6 +9,9 @@ namespace CognitiveSupport;
 
 public class DeepgramSpeechToTextService : ISpeechToTextService
 {
+	private const string ModelNova2 = "nova-2";
+	private const string ModelNova3 = "nova-3";
+
 	public string ServiceName { get; init; }
 
 	private readonly string _modelId;
@@ -22,7 +25,7 @@ public class DeepgramSpeechToTextService : ISpeechToTextService
 	{
 		ServiceName = serviceName;
 		_deepgramClient = deepgramClient ?? throw new ArgumentNullException(nameof(deepgramClient));
-		_modelId = modelId ?? throw new ArgumentNullException(nameof(modelId), "Check your Whisper API provider's documentation for supported modelIds. On OpenAI, it's something like 'whisper-1'. On Groq, it's something like 'whisper-large-v3'.");
+		_modelId = modelId ?? throw new ArgumentNullException(nameof(modelId), "Check your Deepgram API documentation for supported modelIds.");
 	}
 
 	public async Task<string> ConvertAudioToText(
@@ -33,7 +36,18 @@ public class DeepgramSpeechToTextService : ISpeechToTextService
 		if (string.IsNullOrEmpty(audioffilePath))
 			throw new ArgumentException($"'{nameof(audioffilePath)}' cannot be null or empty.", nameof(audioffilePath));
 
-		List<string> keywords = ParseKeywords(speechToTextPrompt);
+		List<string> keywordsOrKeyterms = new();
+
+		switch (_modelId)
+		{
+			case ModelNova2:
+				keywordsOrKeyterms = ParseKeywords(speechToTextPrompt);
+				break;
+			case ModelNova3:
+				keywordsOrKeyterms = ParseKeyterms(speechToTextPrompt);
+				break;
+		}
+
 		var audioBytes = await File.ReadAllBytesAsync(audioffilePath).ConfigureAwait(false);
 		const string AttemptKey = "Attempt";
 
@@ -62,7 +76,7 @@ public class DeepgramSpeechToTextService : ISpeechToTextService
 			if (attempt > 0)
 				this.Beep(attempt);
 
-			return await TranscribeViaDeepgram(keywords, audioBytes, linkedCts).ConfigureAwait(false);
+			return await TranscribeViaDeepgram(keywordsOrKeyterms, audioBytes, linkedCts).ConfigureAwait(false);
 		}, context, overallCancellationToken).ConfigureAwait(false);
 
 		return response.Results.Channels?.FirstOrDefault()?.Alternatives?.FirstOrDefault().Transcript
@@ -70,7 +84,7 @@ public class DeepgramSpeechToTextService : ISpeechToTextService
 	}
 
 	private async Task<SyncResponse> TranscribeViaDeepgram(
-		List<string> keywords,
+		List<string> keywordsOrKeyterms,
 		byte[] audioBytes,
 		CancellationTokenSource cancellationTokenSource)
 	{
@@ -79,7 +93,9 @@ public class DeepgramSpeechToTextService : ISpeechToTextService
 		  new PreRecordedSchema()
 		  {
 			  Model = _modelId,
-			  Keywords = keywords,
+			  // nova-2 uses keywordsOrKeyterms, nova-3 uses keyterms
+			  Keywords = _modelId.StartsWith(ModelNova2) ? keywordsOrKeyterms : null,
+			  Keyterm = _modelId.StartsWith(ModelNova3) ? keywordsOrKeyterms : null,
 
 			  Punctuate = true,
 			  FillerWords = false,
@@ -104,13 +120,31 @@ public class DeepgramSpeechToTextService : ISpeechToTextService
 				.Select(n =>
 				{
 					//If the keyword already contains an intensifier, return it as is. Else add an intensifier of 1. 
-					//https://developers.deepgram.com/docs/keywords
+					//https://developers.deepgram.com/docs/keywordsOrKeyterms
 					return n.IndexOf(":") > 0 ?
 						n :
 						$"{n}1";
 				})
 				.ToList();
 			return keywords;
+		}
+		else
+			return null;
+	}
+
+	private static List<string> ParseKeyterms(string speechToTextPrompt)
+	{
+		if (speechToTextPrompt == null)
+			speechToTextPrompt = string.Empty;
+
+		string pattern = @"(?<=\bkeyterms:\s*).*?(?=\.)";
+		Match match = Regex.Match(speechToTextPrompt, pattern, RegexOptions.IgnoreCase);
+		if (match.Success)
+		{
+			string keytermsString = match.Value.Trim();
+			var keyterms = keytermsString.Split(",", StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
+			.ToList();
+			return keyterms;
 		}
 		else
 			return null;

--- a/CognitiveSupport/DeepgramSpeechToTextService.cs
+++ b/CognitiveSupport/DeepgramSpeechToTextService.cs
@@ -9,14 +9,18 @@ namespace CognitiveSupport;
 
 public class DeepgramSpeechToTextService : ISpeechToTextService
 {
+	public string ServiceName { get; init; }
+
 	private readonly string _modelId;
 	private readonly object _lock = new object();
 	private readonly Deepgram.Clients.Interfaces.v1.IListenRESTClient _deepgramClient;
 
 	public DeepgramSpeechToTextService(
+		string serviceName,
 		Deepgram.Clients.Interfaces.v1.IListenRESTClient deepgramClient,
 		string modelId)
 	{
+		ServiceName = serviceName;
 		_deepgramClient = deepgramClient ?? throw new ArgumentNullException(nameof(deepgramClient));
 		_modelId = modelId ?? throw new ArgumentNullException(nameof(modelId), "Check your Whisper API provider's documentation for supported modelIds. On OpenAI, it's something like 'whisper-1'. On Groq, it's something like 'whisper-large-v3'.");
 	}

--- a/CognitiveSupport/Enums.cs
+++ b/CognitiveSupport/Enums.cs
@@ -1,6 +1,6 @@
 ﻿namespace CognitiveSupport;
 
-public enum SpeechToTextServices
+public enum SpeechToTextProviders
 {
 	None = 0,
 	OpenAiWhisper = 1,

--- a/CognitiveSupport/Enums.cs
+++ b/CognitiveSupport/Enums.cs
@@ -3,6 +3,6 @@
 public enum SpeechToTextProviders
 {
 	None = 0,
-	OpenAiWhisper = 1,
+	OpenAi = 1,
 	Deepgram = 2,
 }

--- a/CognitiveSupport/ISpeechToTextService.cs
+++ b/CognitiveSupport/ISpeechToTextService.cs
@@ -2,5 +2,7 @@
 
 public interface ISpeechToTextService
 {
+	string ServiceName { get; init; }
+
 	Task<string> ConvertAudioToText(string speechToTextPrompt, string audioffilePath, CancellationToken overallCancellationToken);
 }

--- a/CognitiveSupport/LlmService.cs
+++ b/CognitiveSupport/LlmService.cs
@@ -12,7 +12,6 @@ public class LlmService : ILlmService
 	private readonly object _lock = new object();
 	private readonly Dictionary<string, IOpenAIService> _openAIServices;
 
-
 	public LlmService(
 		string apiKey,
 		string azureResourceName,

--- a/CognitiveSupport/Settings.cs
+++ b/CognitiveSupport/Settings.cs
@@ -89,29 +89,22 @@ public class AzureComputerVisionSettings
 
 public class SpeetchToTextSettings
 {
-	public SpeechToTextServices Service { get; set; }
+	public string TempDirectory { get; set; }
 	public string SpeechToTextHotKey { get; set; }
+	public List<SpeetchToTextService> SpeetchToTextServices { get; set; }
+	public string ActiveSpeetchToTextService { get; set; }
+}
+
+public class SpeetchToTextService
+{
+	public string Name { get; set; }
+	public SpeechToTextProviders Provider { get; set; }
 	public string ApiKey { get; set; }
 	public string BaseDomain { get; set; }
 	public string ModelId { get; set; }
-	public string TempDirectory { get; set; }
 	public string SpeechToTextPrompt { get; set; }
-
-	public SpeetchToTextSettings()
-	{
-	}
-
-	public SpeetchToTextSettings(SpeechToTextServices service, string speechToTextHotKey, string apiKey, string baseDomain, string modelId, string tempDirectory, string speechToTextPrompt)
-	{
-		Service = service;
-		SpeechToTextHotKey = speechToTextHotKey;
-		ApiKey = apiKey;
-		BaseDomain = baseDomain;
-		ModelId = modelId;
-		TempDirectory = tempDirectory;
-		SpeechToTextPrompt = speechToTextPrompt;
-	}
 }
+
 
 public class LlmSettings
 {

--- a/CognitiveSupport/Settings.cs
+++ b/CognitiveSupport/Settings.cs
@@ -1,4 +1,5 @@
-﻿using System.Drawing;
+﻿using Newtonsoft.Json;
+using System.Drawing;
 
 namespace CognitiveSupport;
 
@@ -91,7 +92,7 @@ public class SpeetchToTextSettings
 {
 	public string TempDirectory { get; set; }
 	public string SpeechToTextHotKey { get; set; }
-	public List<SpeetchToTextService> SpeetchToTextServices { get; set; }
+	public SpeetchToTextService[] Services { get; set; }
 	public string ActiveSpeetchToTextService { get; set; }
 }
 

--- a/CognitiveSupport/Settings.cs
+++ b/CognitiveSupport/Settings.cs
@@ -92,11 +92,11 @@ public class SpeetchToTextSettings
 {
 	public string TempDirectory { get; set; }
 	public string SpeechToTextHotKey { get; set; }
-	public SpeetchToTextService[] Services { get; set; }
+	public SpeetchToTextServiceSettings[] Services { get; set; }
 	public string ActiveSpeetchToTextService { get; set; }
 }
 
-public class SpeetchToTextService
+public class SpeetchToTextServiceSettings
 {
 	public string Name { get; set; }
 	public SpeechToTextProviders Provider { get; set; }

--- a/CognitiveSupport/WhisperSpeechToTextService.cs
+++ b/CognitiveSupport/WhisperSpeechToTextService.cs
@@ -10,14 +10,18 @@ namespace CognitiveSupport;
 
 public class WhisperSpeechToTextService : ISpeechToTextService
 {
+	public string ServiceName { get; init; }
+
 	private readonly string _modelId;
 	private readonly object _lock = new object();
 	private readonly IOpenAIService _openAIService;
 
 	public WhisperSpeechToTextService(
+		string serviceName,
 		IOpenAIService openAIService,
 		string modelId)
 	{
+		this.ServiceName = serviceName;
 		_openAIService = openAIService ?? throw new ArgumentNullException(nameof(openAIService));
 		_modelId = modelId ?? throw new ArgumentNullException(nameof(modelId), "Check your Whisper API provider's documentation for supported modelIds. On OpenAI, it's something like 'whisper-1'. On Groq, it's something like 'whisper-large-v3'.");
 	}
@@ -49,7 +53,7 @@ public class WhisperSpeechToTextService : ISpeechToTextService
 
 		var context = new Context();
 		context[AttemptKey] = 1;
-		
+
 		var response = await retryPolicy.ExecuteAsync(async (context, overallToken) =>
 		{
 			int attempt = context.ContainsKey(AttemptKey) ? (int)context[AttemptKey] : 1;

--- a/CognitiveSupport/WhisperSpeechToTextService.cs
+++ b/CognitiveSupport/WhisperSpeechToTextService.cs
@@ -92,7 +92,7 @@ public class WhisperSpeechToTextService : ISpeechToTextService
 			FileName = Path.GetFileName(audioffilePath),
 			File = audioBytes,
 			Model = _modelId,
-			ResponseFormat = StaticValues.AudioStatics.ResponseFormat.VerboseJson
+			ResponseFormat = StaticValues.AudioStatics.ResponseFormat.Json
 		}, cancellationToken);
 	}
 }

--- a/Mutation/CaptureDeviceComboItem.cs
+++ b/Mutation/CaptureDeviceComboItem.cs
@@ -1,16 +1,15 @@
 ﻿using AudioSwitcher.AudioApi.CoreAudio;
 
-namespace Mutation
-{
-	internal class CaptureDeviceComboItem
-	{
-		public CoreAudioDevice CaptureDevice { get; set; }
-		public string Display =>
-			$"{CaptureDevice.FullName}";
+namespace Mutation;
 
-		public override string ToString()
-		{
-			return this.Display;
-		}
+internal class CaptureDeviceComboItem
+{
+	public CoreAudioDevice CaptureDevice { get; set; }
+	public string Display =>
+		$"{CaptureDevice.FullName}";
+
+	public override string ToString()
+	{
+		return this.Display;
 	}
 }

--- a/Mutation/Mutation.csproj
+++ b/Mutation/Mutation.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="AudioSwitcher.AudioApi" Version="3.0.0" />
     <PackageReference Include="AudioSwitcher.AudioApi.CoreAudio" Version="3.0.3" />
-    <PackageReference Include="Deepgram" Version="4.1.0" />
+    <PackageReference Include="Deepgram" Version="5.1.2" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="StringExtensionsLibrary" Version="1.0.0" />

--- a/Mutation/MutationForm.Designer.cs
+++ b/Mutation/MutationForm.Designer.cs
@@ -493,7 +493,7 @@
 			lblSpeechToTextService.Name = "lblSpeechToTextService";
 			lblSpeechToTextService.Size = new Size(47, 15);
 			lblSpeechToTextService.TabIndex = 22;
-			lblSpeechToTextService.Text = "Service:";
+			lblSpeechToTextService.Text = "Provider:";
 			// 
 			// txtSpeechToTextService
 			// 

--- a/Mutation/MutationForm.Designer.cs
+++ b/Mutation/MutationForm.Designer.cs
@@ -517,6 +517,7 @@
 			cmbSpeechToTextService.Name = "cmbSpeechToTextService";
 			cmbSpeechToTextService.Size = new Size(176, 23);
 			cmbSpeechToTextService.TabIndex = 24;
+			cmbSpeechToTextService.SelectedIndexChanged += cmbSpeechToTextService_SelectedIndexChanged;
 			// 
 			// MutationForm
 			// 

--- a/Mutation/MutationForm.Designer.cs
+++ b/Mutation/MutationForm.Designer.cs
@@ -66,8 +66,8 @@
 			radManualPunctuation = new RadioButton();
 			label1 = new Label();
 			lblSpeechToTextService = new Label();
-			txtSpeechToTextService = new TextBox();
 			cmbActiveMicrophone = new ComboBox();
+			cmbSpeechToTextService = new ComboBox();
 			((System.ComponentModel.ISupportInitialize)splitContainerLlmProcessing).BeginInit();
 			splitContainerLlmProcessing.Panel1.SuspendLayout();
 			splitContainerLlmProcessing.Panel2.SuspendLayout();
@@ -493,15 +493,7 @@
 			lblSpeechToTextService.Name = "lblSpeechToTextService";
 			lblSpeechToTextService.Size = new Size(47, 15);
 			lblSpeechToTextService.TabIndex = 22;
-			lblSpeechToTextService.Text = "Provider:";
-			// 
-			// txtSpeechToTextService
-			// 
-			txtSpeechToTextService.Location = new Point(71, 217);
-			txtSpeechToTextService.Name = "txtSpeechToTextService";
-			txtSpeechToTextService.ReadOnly = true;
-			txtSpeechToTextService.Size = new Size(174, 23);
-			txtSpeechToTextService.TabIndex = 23;
+			lblSpeechToTextService.Text = "Service:";
 			// 
 			// cmbActiveMicrophone
 			// 
@@ -515,13 +507,24 @@
 			cmbActiveMicrophone.TabIndex = 1;
 			cmbActiveMicrophone.SelectedIndexChanged += cmbActiveMicrophone_SelectedIndexChanged;
 			// 
+			// cmbSpeechToTextService
+			// 
+			cmbSpeechToTextService.AccessibleName = "Active Microphone";
+			cmbSpeechToTextService.Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right;
+			cmbSpeechToTextService.DropDownStyle = ComboBoxStyle.DropDownList;
+			cmbSpeechToTextService.FormattingEnabled = true;
+			cmbSpeechToTextService.Location = new Point(71, 217);
+			cmbSpeechToTextService.Name = "cmbSpeechToTextService";
+			cmbSpeechToTextService.Size = new Size(176, 23);
+			cmbSpeechToTextService.TabIndex = 24;
+			// 
 			// MutationForm
 			// 
 			AutoScaleDimensions = new SizeF(7F, 15F);
 			AutoScaleMode = AutoScaleMode.Font;
 			ClientSize = new Size(1184, 711);
+			Controls.Add(cmbSpeechToTextService);
 			Controls.Add(cmbActiveMicrophone);
-			Controls.Add(txtSpeechToTextService);
 			Controls.Add(lblSpeechToTextService);
 			Controls.Add(label1);
 			Controls.Add(gbPunctuation);
@@ -597,8 +600,8 @@
 		private ComboBox cmbReviewTemperature;
 		private Label label1;
 		private Label lblSpeechToTextService;
-		private TextBox txtSpeechToTextService;
 		private ComboBox cmbActiveMicrophone;
+		private ComboBox cmbSpeechToTextService;
 	}
 }
 

--- a/Mutation/MutationForm.cs
+++ b/Mutation/MutationForm.cs
@@ -15,6 +15,7 @@ namespace Mutation
 	public partial class MutationForm : Form
 	{
 		private ScreenCaptureForm _activeScreenCaptureForm = null;
+		private SpeetchToTextService _activeSpeetchToTextService = null;
 
 		private Settings _settings { get; set; }
 		private ISettingsManager _settingsManager { get; set; }
@@ -66,7 +67,7 @@ namespace Mutation
 			InitializeComponent();
 			InitializeAudioControls();
 
-			txtSpeechToTextPrompt.Text = _settings.SpeetchToTextSettings.SpeechToTextPrompt;
+			txtSpeechToTextPrompt.Text = _activeSpeetchToTextService.SpeechToTextPrompt;
 
 			HookupTooltips();
 
@@ -793,7 +794,7 @@ The model may also leave out common filler words in the audio. If you want to ke
 			_settings.MainWindowUiSettings.WindowSize = this.Size;
 			_settings.MainWindowUiSettings.WindowLocation = this.Location;
 
-			_settings.SpeetchToTextSettings.SpeechToTextPrompt = txtSpeechToTextPrompt.Text;
+			_activeSpeetchToTextService.SpeechToTextPrompt = txtSpeechToTextPrompt.Text;
 			_settings.LlmSettings.FormatTranscriptPrompt = txtFormatTranscriptPrompt.Text;
 			_settings.LlmSettings.ReviewTranscriptPrompt = txtReviewTranscriptPrompt.Text;
 			this._settingsManager.SaveSettingsToFile(_settings);
@@ -813,7 +814,7 @@ The model may also leave out common filler words in the audio. If you want to ke
 			RestoreWindowLocationAndSizeFromSettings();
 
 			txtSpeechToTextService.Text =
-				$"{this._settings.SpeetchToTextSettings.Service}: {this._settings.SpeetchToTextSettings.ModelId}";
+				$"{ _activeSpeetchToTextService.Provider}: {_activeSpeetchToTextService.ModelId}";
 		}
 
 		private async void btnSpeechToTextRecord_Click(object sender, EventArgs e)

--- a/Mutation/MutationForm.cs
+++ b/Mutation/MutationForm.cs
@@ -67,6 +67,10 @@ namespace Mutation
 			InitializeComponent();
 			InitializeAudioControls();
 
+			_activeSpeetchToTextService= _settings.SpeetchToTextSettings.Services
+				.Single(x => x.Name == settings.SpeetchToTextSettings.ActiveSpeetchToTextService);
+
+			PopulateSpeechToTextServiceCombo();
 			txtSpeechToTextPrompt.Text = _activeSpeetchToTextService.SpeechToTextPrompt;
 
 			HookupTooltips();
@@ -274,6 +278,31 @@ The model may also leave out common filler words in the audio. If you want to ke
 				}));
 		}
 
+		private void PopulateSpeechToTextServiceCombo()
+		{
+			cmbSpeechToTextService.Items.Clear();
+			_settings.SpeetchToTextSettings.Services
+				.ToList()
+				.ForEach(m => cmbSpeechToTextService.Items.Add(new SpeechToTextServiceComboItem
+				{
+					SpeetchToTextService = m,
+				}));
+
+			SelectActiveServiceInSpeechToTextServiceCombo();
+		}
+
+		private void SelectActiveServiceInSpeechToTextServiceCombo()
+		{
+			foreach (SpeechToTextServiceComboItem item in cmbSpeechToTextService.Items)
+			{
+				if (item.SpeetchToTextService.Name == _activeSpeetchToTextService.Name)
+				{
+					cmbSpeechToTextService.SelectedItem = item;
+					break;
+				}
+			}
+		}
+
 		private void SelectActiveCaptureDeviceInActiveMicrophoneCombo()
 		{
 			foreach (CaptureDeviceComboItem item in cmbActiveMicrophone.Items)
@@ -391,7 +420,7 @@ The model may also leave out common filler words in the audio. If you want to ke
 			using (Graphics g = Graphics.FromImage(screenshot))
 			{
 				g.CopyFromScreen(0, 0, 0, 0, Screen.PrimaryScreen.Bounds.Size);
-				
+
 				var displayShot = screenshot;
 				using Bitmap invertedScreenshot = InvertScreenshotColors(screenshot);
 				if (_settings.AzureComputerVisionSettings.InvertScreenshot)
@@ -812,9 +841,9 @@ The model may also leave out common filler words in the audio. If you want to ke
 		private void MutationForm_Load(object sender, EventArgs e)
 		{
 			RestoreWindowLocationAndSizeFromSettings();
-
-			txtSpeechToTextService.Text =
-				$"{ _activeSpeetchToTextService.Provider}: {_activeSpeetchToTextService.ModelId}";
+			//BookMark??888
+			//cmbSpeechToTextService.Text =
+			//	$"{ _activeSpeetchToTextService.Provider}: {_activeSpeetchToTextService.ModelId}";
 		}
 
 		private async void btnSpeechToTextRecord_Click(object sender, EventArgs e)

--- a/Mutation/MutationForm.cs
+++ b/Mutation/MutationForm.cs
@@ -832,6 +832,8 @@ The model may also leave out common filler words in the audio. If you want to ke
 			_settings.MainWindowUiSettings.WindowLocation = this.Location;
 
 			_activeSpeetchToTextServiceComboItem.SpeetchToTextServiceSettings.SpeechToTextPrompt = txtSpeechToTextPrompt.Text;
+			_settings.SpeetchToTextSettings.ActiveSpeetchToTextService = _activeSpeetchToTextServiceComboItem.SpeetchToTextServiceSettings.Name;
+
 			_settings.LlmSettings.FormatTranscriptPrompt = txtFormatTranscriptPrompt.Text;
 			_settings.LlmSettings.ReviewTranscriptPrompt = txtReviewTranscriptPrompt.Text;
 			this._settingsManager.SaveSettingsToFile(_settings);

--- a/Mutation/Program.cs
+++ b/Mutation/Program.cs
@@ -62,7 +62,7 @@ internal static class Program
 		const string OpenAiHttpClient = "openai-http-client";
 		builder.Services.AddHttpClient(OpenAiHttpClient);
 
-		SpeetchToTextService activeSpeetchToTextService = settings.SpeetchToTextSettings.SpeetchToTextServices
+		SpeetchToTextService activeSpeetchToTextService = settings.SpeetchToTextSettings.Services
 			.Single(x => x.Name == settings.SpeetchToTextSettings.ActiveSpeetchToTextService);
 
 		builder.Services.AddSingleton<IOpenAIService>(x =>
@@ -105,7 +105,7 @@ internal static class Program
 
 	private static void AddWhisperSpeechToTextService(HostApplicationBuilder builder, Settings settings)
 	{
-		SpeetchToTextService activeSpeetchToTextService = settings.SpeetchToTextSettings.SpeetchToTextServices
+		SpeetchToTextService activeSpeetchToTextService = settings.SpeetchToTextSettings.Services
 			.Single(x => x.Name == settings.SpeetchToTextSettings.ActiveSpeetchToTextService);
 
 		builder.Services.AddSingleton<ISpeechToTextService>(x =>
@@ -120,7 +120,7 @@ internal static class Program
 
 	private static void AddDeepgramSpeechToTextService(HostApplicationBuilder builder, Settings settings)
 	{
-		SpeetchToTextService activeSpeetchToTextService = settings.SpeetchToTextSettings.SpeetchToTextServices
+		SpeetchToTextService activeSpeetchToTextService = settings.SpeetchToTextSettings.Services
 			.Single(x => x.Name == settings.SpeetchToTextSettings.ActiveSpeetchToTextService);
 
 		builder.Services.AddSingleton<ISpeechToTextService>(x =>

--- a/Mutation/Program.cs
+++ b/Mutation/Program.cs
@@ -82,7 +82,7 @@ internal static class Program
 			{
 				switch (serviceSettings.Provider)
 				{
-					case SpeechToTextProviders.OpenAiWhisper:
+					case SpeechToTextProviders.OpenAi:
 						speechToTextServices.Add(CreateWhisperSpeechToTextService(builder, serviceSettings, x));
 						break;
 					case SpeechToTextProviders.Deepgram:

--- a/Mutation/SettingsManager.cs
+++ b/Mutation/SettingsManager.cs
@@ -108,12 +108,12 @@ internal class SettingsManager : ISettingsManager
 		}
 		if (speechToTextSettings.Services is null)
 		{
-			speechToTextSettings.Services = new SpeetchToTextService[] { };
+			speechToTextSettings.Services = new SpeetchToTextServiceSettings[] { };
 		}
 		if (!speechToTextSettings.Services.Any())
 		{
 			speechToTextSettings.ActiveSpeetchToTextService = "OpenAI Whisper 1";
-			SpeetchToTextService service = new SpeetchToTextService
+			SpeetchToTextServiceSettings service = new SpeetchToTextServiceSettings
 			{
 				Name = speechToTextSettings.ActiveSpeetchToTextService,
 				Provider = SpeechToTextProviders.OpenAiWhisper,

--- a/Mutation/SettingsManager.cs
+++ b/Mutation/SettingsManager.cs
@@ -109,6 +109,7 @@ internal class SettingsManager : ISettingsManager
 		if (speechToTextSettings.Services is null)
 		{
 			speechToTextSettings.Services = new SpeetchToTextServiceSettings[] { };
+			somethingWasMissing = true;
 		}
 		if (!speechToTextSettings.Services.Any())
 		{
@@ -117,8 +118,11 @@ internal class SettingsManager : ISettingsManager
 			{
 				Name = speechToTextSettings.ActiveSpeetchToTextService,
 				Provider = SpeechToTextProviders.OpenAiWhisper,
+				ModelId = "whisper-1",
+				BaseDomain = "https://api.openai.com/",
 			};
-			speechToTextSettings.Services.Append(service);
+			speechToTextSettings.Services = speechToTextSettings.Services.Append(service).ToArray();
+			somethingWasMissing = true;
 		}
 		foreach (var s in speechToTextSettings.Services)
 		{
@@ -413,7 +417,7 @@ When you are asked to apply revision corrections, you should do the following:
 		// Check if the JSON is already in the desired format.
 		// Here, we assume correctness if a "Services" property (as an array) exists.
 		if (settings["Services"] != null && settings["Services"].Type == JTokenType.Array)
-			return ;
+			return;
 
 		string providerName = settings.Value<string>("Service") ?? "";
 

--- a/Mutation/SettingsManager.cs
+++ b/Mutation/SettingsManager.cs
@@ -4,6 +4,7 @@ using Newtonsoft.Json.Converters;
 using OpenAI.ObjectModels;
 using System.Diagnostics;
 using System.Text;
+using System.Xml.Linq;
 
 namespace Mutation;
 
@@ -105,18 +106,38 @@ internal class SettingsManager : ISettingsManager
 			speechToTextSettings.SpeechToTextHotKey = "SHIFT+ALT+U";
 			somethingWasMissing = true;
 		}
-		if (speechToTextSettings.Service == SpeechToTextServices.None)
+		if (speechToTextSettings.SpeetchToTextServices is null)
 		{
-			speechToTextSettings.Service = SpeechToTextServices.OpenAiWhisper;
+			speechToTextSettings.SpeetchToTextServices = new();
 		}
+		if (!speechToTextSettings.SpeetchToTextServices.Any())
+		{
+			speechToTextSettings.ActiveSpeetchToTextService = "OpenAI Whisper 1";
+			SpeetchToTextService service = new SpeetchToTextService
+			{
+				Name = speechToTextSettings.ActiveSpeetchToTextService,
+				Provider = SpeechToTextProviders.OpenAiWhisper,
+			};
+		}
+		foreach (var s in speechToTextSettings.SpeetchToTextServices)
+		{
+			if (s.Provider == SpeechToTextProviders.None)
+				s.Provider = SpeechToTextProviders.OpenAiWhisper;
+			if (string.IsNullOrWhiteSpace(s.ApiKey))
+			{
+				s.ApiKey = PlaceholderValue;
+				somethingWasMissing = true;
+			}
+			if (string.IsNullOrWhiteSpace(s.SpeechToTextPrompt))
+			{
+				s.SpeechToTextPrompt = "Hello, let's use punctuation. Names: Kobus, Piro.";
+				// This is optional, so we don't need to flag that something was missing.
+			}
+		}
+
 		if (string.IsNullOrWhiteSpace(speechToTextSettings.SpeechToTextHotKey))
 		{
 			speechToTextSettings.SpeechToTextHotKey = "SHIFT+ALT+U";
-			somethingWasMissing = true;
-		}
-		if (string.IsNullOrWhiteSpace(speechToTextSettings.ApiKey))
-		{
-			speechToTextSettings.ApiKey = PlaceholderValue;
 			somethingWasMissing = true;
 		}
 		if (string.IsNullOrWhiteSpace(speechToTextSettings.TempDirectory))
@@ -124,13 +145,6 @@ internal class SettingsManager : ISettingsManager
 			speechToTextSettings.TempDirectory = @"C:\Temp\Mutation";
 			somethingWasMissing = true;
 		}
-
-		if (string.IsNullOrWhiteSpace(speechToTextSettings.SpeechToTextPrompt))
-		{
-			speechToTextSettings.SpeechToTextPrompt = "Hello, let's use punctuation. Names: Kobus, Piro.";
-			// This is optional, so we don't need to flag that something was missing.
-		}
-
 
 		//-------------------------------
 		if (settings.LlmSettings is null)

--- a/Mutation/SpeechToTextServiceComboItem.cs
+++ b/Mutation/SpeechToTextServiceComboItem.cs
@@ -1,0 +1,16 @@
+﻿using AudioSwitcher.AudioApi.CoreAudio;
+using CognitiveSupport;
+
+namespace Mutation;
+
+internal class SpeechToTextServiceComboItem
+{
+	public SpeetchToTextService SpeetchToTextService { get; set; }
+	public string Display =>
+		$"{SpeetchToTextService.Name}";
+
+	public override string ToString()
+	{
+		return this.Display;
+	}
+}

--- a/Mutation/SpeechToTextServiceComboItem.cs
+++ b/Mutation/SpeechToTextServiceComboItem.cs
@@ -5,9 +5,10 @@ namespace Mutation;
 
 internal class SpeechToTextServiceComboItem
 {
-	public SpeetchToTextService SpeetchToTextService { get; set; }
+	public SpeetchToTextServiceSettings SpeetchToTextServiceSettings { get; set; }
+	public ISpeechToTextService SpeechToTextService { get; set; }
 	public string Display =>
-		$"{SpeetchToTextService.Name}";
+		$"{SpeetchToTextServiceSettings.Name}";
 
 	public override string ToString()
 	{


### PR DESCRIPTION
The new JSON structure for SpeetchToTextSettings now supports a multi-service configuration. Instead of a single flat configuration, the settings related to API keys, domains, model IDs, and prompts are now encapsulated within a "services" array, allowing for multiple service entries. Additionally, the "Service" key has been replaced with "ActiveSpeetchToTextService" to clearly indicate which service is currently in use, while "TempDirectory" and "SpeechToTextHotKey" remain at the top level. At application startup, the old version 1 settings will be automatically transformed into the new version 2 format.

Furthermore, a new drop-down box labeled "Service" has been added to the user interface. This drop-down enables users to select from any of the available speech-to-text services at runtime, providing greater flexibility and control over their configuration.

Along with neva-2, Mutation now also supports Deepgram nova-3, as well as OpenAI gpt-4o-transcribe and gpt-4o-mini-transcribe. These additional integrations expand the range of speech-to-text options, allowing users to choose the service that best meets their transcription needs.






