### PR TITLE
**Improve OCR Service Reliability and Compatibility with Image Padding, Stream Handling, and Refactoring**

### DIFF
--- a/CognitiveSupport/OcrService.cs
+++ b/CognitiveSupport/OcrService.cs
@@ -63,6 +63,9 @@ public class OcrService : IOcrService
 
 			if (attempt > 0) this.Beep(attempt);
 
+			// Reset the stream position before retrying
+			imageStream.Seek(0, SeekOrigin.Begin);
+
 			return await ReadFileInternal(ocrReadingOrder, imageStream, linkedCts.Token).ConfigureAwait(false);
 
 		}, context, overallCancellationToken).ConfigureAwait(false);

--- a/CognitiveSupport/OcrService.cs
+++ b/CognitiveSupport/OcrService.cs
@@ -73,6 +73,8 @@ public class OcrService : IOcrService
 		}, context, overallCancellationToken).ConfigureAwait(false);
 	}
 
+	// This method ensures that images meet Azure OCR's minimum size requirement of 50x50 pixels.
+	// If an image is smaller than the required dimensions, it is padded with a neutral background color to comply with the requirement.
 	private Stream EnsureMinimumImageSize(Stream imageStream)
 	{
 		using var image = Image.FromStream(imageStream);

--- a/CognitiveSupport/OcrService.cs
+++ b/CognitiveSupport/OcrService.cs
@@ -34,7 +34,7 @@ public class OcrService : IOcrService
 		Stream imageStream,
 		CancellationToken overallCancellationToken)
 	{
-		return ReadFile(ocrReadingOrder, imageStream, overallCancellationToken);
+		return Read(ocrReadingOrder, imageStream, overallCancellationToken);
 	}
 
 	private static ComputerVisionClient CreateComputerVisionClient(string endpoint, string key) =>
@@ -61,7 +61,7 @@ public class OcrService : IOcrService
 		return CancellationTokenSource.CreateLinkedTokenSource(overallToken, perTryCts.Token);
 	}
 
-	private async Task<string> ExecuteReadFileInternal(
+	private async Task<string> ExecuteReadInternal(
 		OcrReadingOrder ocrReadingOrder,
 		Stream imageStream,
 		Context context,
@@ -76,7 +76,7 @@ public class OcrService : IOcrService
 
 			imageStream.Seek(0, SeekOrigin.Begin);
 
-			return await ReadFileInternal(ocrReadingOrder, imageStream, linkedCts.Token).ConfigureAwait(false);
+			return await ReadInternal(ocrReadingOrder, imageStream, linkedCts.Token).ConfigureAwait(false);
 		}
 		finally
 		{
@@ -84,7 +84,7 @@ public class OcrService : IOcrService
 		}
 	}
 
-	private async Task<string> ReadFile(
+	private async Task<string> Read(
 		OcrReadingOrder ocrReadingOrder,
 		Stream imageStream,
 		CancellationToken overallCancellationToken)
@@ -93,7 +93,7 @@ public class OcrService : IOcrService
 		var context = CreateRetryContext();
 
 		return await retryPolicy.ExecuteAsync(
-			(ctx, overallToken) => ExecuteReadFileInternal(ocrReadingOrder, imageStream, ctx, overallToken),
+			(ctx, overallToken) => ExecuteReadInternal(ocrReadingOrder, imageStream, ctx, overallToken),
 			context,
 			overallCancellationToken).ConfigureAwait(false);
 	}
@@ -129,7 +129,7 @@ public class OcrService : IOcrService
 		return paddedStream;
 	}
 
-	private async Task<string> ReadFileInternal(
+	private async Task<string> ReadInternal(
 		OcrReadingOrder ocrReadingOrder,
 		Stream imageStream,
 		CancellationToken cancellationToken)


### PR DESCRIPTION
Enhancements to OCR Service:

Image Size Padding: Azure Computer Vision requires images to be at least 50x50px. Screenshots smaller than this in either dimension are now padded to meet the minimum size requirement.

Stream Reset on Retry: Fixed an issue where the image stream wasn't being reset during retries, causing OCR retries to fail. This has been resolved — retries now work as expected.

Improved Resource Management: Ensured proper disposal of image streams and correct usage of cancellation tokens to avoid resource leaks and improve reliability.

Code Improvements: Refactored the OCR service for better structure and readability.








