### PR TITLE
Improve WinUI service implementations

### DIFF
--- a/Mutation.Ui/App.xaml.cs
+++ b/Mutation.Ui/App.xaml.cs
@@ -32,6 +32,7 @@ namespace Mutation.Ui
         {
                 private Window? _window;
                 private IHost? _host;
+                public static Window? MainWindow { get; private set; }
 
 		/// <summary>
 		/// Initializes the singleton application object.  This is the first line of authored code
@@ -70,6 +71,7 @@ namespace Mutation.Ui
                         _host = builder.Build();
 
                         _window = _host.Services.GetRequiredService<MainWindow>();
+                        MainWindow = _window;
                         _window.Activate();
                 }
         }

--- a/Mutation.Ui/MainWindow.xaml.cs
+++ b/Mutation.Ui/MainWindow.xaml.cs
@@ -44,6 +44,16 @@ namespace Mutation.Ui
                 {
                         _uiStateManager.Restore(this);
                         _hotkeyManager.Initialize(this);
+                        _hotkeyManager.RegisterHotkey(Windows.System.VirtualKey.F9, Services.HotkeyModifiers.Control, () =>
+                        {
+                                _ = DispatcherQueue.TryEnqueue(async () =>
+                                {
+                                        var result = await _ocrManager.TakeScreenshotAndExtractText(CognitiveSupport.OcrReadingOrder.TopToBottomColumnAware);
+                                        if (result.Success)
+                                                txtOcr.Text = result.Message;
+                                });
+                        });
+
                         btnOcr.Click += async (_, _) =>
                         {
                                 var result = await _ocrManager.TakeScreenshotAndExtractText(CognitiveSupport.OcrReadingOrder.TopToBottomColumnAware);

--- a/Mutation.Ui/Services/HotkeyManager.cs
+++ b/Mutation.Ui/Services/HotkeyManager.cs
@@ -1,4 +1,6 @@
 using Microsoft.UI.Xaml;
+using System.Runtime.InteropServices;
+using System.Collections.Generic;
 using Windows.System;
 
 namespace Mutation.Ui.Services;
@@ -9,14 +11,63 @@ namespace Mutation.Ui.Services;
 /// </summary>
 public class HotkeyManager
 {
-    public void Initialize(Window window) { /* TODO: implement global hotkey registration */ }
+    private Window? _window;
+    private IntPtr _hwnd;
+    private WndProc? _newWndProc;
+    private IntPtr _oldWndProc;
+    private int _currentId = 0;
+    private readonly Dictionary<int, Action> _callbacks = new();
+
+    public void Initialize(Window window)
+    {
+        _window = window;
+        _hwnd = WinRT.Interop.WindowNative.GetWindowHandle(window);
+        _newWndProc = WndProc;
+        _oldWndProc = SetWindowLongPtr(_hwnd, -4, Marshal.GetFunctionPointerForDelegate(_newWndProc));
+    }
 
     public void RegisterHotkey(VirtualKey key, HotkeyModifiers modifiers, Action callback)
     {
-        // TODO: implement
+        int id = ++_currentId;
+        if (!RegisterHotKey(_hwnd, id, (uint)modifiers, (uint)key))
+            throw new InvalidOperationException("Failed to register hotkey.");
+        _callbacks[id] = callback;
     }
 
-    public void UnregisterAll() { }
+    public void UnregisterAll()
+    {
+        foreach (var id in _callbacks.Keys)
+            UnregisterHotKey(_hwnd, id);
+        _callbacks.Clear();
+        if (_newWndProc != null)
+            SetWindowLongPtr(_hwnd, -4, _oldWndProc);
+    }
+
+    private IntPtr WndProc(IntPtr hWnd, int msg, IntPtr wParam, IntPtr lParam)
+    {
+        const int WM_HOTKEY = 0x0312;
+        if (msg == WM_HOTKEY)
+        {
+            int id = wParam.ToInt32();
+            if (_callbacks.TryGetValue(id, out var action))
+                action();
+        }
+        return CallWindowProc(_oldWndProc, hWnd, msg, wParam, lParam);
+    }
+
+    private delegate IntPtr WndProc(IntPtr hWnd, int msg, IntPtr wParam, IntPtr lParam);
+
+    [DllImport("user32.dll")]
+    private static extern bool RegisterHotKey(IntPtr hWnd, int id, uint fsModifiers, uint vk);
+
+    [DllImport("user32.dll")]
+    private static extern bool UnregisterHotKey(IntPtr hWnd, int id);
+
+    [DllImport("user32.dll")]
+    private static extern IntPtr CallWindowProc(IntPtr lpPrevWndFunc, IntPtr hWnd, int msg, IntPtr wParam, IntPtr lParam);
+
+    [DllImport("user32.dll")]
+    private static extern IntPtr SetWindowLongPtr(IntPtr hWnd, int nIndex, IntPtr dwNewLong);
 }
 
 [Flags]

--- a/Mutation.Ui/Services/OcrManager.cs
+++ b/Mutation.Ui/Services/OcrManager.cs
@@ -1,5 +1,8 @@
 using CognitiveSupport;
-using Windows.Graphics.Capture;
+using Windows.ApplicationModel.DataTransfer;
+using Windows.Graphics.Imaging;
+using Windows.Storage.Streams;
+using Windows.System;
 
 namespace Mutation.Ui.Services;
 
@@ -21,8 +24,51 @@ public class OcrManager
 
     public async Task<OcrResult> TakeScreenshotAndExtractText(OcrReadingOrder order)
     {
-        // TODO: implement capture and OCR
-        return new OcrResult(false, "Not implemented");
+        bool launched = await Launcher.LaunchUriAsync(new Uri("ms-screenclip:"));
+        if (!launched)
+            return new OcrResult(false, "Failed to launch screen clip tool.");
+
+        var image = await _clipboardManager.TryGetImageAsync(20, 300);
+        if (image is null)
+            return new OcrResult(false, "No image captured.");
+
+        return await ExtractTextFromBitmap(order, image);
+    }
+
+    public async Task<OcrResult> ExtractTextFromClipboardImage(OcrReadingOrder order)
+    {
+        var image = await _clipboardManager.TryGetImageAsync();
+        if (image is null)
+        {
+            const string msg = "No image found on the clipboard.";
+            _clipboardManager.SetText(msg);
+            return new OcrResult(false, msg);
+        }
+
+        return await ExtractTextFromBitmap(order, image);
+    }
+
+    private async Task<OcrResult> ExtractTextFromBitmap(OcrReadingOrder order, SoftwareBitmap bitmap)
+    {
+        try
+        {
+            using InMemoryRandomAccessStream mem = new();
+            BitmapEncoder encoder = await BitmapEncoder.CreateAsync(BitmapEncoder.JpegEncoderId, mem);
+            encoder.SetSoftwareBitmap(bitmap);
+            await encoder.FlushAsync();
+            mem.Seek(0);
+
+            using var stream = mem.AsStream();
+            string text = await _ocrService.ExtractText(order, stream, CancellationToken.None);
+            _clipboardManager.SetText(text);
+            return new OcrResult(true, $"Converted text is on clipboard:{Environment.NewLine}{text}");
+        }
+        catch (Exception ex)
+        {
+            string msg = $"Failed to extract text via OCR: {ex.Message}";
+            _clipboardManager.SetText(msg);
+            return new OcrResult(false, msg);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- store the `MainWindow` instance for easy access
- add a basic screenshot-based OCR workflow
- implement Win32 global hotkeys in the WinUI service
- register an example hotkey in `MainWindow`

## Testing
- `dotnet build` *(fails: `dotnet` not found)*