### PR TITLE
Implement hotkey router and send-input support

### DIFF
--- a/Mutation.Ui/App.xaml.cs
+++ b/Mutation.Ui/App.xaml.cs
@@ -57,7 +57,7 @@ namespace Mutation.Ui
                                        sp.GetRequiredService<IOcrService>(),
                                        sp.GetRequiredService<ClipboardManager>()));
                 builder.Services.AddSingleton<HotkeyManager>(sp =>
-                        new HotkeyManager(sp.GetRequiredService<MainWindow>()));
+                        new HotkeyManager(sp.GetRequiredService<MainWindow>(), sp.GetRequiredService<Settings>()));
                 builder.Services.AddSingleton<ILlmService>(
                         new LlmService(
                                 settings.LlmSettings?.ApiKey ?? string.Empty,
@@ -125,6 +125,8 @@ namespace Mutation.Ui
                                 Hotkey.Parse(settingsSvc.TextToSpeechSettings.TextToSpeechHotKey!),
                                 () => _window.DispatcherQueue.TryEnqueue(() => ((MainWindow)_window).BtnTextToSpeech_Click(null!, null!)));
                 }
+
+                hkManager.RegisterRouterHotkeys();
         }
 
         private static void AddSpeechToTextServices(HostApplicationBuilder builder, Settings settings)

--- a/Mutation.Ui/MainWindow.xaml.cs
+++ b/Mutation.Ui/MainWindow.xaml.cs
@@ -83,18 +83,21 @@ namespace Mutation.Ui
                 private async void BtnScreenshot_Click(object sender, RoutedEventArgs e)
                 {
                         await _ocrManager.TakeScreenshotToClipboardAsync();
+                        HotkeyManager.SendHotkeyAfterDelay(_settings.AzureComputerVisionSettings?.SendKotKeyAfterOcrOperation ?? string.Empty, 50);
                 }
 
                 private async void BtnScreenshotOcr_Click(object sender, RoutedEventArgs e)
                 {
                         var result = await _ocrManager.TakeScreenshotAndExtractTextAsync(OcrReadingOrder.TopToBottomColumnAware);
                         TxtOcr.Text = result.Message;
+                        HotkeyManager.SendHotkeyAfterDelay(_settings.AzureComputerVisionSettings?.SendKotKeyAfterOcrOperation ?? string.Empty, result.Success ? 50 : 25);
                 }
 
                 private async void BtnOcrClipboard_Click(object sender, RoutedEventArgs e)
                 {
                         var result = await _ocrManager.ExtractTextFromClipboardImageAsync(OcrReadingOrder.TopToBottomColumnAware);
                         TxtOcr.Text = result.Message;
+                        HotkeyManager.SendHotkeyAfterDelay(_settings.AzureComputerVisionSettings?.SendKotKeyAfterOcrOperation ?? string.Empty, result.Success ? 50 : 25);
                 }
 
                 public async void BtnSpeechToText_Click(object? sender, RoutedEventArgs? e)
@@ -122,6 +125,7 @@ namespace Mutation.Ui
                                 BtnSpeechToText.Content = "Record";
                                 BtnSpeechToText.IsEnabled = true;
                                 _clipboard.SetText(text);
+                                HotkeyManager.SendHotkeyAfterDelay(_settings.SpeetchToTextSettings?.SendKotKeyAfterTranscriptionOperation ?? string.Empty, 50);
                         }
                 }
 


### PR DESCRIPTION
## Summary
- extend HotkeyManager to send synthetic hotkeys via `SendInput`
- support hotkey routing based on `Settings.HotKeyRouterSettings`
- issue configured hotkeys automatically after OCR and STT actions
- register router mappings during application startup

## Testing
- `git status --short`