### PR TITLE
Fix compilation and enhance transcript tools

### DIFF
--- a/Mutation.Ui/App.xaml.cs
+++ b/Mutation.Ui/App.xaml.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using System;
+using System.Collections.Generic;
 using AudioSwitcher.AudioApi.CoreAudio;
 using Deepgram;
 using System.Net.Http;

--- a/Mutation.Ui/Core/DictationInsertOption.cs
+++ b/Mutation.Ui/Core/DictationInsertOption.cs
@@ -1,5 +1,7 @@
 ﻿using System.ComponentModel;
 
+using System.ComponentModel;
+
 namespace Mutation.Ui;
 
 public enum DictationInsertOption

--- a/Mutation.Ui/MainWindow.xaml
+++ b/Mutation.Ui/MainWindow.xaml
@@ -29,10 +29,11 @@
                 <TextBox x:Name="TxtOcr" AcceptsReturn="True" TextWrapping="Wrap" Height="80"/>
 
                 <Button x:Name="BtnSpeechToText" Content="Record" Click="BtnSpeechToText_Click"/>
-                <TextBox x:Name="TxtSpeechToText" AcceptsReturn="True" TextWrapping="Wrap" Height="80"/>
+                <TextBox x:Name="TxtSpeechToText" AcceptsReturn="True" TextWrapping="Wrap" Height="80" TextChanged="TxtSpeechToText_TextChanged"/>
 
                 <TextBox x:Name="TxtFormatPrompt" PlaceholderText="Format prompt" AcceptsReturn="True" TextWrapping="Wrap" Height="60"/>
                 <Button x:Name="BtnFormatTranscript" Content="Format Transcript" Click="BtnFormatTranscript_Click"/>
+                <Button x:Name="BtnFormatLlm" Content="Format Transcript with LLM" Click="BtnFormatLlm_Click"/>
                 <TextBox x:Name="TxtFormatTranscript" AcceptsReturn="True" TextWrapping="Wrap" Height="80"/>
 
                 <TextBox x:Name="TxtReviewPrompt" PlaceholderText="Review prompt" AcceptsReturn="True" TextWrapping="Wrap" Height="60"/>


### PR DESCRIPTION
## Summary
- fix missing using for List in App
- ensure description attribute can compile
- add LLM formatting button and auto-format after transcription

## Testing
- `dotnet build` *(fails: `dotnet: command not found`)*