### PR TITLE
Migrate Mutation.Ui from AudioSwitcher to CoreAudio

### DIFF
--- a/Mutation.Ui/App.xaml.cs
+++ b/Mutation.Ui/App.xaml.cs
@@ -1,4 +1,4 @@
-﻿using AudioSwitcher.AudioApi.CoreAudio;
+using CoreAudio;
 using CognitiveSupport;
 using Deepgram;
 using Microsoft.Extensions.DependencyInjection;
@@ -57,8 +57,8 @@ public partial class App : Application
 			builder.Services.AddSingleton(settings);
 			builder.Services.AddSingleton<ClipboardManager>();
 			builder.Services.AddSingleton<UiStateManager>();
-			builder.Services.AddSingleton<CoreAudioController>();
-			builder.Services.AddSingleton<AudioDeviceManager>();
+                        builder.Services.AddSingleton<MMDeviceEnumerator>(_ => new MMDeviceEnumerator(Guid.NewGuid()));
+                        builder.Services.AddSingleton<AudioDeviceManager>();
 			builder.Services.AddSingleton<IOcrService>(sp =>
     new OcrService(
         settings.AzureComputerVisionSettings?.ApiKey,

--- a/Mutation.Ui/Core/CaptureDeviceComboItem.cs
+++ b/Mutation.Ui/Core/CaptureDeviceComboItem.cs
@@ -1,12 +1,12 @@
-﻿using AudioSwitcher.AudioApi.CoreAudio;
+using CoreAudio;
 
 namespace Mutation.Ui;
 
 internal class CaptureDeviceComboItem
 {
-	public CoreAudioDevice CaptureDevice { get; set; }
-	public string Display =>
-		$"{CaptureDevice.FullName}";
+        public MMDevice CaptureDevice { get; set; }
+        public string Display =>
+                $"{CaptureDevice.FriendlyName}";
 
 	public override string ToString()
 	{

--- a/Mutation.Ui/Core/SpeechToTextServiceComboItem.cs
+++ b/Mutation.Ui/Core/SpeechToTextServiceComboItem.cs
@@ -1,4 +1,3 @@
-﻿using AudioSwitcher.AudioApi.CoreAudio;
 using CognitiveSupport;
 
 namespace Mutation.Ui;

--- a/Mutation.Ui/MainWindow.xaml.cs
+++ b/Mutation.Ui/MainWindow.xaml.cs
@@ -3,6 +3,7 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
 using System;
+using CoreAudio;
 using System.Collections.Generic;
 using CognitiveSupport;
 using Mutation.Ui.Services;
@@ -67,13 +68,13 @@ namespace Mutation.Ui
                         TxtMicState.Text = _audioDeviceManager.IsMuted ? "Muted" : "Unmuted";
                         var micList = _audioDeviceManager.CaptureDevices.ToList();
                         CmbMicrophone.ItemsSource = micList;
-                        CmbMicrophone.DisplayMemberPath = nameof(AudioSwitcher.AudioApi.CoreAudio.CoreAudioDevice.FullName);
+                        CmbMicrophone.DisplayMemberPath = nameof(CoreAudio.MMDevice.FriendlyName);
 
                         // Restore persisted microphone selection
                         string? savedMicFullName = _settings.AudioSettings?.ActiveCaptureDeviceFullName;
                         if (!string.IsNullOrWhiteSpace(savedMicFullName))
                         {
-                            var match = micList.FirstOrDefault(m => m.FullName == savedMicFullName);
+                            var match = micList.FirstOrDefault(m => m.FriendlyName == savedMicFullName);
                             if (match != null)
                                 CmbMicrophone.SelectedItem = match;
                             else if (_audioDeviceManager.Microphone != null)
@@ -257,12 +258,12 @@ namespace Mutation.Ui
 
         private void CmbMicrophone_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-                if (CmbMicrophone.SelectedItem is AudioSwitcher.AudioApi.CoreAudio.CoreAudioDevice device)
+                if (CmbMicrophone.SelectedItem is CoreAudio.MMDevice device)
                 {
                         _audioDeviceManager.SelectMicrophone(device);
                         if (_settings.AudioSettings != null)
                         {
-                                _settings.AudioSettings.ActiveCaptureDeviceFullName = device.FullName;
+                                _settings.AudioSettings.ActiveCaptureDeviceFullName = device.FriendlyName;
                                 _settingsManager.SaveSettingsToFile(_settings);
                         }
                 }


### PR DESCRIPTION
## Summary
- swap AudioSwitcher types for CoreAudio equivalents
- register `MMDeviceEnumerator` instead of `CoreAudioController`
- update microphone display and selection handling
- adjust helper classes to work with CoreAudio

## Testing
- `dotnet build Mutation.sln -c Release` *(fails: command not found)*