### PR TITLE
Remove unnecessary comments

### DIFF
--- a/CognitiveSupport/AudioRecorder.cs
+++ b/CognitiveSupport/AudioRecorder.cs
@@ -15,9 +15,6 @@ public class AudioRecorder : IDisposable
 		waveIn = new WaveInEvent();
 		waveIn.DeviceNumber = captureDeviceIndex;
 		
-		// Debugging exception to show the name.
-		//throw new Exception("Device Index " + captureDeviceIndex + "   " + WaveInEvent.GetCapabilities(captureDeviceIndex).ProductName);
-
 		mp3Writer = new LameMP3FileWriter(outputFile, waveIn.WaveFormat, LAMEPreset.STANDARD);
 
 		waveIn.DataAvailable += (sender, e) =>

--- a/CognitiveSupport/DeepgramSpeechToTextService.cs
+++ b/CognitiveSupport/DeepgramSpeechToTextService.cs
@@ -105,7 +105,6 @@ public class DeepgramSpeechToTextService : ISpeechToTextService
 			  FillerWords = false,
 			  Measurements = true,
 			  SmartFormat = true,
-			  //Diarize = true,
 		  }, cancellationTokenSource = cancellationTokenSource);
 		return response;
 	}

--- a/CognitiveSupport/Extensions/EnumExtensions.cs
+++ b/CognitiveSupport/Extensions/EnumExtensions.cs
@@ -5,9 +5,6 @@ namespace CognitiveSupport.Extensions;
 
 public static class EnumExtensions
 {
-	/// <summary>
-	/// Returns the string specified in [EnumMember(Value = "...")], or the enum member name if no attribute is present.
-	/// </summary>
 	public static string ToEnumMemberValue<TEnum>(this TEnum enumValue)
 		 where TEnum : struct, Enum
 	{

--- a/CognitiveSupport/Extensions/StringExtensions.cs
+++ b/CognitiveSupport/Extensions/StringExtensions.cs
@@ -2,13 +2,6 @@
 
 public static class StringExtensions
 {
-	/// <summary>
-	/// Converts any partial new lines and carriage returns in the given string to the system's new line representation.
-	/// If the input string contains only '\n' or '\r', they are replaced with the appropriate new line string for the system.
-	/// If a correct new line for the system already exists, it remains unchanged.
-	/// </summary>
-	/// <param name="text">The input string that may contain partial new lines or carriage returns.</param>
-	/// <returns>A new string with all partial new lines and carriage returns replaced by the system's new line representation, or null if the input is null.</returns>
 	public static string FixNewLines(
 		this string text)
 	{

--- a/CognitiveSupport/TextFormatter.cs
+++ b/CognitiveSupport/TextFormatter.cs
@@ -81,16 +81,12 @@ namespace CognitiveSupport
 			if (line is null)
 				return line;
 
-			// Trim outer whitespace first
 			string output = line.Trim();
 
-			// Remove simple leading punctuation prefixes like ", ", ". ", "; ", ": "
 			output = Regex.Replace(output, "^[,.;:]\\s+", string.Empty);
 
-			// Normalize bullet lines: "- , ", "- . ", "- ; ", "- : " → "- "
 			output = Regex.Replace(output, "^-\\s*[,.;:]\\s*", "- ");
 
-			// Clean a few known colon artifacts
 			output = output.Replace(", : ,", ":")
 						 .Replace(". : .", ":")
 						 .Replace(". : ,", ":")

--- a/CognitiveSupport/TextToSpeechService.cs
+++ b/CognitiveSupport/TextToSpeechService.cs
@@ -16,11 +16,6 @@ namespace CognitiveSupport
 
 				synth.Speak(text);
 
-				//var voices = synth.GetInstalledVoices();
-				//string voiceNames = "";
-				//foreach (var voice in voices)
-				//	voiceNames += voice.VoiceInfo.Name + Environment.NewLine;
-				//MessageBox.Show(voiceNames, "Available Voices");
 			}
 
 		}

--- a/Mutation.Ui/App.xaml
+++ b/Mutation.Ui/App.xaml
@@ -8,9 +8,7 @@
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
                 <XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />
-                <!-- Other merged dictionaries here -->
             </ResourceDictionary.MergedDictionaries>
-            <!-- Other app resources here -->
         </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/Mutation.Ui/App.xaml.cs
+++ b/Mutation.Ui/App.xaml.cs
@@ -13,37 +13,23 @@ using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
 
-// To learn more about WinUI, the WinUI project structure,
-// and more about our project templates, see: http://aka.ms/winui-project-info.
-
 namespace Mutation.Ui;
 
-/// <summary>
-/// Provides application-specific behavior to supplement the default Application class.
-/// </summary>
 public partial class App : Application
 {
-	private Window? _window;
+        private Window? _window;
 	private IHost? _host;
 	private const string OpenAiHttpClientName = "openai-http-client";
 	private bool _isShuttingDown = false;
 
-	/// <summary>
-	/// Initializes the singleton application object.  This is the first line of authored code
-	/// executed, and as such is the logical equivalent of main() or WinMain().
-	/// </summary>
-	public App()
-	{
+        public App()
+        {
 
-	}
+        }
 
-	/// <summary>
-	/// Invoked when the application is launched.
-	/// </summary>
-	/// <param name="args">Details about the launch request and process.</param>
-	protected override async void OnLaunched(Microsoft.UI.Xaml.LaunchActivatedEventArgs args)
-	{
-		try
+        protected override async void OnLaunched(Microsoft.UI.Xaml.LaunchActivatedEventArgs args)
+        {
+                try
 		{
 			HostApplicationBuilder builder = Host.CreateApplicationBuilder();
 
@@ -77,8 +63,7 @@ public partial class App : Application
 							 settings.LlmSettings?.ResourceName ?? string.Empty,
 							 settings.LlmSettings?.ModelDeploymentIdMaps ?? new List<LlmSettings.ModelDeploymentIdMap>()));
 			builder.Services.AddSingleton<TranscriptFormatter>();
-			// TranscriptReviewer and review transcript UI removed
-			builder.Services.AddSingleton<ITextToSpeechService, TextToSpeechService>();
+                        builder.Services.AddSingleton<ITextToSpeechService, TextToSpeechService>();
 			builder.Services.AddHttpClient(OpenAiHttpClientName);
 			AddSpeechToTextServices(builder, settings);
 			builder.Services.AddSingleton<MainWindow>();
@@ -91,8 +76,7 @@ public partial class App : Application
 
 			_window.Activate();
 
-			// Preflight: check if screen capture via GDI works to avoid surprises
-			var preflight = ScreenCapturePreflight.TryCaptureProbe();
+                        var preflight = ScreenCapturePreflight.TryCaptureProbe();
 			if (!preflight.ok)
 			{
 				string title = "Screen Capture Disabled";
@@ -151,8 +135,7 @@ public partial class App : Application
 			var ocrMgr = _host.Services.GetRequiredService<OcrManager>();
 			ocrMgr.InitializeWindow(_window);
 
-			// Register global hotkeys
-			var hkManager = _host.Services.GetRequiredService<HotkeyManager>();
+                        var hkManager = _host.Services.GetRequiredService<HotkeyManager>();
 			var settingsSvc = _host.Services.GetRequiredService<Settings>();
 
 			if (!string.IsNullOrWhiteSpace(settingsSvc.AzureComputerVisionSettings?.ScreenshotHotKey))

--- a/Mutation.Ui/Core/AudioDeviceManager.cs
+++ b/Mutation.Ui/Core/AudioDeviceManager.cs
@@ -6,11 +6,9 @@ using System.Linq;
 
 namespace Mutation.Ui;
 
-/// <summary>
 /// Manages enumeration and selection of audio capture devices as well as
 /// mute and unmute operations.  This keeps audio related responsibilities
 /// away from the WinForms logic in <see cref="MutationForm"/>.
-/// </summary>
 public class AudioDeviceManager
 {
         private readonly MMDeviceEnumerator _deviceEnumerator;
@@ -24,48 +22,26 @@ public class AudioDeviceManager
                 RefreshCaptureDevices();
         }
 
-	/// <summary>
-	/// List of active capture devices.
-	/// </summary>
         public IEnumerable<MMDevice> CaptureDevices => _captureDevices;
 
-	/// <summary>
-	/// The currently selected microphone device.
-	/// </summary>
         public MMDevice? Microphone => _microphone;
 
-	/// <summary>
-	/// Gets the NAudio device index for the selected microphone.
-	/// </summary>
 	public int MicrophoneDeviceIndex => _microphoneDeviceIndex;
 
-	/// <summary>
-	/// Indicates if the microphone is muted.
-	/// </summary>
         public bool IsMuted => _microphone != null && _microphone.AudioEndpointVolume.Mute;
 
-	/// <summary>
-	/// Refreshes the list of capture devices from the system.
-	/// </summary>
         public void RefreshCaptureDevices()
         {
                 var devices = _deviceEnumerator.EnumerateAudioEndPoints(DataFlow.Capture, DeviceState.Active);
                 _captureDevices = devices.ToList();
         }
 
-	/// <summary>
-	/// Sets the microphone to the specified device.
-	/// </summary>
         public void SelectMicrophone(MMDevice device)
         {
                 _microphone = device ?? throw new ArgumentNullException(nameof(device));
                 SelectCaptureDeviceForNAudio();
         }
 
-	/// <summary>
-	/// Attempts to select the default system capture device if no microphone
-	/// has been selected yet.
-	/// </summary>
 	public void EnsureDefaultMicrophoneSelected()
 	{
 		if (_microphone != null)
@@ -104,9 +80,6 @@ public class AudioDeviceManager
 		_microphoneDeviceIndex = -1;
 	}
 
-	/// <summary>
-	/// Toggles the mute state for all detected capture devices.
-	/// </summary>
 	public void ToggleMute()
 	{
 		bool newMuteState = !IsMuted;

--- a/Mutation.Ui/MainWindow.xaml
+++ b/Mutation.Ui/MainWindow.xaml
@@ -41,7 +41,6 @@
                 <Button x:Name="BtnFormatLlm" Content="Format Transcript with LLM" Click="BtnFormatLlm_Click"/>
                 <TextBox x:Name="TxtFormatTranscript" AcceptsReturn="True" TextWrapping="Wrap" Height="80" AutomationProperties.Name="Formatted Transcript" />
 
-                <!-- Review transcript UI removed -->
 
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Spacing="8">
                     <Button x:Name="BtnScreenshot" Content="Screenshot to Clipboard" Click="BtnScreenshot_Click"/>

--- a/Mutation.Ui/MainWindow.xaml.cs
+++ b/Mutation.Ui/MainWindow.xaml.cs
@@ -7,14 +7,9 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
-// To learn more about WinUI, the WinUI project structure,
-// and more about our project templates, see: http://aka.ms/winui-project-info.
 
 namespace Mutation.Ui;
 
-/// <summary>
-/// An empty window that can be used on its own or navigated to within a Frame.
-/// </summary>
 public sealed partial class MainWindow : Window
 {
 	private readonly ClipboardManager _clipboard;
@@ -365,7 +360,6 @@ public sealed partial class MainWindow : Window
 
 
 
-	// Apply review issues functionality removed
 
 	public async Task ShowErrorDialog(string title, Exception ex)
 	{
@@ -420,7 +414,6 @@ public sealed partial class MainWindow : Window
 				break;
 			case DictationInsertOption.Paste:
 				_clipboard.SetText(text);
-				//BeepPlayer.Play(BeepType.Start);
 				HotkeyManager.SendHotkey("^v");
 				break;
 		}
@@ -442,7 +435,6 @@ public sealed partial class MainWindow : Window
 			{
 				string raw = TxtSpeechToText.Text;
 				string formatted = _transcriptFormatter.ApplyRules(raw, false);
-				// Update UI preview only; do not modify clipboard or insert into active app here.
 				TxtFormatTranscript.Text = formatted;
 				// Intentionally do not call _clipboard.SetText or InsertIntoActiveApplication here.
 				// Insertion/clipboard updates happen on transcription completion to avoid duplicates.
@@ -456,5 +448,4 @@ public sealed partial class MainWindow : Window
 		TxtOcr.Text = message;
 	}
 
-	// ReviewItem removed
 }

--- a/Mutation.Ui/Mutation.Ui.csproj
+++ b/Mutation.Ui/Mutation.Ui.csproj
@@ -108,7 +108,6 @@
 	</ItemGroup>
 
 
-	<!-- Publish Properties -->
 	<PropertyGroup>
 		<PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
 		<PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>

--- a/Mutation.Ui/Properties/PublishProfiles/win-arm64.pubxml
+++ b/Mutation.Ui/Properties/PublishProfiles/win-arm64.pubxml
@@ -1,7 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<!--
-https://go.microsoft.com/fwlink/?LinkID=208121.
--->
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>

--- a/Mutation.Ui/Properties/PublishProfiles/win-x64.pubxml
+++ b/Mutation.Ui/Properties/PublishProfiles/win-x64.pubxml
@@ -1,7 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<!--
-https://go.microsoft.com/fwlink/?LinkID=208121.
--->
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>

--- a/Mutation.Ui/Properties/PublishProfiles/win-x86.pubxml
+++ b/Mutation.Ui/Properties/PublishProfiles/win-x86.pubxml
@@ -1,7 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<!--
-https://go.microsoft.com/fwlink/?LinkID=208121.
--->
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>

--- a/Mutation.Ui/Services/ClipboardManager.cs
+++ b/Mutation.Ui/Services/ClipboardManager.cs
@@ -6,9 +6,6 @@ using Windows.Storage.Streams;
 
 namespace Mutation.Ui.Services;
 
-/// <summary>
-/// Provides clipboard helpers for WinUI.
-/// </summary>
 public class ClipboardManager
 {
 	public async Task<SoftwareBitmap?> TryGetImageAsync(int attempts = 5, int delayMs = 150)

--- a/Mutation.Ui/Services/HotkeyManager.cs
+++ b/Mutation.Ui/Services/HotkeyManager.cs
@@ -21,9 +21,6 @@ public class HotkeyManager : IDisposable
 	private IntPtr _prevWndProc;
 	private WndProcDelegate? _newWndProc;
 
-	/// <summary>
-	/// Gets the list of hotkeys that failed to register.
-	/// </summary>
 	public List<string> FailedRegistrations { get; } = new();
 
 	private const int WM_HOTKEY = 0x0312;
@@ -313,12 +310,9 @@ public class HotkeyManager : IDisposable
 		if (needAlt) inputs.Add(KeyDown(VK_MENU));
 		if (needWin) inputs.Add(KeyDown(VK_LWIN));
 
-		// Press primary key
 		inputs.Add(KeyDown((ushort)hotkey.Key));
-		// Release primary key
 		inputs.Add(KeyUp((ushort)hotkey.Key));
 
-		// Release modifiers in reverse order
 		if (hotkey.Win) inputs.Add(KeyUp(VK_LWIN));
 		if (hotkey.Alt) inputs.Add(KeyUp(VK_MENU));
 		if (hotkey.Shift) inputs.Add(KeyUp(VK_SHIFT));
@@ -335,7 +329,6 @@ public class HotkeyManager : IDisposable
 		return ok;
 	}
 
-	// Virtual-key codes for common modifiers
 	private const ushort VK_CONTROL = 0x11;
 	private const ushort VK_SHIFT = 0x10;
 	private const ushort VK_MENU = 0x12; // ALT

--- a/Mutation.Ui/Services/ScreenCapturePreflight.cs
+++ b/Mutation.Ui/Services/ScreenCapturePreflight.cs
@@ -5,10 +5,6 @@ using System.IO;
 
 namespace Mutation.Ui.Services
 {
-    /// <summary>
-    /// Performs a lightweight screen-capture preflight to detect environment or policy issues early.
-    /// Uses GDI CopyFromScreen which doesn't prompt user; if this fails, we surface guidance.
-    /// </summary>
     internal static class ScreenCapturePreflight
     {
         public static (bool ok, string? message) TryCaptureProbe()

--- a/Mutation.Ui/Services/SendKeysMapper.cs
+++ b/Mutation.Ui/Services/SendKeysMapper.cs
@@ -5,10 +5,6 @@ using System.Globalization;
 
 namespace Mutation.Ui.Services;
 
-/// <summary>
-/// Maps human-friendly key chords (e.g. "Ctrl+Delete", "Ctrl++", "Ctrl+C, Ctrl+V")
-/// to Windows Forms SendKeys format (e.g. "^{DEL}", "^{+}", "^c^v").
-/// </summary>
 public static class SendKeysMapper
 {
 	// Modifiers in canonical order for stable output
@@ -117,11 +113,6 @@ public static class SendKeysMapper
 		["GREATERTHAN"] = ">"
 	};
 
-	/// <summary>
-	/// Convert a human-friendly chord or sequence into a SendKeys string.
-	/// - Returns input unchanged if it already looks like SendKeys.
-	/// - Accepts comma-separated sequence of chords, e.g. "Ctrl+C, Ctrl+V".
-	/// </summary>
 	public static string Map(string input)
 	{
 		if (input is null)
@@ -130,11 +121,9 @@ public static class SendKeysMapper
 		if (input.Length == 0)
 			throw new ArgumentException("Input cannot be empty.", nameof(input));
 
-		// If it already looks like SendKeys, trust the caller and return as-is
 		if (LooksLikeSendKeys(input))
 			return input;
 
-		// Split multiple chords by comma
 		var parts = SplitByComma(input);
 		var result = new System.Text.StringBuilder(input.Length * 2);
 
@@ -165,7 +154,6 @@ public static class SendKeysMapper
 		{
 			var norm = Normalize(token);
 
-			// Modifiers
 			if (IsCtrl(norm))
 			{
 				hasCtrl = true;
@@ -201,21 +189,18 @@ public static class SendKeysMapper
 				continue;
 			}
 
-			// F-keys
 			if (TryMapFunctionKey(norm, out var fKey))
 			{
 				keys.Add(fKey);
 				continue;
 			}
 
-			// Dictionary of known names/synonyms
 			if (KeyMap.TryGetValue(norm, out var mapped))
 			{
 				keys.Add(EscapeIfReserved(mapped));
 				continue;
 			}
 
-			// Single char literal (letters/digits/some punctuation)
 			if (TrySingleCharLiteral(token, out var literal))
 			{
 				keys.Add(EscapeIfReserved(literal));
@@ -330,7 +315,6 @@ public static class SendKeysMapper
 			tokenIndex++;
 		}
 
-		// Remove empty tokens created by stray separators
 		for (int t = tokens.Count - 1; t >= 0; t--)
 		{
 			if (string.IsNullOrWhiteSpace(tokens[t]))
@@ -415,14 +399,12 @@ public static class SendKeysMapper
 			return char.IsLetter(ch) ? char.ToLowerInvariant(ch) : ch;
 		}
 
-		// Lone single visible character
 		if (t.Length == 1)
 		{
 			literal = LowerIfLetter(t[0]).ToString();
 			return true;
 		}
 
-		// Quoted single char like "'" or "\""
 		if (t.Length == 3 && t[0] == '"' && t[2] == '"')
 		{
 			literal = LowerIfLetter(t[1]).ToString();

--- a/Mutation.Ui/Services/SettingsManager.cs
+++ b/Mutation.Ui/Services/SettingsManager.cs
@@ -101,7 +101,6 @@ internal class SettingsManager : ISettingsManager
 		}
 
 
-		//--------------------------------------
 		if (settings.AudioSettings is null)
 		{
 			settings.AudioSettings = new AudioSettings();
@@ -228,7 +227,6 @@ internal class SettingsManager : ISettingsManager
 		}
 
 
-		//----------------------------------
 		if (settings.SpeetchToTextSettings is null)
 		{
 			settings.SpeetchToTextSettings = new SpeetchToTextSettings();
@@ -270,8 +268,6 @@ internal class SettingsManager : ISettingsManager
 			if (string.IsNullOrWhiteSpace(s.SpeechToTextPrompt))
 			{
 				s.SpeechToTextPrompt = "Hello, let's use punctuation. Names: Kobus, Piro.";
-				// This is optional, so we don't need to flag that something was missing.
-				//somethingWasMissing = true;
 			}
 			if (s.TimeoutSeconds <= 0)
 			{
@@ -303,7 +299,6 @@ internal class SettingsManager : ISettingsManager
 		}
 
 
-		//-------------------------------
 		if (settings.LlmSettings is null)
 		{
 			settings.LlmSettings = new LlmSettings();
@@ -324,7 +319,6 @@ internal class SettingsManager : ISettingsManager
 
 		if (string.IsNullOrWhiteSpace(llmSettings.FormatTranscriptPrompt))
 		{
-			//TODO: formatting is now done with normal code, so this should be deleted.
 
 			llmSettings.FormatTranscriptPrompt = @"You are a helpful proofreader and editor. When you are asked to format a transcript, apply the following rules to improve the formatting of the text:
 Replace the words 'new line' (case insensitive) with an actual new line character, and replace the words 'new paragraph' (case insensitive) with 2 new line characters, and replace the words 'new bullet' (case insensitive) with a newline character and a bullet character, eg. '- ', and end the preceding sentence with a full stop '.', and start the new sentence with a capital letter, and do not make any other changes.
@@ -348,11 +342,8 @@ Depending on the results, this might include:
 Collaboration among various healthcare professionals ensures that the information gleaned from the radiology report is utilized to provide the most effective and individualized care tailored to your specific condition and needs.
 End of summary.
 ";
-			// No need to mark something as missing.
-			//somethingWasMissing = true;
 		}
 
-		// Review transcript prompt default removed; review functionality deprecated.
 
 
 		if (llmSettings.ModelDeploymentIdMaps == null || !llmSettings.ModelDeploymentIdMaps.Any())
@@ -371,8 +362,6 @@ End of summary.
 				},
 			};
 
-			// no need to flag as we set defaults.
-			//somethingWasMissing = true;
 		}
 
 		if (llmSettings.TranscriptFormatRules == null || !llmSettings.TranscriptFormatRules.Any())
@@ -495,11 +484,8 @@ End of summary.
 
 			};
 
-			// No need to flag something as missing as we set defaults.
-			//somethingWasMissing = true;
 		}
 
-		//----------------------------------
 		if (settings.TextToSpeechSettings is null)
 		{
 			settings.TextToSpeechSettings = new TextToSpeechSettings();
@@ -515,7 +501,6 @@ End of summary.
 		if (settings.HotKeyRouterSettings is null || !settings.HotKeyRouterSettings.Mappings.Any())
 		{
 			settings.HotKeyRouterSettings = new();
-			// Add a sample hotkey router mapping.
 			settings.HotKeyRouterSettings.Mappings.Add
 			(
 				new HotKeyRouterSettings.HotKeyRouterMap("CONTROL+SHIFT+ALT+8", "CONTROL+SHIFT+ALT+9")
@@ -534,34 +519,28 @@ End of summary.
 		if (!(jObj["SpeetchToTextSettings"] is JObject settings))
 			return;
 
-		// Check if the JSON is already in the desired format.
-		// Here, we assume correctness if a "Services" property (as an array) exists.
 		if (settings["Services"] == null || settings["Services"].Type != JTokenType.Array)
 		{
 			string providerName = settings.Value<string>("Service") ?? "";
 
-			// Create the new service object and migrate the relevant properties.
 			JObject serviceObj = new JObject
 			{
-				["Name"] = providerName,             // Use the provider name as the service Name.
-				["Provider"] = providerName,         // Also set the Provider.
+				["Name"] = providerName,
+				["Provider"] = providerName,
 				["ApiKey"] = settings["ApiKey"],
 				["BaseDomain"] = settings["BaseDomain"],
 				["ModelId"] = settings["ModelId"],
 				["SpeechToTextPrompt"] = settings["SpeechToTextPrompt"]
 			};
 
-			// Create a new services array with the service object as the first element.
 			JArray servicesArray = new JArray { serviceObj };
 
-			// Remove the migrated properties from the root of SpeetchToTextSettings.
 			settings.Remove("Service");
 			settings.Remove("ApiKey");
 			settings.Remove("BaseDomain");
 			settings.Remove("ModelId");
 			settings.Remove("SpeechToTextPrompt");
 
-			// Add the new properties: the active service and the services array.
 			settings["ActiveSpeetchToTextService"] = providerName;
 			settings["Services"] = servicesArray;
 		}

--- a/Mutation.Ui/Services/TooltipManager.cs
+++ b/Mutation.Ui/Services/TooltipManager.cs
@@ -6,9 +6,6 @@ using System.Linq;
 
 namespace Mutation.Ui.Services;
 
-/// <summary>
-/// Provides simple tooltip setup for WinUI controls.
-/// </summary>
 public class TooltipManager
 {
     private readonly Settings _settings;
@@ -18,9 +15,6 @@ public class TooltipManager
         _settings = settings ?? throw new ArgumentNullException(nameof(settings));
     }
 
-    /// <summary>
-    /// Apply tooltips describing speech prompt usage and formatting rules.
-    /// </summary>
     public void SetupTooltips(Control speechBox, Control transcriptBox)
     {
         string speechPromptTip =

--- a/Mutation.Ui/Services/UiStateManager.cs
+++ b/Mutation.Ui/Services/UiStateManager.cs
@@ -8,9 +8,6 @@ using Windows.Graphics;
 
 namespace Mutation.Ui.Services;
 
-/// <summary>
-/// Persists and restores the main window size and position for WinUI.
-/// </summary>
 public class UiStateManager
 {
 private readonly Settings _settings;
@@ -28,23 +25,18 @@ var ui = _settings.MainWindowUiSettings;
 if (appWindow == null || ui == null)
 return;
 
-// Get display area for the window
 var displayArea = DisplayArea.GetFromWindowId(appWindow.Id, DisplayAreaFallback.Primary);
 var bounds = displayArea.WorkArea;
 
-// Minimum window size
 const int minWidth = 150;
 const int minHeight = 150;
 
-// Clamp size
 int width = Math.Max(minWidth, Math.Min(ui.WindowSize.Width, bounds.Width));
 int height = Math.Max(minHeight, Math.Min(ui.WindowSize.Height, bounds.Height));
 
-// Clamp position
 int x = Math.Max(bounds.X, Math.Min(ui.WindowLocation.X, bounds.X + bounds.Width - width));
 int y = Math.Max(bounds.Y, Math.Min(ui.WindowLocation.Y, bounds.Y + bounds.Height - height));
 
-// Apply size and position
 appWindow.Resize(new SizeInt32(width, height));
 appWindow.Move(new PointInt32(x, y));
 }

--- a/Mutation.Ui/Views/RegionSelectionWindow.xaml
+++ b/Mutation.Ui/Views/RegionSelectionWindow.xaml
@@ -7,30 +7,26 @@
     mc:Ignorable="d"
     Title="Select Region">
     <Grid Background="Transparent" UseLayoutRounding="True">
-        <!-- Full screenshot image -->
         <Image x:Name="Img" Stretch="Fill">
             <Image.CacheMode>
                 <BitmapCache />
             </Image.CacheMode>
         </Image>
 
-        <!-- Interactive overlay: selection + crosshair -->
-    <Canvas x:Name="Overlay" Background="Transparent"
-        IsTabStop="True"
-                PointerPressed="Overlay_PointerPressed"
-                PointerMoved="Overlay_PointerMoved"
-                PointerReleased="Overlay_PointerReleased"
-        PointerCanceled="Overlay_PointerCanceled"
-        PointerCaptureLost="Overlay_PointerCaptureLost"
-        PointerEntered="Overlay_PointerEntered"
-        PointerExited="Overlay_PointerExited"
-                SizeChanged="Overlay_SizeChanged"
-        Loaded="Overlay_Loaded"
-        KeyDown="Window_KeyDown">
-            <!-- Selection rectangle -->
+        <Canvas x:Name="Overlay" Background="Transparent"
+            IsTabStop="True"
+            PointerPressed="Overlay_PointerPressed"
+            PointerMoved="Overlay_PointerMoved"
+            PointerReleased="Overlay_PointerReleased"
+            PointerCanceled="Overlay_PointerCanceled"
+            PointerCaptureLost="Overlay_PointerCaptureLost"
+            PointerEntered="Overlay_PointerEntered"
+            PointerExited="Overlay_PointerExited"
+            SizeChanged="Overlay_SizeChanged"
+            Loaded="Overlay_Loaded"
+            KeyDown="Window_KeyDown">
             <Rectangle x:Name="Selection" Stroke="#FFFFC300" StrokeThickness="4" Fill="#33FFFFFF" Visibility="Collapsed" Canvas.ZIndex="10"/>
 
-            <!-- Crosshair lines spanning the screen -->
             <Rectangle x:Name="CrosshairV" Width="2" Fill="#FFFFC300" IsHitTestVisible="False" Canvas.ZIndex="20"/>
             <Rectangle x:Name="CrosshairH" Height="2" Fill="#FFFFC300" IsHitTestVisible="False" Canvas.ZIndex="20"/>
         </Canvas>

--- a/Mutation.Ui/app.manifest
+++ b/Mutation.Ui/app.manifest
@@ -4,9 +4,6 @@
 
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>
-      <!-- The ID below informs the system that this application is compatible with OS features first introduced in Windows 10. 
-      It is necessary to support features in unpackaged applications, for example the custom titlebar implementation.
-      For more info see https://docs.microsoft.com/windows/apps/windows-app-sdk/use-windows-app-sdk-run-time#declare-os-compatibility-in-your-application-manifest -->
       <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
     </application>
   </compatibility>


### PR DESCRIPTION
## Summary
- remove commented-out debugging statements and redundant documentation from cognitive support utilities
- prune WinUI template notes and other superfluous comments in app startup and window interaction code while keeping meaningful explanations
- clean manifests and publish profiles by eliminating placeholder comment blocks

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d45168957c832fa8d1229a09ef9cc6