### PR TITLE
Handle speech event exceptions and fix narrow layout

### DIFF
--- a/Mutation.Ui/MainWindow.xaml
+++ b/Mutation.Ui/MainWindow.xaml
@@ -361,6 +361,7 @@
                                 <Setter Target="CaptureCard.(Grid.ColumnSpan)" Value="2" />
                                 <Setter Target="ClipboardCard.(Grid.Column)" Value="0" />
                                 <Setter Target="ClipboardCard.(Grid.ColumnSpan)" Value="2" />
+                                <Setter Target="ClipboardCard.(Grid.Row)" Value="4" />
                                 <Setter Target="FormattingActionsPanel.Orientation" Value="Vertical" />
                                 <Setter Target="ClipboardActionsPanel.Orientation" Value="Vertical" />
                             </VisualState.Setters>
@@ -378,6 +379,7 @@
                                 <Setter Target="CaptureCard.(Grid.ColumnSpan)" Value="1" />
                                 <Setter Target="ClipboardCard.(Grid.Column)" Value="1" />
                                 <Setter Target="ClipboardCard.(Grid.ColumnSpan)" Value="1" />
+                                <Setter Target="ClipboardCard.(Grid.Row)" Value="3" />
                                 <Setter Target="FormattingActionsPanel.Orientation" Value="Horizontal" />
                                 <Setter Target="ClipboardActionsPanel.Orientation" Value="Horizontal" />
                             </VisualState.Setters>

--- a/Mutation.Ui/MainWindow.xaml.cs
+++ b/Mutation.Ui/MainWindow.xaml.cs
@@ -235,10 +235,18 @@ public sealed partial class MainWindow : Window
 		}
 	}
 
-	public async void BtnSpeechToText_Click(object? sender, RoutedEventArgs? e)
-	{
-		await StartStopSpeechToTextAsync();
-	}
+        public async void BtnSpeechToText_Click(object? sender, RoutedEventArgs? e)
+        {
+                try
+                {
+                        await StartStopSpeechToTextAsync();
+                }
+                catch (Exception ex)
+                {
+                        ShowStatus("Speech to Text", ex.Message, InfoBarSeverity.Error);
+                        await ShowErrorDialog("Speech to Text Error", ex);
+                }
+        }
 
 	public async Task StartStopSpeechToTextAsync()
 	{


### PR DESCRIPTION
## Summary
- restore exception handling in the speech-to-text button click handler to surface unexpected errors
- adjust the narrow visual state so the clipboard card moves to the next row and no longer overlaps the capture card

## Testing
- `dotnet build --configuration Release`
  - fails: `TSDK1100` because Windows targeting is unavailable in the container environment

------
https://chatgpt.com/codex/tasks/task_e_68d535d449b0832fb857459c862b7869