### PR TITLE
Fix speech settings naming and enable theme awareness

### DIFF
--- a/CognitiveSupport/Settings.cs
+++ b/CognitiveSupport/Settings.cs
@@ -8,7 +8,7 @@ public class Settings
 
 	public AudioSettings? AudioSettings { get; set; }
 	public AzureComputerVisionSettings? AzureComputerVisionSettings { get; set; }
-	public SpeetchToTextSettings? SpeetchToTextSettings { get; set; }
+        public SpeechToTextSettings? SpeechToTextSettings { get; set; }
 	public LlmSettings? LlmSettings { get; set; }
 	public TextToSpeechSettings? TextToSpeechSettings { get; set; }
 
@@ -20,17 +20,17 @@ public class Settings
 	{
 	}
 
-	public Settings(string? userInstructions, AudioSettings? audioSettings, AzureComputerVisionSettings? azureComputerVisionSettings, SpeetchToTextSettings? speetchToTextSettings, LlmSettings? llmSettings, TextToSpeechSettings? textToSpeechSettings, MainWindowUiSettings mainWindowUiSettings, HotKeyRouterSettings hotKeyRouterSettings)
-	{
-		UserInstructions = userInstructions;
-		AudioSettings = audioSettings;
-		AzureComputerVisionSettings = azureComputerVisionSettings;
-		SpeetchToTextSettings = speetchToTextSettings;
-		LlmSettings = llmSettings;
-		TextToSpeechSettings = textToSpeechSettings;
-		MainWindowUiSettings = mainWindowUiSettings;
-		HotKeyRouterSettings = hotKeyRouterSettings;
-	}
+        public Settings(string? userInstructions, AudioSettings? audioSettings, AzureComputerVisionSettings? azureComputerVisionSettings, SpeechToTextSettings? speechToTextSettings, LlmSettings? llmSettings, TextToSpeechSettings? textToSpeechSettings, MainWindowUiSettings mainWindowUiSettings, HotKeyRouterSettings hotKeyRouterSettings)
+        {
+                UserInstructions = userInstructions;
+                AudioSettings = audioSettings;
+                AzureComputerVisionSettings = azureComputerVisionSettings;
+                SpeechToTextSettings = speechToTextSettings;
+                LlmSettings = llmSettings;
+                TextToSpeechSettings = textToSpeechSettings;
+                MainWindowUiSettings = mainWindowUiSettings;
+                HotKeyRouterSettings = hotKeyRouterSettings;
+        }
 }
 
 public class AudioSettings
@@ -98,7 +98,7 @@ public class AzureComputerVisionSettings
 	public string? OcrLeftToRightTopToBottomHotKey { get; set; }
 
 	// If this is not null, this hotkey will be sent to the system after an OCR operation completes. 
-	public string? SendKotKeyAfterOcrOperation { get; set; }
+        public string? SendHotkeyAfterOcrOperation { get; set; }
 
 	public string? ApiKey { get; set; }
 	public string? Endpoint { get; set; }
@@ -109,21 +109,21 @@ public class AzureComputerVisionSettings
 	}
 }
 
-public class SpeetchToTextSettings
+public class SpeechToTextSettings
 {
-	public string? TempDirectory { get; set; }
-	public string? SpeechToTextHotKey { get; set; }
+        public string? TempDirectory { get; set; }
+        public string? SpeechToTextHotKey { get; set; }
 
-	// If this is not null, this hotkey will be sent to the system after a transcription operation completes. 
-	public string? SendKotKeyAfterTranscriptionOperation { get; set; }
+        // If this is not null, this hotkey will be sent to the system after a transcription operation completes.
+        public string? SendHotkeyAfterTranscriptionOperation { get; set; }
 
-	public SpeetchToTextServiceSettings[]? Services { get; set; }
-	public string? ActiveSpeetchToTextService { get; set; }
+        public SpeechToTextServiceSettings[]? Services { get; set; }
+        public string? ActiveSpeechToTextService { get; set; }
 }
 
-public class SpeetchToTextServiceSettings
+public class SpeechToTextServiceSettings
 {
-	public string? Name { get; set; }
+        public string? Name { get; set; }
 	public SpeechToTextProviders Provider { get; set; }
 	public string? ApiKey { get; set; }
 	public string? BaseDomain { get; set; }

--- a/Mutation.Ui/App.xaml
+++ b/Mutation.Ui/App.xaml
@@ -10,39 +10,60 @@
                 <XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />
             </ResourceDictionary.MergedDictionaries>
 
-            <!-- Color palette -->
-            <Color x:Key="PrimaryColor">#FF4C6EF5</Color>
-            <Color x:Key="PrimaryColorHover">#FF6A86FB</Color>
-            <Color x:Key="PrimaryColorPressed">#FF3C59D7</Color>
-            <Color x:Key="SecondaryColor">#FFE8EDFF</Color>
-            <Color x:Key="SecondaryColorHover">#FFD7DEFF</Color>
-            <Color x:Key="SurfaceColor">#FFFFFFFF</Color>
-            <Color x:Key="AppBackgroundColor">#FFF7F8FC</Color>
-            <Color x:Key="OnPrimaryColor">#FFFFFFFF</Color>
-            <Color x:Key="OnSurfaceColor">#FF1C2333</Color>
-            <Color x:Key="SecondaryTextColor">#FF4A5368</Color>
-            <Color x:Key="BorderColor">#FFD6DAE8</Color>
-            <Color x:Key="FocusColor">#FF254EDB</Color>
-            <Color x:Key="SuccessColor">#FF2EA94D</Color>
-            <Color x:Key="WarningColor">#FFE3A400</Color>
-            <Color x:Key="ErrorColor">#FFD64545</Color>
+            <!-- Theme-aware color palette -->
+            <ResourceDictionary.ThemeDictionaries>
+                <ResourceDictionary x:Key="Light">
+                    <Color x:Key="PrimaryColor">#FF4C6EF5</Color>
+                    <Color x:Key="PrimaryColorHover">#FF6A86FB</Color>
+                    <Color x:Key="PrimaryColorPressed">#FF3C59D7</Color>
+                    <Color x:Key="SecondaryColor">#FFE8EDFF</Color>
+                    <Color x:Key="SecondaryColorHover">#FFD7DEFF</Color>
+                    <Color x:Key="SurfaceColor">#FFFFFFFF</Color>
+                    <Color x:Key="AppBackgroundColor">#FFF7F8FC</Color>
+                    <Color x:Key="OnPrimaryColor">#FFFFFFFF</Color>
+                    <Color x:Key="OnSurfaceColor">#FF1C2333</Color>
+                    <Color x:Key="SecondaryTextColor">#FF4A5368</Color>
+                    <Color x:Key="BorderColor">#FFD6DAE8</Color>
+                    <Color x:Key="FocusColor">#FF254EDB</Color>
+                    <Color x:Key="SuccessColor">#FF2EA94D</Color>
+                    <Color x:Key="WarningColor">#FFE3A400</Color>
+                    <Color x:Key="ErrorColor">#FFD64545</Color>
+                </ResourceDictionary>
+                <ResourceDictionary x:Key="Dark">
+                    <Color x:Key="PrimaryColor">#FF879BFF</Color>
+                    <Color x:Key="PrimaryColorHover">#FFA1B3FF</Color>
+                    <Color x:Key="PrimaryColorPressed">#FF6F86E0</Color>
+                    <Color x:Key="SecondaryColor">#FF2B3140</Color>
+                    <Color x:Key="SecondaryColorHover">#FF353D4F</Color>
+                    <Color x:Key="SurfaceColor">#FF1D222C</Color>
+                    <Color x:Key="AppBackgroundColor">#FF11151C</Color>
+                    <Color x:Key="OnPrimaryColor">#FFFFFFFF</Color>
+                    <Color x:Key="OnSurfaceColor">#FFE7E9F2</Color>
+                    <Color x:Key="SecondaryTextColor">#FFA8B0C5</Color>
+                    <Color x:Key="BorderColor">#FF3D4352</Color>
+                    <Color x:Key="FocusColor">#FF6A96FF</Color>
+                    <Color x:Key="SuccessColor">#FF48C870</Color>
+                    <Color x:Key="WarningColor">#FFE6C15A</Color>
+                    <Color x:Key="ErrorColor">#FFFF6B6B</Color>
+                </ResourceDictionary>
+            </ResourceDictionary.ThemeDictionaries>
 
             <!-- Brushes -->
-            <SolidColorBrush x:Key="PrimaryBrush" Color="{StaticResource PrimaryColor}" />
-            <SolidColorBrush x:Key="PrimaryHoverBrush" Color="{StaticResource PrimaryColorHover}" />
-            <SolidColorBrush x:Key="PrimaryPressedBrush" Color="{StaticResource PrimaryColorPressed}" />
-            <SolidColorBrush x:Key="SecondaryBrush" Color="{StaticResource SecondaryColor}" />
-            <SolidColorBrush x:Key="SecondaryHoverBrush" Color="{StaticResource SecondaryColorHover}" />
-            <SolidColorBrush x:Key="SurfaceBrush" Color="{StaticResource SurfaceColor}" />
-            <SolidColorBrush x:Key="AppBackgroundBrush" Color="{StaticResource AppBackgroundColor}" />
-            <SolidColorBrush x:Key="OnPrimaryBrush" Color="{StaticResource OnPrimaryColor}" />
-            <SolidColorBrush x:Key="OnSurfaceBrush" Color="{StaticResource OnSurfaceColor}" />
-            <SolidColorBrush x:Key="SecondaryTextBrush" Color="{StaticResource SecondaryTextColor}" />
-            <SolidColorBrush x:Key="BorderBrush" Color="{StaticResource BorderColor}" />
-            <SolidColorBrush x:Key="FocusBrush" Color="{StaticResource FocusColor}" />
-            <SolidColorBrush x:Key="SuccessBrush" Color="{StaticResource SuccessColor}" />
-            <SolidColorBrush x:Key="WarningBrush" Color="{StaticResource WarningColor}" />
-            <SolidColorBrush x:Key="ErrorBrush" Color="{StaticResource ErrorColor}" />
+            <SolidColorBrush x:Key="PrimaryBrush" Color="{ThemeResource PrimaryColor}" />
+            <SolidColorBrush x:Key="PrimaryHoverBrush" Color="{ThemeResource PrimaryColorHover}" />
+            <SolidColorBrush x:Key="PrimaryPressedBrush" Color="{ThemeResource PrimaryColorPressed}" />
+            <SolidColorBrush x:Key="SecondaryBrush" Color="{ThemeResource SecondaryColor}" />
+            <SolidColorBrush x:Key="SecondaryHoverBrush" Color="{ThemeResource SecondaryColorHover}" />
+            <SolidColorBrush x:Key="SurfaceBrush" Color="{ThemeResource SurfaceColor}" />
+            <SolidColorBrush x:Key="AppBackgroundBrush" Color="{ThemeResource AppBackgroundColor}" />
+            <SolidColorBrush x:Key="OnPrimaryBrush" Color="{ThemeResource OnPrimaryColor}" />
+            <SolidColorBrush x:Key="OnSurfaceBrush" Color="{ThemeResource OnSurfaceColor}" />
+            <SolidColorBrush x:Key="SecondaryTextBrush" Color="{ThemeResource SecondaryTextColor}" />
+            <SolidColorBrush x:Key="BorderBrush" Color="{ThemeResource BorderColor}" />
+            <SolidColorBrush x:Key="FocusBrush" Color="{ThemeResource FocusColor}" />
+            <SolidColorBrush x:Key="SuccessBrush" Color="{ThemeResource SuccessColor}" />
+            <SolidColorBrush x:Key="WarningBrush" Color="{ThemeResource WarningColor}" />
+            <SolidColorBrush x:Key="ErrorBrush" Color="{ThemeResource ErrorColor}" />
 
             <Thickness x:Key="CardPadding">20</Thickness>
 

--- a/Mutation.Ui/App.xaml.cs
+++ b/Mutation.Ui/App.xaml.cs
@@ -163,7 +163,7 @@ public partial class App : Application
 								  var result = await ocrMgr.TakeScreenshotAndExtractTextAsync(OcrReadingOrder.TopToBottomColumnAware);
 								  var mainWindow = _host.Services.GetRequiredService<MainWindow>();
 								  mainWindow.SetOcrText(result.Message);
-								  HotkeyManager.SendHotkeyAfterDelay(settingsSvc.AzureComputerVisionSettings?.SendKotKeyAfterOcrOperation, result.Success ? Constants.SendHotkeyDelay : Constants.FailureSendHotkeyDelay);
+                                                              HotkeyManager.SendHotkeyAfterDelay(settingsSvc.AzureComputerVisionSettings?.SendHotkeyAfterOcrOperation, result.Success ? Constants.SendHotkeyDelay : Constants.FailureSendHotkeyDelay);
 							  }
 							  catch (Exception ex) { await ((MainWindow)_window).ShowErrorDialog("Screenshot + OCR Error", ex); }
 						  });
@@ -180,7 +180,7 @@ public partial class App : Application
 								  var result = await ocrMgr.TakeScreenshotAndExtractTextAsync(OcrReadingOrder.LeftToRightTopToBottom);
 								  var mainWindow = _host.Services.GetRequiredService<MainWindow>();
 								  mainWindow.SetOcrText(result.Message);
-								  HotkeyManager.SendHotkeyAfterDelay(settingsSvc.AzureComputerVisionSettings?.SendKotKeyAfterOcrOperation, result.Success ? Constants.SendHotkeyDelay : Constants.FailureSendHotkeyDelay);
+                                                              HotkeyManager.SendHotkeyAfterDelay(settingsSvc.AzureComputerVisionSettings?.SendHotkeyAfterOcrOperation, result.Success ? Constants.SendHotkeyDelay : Constants.FailureSendHotkeyDelay);
 							  }
 							  catch (Exception ex) { await ((MainWindow)_window).ShowErrorDialog("Screenshot + OCR (LRTB) Error", ex); }
 						  });
@@ -197,7 +197,7 @@ public partial class App : Application
 								  var result = await ocrMgr.ExtractTextFromClipboardImageAsync(OcrReadingOrder.TopToBottomColumnAware);
 								  var mainWindow = _host.Services.GetRequiredService<MainWindow>();
 								  mainWindow.SetOcrText(result.Message);
-								  HotkeyManager.SendHotkeyAfterDelay(settingsSvc.AzureComputerVisionSettings?.SendKotKeyAfterOcrOperation, result.Success ? Constants.SendHotkeyDelay : Constants.FailureSendHotkeyDelay);
+                                                              HotkeyManager.SendHotkeyAfterDelay(settingsSvc.AzureComputerVisionSettings?.SendHotkeyAfterOcrOperation, result.Success ? Constants.SendHotkeyDelay : Constants.FailureSendHotkeyDelay);
 							  }
 							  catch (Exception ex) { await ((MainWindow)_window).ShowErrorDialog("OCR Clipboard Error", ex); }
 						  });
@@ -214,7 +214,7 @@ public partial class App : Application
 								  var result = await ocrMgr.ExtractTextFromClipboardImageAsync(OcrReadingOrder.LeftToRightTopToBottom);
 								  var mainWindow = _host.Services.GetRequiredService<MainWindow>();
 								  mainWindow.SetOcrText(result.Message);
-								  HotkeyManager.SendHotkeyAfterDelay(settingsSvc.AzureComputerVisionSettings?.SendKotKeyAfterOcrOperation, result.Success ? Constants.SendHotkeyDelay : Constants.FailureSendHotkeyDelay);
+                                                              HotkeyManager.SendHotkeyAfterDelay(settingsSvc.AzureComputerVisionSettings?.SendHotkeyAfterOcrOperation, result.Success ? Constants.SendHotkeyDelay : Constants.FailureSendHotkeyDelay);
 							  }
 							  catch (Exception ex) { await ((MainWindow)_window).ShowErrorDialog("OCR Clipboard (LRTB) Error", ex); }
 						  });
@@ -231,10 +231,10 @@ public partial class App : Application
 						  });
 			}
 
-			if (!string.IsNullOrWhiteSpace(settingsSvc.SpeetchToTextSettings?.SpeechToTextHotKey))
+			if (!string.IsNullOrWhiteSpace(settingsSvc.SpeechToTextSettings?.SpeechToTextHotKey))
 			{
 				hkManager.RegisterHotkey(
-						  Hotkey.Parse(settingsSvc.SpeetchToTextSettings.SpeechToTextHotKey!),
+						  Hotkey.Parse(settingsSvc.SpeechToTextSettings.SpeechToTextHotKey!),
 						  () =>
 						  {
 							  try { _window.DispatcherQueue.TryEnqueue(async () => await ((MainWindow)_window).StartStopSpeechToTextAsync()); }
@@ -371,7 +371,7 @@ public partial class App : Application
 		builder.Services.AddSingleton<ISpeechToTextService[]>(sp =>
 		{
 			List<ISpeechToTextService> services = new();
-			var sttSettings = settings.SpeetchToTextSettings?.Services ?? Array.Empty<SpeetchToTextServiceSettings>();
+			var sttSettings = settings.SpeechToTextSettings?.Services ?? Array.Empty<SpeechToTextServiceSettings>();
 			foreach (var serviceSettings in sttSettings)
 			{
 				switch (serviceSettings.Provider)
@@ -383,14 +383,14 @@ public partial class App : Application
 						services.Add(CreateDeepgramSpeechToTextService(builder, serviceSettings));
 						break;
 					default:
-						throw new NotSupportedException($"The SpeetchToText service '{serviceSettings.Provider}' is not supported.");
+						throw new NotSupportedException($"The SpeechToText service '{serviceSettings.Provider}' is not supported.");
 				}
 			}
 			return services.ToArray();
 		});
 	}
 
-	private static ISpeechToTextService CreateWhisperSpeechToTextService(HostApplicationBuilder builder, SpeetchToTextServiceSettings serviceSettings, IServiceProvider sp)
+	private static ISpeechToTextService CreateWhisperSpeechToTextService(HostApplicationBuilder builder, SpeechToTextServiceSettings serviceSettings, IServiceProvider sp)
 	{
 		string baseDomain = serviceSettings.BaseDomain?.Trim() ?? string.Empty;
 
@@ -411,7 +411,7 @@ public partial class App : Application
 				  serviceSettings.TimeoutSeconds > 0 ? serviceSettings.TimeoutSeconds : 10);
 	}
 
-	private static ISpeechToTextService CreateDeepgramSpeechToTextService(HostApplicationBuilder builder, SpeetchToTextServiceSettings serviceSettings)
+	private static ISpeechToTextService CreateDeepgramSpeechToTextService(HostApplicationBuilder builder, SpeechToTextServiceSettings serviceSettings)
 	{
 		Deepgram.Clients.Interfaces.v1.IListenRESTClient deepgramClient = ClientFactory.CreateListenRESTClient(serviceSettings.ApiKey ?? string.Empty);
 

--- a/Mutation.Ui/Core/SpeechToTextManager.cs
+++ b/Mutation.Ui/Core/SpeechToTextManager.cs
@@ -21,7 +21,7 @@ internal class SpeechToTextManager
 	public bool Recording => _state.RecordingAudio;
 	public bool Transcribing => _state.TranscribingAudio;
 
-	private string SessionsDirectory => Path.Combine(_settings.SpeetchToTextSettings!.TempDirectory!, Constants.SessionsDirectoryName);
+        private string SessionsDirectory => Path.Combine(_settings.SpeechToTextSettings!.TempDirectory!, Constants.SessionsDirectoryName);
 	private string AudioFilePath => Path.Combine(SessionsDirectory, "mutation_recording.mp3");
 
 	public async Task StartRecordingAsync(int microphoneDeviceIndex)

--- a/Mutation.Ui/Core/SpeechToTextServiceComboItem.cs
+++ b/Mutation.Ui/Core/SpeechToTextServiceComboItem.cs
@@ -4,10 +4,10 @@ namespace Mutation.Ui;
 
 internal class SpeechToTextServiceComboItem
 {
-	public SpeetchToTextServiceSettings SpeetchToTextServiceSettings { get; set; }
-	public ISpeechToTextService SpeechToTextService { get; set; }
-	public string Display =>
-		$"{SpeetchToTextServiceSettings.Name}";
+        public SpeechToTextServiceSettings SpeechToTextServiceSettings { get; set; }
+        public ISpeechToTextService SpeechToTextService { get; set; }
+        public string Display =>
+                $"{SpeechToTextServiceSettings.Name}";
 
 	public override string ToString()
 	{

--- a/Mutation.Ui/MainWindow.xaml.cs
+++ b/Mutation.Ui/MainWindow.xaml.cs
@@ -102,7 +102,7 @@ public sealed partial class MainWindow : Window
 
 	private void RestorePersistedSpeechServiceSelection()
 	{
-		string? savedServiceName = _settings.SpeetchToTextSettings?.ActiveSpeetchToTextService;
+                string? savedServiceName = _settings.SpeechToTextSettings?.ActiveSpeechToTextService;
 		if (!string.IsNullOrWhiteSpace(savedServiceName))
 		{
 			var match = _speechServices.FirstOrDefault(s => s.ServiceName == savedServiceName);
@@ -146,7 +146,7 @@ public sealed partial class MainWindow : Window
         private void InitializeHotkeyVisuals()
         {
                 ConfigureButtonHotkey(BtnToggleMic, BtnToggleMicHotkey, _settings.AudioSettings?.MicrophoneToggleMuteHotKey, BtnToggleMicLabel.Text);
-                ConfigureButtonHotkey(BtnSpeechToText, BtnSpeechToTextHotkey, _settings.SpeetchToTextSettings?.SpeechToTextHotKey, BtnSpeechToTextLabel.Text);
+                ConfigureButtonHotkey(BtnSpeechToText, BtnSpeechToTextHotkey, _settings.SpeechToTextSettings?.SpeechToTextHotKey, BtnSpeechToTextLabel.Text);
                 ConfigureButtonHotkey(BtnScreenshot, BtnScreenshotHotkey, _settings.AzureComputerVisionSettings?.ScreenshotHotKey, "Copy a screenshot directly to the clipboard");
                 ConfigureButtonHotkey(BtnOcrClipboard, BtnOcrClipboardHotkey, _settings.AzureComputerVisionSettings?.OcrHotKey, "Run OCR on an image stored in the clipboard");
                 ConfigureButtonHotkey(BtnOcrClipboardLrtb, BtnOcrClipboardLrtbHotkey, _settings.AzureComputerVisionSettings?.OcrLeftToRightTopToBottomHotKey, "Run OCR on an image stored in the clipboard using left-to-right reading order");
@@ -174,8 +174,8 @@ public sealed partial class MainWindow : Window
 		catch { }
 		_uiStateManager.Save(this);
 
-		if (_activeSpeechService != null)
-			_settings.SpeetchToTextSettings!.ActiveSpeetchToTextService = _activeSpeechService.ServiceName;
+                if (_activeSpeechService != null)
+                        _settings.SpeechToTextSettings!.ActiveSpeechToTextService = _activeSpeechService.ServiceName;
 		_settings.LlmSettings!.FormatTranscriptPrompt = TxtFormatPrompt.Text;
 
 		_settingsManager.SaveSettingsToFile(_settings);
@@ -217,7 +217,7 @@ public sealed partial class MainWindow : Window
                 {
                         var result = await _ocrManager.TakeScreenshotAndExtractTextAsync(OcrReadingOrder.TopToBottomColumnAware);
 			SetOcrText(result.Message);
-			HotkeyManager.SendHotkeyAfterDelay(_settings.AzureComputerVisionSettings?.SendKotKeyAfterOcrOperation, result.Success ? Constants.SendHotkeyDelay : Constants.FailureSendHotkeyDelay);
+                    HotkeyManager.SendHotkeyAfterDelay(_settings.AzureComputerVisionSettings?.SendHotkeyAfterOcrOperation, result.Success ? Constants.SendHotkeyDelay : Constants.FailureSendHotkeyDelay);
 			if (result.Success)
 				ShowStatus("Screenshot & OCR", "Text captured from screenshot.", InfoBarSeverity.Success);
 			else
@@ -236,7 +236,7 @@ public sealed partial class MainWindow : Window
                 {
                         var result = await _ocrManager.TakeScreenshotAndExtractTextAsync(OcrReadingOrder.LeftToRightTopToBottom);
                         SetOcrText(result.Message);
-                        HotkeyManager.SendHotkeyAfterDelay(_settings.AzureComputerVisionSettings?.SendKotKeyAfterOcrOperation, result.Success ? Constants.SendHotkeyDelay : Constants.FailureSendHotkeyDelay);
+                        HotkeyManager.SendHotkeyAfterDelay(_settings.AzureComputerVisionSettings?.SendHotkeyAfterOcrOperation, result.Success ? Constants.SendHotkeyDelay : Constants.FailureSendHotkeyDelay);
                         if (result.Success)
                                 ShowStatus("Screenshot & OCR (left-to-right)", "Text captured from screenshot using left-to-right reading order.", InfoBarSeverity.Success);
                         else
@@ -255,7 +255,7 @@ public sealed partial class MainWindow : Window
                 {
                         var result = await _ocrManager.ExtractTextFromClipboardImageAsync(OcrReadingOrder.TopToBottomColumnAware);
 			SetOcrText(result.Message);
-			HotkeyManager.SendHotkeyAfterDelay(_settings.AzureComputerVisionSettings?.SendKotKeyAfterOcrOperation ?? string.Empty, result.Success ? Constants.SendHotkeyDelay : Constants.FailureSendHotkeyDelay);
+                    HotkeyManager.SendHotkeyAfterDelay(_settings.AzureComputerVisionSettings?.SendHotkeyAfterOcrOperation ?? string.Empty, result.Success ? Constants.SendHotkeyDelay : Constants.FailureSendHotkeyDelay);
 			if (result.Success)
 				ShowStatus("OCR", "Clipboard image converted to text.", InfoBarSeverity.Success);
 			else
@@ -287,7 +287,7 @@ public sealed partial class MainWindow : Window
                 {
                         var result = await _ocrManager.ExtractTextFromClipboardImageAsync(OcrReadingOrder.LeftToRightTopToBottom);
                         SetOcrText(result.Message);
-                        HotkeyManager.SendHotkeyAfterDelay(_settings.AzureComputerVisionSettings?.SendKotKeyAfterOcrOperation ?? string.Empty, result.Success ? Constants.SendHotkeyDelay : Constants.FailureSendHotkeyDelay);
+                        HotkeyManager.SendHotkeyAfterDelay(_settings.AzureComputerVisionSettings?.SendHotkeyAfterOcrOperation ?? string.Empty, result.Success ? Constants.SendHotkeyDelay : Constants.FailureSendHotkeyDelay);
                         if (result.Success)
                                 ShowStatus("OCR (left-to-right)", "Clipboard image converted using left-to-right reading order.", InfoBarSeverity.Success);
                         else
@@ -369,7 +369,7 @@ public sealed partial class MainWindow : Window
 					TxtSpeechToText.IsReadOnly = false;
 					_suppressAutoActions = false;
 					ShowStatus("Speech to Text", "Transcript ready and copied.", InfoBarSeverity.Success);
-					HotkeyManager.SendHotkeyAfterDelay(_settings.SpeetchToTextSettings?.SendKotKeyAfterTranscriptionOperation, Constants.SendHotkeyDelay);
+                                    HotkeyManager.SendHotkeyAfterDelay(_settings.SpeechToTextSettings?.SendHotkeyAfterTranscriptionOperation, Constants.SendHotkeyDelay);
 				}
 				catch (OperationCanceledException)
 				{
@@ -458,7 +458,7 @@ public sealed partial class MainWindow : Window
                 BtnSpeechToTextIcon.Glyph = glyph;
                 BtnSpeechToText.IsEnabled = isEnabled;
                 AutomationProperties.SetName(BtnSpeechToText, label);
-                ConfigureButtonHotkey(BtnSpeechToText, BtnSpeechToTextHotkey, _settings.SpeetchToTextSettings?.SpeechToTextHotKey, label);
+                ConfigureButtonHotkey(BtnSpeechToText, BtnSpeechToTextHotkey, _settings.SpeechToTextSettings?.SpeechToTextHotKey, label);
         }
 
         private void ConfigureButtonHotkey(Button button, TextBlock? hotkeyTextBlock, string? hotkey, string baseTooltip)

--- a/Mutation.Ui/Services/SettingsManager.cs
+++ b/Mutation.Ui/Services/SettingsManager.cs
@@ -227,44 +227,44 @@ internal class SettingsManager : ISettingsManager
 		}
 
 
-		if (settings.SpeetchToTextSettings is null)
-		{
-			settings.SpeetchToTextSettings = new SpeetchToTextSettings();
-			somethingWasMissing = true;
-		}
-		var speechToTextSettings = settings.SpeetchToTextSettings;
+                if (settings.SpeechToTextSettings is null)
+                {
+                        settings.SpeechToTextSettings = new SpeechToTextSettings();
+                        somethingWasMissing = true;
+                }
+                var speechToTextSettings = settings.SpeechToTextSettings;
 		if (string.IsNullOrWhiteSpace(speechToTextSettings.SpeechToTextHotKey))
 		{
 			speechToTextSettings.SpeechToTextHotKey = "SHIFT+ALT+U";
 			somethingWasMissing = true;
 		}
-		if (speechToTextSettings.Services is null)
-		{
-			speechToTextSettings.Services = new SpeetchToTextServiceSettings[] { };
-			somethingWasMissing = true;
-		}
-		if (!speechToTextSettings.Services.Any())
-		{
-			speechToTextSettings.ActiveSpeetchToTextService = "OpenAI Whisper 1";
-			SpeetchToTextServiceSettings service = new SpeetchToTextServiceSettings
-			{
-				Name = speechToTextSettings.ActiveSpeetchToTextService,
-				Provider = SpeechToTextProviders.OpenAi,
-				ModelId = "whisper-1",
-				BaseDomain = "https://api.openai.com/",
-			};
-			speechToTextSettings.Services = speechToTextSettings.Services.Append(service).ToArray();
-			somethingWasMissing = true;
-		}
+                if (speechToTextSettings.Services is null)
+                {
+                        speechToTextSettings.Services = Array.Empty<SpeechToTextServiceSettings>();
+                        somethingWasMissing = true;
+                }
+                if (!speechToTextSettings.Services.Any())
+                {
+                        speechToTextSettings.ActiveSpeechToTextService = "OpenAI Whisper 1";
+                        SpeechToTextServiceSettings service = new SpeechToTextServiceSettings
+                        {
+                                Name = speechToTextSettings.ActiveSpeechToTextService,
+                                Provider = SpeechToTextProviders.OpenAi,
+                                ModelId = "whisper-1",
+                                BaseDomain = "https://api.openai.com/",
+                        };
+                        speechToTextSettings.Services = speechToTextSettings.Services.Append(service).ToArray();
+                        somethingWasMissing = true;
+                }
 		foreach (var s in speechToTextSettings.Services)
 		{
 			if (s.Provider == SpeechToTextProviders.None)
 				s.Provider = SpeechToTextProviders.OpenAi;
 			if (string.IsNullOrWhiteSpace(s.ApiKey))
 			{
-				s.ApiKey = PlaceholderValue;
-				somethingWasMissing = true;
-			}
+                                s.ApiKey = PlaceholderValue;
+                                somethingWasMissing = true;
+                        }
 			if (string.IsNullOrWhiteSpace(s.SpeechToTextPrompt))
 			{
 				s.SpeechToTextPrompt = "Hello, let's use punctuation. Names: Kobus, Piro.";
@@ -291,12 +291,12 @@ internal class SettingsManager : ISettingsManager
 			 .Where(g => g.Count() > 1)
 			 .Select(g => g.Key)
 			 .ToArray();
-		if (duplicateNames.Any())
-		{
-			throw new InvalidOperationException(
-				 $"Duplicate service names found in SpeetchToTextSettings.Services: {string.Join(", ", duplicateNames)}. " +
-				 "Please ensure each speech-to-text service has a unique name to avoid conflicts.");
-		}
+                if (duplicateNames.Any())
+                {
+                        throw new InvalidOperationException(
+                                 $"Duplicate service names found in SpeechToTextSettings.Services: {string.Join(", ", duplicateNames)}. " +
+                                 "Please ensure each speech-to-text service has a unique name to avoid conflicts.");
+                }
 
 
 		if (settings.LlmSettings is null)
@@ -510,49 +510,93 @@ End of summary.
 		return somethingWasMissing;
 	}
 
-	public void UpgradeSettings()
-	{
-		string json = File.ReadAllText(SettingsFileFullPath);
+        public void UpgradeSettings()
+        {
+                string json = File.ReadAllText(SettingsFileFullPath);
 
-		JObject jObj = JObject.Parse(json);
+                JObject jObj = JObject.Parse(json);
+                bool saveRequired = false;
 
-		if (!(jObj["SpeetchToTextSettings"] is JObject settings))
-			return;
+                JObject? speechSettings = jObj["SpeechToTextSettings"] as JObject;
+                if (speechSettings is null && jObj["SpeetchToTextSettings"] is JObject legacySpeechSettings)
+                {
+                        speechSettings = legacySpeechSettings;
+                        jObj["SpeechToTextSettings"] = legacySpeechSettings;
+                        jObj.Remove("SpeetchToTextSettings");
+                        saveRequired = true;
+                }
 
-		if (settings["Services"] == null || settings["Services"].Type != JTokenType.Array)
-		{
-			string providerName = settings.Value<string>("Service") ?? "";
+                if (speechSettings is not null)
+                {
+                        if (speechSettings["Services"] == null || speechSettings["Services"].Type != JTokenType.Array)
+                        {
+                                string providerName = speechSettings.Value<string>("Service") ?? string.Empty;
 
-			JObject serviceObj = new JObject
-			{
-				["Name"] = providerName,
-				["Provider"] = providerName,
-				["ApiKey"] = settings["ApiKey"],
-				["BaseDomain"] = settings["BaseDomain"],
-				["ModelId"] = settings["ModelId"],
-				["SpeechToTextPrompt"] = settings["SpeechToTextPrompt"]
-			};
+                                JObject serviceObj = new JObject
+                                {
+                                        ["Name"] = providerName,
+                                        ["Provider"] = providerName,
+                                        ["ApiKey"] = speechSettings["ApiKey"],
+                                        ["BaseDomain"] = speechSettings["BaseDomain"],
+                                        ["ModelId"] = speechSettings["ModelId"],
+                                        ["SpeechToTextPrompt"] = speechSettings["SpeechToTextPrompt"]
+                                };
 
-			JArray servicesArray = new JArray { serviceObj };
+                                JArray servicesArray = new JArray { serviceObj };
 
-			settings.Remove("Service");
-			settings.Remove("ApiKey");
-			settings.Remove("BaseDomain");
-			settings.Remove("ModelId");
-			settings.Remove("SpeechToTextPrompt");
+                                speechSettings.Remove("Service");
+                                speechSettings.Remove("ApiKey");
+                                speechSettings.Remove("BaseDomain");
+                                speechSettings.Remove("ModelId");
+                                speechSettings.Remove("SpeechToTextPrompt");
 
-			settings["ActiveSpeetchToTextService"] = providerName;
-			settings["Services"] = servicesArray;
-		}
+                                speechSettings["ActiveSpeechToTextService"] = providerName;
+                                speechSettings["Services"] = servicesArray;
+                                saveRequired = true;
+                        }
 
-		foreach (var service in settings["Services"])
-		{
-			if (service["Provider"]?.ToString() == "OpenAiWhisper")
-				service["Provider"] = "OpenAi";
-		}
+                        if (speechSettings["ActiveSpeechToTextService"] == null && speechSettings["ActiveSpeetchToTextService"] != null)
+                        {
+                                speechSettings["ActiveSpeechToTextService"] = speechSettings["ActiveSpeetchToTextService"];
+                                speechSettings.Remove("ActiveSpeetchToTextService");
+                                saveRequired = true;
+                        }
 
-		File.WriteAllText(SettingsFileFullPath, jObj.ToString(Formatting.Indented), Encoding.UTF8);
-	}
+                        if (speechSettings["SendHotkeyAfterTranscriptionOperation"] == null && speechSettings["SendKotKeyAfterTranscriptionOperation"] != null)
+                        {
+                                speechSettings["SendHotkeyAfterTranscriptionOperation"] = speechSettings["SendKotKeyAfterTranscriptionOperation"];
+                                speechSettings.Remove("SendKotKeyAfterTranscriptionOperation");
+                                saveRequired = true;
+                        }
+
+                        if (speechSettings["Services"] is JArray servicesArray)
+                        {
+                                foreach (var service in servicesArray)
+                                {
+                                        if (service["Provider"]?.ToString() == "OpenAiWhisper")
+                                        {
+                                                service["Provider"] = "OpenAi";
+                                                saveRequired = true;
+                                        }
+                                }
+                        }
+                }
+
+                if (jObj["AzureComputerVisionSettings"] is JObject visionSettings)
+                {
+                        if (visionSettings["SendHotkeyAfterOcrOperation"] == null && visionSettings["SendKotKeyAfterOcrOperation"] != null)
+                        {
+                                visionSettings["SendHotkeyAfterOcrOperation"] = visionSettings["SendKotKeyAfterOcrOperation"];
+                                visionSettings.Remove("SendKotKeyAfterOcrOperation");
+                                saveRequired = true;
+                        }
+                }
+
+                if (saveRequired)
+                {
+                        File.WriteAllText(SettingsFileFullPath, jObj.ToString(Formatting.Indented), Encoding.UTF8);
+                }
+        }
 
 	public void SaveSettingsToFile(Settings settings)
 	{

--- a/Mutation.Ui/Services/SettingsManager.cs
+++ b/Mutation.Ui/Services/SettingsManager.cs
@@ -227,44 +227,44 @@ internal class SettingsManager : ISettingsManager
 		}
 
 
-                if (settings.SpeechToTextSettings is null)
-                {
-                        settings.SpeechToTextSettings = new SpeechToTextSettings();
-                        somethingWasMissing = true;
-                }
-                var speechToTextSettings = settings.SpeechToTextSettings;
+		if (settings.SpeechToTextSettings is null)
+		{
+			settings.SpeechToTextSettings = new SpeechToTextSettings();
+			somethingWasMissing = true;
+		}
+		var speechToTextSettings = settings.SpeechToTextSettings;
 		if (string.IsNullOrWhiteSpace(speechToTextSettings.SpeechToTextHotKey))
 		{
 			speechToTextSettings.SpeechToTextHotKey = "SHIFT+ALT+U";
 			somethingWasMissing = true;
 		}
-                if (speechToTextSettings.Services is null)
-                {
-                        speechToTextSettings.Services = Array.Empty<SpeechToTextServiceSettings>();
-                        somethingWasMissing = true;
-                }
-                if (!speechToTextSettings.Services.Any())
-                {
-                        speechToTextSettings.ActiveSpeechToTextService = "OpenAI Whisper 1";
-                        SpeechToTextServiceSettings service = new SpeechToTextServiceSettings
-                        {
-                                Name = speechToTextSettings.ActiveSpeechToTextService,
-                                Provider = SpeechToTextProviders.OpenAi,
-                                ModelId = "whisper-1",
-                                BaseDomain = "https://api.openai.com/",
-                        };
-                        speechToTextSettings.Services = speechToTextSettings.Services.Append(service).ToArray();
-                        somethingWasMissing = true;
-                }
+		if (speechToTextSettings.Services is null)
+		{
+			speechToTextSettings.Services = Array.Empty<SpeechToTextServiceSettings>();
+			somethingWasMissing = true;
+		}
+		if (!speechToTextSettings.Services.Any())
+		{
+			speechToTextSettings.ActiveSpeechToTextService = "OpenAI Whisper 1";
+			SpeechToTextServiceSettings service = new SpeechToTextServiceSettings
+			{
+				Name = speechToTextSettings.ActiveSpeechToTextService,
+				Provider = SpeechToTextProviders.OpenAi,
+				ModelId = "whisper-1",
+				BaseDomain = "https://api.openai.com/",
+			};
+			speechToTextSettings.Services = speechToTextSettings.Services.Append(service).ToArray();
+			somethingWasMissing = true;
+		}
 		foreach (var s in speechToTextSettings.Services)
 		{
 			if (s.Provider == SpeechToTextProviders.None)
 				s.Provider = SpeechToTextProviders.OpenAi;
 			if (string.IsNullOrWhiteSpace(s.ApiKey))
 			{
-                                s.ApiKey = PlaceholderValue;
-                                somethingWasMissing = true;
-                        }
+				s.ApiKey = PlaceholderValue;
+				somethingWasMissing = true;
+			}
 			if (string.IsNullOrWhiteSpace(s.SpeechToTextPrompt))
 			{
 				s.SpeechToTextPrompt = "Hello, let's use punctuation. Names: Kobus, Piro.";
@@ -291,12 +291,12 @@ internal class SettingsManager : ISettingsManager
 			 .Where(g => g.Count() > 1)
 			 .Select(g => g.Key)
 			 .ToArray();
-                if (duplicateNames.Any())
-                {
-                        throw new InvalidOperationException(
-                                 $"Duplicate service names found in SpeechToTextSettings.Services: {string.Join(", ", duplicateNames)}. " +
-                                 "Please ensure each speech-to-text service has a unique name to avoid conflicts.");
-                }
+		if (duplicateNames.Any())
+		{
+			throw new InvalidOperationException(
+						$"Duplicate service names found in SpeechToTextSettings.Services: {string.Join(", ", duplicateNames)}. " +
+						"Please ensure each speech-to-text service has a unique name to avoid conflicts.");
+		}
 
 
 		if (settings.LlmSettings is null)
@@ -510,93 +510,93 @@ End of summary.
 		return somethingWasMissing;
 	}
 
-        public void UpgradeSettings()
-        {
-                string json = File.ReadAllText(SettingsFileFullPath);
+	public void UpgradeSettings()
+	{
+		string json = File.ReadAllText(SettingsFileFullPath);
 
-                JObject jObj = JObject.Parse(json);
-                bool saveRequired = false;
+		JObject jObj = JObject.Parse(json);
+		bool saveRequired = false;
 
-                JObject? speechSettings = jObj["SpeechToTextSettings"] as JObject;
-                if (speechSettings is null && jObj["SpeetchToTextSettings"] is JObject legacySpeechSettings)
-                {
-                        speechSettings = legacySpeechSettings;
-                        jObj["SpeechToTextSettings"] = legacySpeechSettings;
-                        jObj.Remove("SpeetchToTextSettings");
-                        saveRequired = true;
-                }
+		JObject? speechSettings = jObj["SpeechToTextSettings"] as JObject;
+		if (speechSettings is null && jObj["SpeetchToTextSettings"] is JObject legacySpeechSettings)
+		{
+			speechSettings = legacySpeechSettings;
+			jObj["SpeechToTextSettings"] = legacySpeechSettings;
+			jObj.Remove("SpeetchToTextSettings");
+			saveRequired = true;
+		}
 
-                if (speechSettings is not null)
-                {
-                        if (speechSettings["Services"] == null || speechSettings["Services"].Type != JTokenType.Array)
-                        {
-                                string providerName = speechSettings.Value<string>("Service") ?? string.Empty;
+		if (speechSettings is not null)
+		{
+			if (speechSettings["Services"] == null || speechSettings["Services"].Type != JTokenType.Array)
+			{
+				string providerName = speechSettings.Value<string>("Service") ?? string.Empty;
 
-                                JObject serviceObj = new JObject
-                                {
-                                        ["Name"] = providerName,
-                                        ["Provider"] = providerName,
-                                        ["ApiKey"] = speechSettings["ApiKey"],
-                                        ["BaseDomain"] = speechSettings["BaseDomain"],
-                                        ["ModelId"] = speechSettings["ModelId"],
-                                        ["SpeechToTextPrompt"] = speechSettings["SpeechToTextPrompt"]
-                                };
+				JObject serviceObj = new JObject
+				{
+					["Name"] = providerName,
+					["Provider"] = providerName,
+					["ApiKey"] = speechSettings["ApiKey"],
+					["BaseDomain"] = speechSettings["BaseDomain"],
+					["ModelId"] = speechSettings["ModelId"],
+					["SpeechToTextPrompt"] = speechSettings["SpeechToTextPrompt"]
+				};
 
-                                JArray servicesArray = new JArray { serviceObj };
+				JArray createdServicesArray = new JArray { serviceObj };
 
-                                speechSettings.Remove("Service");
-                                speechSettings.Remove("ApiKey");
-                                speechSettings.Remove("BaseDomain");
-                                speechSettings.Remove("ModelId");
-                                speechSettings.Remove("SpeechToTextPrompt");
+				speechSettings.Remove("Service");
+				speechSettings.Remove("ApiKey");
+				speechSettings.Remove("BaseDomain");
+				speechSettings.Remove("ModelId");
+				speechSettings.Remove("SpeechToTextPrompt");
 
-                                speechSettings["ActiveSpeechToTextService"] = providerName;
-                                speechSettings["Services"] = servicesArray;
-                                saveRequired = true;
-                        }
+				speechSettings["ActiveSpeechToTextService"] = providerName;
+				speechSettings["Services"] = createdServicesArray;
+				saveRequired = true;
+			}
 
-                        if (speechSettings["ActiveSpeechToTextService"] == null && speechSettings["ActiveSpeetchToTextService"] != null)
-                        {
-                                speechSettings["ActiveSpeechToTextService"] = speechSettings["ActiveSpeetchToTextService"];
-                                speechSettings.Remove("ActiveSpeetchToTextService");
-                                saveRequired = true;
-                        }
+			if (speechSettings["ActiveSpeechToTextService"] == null && speechSettings["ActiveSpeetchToTextService"] != null)
+			{
+				speechSettings["ActiveSpeechToTextService"] = speechSettings["ActiveSpeetchToTextService"];
+				speechSettings.Remove("ActiveSpeetchToTextService");
+				saveRequired = true;
+			}
 
-                        if (speechSettings["SendHotkeyAfterTranscriptionOperation"] == null && speechSettings["SendKotKeyAfterTranscriptionOperation"] != null)
-                        {
-                                speechSettings["SendHotkeyAfterTranscriptionOperation"] = speechSettings["SendKotKeyAfterTranscriptionOperation"];
-                                speechSettings.Remove("SendKotKeyAfterTranscriptionOperation");
-                                saveRequired = true;
-                        }
+			if (speechSettings["SendHotkeyAfterTranscriptionOperation"] == null && speechSettings["SendKotKeyAfterTranscriptionOperation"] != null)
+			{
+				speechSettings["SendHotkeyAfterTranscriptionOperation"] = speechSettings["SendKotKeyAfterTranscriptionOperation"];
+				speechSettings.Remove("SendKotKeyAfterTranscriptionOperation");
+				saveRequired = true;
+			}
 
-                        if (speechSettings["Services"] is JArray servicesArray)
-                        {
-                                foreach (var service in servicesArray)
-                                {
-                                        if (service["Provider"]?.ToString() == "OpenAiWhisper")
-                                        {
-                                                service["Provider"] = "OpenAi";
-                                                saveRequired = true;
-                                        }
-                                }
-                        }
-                }
+			if (speechSettings["Services"] is JArray servicesArray)
+			{
+				foreach (var service in servicesArray)
+				{
+					if (service["Provider"]?.ToString() == "OpenAiWhisper")
+					{
+						service["Provider"] = "OpenAi";
+						saveRequired = true;
+					}
+				}
+			}
+		}
 
-                if (jObj["AzureComputerVisionSettings"] is JObject visionSettings)
-                {
-                        if (visionSettings["SendHotkeyAfterOcrOperation"] == null && visionSettings["SendKotKeyAfterOcrOperation"] != null)
-                        {
-                                visionSettings["SendHotkeyAfterOcrOperation"] = visionSettings["SendKotKeyAfterOcrOperation"];
-                                visionSettings.Remove("SendKotKeyAfterOcrOperation");
-                                saveRequired = true;
-                        }
-                }
+		if (jObj["AzureComputerVisionSettings"] is JObject visionSettings)
+		{
+			if (visionSettings["SendHotkeyAfterOcrOperation"] == null && visionSettings["SendKotKeyAfterOcrOperation"] != null)
+			{
+				visionSettings["SendHotkeyAfterOcrOperation"] = visionSettings["SendKotKeyAfterOcrOperation"];
+				visionSettings.Remove("SendKotKeyAfterOcrOperation");
+				saveRequired = true;
+			}
+		}
 
-                if (saveRequired)
-                {
-                        File.WriteAllText(SettingsFileFullPath, jObj.ToString(Formatting.Indented), Encoding.UTF8);
-                }
-        }
+		if (saveRequired)
+		{
+			File.WriteAllText(SettingsFileFullPath, jObj.ToString(Formatting.Indented), Encoding.UTF8);
+		}
+	}
 
 	public void SaveSettingsToFile(Settings settings)
 	{

--- a/README.md
+++ b/README.md
@@ -50,12 +50,12 @@ All hotkeys are global and fully customisable. Below is a comprehensive example 
     "ScreenshotOcrHotKey": "Ctrl+Shift+Q",
     "OcrLeftToRightTopToBottomHotKey": "Ctrl+Shift+L",
     "ScreenshotLeftToRightTopToBottomOcrHotKey": "Ctrl+Shift+K",
-    "SendHotKeyAfterOcrOperation": "Ctrl+Alt+C"
+    "SendHotkeyAfterOcrOperation": "Ctrl+Alt+C"
   },
 
-  "SpeetchToTextSettings": {
+  "SpeechToTextSettings": {
     "StartStopTranscriptionHotKey": "Ctrl+Shift+T",
-    "SendHotKeyAfterTranscriptionOperation": "Ctrl+Alt+V",
+    "SendHotkeyAfterTranscriptionOperation": "Ctrl+Alt+V",
     "Providers": [
       {
         "Name": "OpenAI gpt-4o-transcribe",
@@ -99,7 +99,7 @@ All hotkeys are global and fully customisable. Below is a comprehensive example 
 ### Provisioning Speech-to-Text Providers
 
 * Follow each provider’s portal to create an account and API key.
-* Paste the credentials into the relevant object under `SpeetchToTextSettings → Providers`.
+* Paste the credentials into the relevant object under `SpeechToTextSettings → Providers`.
 
 ## Contribute
 


### PR DESCRIPTION
## Summary
- rename the speech-to-text settings classes and properties to fix the long-standing spelling errors and use SendHotkey* names
- update settings migration and UI logic to use the corrected names and keep backward compatibility with older files
- introduce light/dark theme dictionaries so the WinUI 3 application follows the system theme and document the new setting names

## Testing
- MSBUILDTERMINALLOGGER=false dotnet restore -p:EnableWindowsTargeting=true *(fails: proxy 403 to https://api.nuget.org/v3/index.json)*
- MSBUILDTERMINALLOGGER=false dotnet build --configuration Release -p:EnableWindowsTargeting=true *(fails: proxy 403 to https://api.nuget.org/v3/index.json)*
- MSBUILDTERMINALLOGGER=false dotnet test --configuration Release --logger "trx;LogFileName=test-results.trx" -p:EnableWindowsTargeting=true *(fails: proxy 403 to https://api.nuget.org/v3/index.json)*

------
https://chatgpt.com/codex/tasks/task_e_68d551a1a190832fbfbf46bb35c535f8