### PR TITLE
Improve mute icon and align visual capture buttons

### DIFF
--- a/Mutation.Ui/MainWindow.xaml
+++ b/Mutation.Ui/MainWindow.xaml
@@ -19,10 +19,18 @@
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
 
-        <StackPanel Grid.Row="0" Margin="32,24,32,12" Spacing="4">
-            <TextBlock Text="Mutation Workspace" Style="{StaticResource TitleTextStyle}" AutomationProperties.Name="Application Title" />
-            <TextBlock Text="Capture ideas, format transcripts, and automate workflows from one polished surface." Style="{StaticResource SubtitleTextStyle}" />
-        </StackPanel>
+        <Grid Grid.Row="0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="6*" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+
+            <StackPanel Grid.Column="1" Margin="32,24,32,12" Spacing="4">
+                <TextBlock Text="Mutation Workspace" Style="{StaticResource TitleTextStyle}" AutomationProperties.Name="Application Title" />
+                <TextBlock Text="Capture ideas, format transcripts, and automate workflows from one polished surface." Style="{StaticResource SubtitleTextStyle}" />
+            </StackPanel>
+        </Grid>
 
         <Grid Grid.Row="1">
             <Grid.ColumnDefinitions>

--- a/Mutation.Ui/MainWindow.xaml
+++ b/Mutation.Ui/MainWindow.xaml
@@ -107,7 +107,8 @@
                                                 HorizontalAlignment="Center"
                                                 VerticalAlignment="Center"
                                                 Visibility="Collapsed"
-                                                IsHitTestVisible="False">
+                                                IsHitTestVisible="False"
+                                                RenderTransformOrigin="0.5,0.5">
                                                 <Rectangle.RenderTransform>
                                                     <CompositeTransform Rotation="-45" />
                                                 </Rectangle.RenderTransform>
@@ -152,7 +153,8 @@
                                                 HorizontalAlignment="Center"
                                                 VerticalAlignment="Center"
                                                 Visibility="Collapsed"
-                                                IsHitTestVisible="False">
+                                                IsHitTestVisible="False"
+                                                RenderTransformOrigin="0.5,0.5">
                                                 <Rectangle.RenderTransform>
                                                     <CompositeTransform Rotation="-45" />
                                                 </Rectangle.RenderTransform>

--- a/Mutation.Ui/MainWindow.xaml
+++ b/Mutation.Ui/MainWindow.xaml
@@ -299,9 +299,13 @@
                                     AccessKey="S"
                                     AutomationProperties.Name="Screenshot to clipboard"
                                     ToolTipService.ToolTip="Copy a screenshot directly to the clipboard">
-                                    <StackPanel Orientation="Horizontal" Spacing="8" HorizontalAlignment="Center">
-                                        <FontIcon Glyph="&#xE70F;" FontFamily="Segoe Fluent Icons" />
-                                        <StackPanel Spacing="2">
+                                    <Grid ColumnSpacing="8">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto" />
+                                            <ColumnDefinition Width="*" />
+                                        </Grid.ColumnDefinitions>
+                                        <FontIcon Glyph="&#xE70F;" FontFamily="Segoe Fluent Icons" VerticalAlignment="Center" />
+                                        <StackPanel Grid.Column="1" Spacing="2" VerticalAlignment="Center">
                                             <TextBlock Text="Screenshot to clipboard" />
                                             <TextBlock
                                                 x:Name="BtnScreenshotHotkey"
@@ -309,7 +313,7 @@
                                                 Style="{StaticResource CaptionTextStyle}"
                                                 Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
                                         </StackPanel>
-                                    </StackPanel>
+                                    </Grid>
                                 </Button>
 
                                 <Button
@@ -319,9 +323,13 @@
                                     AccessKey="C"
                                     AutomationProperties.Name="OCR clipboard"
                                     ToolTipService.ToolTip="Run OCR on an image stored in the clipboard">
-                                    <StackPanel Orientation="Horizontal" Spacing="8" HorizontalAlignment="Center">
-                                        <FontIcon Glyph="&#xE8F1;" FontFamily="Segoe Fluent Icons" />
-                                        <StackPanel Spacing="2">
+                                    <Grid ColumnSpacing="8">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto" />
+                                            <ColumnDefinition Width="*" />
+                                        </Grid.ColumnDefinitions>
+                                        <FontIcon Glyph="&#xE8F1;" FontFamily="Segoe Fluent Icons" VerticalAlignment="Center" />
+                                        <StackPanel Grid.Column="1" Spacing="2" VerticalAlignment="Center">
                                             <TextBlock Text="OCR clipboard" />
                                             <TextBlock
                                                 x:Name="BtnOcrClipboardHotkey"
@@ -329,7 +337,7 @@
                                                 Style="{StaticResource CaptionTextStyle}"
                                                 Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
                                         </StackPanel>
-                                    </StackPanel>
+                                    </Grid>
                                 </Button>
 
                                 <Button
@@ -339,9 +347,13 @@
                                     AccessKey="D"
                                     AutomationProperties.Name="OCR clipboard left to right"
                                     ToolTipService.ToolTip="Run OCR on an image stored in the clipboard using left-to-right reading order">
-                                    <StackPanel Orientation="Horizontal" Spacing="8" HorizontalAlignment="Center">
-                                        <FontIcon Glyph="&#xE8F1;" FontFamily="Segoe Fluent Icons" />
-                                        <StackPanel Spacing="2">
+                                    <Grid ColumnSpacing="8">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto" />
+                                            <ColumnDefinition Width="*" />
+                                        </Grid.ColumnDefinitions>
+                                        <FontIcon Glyph="&#xE8F1;" FontFamily="Segoe Fluent Icons" VerticalAlignment="Center" />
+                                        <StackPanel Grid.Column="1" Spacing="2" VerticalAlignment="Center">
                                             <TextBlock Text="OCR clipboard (L→R)" />
                                             <TextBlock
                                                 x:Name="BtnOcrClipboardLrtbHotkey"
@@ -349,7 +361,7 @@
                                                 Style="{StaticResource CaptionTextStyle}"
                                                 Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
                                         </StackPanel>
-                                    </StackPanel>
+                                    </Grid>
                                 </Button>
 
                                 <Button
@@ -359,9 +371,13 @@
                                     AccessKey="O"
                                     AutomationProperties.Name="Screenshot and OCR"
                                     ToolTipService.ToolTip="Capture a screenshot and extract text automatically">
-                                    <StackPanel Orientation="Horizontal" Spacing="8" HorizontalAlignment="Center">
-                                        <FontIcon Glyph="&#xE8D2;" FontFamily="Segoe Fluent Icons" />
-                                        <StackPanel Spacing="2">
+                                    <Grid ColumnSpacing="8">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto" />
+                                            <ColumnDefinition Width="*" />
+                                        </Grid.ColumnDefinitions>
+                                        <FontIcon Glyph="&#xE8D2;" FontFamily="Segoe Fluent Icons" VerticalAlignment="Center" />
+                                        <StackPanel Grid.Column="1" Spacing="2" VerticalAlignment="Center">
                                             <TextBlock Text="Screenshot &amp; OCR" />
                                             <TextBlock
                                                 x:Name="BtnScreenshotOcrHotkey"
@@ -369,7 +385,7 @@
                                                 Style="{StaticResource CaptionTextStyle}"
                                                 Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
                                         </StackPanel>
-                                    </StackPanel>
+                                    </Grid>
                                 </Button>
 
                                 <Button
@@ -379,9 +395,13 @@
                                     AccessKey="B"
                                     AutomationProperties.Name="Screenshot and OCR left to right"
                                     ToolTipService.ToolTip="Capture a screenshot and extract text using left-to-right reading order">
-                                    <StackPanel Orientation="Horizontal" Spacing="8" HorizontalAlignment="Center">
-                                        <FontIcon Glyph="&#xE8D2;" FontFamily="Segoe Fluent Icons" />
-                                        <StackPanel Spacing="2">
+                                    <Grid ColumnSpacing="8">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto" />
+                                            <ColumnDefinition Width="*" />
+                                        </Grid.ColumnDefinitions>
+                                        <FontIcon Glyph="&#xE8D2;" FontFamily="Segoe Fluent Icons" VerticalAlignment="Center" />
+                                        <StackPanel Grid.Column="1" Spacing="2" VerticalAlignment="Center">
                                             <TextBlock Text="Screenshot &amp; OCR (L→R)" />
                                             <TextBlock
                                                 x:Name="BtnScreenshotOcrLrtbHotkey"
@@ -389,7 +409,7 @@
                                                 Style="{StaticResource CaptionTextStyle}"
                                                 Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
                                         </StackPanel>
-                                    </StackPanel>
+                                    </Grid>
                                 </Button>
                             </StackPanel>
 

--- a/Mutation.Ui/MainWindow.xaml
+++ b/Mutation.Ui/MainWindow.xaml
@@ -347,13 +347,17 @@
                                     AccessKey="S"
                                     AutomationProperties.Name="Screenshot to clipboard"
                                     ToolTipService.ToolTip="Copy a screenshot directly to the clipboard">
-                                    <Grid ColumnSpacing="12" VerticalAlignment="Center">
+                                    <Grid ColumnSpacing="12" VerticalAlignment="Stretch">
                                         <Grid.ColumnDefinitions>
                                             <ColumnDefinition Width="32" />
                                             <ColumnDefinition Width="*" />
                                         </Grid.ColumnDefinitions>
-                                        <FontIcon Glyph="&#xE70F;" FontFamily="Segoe Fluent Icons" HorizontalAlignment="Center" VerticalAlignment="Center" />
-                                        <StackPanel Grid.Column="1" Spacing="2" VerticalAlignment="Center">
+                                        <FontIcon
+                                            Glyph="&#xE70F;"
+                                            FontFamily="Segoe Fluent Icons"
+                                            HorizontalAlignment="Center"
+                                            VerticalAlignment="Top" />
+                                        <StackPanel Grid.Column="1" Spacing="2" VerticalAlignment="Top">
                                             <TextBlock Text="Screenshot to clipboard" />
                                             <TextBlock
                                                 x:Name="BtnScreenshotHotkey"
@@ -371,13 +375,17 @@
                                     AccessKey="C"
                                     AutomationProperties.Name="OCR clipboard"
                                     ToolTipService.ToolTip="Run OCR on an image stored in the clipboard">
-                                    <Grid ColumnSpacing="12" VerticalAlignment="Center">
+                                    <Grid ColumnSpacing="12" VerticalAlignment="Stretch">
                                         <Grid.ColumnDefinitions>
                                             <ColumnDefinition Width="32" />
                                             <ColumnDefinition Width="*" />
                                         </Grid.ColumnDefinitions>
-                                        <FontIcon Glyph="&#xE8F1;" FontFamily="Segoe Fluent Icons" HorizontalAlignment="Center" VerticalAlignment="Center" />
-                                        <StackPanel Grid.Column="1" Spacing="2" VerticalAlignment="Center">
+                                        <FontIcon
+                                            Glyph="&#xE8F1;"
+                                            FontFamily="Segoe Fluent Icons"
+                                            HorizontalAlignment="Center"
+                                            VerticalAlignment="Top" />
+                                        <StackPanel Grid.Column="1" Spacing="2" VerticalAlignment="Top">
                                             <TextBlock Text="OCR clipboard" />
                                             <TextBlock
                                                 x:Name="BtnOcrClipboardHotkey"
@@ -395,13 +403,17 @@
                                     AccessKey="D"
                                     AutomationProperties.Name="OCR clipboard left to right"
                                     ToolTipService.ToolTip="Run OCR on an image stored in the clipboard using left-to-right reading order">
-                                    <Grid ColumnSpacing="12" VerticalAlignment="Center">
+                                    <Grid ColumnSpacing="12" VerticalAlignment="Stretch">
                                         <Grid.ColumnDefinitions>
                                             <ColumnDefinition Width="32" />
                                             <ColumnDefinition Width="*" />
                                         </Grid.ColumnDefinitions>
-                                        <FontIcon Glyph="&#xE8F1;" FontFamily="Segoe Fluent Icons" HorizontalAlignment="Center" VerticalAlignment="Center" />
-                                        <StackPanel Grid.Column="1" Spacing="2" VerticalAlignment="Center">
+                                        <FontIcon
+                                            Glyph="&#xE8F1;"
+                                            FontFamily="Segoe Fluent Icons"
+                                            HorizontalAlignment="Center"
+                                            VerticalAlignment="Top" />
+                                        <StackPanel Grid.Column="1" Spacing="2" VerticalAlignment="Top">
                                             <TextBlock Text="OCR clipboard (L→R)" />
                                             <TextBlock
                                                 x:Name="BtnOcrClipboardLrtbHotkey"
@@ -419,13 +431,17 @@
                                     AccessKey="O"
                                     AutomationProperties.Name="Screenshot and OCR"
                                     ToolTipService.ToolTip="Capture a screenshot and extract text automatically">
-                                    <Grid ColumnSpacing="12" VerticalAlignment="Center">
+                                    <Grid ColumnSpacing="12" VerticalAlignment="Stretch">
                                         <Grid.ColumnDefinitions>
                                             <ColumnDefinition Width="32" />
                                             <ColumnDefinition Width="*" />
                                         </Grid.ColumnDefinitions>
-                                        <FontIcon Glyph="&#xE8D2;" FontFamily="Segoe Fluent Icons" HorizontalAlignment="Center" VerticalAlignment="Center" />
-                                        <StackPanel Grid.Column="1" Spacing="2" VerticalAlignment="Center">
+                                        <FontIcon
+                                            Glyph="&#xE8D2;"
+                                            FontFamily="Segoe Fluent Icons"
+                                            HorizontalAlignment="Center"
+                                            VerticalAlignment="Top" />
+                                        <StackPanel Grid.Column="1" Spacing="2" VerticalAlignment="Top">
                                             <TextBlock Text="Screenshot &amp; OCR" />
                                             <TextBlock
                                                 x:Name="BtnScreenshotOcrHotkey"
@@ -443,13 +459,17 @@
                                     AccessKey="B"
                                     AutomationProperties.Name="Screenshot and OCR left to right"
                                     ToolTipService.ToolTip="Capture a screenshot and extract text using left-to-right reading order">
-                                    <Grid ColumnSpacing="12" VerticalAlignment="Center">
+                                    <Grid ColumnSpacing="12" VerticalAlignment="Stretch">
                                         <Grid.ColumnDefinitions>
                                             <ColumnDefinition Width="32" />
                                             <ColumnDefinition Width="*" />
                                         </Grid.ColumnDefinitions>
-                                        <FontIcon Glyph="&#xE8D2;" FontFamily="Segoe Fluent Icons" HorizontalAlignment="Center" VerticalAlignment="Center" />
-                                        <StackPanel Grid.Column="1" Spacing="2" VerticalAlignment="Center">
+                                        <FontIcon
+                                            Glyph="&#xE8D2;"
+                                            FontFamily="Segoe Fluent Icons"
+                                            HorizontalAlignment="Center"
+                                            VerticalAlignment="Top" />
+                                        <StackPanel Grid.Column="1" Spacing="2" VerticalAlignment="Top">
                                             <TextBlock Text="Screenshot &amp; OCR (L→R)" />
                                             <TextBlock
                                                 x:Name="BtnScreenshotOcrLrtbHotkey"

--- a/Mutation.Ui/MainWindow.xaml
+++ b/Mutation.Ui/MainWindow.xaml
@@ -39,14 +39,15 @@
                 VerticalScrollBarVisibility="Auto"
                 VerticalScrollMode="Auto">
                 <StackPanel x:Name="ContentStack" Spacing="20">
-                <InfoBar
-                    x:Name="StatusInfoBar"
-                    Title="Status"
-                    IsOpen="False"
-                    Visibility="Collapsed"
-                    AutomationProperties.Name="Status notifications"
-                    AutomationProperties.LiveSetting="Polite"
-                    AutomationProperties.HelpText="Latest status messages for Mutation workspace" />
+                <Grid x:Name="StatusRegion" MinHeight="72">
+                    <InfoBar
+                        x:Name="StatusInfoBar"
+                        Title="Status"
+                        IsOpen="False"
+                        AutomationProperties.Name="Status notifications"
+                        AutomationProperties.LiveSetting="Polite"
+                        AutomationProperties.HelpText="Latest status messages for Mutation workspace" />
+                </Grid>
 
                 <Grid x:Name="ContentGrid" ColumnSpacing="18" RowSpacing="18">
                     <Grid.ColumnDefinitions>
@@ -89,11 +90,29 @@
                                             <ColumnDefinition Width="Auto" />
                                             <ColumnDefinition Width="*" />
                                         </Grid.ColumnDefinitions>
-                                        <FontIcon
-                                            x:Name="MicStatusIcon"
-                                            Glyph="&#xE720;"
-                                            FontFamily="Segoe Fluent Icons"
-                                            VerticalAlignment="Center" />
+                                        <Grid Width="28" Height="28" VerticalAlignment="Center">
+                                            <FontIcon
+                                                x:Name="MicStatusIcon"
+                                                Glyph="&#xE720;"
+                                                FontFamily="Segoe Fluent Icons"
+                                                HorizontalAlignment="Center"
+                                                VerticalAlignment="Center" />
+                                            <Rectangle
+                                                x:Name="MicStatusIconSlash"
+                                                Width="20"
+                                                Height="2"
+                                                RadiusX="1"
+                                                RadiusY="1"
+                                                Fill="{Binding Foreground, ElementName=MicStatusIcon}"
+                                                HorizontalAlignment="Center"
+                                                VerticalAlignment="Center"
+                                                Visibility="Collapsed"
+                                                IsHitTestVisible="False">
+                                                <Rectangle.RenderTransform>
+                                                    <CompositeTransform Rotation="-45" />
+                                                </Rectangle.RenderTransform>
+                                            </Rectangle>
+                                        </Grid>
                                         <ComboBox
                                             x:Name="CmbMicrophone"
                                             Grid.Column="1"
@@ -115,11 +134,30 @@
                                     AutomationProperties.Name="Toggle microphone"
                                     ToolTipService.ToolTip="Toggle microphone mute state">
                                     <StackPanel Orientation="Horizontal" Spacing="8" HorizontalAlignment="Center">
-                                        <FontIcon
-                                            x:Name="BtnToggleMicIcon"
-                                            Glyph="&#xE720;"
-                                            FontFamily="Segoe Fluent Icons"
-                                        />
+                                        <Grid Width="28" Height="28">
+                                            <FontIcon
+                                                x:Name="BtnToggleMicIcon"
+                                                Glyph="&#xE720;"
+                                                FontFamily="Segoe Fluent Icons"
+                                                HorizontalAlignment="Center"
+                                                VerticalAlignment="Center"
+                                            />
+                                            <Rectangle
+                                                x:Name="BtnToggleMicSlash"
+                                                Width="20"
+                                                Height="2"
+                                                RadiusX="1"
+                                                RadiusY="1"
+                                                Fill="{Binding Foreground, ElementName=BtnToggleMicIcon}"
+                                                HorizontalAlignment="Center"
+                                                VerticalAlignment="Center"
+                                                Visibility="Collapsed"
+                                                IsHitTestVisible="False">
+                                                <Rectangle.RenderTransform>
+                                                    <CompositeTransform Rotation="-45" />
+                                                </Rectangle.RenderTransform>
+                                            </Rectangle>
+                                        </Grid>
                                         <StackPanel Spacing="2">
                                             <TextBlock x:Name="BtnToggleMicLabel" Text="Mute microphone" />
                                             <TextBlock
@@ -299,12 +337,12 @@
                                     AccessKey="S"
                                     AutomationProperties.Name="Screenshot to clipboard"
                                     ToolTipService.ToolTip="Copy a screenshot directly to the clipboard">
-                                    <Grid ColumnSpacing="8">
+                                    <Grid ColumnSpacing="12" VerticalAlignment="Center">
                                         <Grid.ColumnDefinitions>
-                                            <ColumnDefinition Width="Auto" />
+                                            <ColumnDefinition Width="32" />
                                             <ColumnDefinition Width="*" />
                                         </Grid.ColumnDefinitions>
-                                        <FontIcon Glyph="&#xE70F;" FontFamily="Segoe Fluent Icons" VerticalAlignment="Center" />
+                                        <FontIcon Glyph="&#xE70F;" FontFamily="Segoe Fluent Icons" HorizontalAlignment="Center" VerticalAlignment="Center" />
                                         <StackPanel Grid.Column="1" Spacing="2" VerticalAlignment="Center">
                                             <TextBlock Text="Screenshot to clipboard" />
                                             <TextBlock
@@ -323,12 +361,12 @@
                                     AccessKey="C"
                                     AutomationProperties.Name="OCR clipboard"
                                     ToolTipService.ToolTip="Run OCR on an image stored in the clipboard">
-                                    <Grid ColumnSpacing="8">
+                                    <Grid ColumnSpacing="12" VerticalAlignment="Center">
                                         <Grid.ColumnDefinitions>
-                                            <ColumnDefinition Width="Auto" />
+                                            <ColumnDefinition Width="32" />
                                             <ColumnDefinition Width="*" />
                                         </Grid.ColumnDefinitions>
-                                        <FontIcon Glyph="&#xE8F1;" FontFamily="Segoe Fluent Icons" VerticalAlignment="Center" />
+                                        <FontIcon Glyph="&#xE8F1;" FontFamily="Segoe Fluent Icons" HorizontalAlignment="Center" VerticalAlignment="Center" />
                                         <StackPanel Grid.Column="1" Spacing="2" VerticalAlignment="Center">
                                             <TextBlock Text="OCR clipboard" />
                                             <TextBlock
@@ -347,12 +385,12 @@
                                     AccessKey="D"
                                     AutomationProperties.Name="OCR clipboard left to right"
                                     ToolTipService.ToolTip="Run OCR on an image stored in the clipboard using left-to-right reading order">
-                                    <Grid ColumnSpacing="8">
+                                    <Grid ColumnSpacing="12" VerticalAlignment="Center">
                                         <Grid.ColumnDefinitions>
-                                            <ColumnDefinition Width="Auto" />
+                                            <ColumnDefinition Width="32" />
                                             <ColumnDefinition Width="*" />
                                         </Grid.ColumnDefinitions>
-                                        <FontIcon Glyph="&#xE8F1;" FontFamily="Segoe Fluent Icons" VerticalAlignment="Center" />
+                                        <FontIcon Glyph="&#xE8F1;" FontFamily="Segoe Fluent Icons" HorizontalAlignment="Center" VerticalAlignment="Center" />
                                         <StackPanel Grid.Column="1" Spacing="2" VerticalAlignment="Center">
                                             <TextBlock Text="OCR clipboard (L→R)" />
                                             <TextBlock
@@ -371,12 +409,12 @@
                                     AccessKey="O"
                                     AutomationProperties.Name="Screenshot and OCR"
                                     ToolTipService.ToolTip="Capture a screenshot and extract text automatically">
-                                    <Grid ColumnSpacing="8">
+                                    <Grid ColumnSpacing="12" VerticalAlignment="Center">
                                         <Grid.ColumnDefinitions>
-                                            <ColumnDefinition Width="Auto" />
+                                            <ColumnDefinition Width="32" />
                                             <ColumnDefinition Width="*" />
                                         </Grid.ColumnDefinitions>
-                                        <FontIcon Glyph="&#xE8D2;" FontFamily="Segoe Fluent Icons" VerticalAlignment="Center" />
+                                        <FontIcon Glyph="&#xE8D2;" FontFamily="Segoe Fluent Icons" HorizontalAlignment="Center" VerticalAlignment="Center" />
                                         <StackPanel Grid.Column="1" Spacing="2" VerticalAlignment="Center">
                                             <TextBlock Text="Screenshot &amp; OCR" />
                                             <TextBlock
@@ -395,12 +433,12 @@
                                     AccessKey="B"
                                     AutomationProperties.Name="Screenshot and OCR left to right"
                                     ToolTipService.ToolTip="Capture a screenshot and extract text using left-to-right reading order">
-                                    <Grid ColumnSpacing="8">
+                                    <Grid ColumnSpacing="12" VerticalAlignment="Center">
                                         <Grid.ColumnDefinitions>
-                                            <ColumnDefinition Width="Auto" />
+                                            <ColumnDefinition Width="32" />
                                             <ColumnDefinition Width="*" />
                                         </Grid.ColumnDefinitions>
-                                        <FontIcon Glyph="&#xE8D2;" FontFamily="Segoe Fluent Icons" VerticalAlignment="Center" />
+                                        <FontIcon Glyph="&#xE8D2;" FontFamily="Segoe Fluent Icons" HorizontalAlignment="Center" VerticalAlignment="Center" />
                                         <StackPanel Grid.Column="1" Spacing="2" VerticalAlignment="Center">
                                             <TextBlock Text="Screenshot &amp; OCR (L→R)" />
                                             <TextBlock

--- a/Mutation.Ui/MainWindow.xaml.cs
+++ b/Mutation.Ui/MainWindow.xaml.cs
@@ -34,7 +34,6 @@ public sealed partial class MainWindow : Window
 	private readonly DispatcherTimer _statusDismissTimer;
 
         private const string MicOnGlyph = "\uE720";
-        private const string MicOffGlyph = "\uEC26";
         private const string RecordGlyph = "\uE768";
         private const string StopGlyph = "\uE71A";
         private const string ProcessingGlyph = "\uE8A0";
@@ -453,10 +452,12 @@ public sealed partial class MainWindow : Window
         {
                 bool muted = _audioDeviceManager.IsMuted;
                 BtnToggleMicLabel.Text = muted ? "Unmute microphone" : "Mute microphone";
-                BtnToggleMicIcon.Glyph = muted ? MicOffGlyph : MicOnGlyph;
+                BtnToggleMicIcon.Glyph = MicOnGlyph;
+                BtnToggleMicSlash.Visibility = muted ? Visibility.Visible : Visibility.Collapsed;
                 AutomationProperties.SetName(BtnToggleMic, BtnToggleMicLabel.Text);
                 ConfigureButtonHotkey(BtnToggleMic, BtnToggleMicHotkey, _settings.AudioSettings?.MicrophoneToggleMuteHotKey, BtnToggleMicLabel.Text);
-                MicStatusIcon.Glyph = muted ? MicOffGlyph : MicOnGlyph;
+                MicStatusIcon.Glyph = MicOnGlyph;
+                MicStatusIconSlash.Visibility = muted ? Visibility.Visible : Visibility.Collapsed;
                 MicStatusIcon.Foreground = ResolveBrush(muted ? "TextFillColorSecondaryBrush" : "TextFillColorPrimaryBrush");
                 ToolTipService.SetToolTip(MicStatusIcon, muted ? "Microphone muted" : "Microphone live");
                 AutomationProperties.SetName(MicStatusIcon, muted ? "Microphone muted" : "Microphone live");
@@ -515,8 +516,7 @@ public sealed partial class MainWindow : Window
                         StatusInfoBar.Title = title;
 			StatusInfoBar.Message = message;
 			StatusInfoBar.Severity = severity;
-			StatusInfoBar.Visibility = Visibility.Visible;
-			StatusInfoBar.IsOpen = true;
+                        StatusInfoBar.IsOpen = true;
 			AutomationProperties.SetName(StatusInfoBar, $"{title} status");
 			AutomationProperties.SetHelpText(StatusInfoBar, message);
 			_statusDismissTimer.Stop();
@@ -532,15 +532,13 @@ public sealed partial class MainWindow : Window
 	private void StatusDismissTimer_Tick(object? sender, object e)
 	{
 		_statusDismissTimer.Stop();
-		StatusInfoBar.IsOpen = false;
-		StatusInfoBar.Visibility = Visibility.Collapsed;
+                StatusInfoBar.IsOpen = false;
 	}
 
 	private void StatusInfoBar_CloseButtonClick(InfoBar sender, object args)
 	{
 		_statusDismissTimer.Stop();
-		StatusInfoBar.IsOpen = false;
-		StatusInfoBar.Visibility = Visibility.Collapsed;
+                StatusInfoBar.IsOpen = false;
 	}
 
 

--- a/Mutation.Ui/MainWindow.xaml.cs
+++ b/Mutation.Ui/MainWindow.xaml.cs
@@ -33,11 +33,15 @@ public sealed partial class MainWindow : Window
 	private DictationInsertOption _insertOption = DictationInsertOption.Paste;
 	private readonly DispatcherTimer _statusDismissTimer;
 
-	private const string MicOnGlyph = "\uE720";
-	private const string MicOffGlyph = "\uE721";
-	private const string RecordGlyph = "\uE768";
-	private const string StopGlyph = "\uE71A";
-	private const string ProcessingGlyph = "\uE8A0";
+        private const string MicOnGlyph = "\uE720";
+        private const string MicOffGlyph = "\uEC26";
+        private const string RecordGlyph = "\uE768";
+        private const string StopGlyph = "\uE71A";
+        private const string ProcessingGlyph = "\uE8A0";
+
+        private const string DoNotInsertExplanation = "Keep the transcript inside Mutation without sending it anywhere.";
+        private const string SendKeysExplanation = "Types the transcript into the active app as if you entered it yourself.";
+        private const string PasteExplanation = "Copies the transcript and pastes it into the active application.";
 
 	public MainWindow(
 		ClipboardManager clipboard,
@@ -589,9 +593,9 @@ public sealed partial class MainWindow : Window
         {
                 string explanation = option switch
                 {
-                        DictationInsertOption.DoNotInsert => "Keep the transcript inside Mutation without sending it anywhere.",
-                        DictationInsertOption.SendKeys => "Types the transcript into the active app as if you entered it yourself.",
-                        DictationInsertOption.Paste => "Copies the transcript and pastes it into the active application.",
+                        DictationInsertOption.DoNotInsert => DoNotInsertExplanation,
+                        DictationInsertOption.SendKeys => SendKeysExplanation,
+                        DictationInsertOption.Paste => PasteExplanation,
                         _ => string.Empty
                 };
 


### PR DESCRIPTION
## Summary
- update the microphone mute glyph to use the Segoe Fluent microphone-off icon so the state is clearer
- rework the visual capture buttons to share a common grid layout that vertically aligns glyphs and labels
- extract dictation insert option explanations into reusable constants

## Testing
- dotnet build *(fails: NETSDK1100 To build a project targeting Windows on this operating system, set the EnableWindowsTargeting property to true)*

------
https://chatgpt.com/codex/tasks/task_e_68d59ef33400832f9ae713cf693ac32e