### PR TITLE
Enable Windows targeting on non-Windows hosts

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,6 @@
+<Project>
+  <PropertyGroup>
+    <!-- Allow Windows-targeted TFMs to build on non‑Windows hosts -->
+    <EnableWindowsTargeting Condition="'$(OS)' != 'Windows_NT'">true</EnableWindowsTargeting>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
----------------------------------------

- Added a new `<Project>` element in `Directory.Build.props`.
- Introduced a `<PropertyGroup>` to set `EnableWindowsTargeting` to `true` for non-Windows operating systems.
- This change allows building projects targeting Windows frameworks on non-Windows environments.