### PR TITLE
Align capture buttons content to the left

### DIFF
--- a/Mutation.Ui/MainWindow.xaml
+++ b/Mutation.Ui/MainWindow.xaml
@@ -355,9 +355,9 @@
                                         <FontIcon
                                             Glyph="&#xE70F;"
                                             FontFamily="Segoe Fluent Icons"
-                                            HorizontalAlignment="Center"
-                                            VerticalAlignment="Top" />
-                                        <StackPanel Grid.Column="1" Spacing="2" VerticalAlignment="Top">
+                                            HorizontalAlignment="Left"
+                                            VerticalAlignment="Center" />
+                                        <StackPanel Grid.Column="1" Spacing="2" VerticalAlignment="Center">
                                             <TextBlock Text="Screenshot to clipboard" />
                                             <TextBlock
                                                 x:Name="BtnScreenshotHotkey"
@@ -383,9 +383,9 @@
                                         <FontIcon
                                             Glyph="&#xE8F1;"
                                             FontFamily="Segoe Fluent Icons"
-                                            HorizontalAlignment="Center"
-                                            VerticalAlignment="Top" />
-                                        <StackPanel Grid.Column="1" Spacing="2" VerticalAlignment="Top">
+                                            HorizontalAlignment="Left"
+                                            VerticalAlignment="Center" />
+                                        <StackPanel Grid.Column="1" Spacing="2" VerticalAlignment="Center">
                                             <TextBlock Text="OCR clipboard" />
                                             <TextBlock
                                                 x:Name="BtnOcrClipboardHotkey"
@@ -411,9 +411,9 @@
                                         <FontIcon
                                             Glyph="&#xE8F1;"
                                             FontFamily="Segoe Fluent Icons"
-                                            HorizontalAlignment="Center"
-                                            VerticalAlignment="Top" />
-                                        <StackPanel Grid.Column="1" Spacing="2" VerticalAlignment="Top">
+                                            HorizontalAlignment="Left"
+                                            VerticalAlignment="Center" />
+                                        <StackPanel Grid.Column="1" Spacing="2" VerticalAlignment="Center">
                                             <TextBlock Text="OCR clipboard (L→R)" />
                                             <TextBlock
                                                 x:Name="BtnOcrClipboardLrtbHotkey"
@@ -439,9 +439,9 @@
                                         <FontIcon
                                             Glyph="&#xE8D2;"
                                             FontFamily="Segoe Fluent Icons"
-                                            HorizontalAlignment="Center"
-                                            VerticalAlignment="Top" />
-                                        <StackPanel Grid.Column="1" Spacing="2" VerticalAlignment="Top">
+                                            HorizontalAlignment="Left"
+                                            VerticalAlignment="Center" />
+                                        <StackPanel Grid.Column="1" Spacing="2" VerticalAlignment="Center">
                                             <TextBlock Text="Screenshot &amp; OCR" />
                                             <TextBlock
                                                 x:Name="BtnScreenshotOcrHotkey"
@@ -467,9 +467,9 @@
                                         <FontIcon
                                             Glyph="&#xE8D2;"
                                             FontFamily="Segoe Fluent Icons"
-                                            HorizontalAlignment="Center"
-                                            VerticalAlignment="Top" />
-                                        <StackPanel Grid.Column="1" Spacing="2" VerticalAlignment="Top">
+                                            HorizontalAlignment="Left"
+                                            VerticalAlignment="Center" />
+                                        <StackPanel Grid.Column="1" Spacing="2" VerticalAlignment="Center">
                                             <TextBlock Text="Screenshot &amp; OCR (L→R)" />
                                             <TextBlock
                                                 x:Name="BtnScreenshotOcrLrtbHotkey"

--- a/Mutation.Ui/MainWindow.xaml
+++ b/Mutation.Ui/MainWindow.xaml
@@ -343,6 +343,8 @@
                                 <Button
                                     x:Name="BtnScreenshot"
                                     Style="{StaticResource OutlinedButtonStyle}"
+                                    HorizontalAlignment="Stretch"
+                                    HorizontalContentAlignment="Stretch"
                                     Click="BtnScreenshot_Click"
                                     AccessKey="S"
                                     AutomationProperties.Name="Screenshot to clipboard"
@@ -371,6 +373,8 @@
                                 <Button
                                     x:Name="BtnOcrClipboard"
                                     Style="{StaticResource OutlinedButtonStyle}"
+                                    HorizontalAlignment="Stretch"
+                                    HorizontalContentAlignment="Stretch"
                                     Click="BtnOcrClipboard_Click"
                                     AccessKey="C"
                                     AutomationProperties.Name="OCR clipboard"
@@ -399,6 +403,8 @@
                                 <Button
                                     x:Name="BtnOcrClipboardLrtb"
                                     Style="{StaticResource OutlinedButtonStyle}"
+                                    HorizontalAlignment="Stretch"
+                                    HorizontalContentAlignment="Stretch"
                                     Click="BtnOcrClipboardLrtb_Click"
                                     AccessKey="D"
                                     AutomationProperties.Name="OCR clipboard left to right"
@@ -427,6 +433,8 @@
                                 <Button
                                     x:Name="BtnScreenshotOcr"
                                     Style="{StaticResource OutlinedButtonStyle}"
+                                    HorizontalAlignment="Stretch"
+                                    HorizontalContentAlignment="Stretch"
                                     Click="BtnScreenshotOcr_Click"
                                     AccessKey="O"
                                     AutomationProperties.Name="Screenshot and OCR"
@@ -455,6 +463,8 @@
                                 <Button
                                     x:Name="BtnScreenshotOcrLrtb"
                                     Style="{StaticResource OutlinedButtonStyle}"
+                                    HorizontalAlignment="Stretch"
+                                    HorizontalContentAlignment="Stretch"
                                     Click="BtnScreenshotOcrLrtb_Click"
                                     AccessKey="B"
                                     AutomationProperties.Name="Screenshot and OCR left to right"


### PR DESCRIPTION
## Summary
- align the icon and text layout inside the Capture & OCR vertical buttons so their content is left aligned and vertically centered

## Testing
- dotnet build *(fails: Microsoft.Build.Logging.TerminalLogger WrapText ArgumentOutOfRangeException)*

------
https://chatgpt.com/codex/tasks/task_e_68d5adc2abb0832f807e1db66f85fee9