### PR TITLE
Improve hotkey router validation and binding feedback

### DIFF
--- a/Mutation.Ui/App.xaml.cs
+++ b/Mutation.Ui/App.xaml.cs
@@ -255,7 +255,7 @@ public partial class App : Application
 						  });
 			}
 
-			hkManager.RegisterRouterHotkeys();
+                        _ = hkManager.RegisterRouterHotkeys();
 
 			if (hkManager.FailedRegistrations.Count > 0)
 			{

--- a/Mutation.Ui/HotkeyRouterEntry.cs
+++ b/Mutation.Ui/HotkeyRouterEntry.cs
@@ -1,55 +1,303 @@
+using CognitiveSupport;
 using Mutation.Ui.Services;
 using System;
-using CognitiveSupport;
+using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Media;
+using Windows.UI;
 
 namespace Mutation.Ui;
 
+public enum HotkeyBindingState
+{
+        Inactive,
+        Bound,
+        Failed
+}
+
 public sealed class HotkeyRouterEntry : INotifyPropertyChanged
 {
-        private readonly Action _onChanged;
+        private static readonly Brush TransparentBrush = new SolidColorBrush(Colors.Transparent);
+        private static readonly Brush InvalidBackgroundBrush = new SolidColorBrush(Color.FromArgb(0x33, 0xB2, 0x1E, 0x1E));
+        private static readonly Brush NeutralStatusBrush = ResolveThemeBrush("SystemFillColorNeutralBrush") ?? new SolidColorBrush(Color.FromArgb(0xFF, 0x6B, 0x6B, 0x6B));
+        private static readonly Brush SuccessStatusBrush = ResolveThemeBrush("SystemFillColorSuccessBrush") ?? new SolidColorBrush(Color.FromArgb(0xFF, 0x0B, 0x8A, 0x00));
+        private static readonly Brush FailureStatusBrush = ResolveThemeBrush("SystemFillColorCriticalBrush") ?? new SolidColorBrush(Color.FromArgb(0xFF, 0xD1, 0x42, 0x42));
+
+        private readonly char[] _separators = new[] { '+', '-', ',', '/', '\\', '|' , ';', ':' , ' ' };
+
+        private string _fromHotkeyText = string.Empty;
+        private string _toHotkeyText = string.Empty;
+        private string? _formattedFrom;
+        private string? _formattedTo;
+        private bool _isFromValid;
+        private bool _isToValid;
+        private bool _isDuplicate;
+        private string? _fromValidationMessage;
+        private string? _toValidationMessage;
+        private HotkeyBindingState _bindingState = HotkeyBindingState.Inactive;
+        private string? _bindingError;
+        private string? _combinedError;
 
         internal HotKeyRouterSettings.HotKeyRouterMap Map { get; }
 
-        public HotkeyRouterEntry(HotKeyRouterSettings.HotKeyRouterMap map, Action onChanged)
+        public HotkeyRouterEntry(HotKeyRouterSettings.HotKeyRouterMap map)
         {
                 Map = map ?? throw new ArgumentNullException(nameof(map));
-                _onChanged = onChanged ?? throw new ArgumentNullException(nameof(onChanged));
-        }
 
-        public string FromHotkey
-        {
-                get => Map.FromHotKey ?? string.Empty;
-                set => UpdateHotkey(value, true);
-        }
+                _fromHotkeyText = map.FromHotKey ?? string.Empty;
+                _toHotkeyText = map.ToHotKey ?? string.Empty;
 
-        public string ToHotkey
-        {
-                get => Map.ToHotKey ?? string.Empty;
-                set => UpdateHotkey(value, false);
+                EvaluateFrom(commit: true);
+                EvaluateTo(commit: true);
         }
 
         public event PropertyChangedEventHandler? PropertyChanged;
 
-        private void UpdateHotkey(string? value, bool isFrom)
+        public string FromHotkey
         {
-                string normalized = Normalize(value);
-                string current = Normalize(isFrom ? Map.FromHotKey : Map.ToHotKey);
-                if (string.Equals(normalized, current, StringComparison.Ordinal))
-                        return;
-
-                string? storedValue = string.IsNullOrWhiteSpace(normalized) ? null : normalized;
-                if (isFrom)
-                        Map.FromHotKey = storedValue;
-                else
-                        Map.ToHotKey = storedValue;
-
-                OnPropertyChanged(isFrom ? nameof(FromHotkey) : nameof(ToHotkey));
-                _onChanged();
+                get => _fromHotkeyText;
+                set
+                {
+                        if (SetField(ref _fromHotkeyText, value ?? string.Empty, nameof(FromHotkey)))
+                        {
+                                EvaluateFrom(commit: false);
+                                SetBindingResult(HotkeyBindingState.Inactive, null);
+                        }
+                }
         }
 
-        private static string Normalize(string? value) =>
-                string.IsNullOrWhiteSpace(value) ? string.Empty : value.Trim().ToUpperInvariant();
+        public string ToHotkey
+        {
+                get => _toHotkeyText;
+                set
+                {
+                        if (SetField(ref _toHotkeyText, value ?? string.Empty, nameof(ToHotkey)))
+                        {
+                                EvaluateTo(commit: false);
+                                SetBindingResult(HotkeyBindingState.Inactive, null);
+                        }
+                }
+        }
+
+        public bool IsFromValid => _isFromValid;
+
+        public bool IsToValid => _isToValid;
+
+        public bool IsDuplicate => _isDuplicate;
+
+        public bool IsFromInputValid => _isFromValid && !_isDuplicate;
+
+        public bool IsValid => IsFromInputValid && _isToValid;
+
+        public string? NormalizedFromHotkey => string.IsNullOrWhiteSpace(_formattedFrom) ? null : _formattedFrom;
+
+        public string? NormalizedToHotkey => string.IsNullOrWhiteSpace(_formattedTo) ? null : _formattedTo;
+
+        public Brush FromBackgroundBrush => IsFromInputValid ? TransparentBrush : InvalidBackgroundBrush;
+
+        public Brush ToBackgroundBrush => _isToValid ? TransparentBrush : InvalidBackgroundBrush;
+
+        public HotkeyBindingState BindingState => _bindingState;
+
+        public string BindingStatusGlyph => _bindingState switch
+        {
+                HotkeyBindingState.Bound => "\uE73E", // CheckMark
+                HotkeyBindingState.Failed => "\uEA39", // StatusErrorFull
+                _ => "\uF142" // Record
+        };
+
+        public Brush BindingStatusBrush => _bindingState switch
+        {
+                HotkeyBindingState.Bound => SuccessStatusBrush,
+                HotkeyBindingState.Failed => FailureStatusBrush,
+                _ => NeutralStatusBrush
+        };
+
+        public string BindingStatusTooltip
+        {
+                get
+                {
+                        if (_bindingState == HotkeyBindingState.Bound)
+                                return "Hotkey is bound.";
+                        if (HasBindingError && !string.IsNullOrEmpty(_combinedError))
+                                return _combinedError!;
+                        if (_bindingState == HotkeyBindingState.Failed)
+                                return "Hotkey binding failed.";
+                        return "Hotkey is not currently bound.";
+                }
+        }
+
+        public bool HasBindingError => !string.IsNullOrEmpty(_combinedError);
+
+        public Visibility BindingErrorVisibility => HasBindingError ? Visibility.Visible : Visibility.Collapsed;
+
+        public string? BindingErrorMessage => _combinedError;
+
+        public void CommitFromHotkey()
+        {
+                EvaluateFrom(commit: true);
+        }
+
+        public void CommitToHotkey()
+        {
+                EvaluateTo(commit: true);
+        }
+
+        public void SetDuplicate(bool isDuplicate)
+        {
+                if (_isDuplicate == isDuplicate)
+                        return;
+
+                _isDuplicate = isDuplicate;
+                OnPropertyChanged(nameof(IsDuplicate));
+                OnPropertyChanged(nameof(IsFromInputValid));
+                OnPropertyChanged(nameof(IsValid));
+                OnPropertyChanged(nameof(FromBackgroundBrush));
+                if (isDuplicate)
+                        SetBindingResult(HotkeyBindingState.Inactive, null);
+                else
+                        UpdateCombinedError();
+        }
+
+        public void SetBindingResult(HotkeyBindingState state, string? message)
+        {
+                if (_bindingState == state && string.Equals(_bindingError, message, StringComparison.Ordinal))
+                {
+                        UpdateCombinedError();
+                        return;
+                }
+
+                _bindingState = state;
+                _bindingError = message;
+                OnPropertyChanged(nameof(BindingState));
+                OnPropertyChanged(nameof(BindingStatusGlyph));
+                OnPropertyChanged(nameof(BindingStatusBrush));
+                OnPropertyChanged(nameof(BindingStatusTooltip));
+                UpdateCombinedError();
+        }
+
+        private void EvaluateFrom(bool commit)
+        {
+                _formattedFrom = FormatHotkey(_fromHotkeyText);
+                (_isFromValid, _fromValidationMessage) = ValidateFormattedHotkey(_formattedFrom, true);
+
+                if (commit)
+                {
+                        ApplyFormattedValue(ref _fromHotkeyText, _formattedFrom, nameof(FromHotkey));
+                        Map.FromHotKey = _isFromValid ? _formattedFrom : null;
+                }
+                else if (!_isFromValid)
+                {
+                        Map.FromHotKey = null;
+                }
+
+                OnPropertyChanged(nameof(IsFromValid));
+                OnPropertyChanged(nameof(IsFromInputValid));
+                OnPropertyChanged(nameof(IsValid));
+                OnPropertyChanged(nameof(FromBackgroundBrush));
+                UpdateCombinedError();
+        }
+
+        private void EvaluateTo(bool commit)
+        {
+                _formattedTo = FormatHotkey(_toHotkeyText);
+                (_isToValid, _toValidationMessage) = ValidateFormattedHotkey(_formattedTo, false);
+
+                if (commit)
+                {
+                        ApplyFormattedValue(ref _toHotkeyText, _formattedTo, nameof(ToHotkey));
+                        Map.ToHotKey = _isToValid ? _formattedTo : null;
+                }
+                else if (!_isToValid)
+                {
+                        Map.ToHotKey = null;
+                }
+
+                OnPropertyChanged(nameof(IsToValid));
+                OnPropertyChanged(nameof(IsValid));
+                OnPropertyChanged(nameof(ToBackgroundBrush));
+                UpdateCombinedError();
+        }
+
+        private void ApplyFormattedValue(ref string storage, string? formatted, string propertyName)
+        {
+                string newValue = formatted ?? string.Empty;
+                if (!string.Equals(storage, newValue, StringComparison.Ordinal))
+                {
+                        storage = newValue;
+                        OnPropertyChanged(propertyName);
+                }
+        }
+
+        private (bool isValid, string? message) ValidateFormattedHotkey(string? formatted, bool isFrom)
+        {
+                if (string.IsNullOrWhiteSpace(formatted))
+                        return (false, "Enter a hotkey.");
+
+                try
+                {
+                        _ = Hotkey.Parse(formatted);
+                        return (true, null);
+                }
+                catch (Exception ex)
+                {
+                        return (false, ex.Message);
+                }
+        }
+
+        private string? FormatHotkey(string? value)
+        {
+                if (string.IsNullOrWhiteSpace(value))
+                        return string.Empty;
+
+                IEnumerable<string> parts = value
+                        .Split(_separators, StringSplitOptions.RemoveEmptyEntries)
+                        .Select(part => part.Trim())
+                        .Where(part => !string.IsNullOrWhiteSpace(part))
+                        .Select(part => part.ToUpperInvariant());
+
+                string formatted = string.Join('+', parts);
+                return formatted;
+        }
+
+        private void UpdateCombinedError()
+        {
+                string? message = null;
+                if (!IsFromInputValid)
+                        message = _isDuplicate ? "Duplicate 'From' hotkey." : _fromValidationMessage;
+                else if (!_isToValid)
+                        message = _toValidationMessage;
+                else if (_bindingState == HotkeyBindingState.Failed)
+                        message = _bindingError;
+
+                if (!string.Equals(_combinedError, message, StringComparison.Ordinal))
+                {
+                        _combinedError = message;
+                        OnPropertyChanged(nameof(BindingErrorMessage));
+                        OnPropertyChanged(nameof(HasBindingError));
+                        OnPropertyChanged(nameof(BindingErrorVisibility));
+                        OnPropertyChanged(nameof(BindingStatusTooltip));
+                }
+        }
+
+        private bool SetField<T>(ref T storage, T value, string propertyName)
+        {
+                if (EqualityComparer<T>.Default.Equals(storage, value))
+                        return false;
+
+                storage = value;
+                OnPropertyChanged(propertyName);
+                return true;
+        }
+
+        private static Brush? ResolveThemeBrush(string key)
+        {
+                if (Application.Current?.Resources.TryGetValue(key, out object? value) == true && value is Brush brush)
+                        return brush;
+                return null;
+        }
 
         private void OnPropertyChanged(string propertyName) =>
                 PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));

--- a/Mutation.Ui/MainWindow.xaml
+++ b/Mutation.Ui/MainWindow.xaml
@@ -571,13 +571,15 @@
                             <StackPanel Spacing="12">
                                 <Grid ColumnSpacing="12">
                                     <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto" />
                                         <ColumnDefinition Width="2*" />
                                         <ColumnDefinition Width="2*" />
                                         <ColumnDefinition Width="Auto" />
                                     </Grid.ColumnDefinitions>
-                                    <TextBlock Text="From" FontWeight="SemiBold" />
-                                    <TextBlock Grid.Column="1" Text="To" FontWeight="SemiBold" />
-                                    <TextBlock Grid.Column="2" Text="Actions" FontWeight="SemiBold" />
+                                    <TextBlock />
+                                    <TextBlock Grid.Column="1" Text="From" FontWeight="SemiBold" />
+                                    <TextBlock Grid.Column="2" Text="To" FontWeight="SemiBold" />
+                                    <TextBlock Grid.Column="3" Text="Actions" FontWeight="SemiBold" />
                                 </Grid>
 
                                 <ListView
@@ -592,26 +594,51 @@
                                         <DataTemplate x:DataType="local:HotkeyRouterEntry">
                                             <Grid ColumnSpacing="12" Padding="0,4">
                                                 <Grid.ColumnDefinitions>
+                                                    <ColumnDefinition Width="Auto" />
                                                     <ColumnDefinition Width="2*" />
                                                     <ColumnDefinition Width="2*" />
                                                     <ColumnDefinition Width="Auto" />
                                                 </Grid.ColumnDefinitions>
 
-                                                <TextBox
-                                                    Text="{x:Bind FromHotkey, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                                    PlaceholderText="CTRL+ALT+H"
-                                                    HorizontalAlignment="Stretch"
-                                                    ToolTipService.ToolTip="Shortcut to listen for" />
+                                                <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Spacing="4">
+                                                    <FontIcon
+                                                        Glyph="{x:Bind BindingStatusGlyph, Mode=OneWay}"
+                                                        Foreground="{x:Bind BindingStatusBrush, Mode=OneWay}"
+                                                        ToolTipService.ToolTip="{x:Bind BindingStatusTooltip, Mode=OneWay}" />
+                                                </StackPanel>
 
-                                                <TextBox
-                                                    Grid.Column="1"
-                                                    Text="{x:Bind ToHotkey, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                                    PlaceholderText="CTRL+SHIFT+H"
-                                                    HorizontalAlignment="Stretch"
-                                                    ToolTipService.ToolTip="Shortcut to send when triggered" />
+                                                <Grid Grid.Column="1">
+                                                    <Border Background="{x:Bind FromBackgroundBrush, Mode=OneWay}" CornerRadius="4">
+                                                        <TextBox
+                                                            Text="{x:Bind FromHotkey, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                            PlaceholderText="CTRL+ALT+H"
+                                                            Background="Transparent"
+                                                            HorizontalAlignment="Stretch"
+                                                            ToolTipService.ToolTip="Shortcut to listen for"
+                                                            LostFocus="HotkeyRouterFrom_LostFocus" />
+                                                    </Border>
+                                                    <FontIcon
+                                                        Glyph="&#xE783;"
+                                                        Foreground="{ThemeResource SystemFillColorCriticalBrush}"
+                                                        HorizontalAlignment="Right"
+                                                        VerticalAlignment="Center"
+                                                        Margin="0,0,8,0"
+                                                        Visibility="{x:Bind BindingErrorVisibility, Mode=OneWay}"
+                                                        ToolTipService.ToolTip="{x:Bind BindingErrorMessage, Mode=OneWay}" />
+                                                </Grid>
+
+                                                <Border Grid.Column="2" Background="{x:Bind ToBackgroundBrush, Mode=OneWay}" CornerRadius="4">
+                                                    <TextBox
+                                                        Text="{x:Bind ToHotkey, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                        PlaceholderText="CTRL+SHIFT+H"
+                                                        Background="Transparent"
+                                                        HorizontalAlignment="Stretch"
+                                                        ToolTipService.ToolTip="Shortcut to send when triggered"
+                                                        LostFocus="HotkeyRouterTo_LostFocus" />
+                                                </Border>
 
                                                 <Button
-                                                    Grid.Column="2"
+                                                    Grid.Column="3"
                                                     Style="{StaticResource SubtleButtonStyle}"
                                                     Content="Delete"
                                                     Click="HotkeyRouterDelete_Click"

--- a/Mutation.Ui/Services/Hotkey.cs
+++ b/Mutation.Ui/Services/Hotkey.cs
@@ -44,11 +44,11 @@ public class Hotkey
 		if (string.IsNullOrWhiteSpace(text))
 			throw new ArgumentException("Invalid hotkey", nameof(text));
 
-		var parts = text.Split(new[] { '+', '-', ' ' }, StringSplitOptions.RemoveEmptyEntries);
-		var hk = new Hotkey();
-		foreach (var p in parts)
-		{
-			var token = p.Trim().ToUpperInvariant();
+                var parts = text.Split(new[] { '+', '-', ' ', ',', '/', '\\', '|', ';', ':' }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+                var hk = new Hotkey();
+                foreach (var p in parts)
+                {
+                        var token = p.Trim().ToUpperInvariant();
 			switch (token)
 			{
 				case "CTRL":
@@ -63,16 +63,20 @@ public class Hotkey
 				case "WINDOWS":
 				case "START":
 					hk.Win = true; break;
-				default:
-					if (Enum.TryParse<VirtualKey>(token, true, out var vk))
-						hk.Key = vk;
-					else if (Enum.TryParse<VirtualKey>("Number" + token, true, out vk))
-						hk.Key = vk;
-					else
-						throw new NotSupportedException($"Unsupported key '{token}'");
-					break;
-			}
-		}
-		return hk;
-	}
+                                default:
+                                        if (Enum.TryParse<VirtualKey>(token, true, out var vk))
+                                                hk.Key = vk;
+                                        else if (Enum.TryParse<VirtualKey>("Number" + token, true, out vk))
+                                                hk.Key = vk;
+                                        else
+                                                throw new NotSupportedException($"Unsupported key '{token}'");
+                                        break;
+                        }
+                }
+
+                if (hk.Key == VirtualKey.None)
+                        throw new ArgumentException("Hotkey must include a non-modifier key.", nameof(text));
+
+                return hk;
+        }
 }

--- a/Mutation.Ui/Services/HotkeyManager.cs
+++ b/Mutation.Ui/Services/HotkeyManager.cs
@@ -2,7 +2,9 @@
 using Microsoft.UI.Xaml;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -19,14 +21,34 @@ public class HotkeyManager : IDisposable
 	// even though one instance is already active). This prevents false positives
 	// in the FailedRegistrations list when router hotkeys are refreshed.
 	private readonly HashSet<string> _registeredHotkeys = new(StringComparer.Ordinal);
-	private readonly List<int> _routerIds = new();
+        private readonly List<int> _routerIds = new();
+        private readonly Dictionary<int, string> _routerNormalizedHotkeys = new();
+        private readonly List<string> _routerFailedRegistrations = new();
 	private readonly Settings _settings;
 	private static SynchronizationContext? s_uiCtx;
 	private int _id;
 	private IntPtr _prevWndProc;
-	private WndProcDelegate? _newWndProc;
+        private WndProcDelegate? _newWndProc;
 
-	public List<string> FailedRegistrations { get; } = new();
+        public List<string> FailedRegistrations { get; } = new();
+
+        public sealed record HotkeyRegistrationResult(HotKeyRouterSettings.HotKeyRouterMap Map, string NormalizedHotkey, bool Success, int Id, string? ErrorMessage);
+
+        private readonly struct HotkeyRegistrationAttempt
+        {
+                public HotkeyRegistrationAttempt(string normalizedHotkey, int id, bool success, string? errorMessage)
+                {
+                        NormalizedHotkey = normalizedHotkey;
+                        Id = id;
+                        Success = success;
+                        ErrorMessage = errorMessage;
+                }
+
+                public string NormalizedHotkey { get; }
+                public int Id { get; }
+                public bool Success { get; }
+                public string? ErrorMessage { get; }
+        }
 
 	private const int WM_HOTKEY = 0x0312;
 	private const int GWLP_WNDPROC = -4;
@@ -37,7 +59,7 @@ public class HotkeyManager : IDisposable
 	private const uint MOD_WIN = 0x8;
 	private const uint MOD_NOREPEAT = 0x4000;
 
-	[DllImport("user32.dll")] static extern bool RegisterHotKey(IntPtr hWnd, int id, uint fsModifiers, uint vk);
+        [DllImport("user32.dll", SetLastError = true)] static extern bool RegisterHotKey(IntPtr hWnd, int id, uint fsModifiers, uint vk);
 	[DllImport("user32.dll")] static extern bool UnregisterHotKey(IntPtr hWnd, int id);
 	[DllImport("user32.dll")] static extern IntPtr SetWindowLongPtr(IntPtr hWnd, int nIndex, IntPtr newProc);
 	[DllImport("user32.dll")] static extern IntPtr CallWindowProc(IntPtr lpPrevWndFunc, IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam);
@@ -88,79 +110,163 @@ public class HotkeyManager : IDisposable
 		s_uiCtx ??= SynchronizationContext.Current;
 	}
 
-	public int RegisterHotkey(Hotkey hotkey, Action callback)
-	{
-		string norm = NormalizeHotkey(hotkey);
-		// If we've already registered an identical chord, treat as success and skip.
-		if (_registeredHotkeys.Contains(norm))
-		{
-			Log($"Duplicate hotkey skipped: {norm}");
-			return -1; // caller won't use id directly except storing; -1 indicates skipped duplicate
-		}
-
-		int id = Interlocked.Increment(ref _id);
-		uint mods = (hotkey.Alt ? MOD_ALT : 0) |
-											  (hotkey.Control ? MOD_CONTROL : 0) |
-											  (hotkey.Shift ? MOD_SHIFT : 0) |
-											  (hotkey.Win ? MOD_WIN : 0);
-		bool success = RegisterHotKey(_hwnd, id, mods, (uint)hotkey.Key);
-		if (success)
-		{
-			_callbacks[id] = callback;
-			_registeredHotkeys.Add(norm);
-			Log($"Hotkey registered: {norm} (id={id})");
-		}
-		else
-		{
-			// If OS reports failure but we already have it registered, suppress failure message.
-			if (_registeredHotkeys.Contains(norm))
-			{
-				Log($"RegisterHotKey reported failure but hotkey already active (suppressing): {norm}");
-			}
-			else
-			{
-				FailedRegistrations.Add(hotkey.ToString());
-				Log($"Hotkey registration FAILED: {norm}");
-			}
-		}
-		return id;
-	}
-
-        public void RegisterRouterHotkeys()
+        public int RegisterHotkey(Hotkey hotkey, Action callback)
         {
-                if (_settings.HotKeyRouterSettings is null)
-                        return;
-
-                foreach (var map in _settings.HotKeyRouterSettings.Mappings)
-                {
-                        if (string.IsNullOrWhiteSpace(map.FromHotKey) || string.IsNullOrWhiteSpace(map.ToHotKey))
-                                continue;
-                        int id = RegisterHotkey(Hotkey.Parse(map.FromHotKey!), () => SendHotkeyAfterDelay(map.ToHotKey!, Constants.FailureSendHotkeyDelay));
-                        Log($"Router registered: From='{map.FromHotKey}' -> To='{map.ToHotKey}', id={id}");
-                        _routerIds.Add(id);
-                }
+                var attempt = RegisterHotkeyInternal(hotkey, callback);
+                return attempt.Id;
         }
 
-        public void RefreshRouterHotkeys()
+        private HotkeyRegistrationAttempt RegisterHotkeyInternal(Hotkey hotkey, Action callback)
+        {
+                string norm = NormalizeHotkey(hotkey);
+                if (_registeredHotkeys.Contains(norm))
+                {
+                        Log($"Duplicate hotkey detected: {norm}");
+                        FailedRegistrations.Add(hotkey.ToString());
+                        return new HotkeyRegistrationAttempt(norm, -1, success: false, errorMessage: "The shortcut is already registered.");
+                }
+
+                int id = Interlocked.Increment(ref _id);
+                uint mods = (hotkey.Alt ? MOD_ALT : 0) |
+                                                                                          (hotkey.Control ? MOD_CONTROL : 0) |
+                                                                                          (hotkey.Shift ? MOD_SHIFT : 0) |
+                                                                                          (hotkey.Win ? MOD_WIN : 0);
+                bool success = RegisterHotKey(_hwnd, id, mods, (uint)hotkey.Key);
+                if (success)
+                {
+                        _callbacks[id] = callback;
+                        _registeredHotkeys.Add(norm);
+                        Log($"Hotkey registered: {norm} (id={id})");
+                        return new HotkeyRegistrationAttempt(norm, id, true, null);
+                }
+
+                if (_registeredHotkeys.Contains(norm))
+                {
+                        Log($"RegisterHotKey reported failure but hotkey already active (suppressing): {norm}");
+                        return new HotkeyRegistrationAttempt(norm, id, true, null);
+                }
+
+                int error = Marshal.GetLastWin32Error();
+                string? message = null;
+                if (error != 0)
+                {
+                        message = error switch
+                        {
+                                1409 => "The shortcut is already registered by another application.",
+                                _ => new Win32Exception(error).Message
+                        };
+                }
+                message ??= "Failed to register the shortcut.";
+
+                FailedRegistrations.Add(hotkey.ToString());
+                Log($"Hotkey registration FAILED: {norm} (error={error})");
+                return new HotkeyRegistrationAttempt(norm, id, false, message);
+        }
+
+        public IReadOnlyList<HotkeyRegistrationResult> RegisterRouterHotkeys()
+        {
+                if (_settings.HotKeyRouterSettings is null)
+                        return Array.Empty<HotkeyRegistrationResult>();
+
+                return RegisterRouterHotkeys(_settings.HotKeyRouterSettings.Mappings);
+        }
+
+        public IReadOnlyList<HotkeyRegistrationResult> RegisterRouterHotkeys(IEnumerable<HotKeyRouterSettings.HotKeyRouterMap> mappings)
+        {
+                foreach (var previous in _routerFailedRegistrations)
+                        FailedRegistrations.Remove(previous);
+                _routerFailedRegistrations.Clear();
+
+                var results = new List<HotkeyRegistrationResult>();
+
+                foreach (var map in mappings)
+                {
+                        if (string.IsNullOrWhiteSpace(map.FromHotKey) || string.IsNullOrWhiteSpace(map.ToHotKey))
+                        {
+                                results.Add(new HotkeyRegistrationResult(map, map.FromHotKey ?? string.Empty, false, -1, "Both hotkeys must be configured."));
+                                continue;
+                        }
+
+                        try
+                        {
+                                var hotkey = Hotkey.Parse(map.FromHotKey!);
+                                var attempt = RegisterHotkeyInternal(hotkey, () => SendHotkeyAfterDelay(map.ToHotKey!, Constants.FailureSendHotkeyDelay));
+                                if (attempt.Success)
+                                {
+                                        if (attempt.Id > 0)
+                                        {
+                                                _routerIds.Add(attempt.Id);
+                                                _routerNormalizedHotkeys[attempt.Id] = attempt.NormalizedHotkey;
+                                        }
+
+                                        Log($"Router registered: From='{map.FromHotKey}' -> To='{map.ToHotKey}', id={attempt.Id}");
+                                        results.Add(new HotkeyRegistrationResult(map, attempt.NormalizedHotkey, true, attempt.Id, null));
+                                }
+                                else
+                                {
+                                        var failureKey = hotkey.ToString();
+                                        _routerFailedRegistrations.Add(failureKey);
+                                        Log($"Router registration FAILED: From='{map.FromHotKey}' -> To='{map.ToHotKey}' ({attempt.ErrorMessage})");
+                                        results.Add(new HotkeyRegistrationResult(map, attempt.NormalizedHotkey, false, attempt.Id, attempt.ErrorMessage ?? "The shortcut could not be registered."));
+                                }
+                        }
+                        catch (Exception ex)
+                        {
+                                FailedRegistrations.Add(map.FromHotKey ?? string.Empty);
+                                _routerFailedRegistrations.Add(map.FromHotKey ?? string.Empty);
+                                Log($"Router registration FAILED: From='{map.FromHotKey}' -> To='{map.ToHotKey}' ({ex.Message})");
+                                results.Add(new HotkeyRegistrationResult(map, map.FromHotKey ?? string.Empty, false, -1, ex.Message));
+                        }
+                }
+
+                return results;
+        }
+
+        public IReadOnlyList<HotkeyRegistrationResult> RefreshRouterHotkeys()
+        {
+                if (_settings.HotKeyRouterSettings is null)
+                {
+                        ClearRouterHotkeys();
+                        return Array.Empty<HotkeyRegistrationResult>();
+                }
+
+                return RefreshRouterHotkeys(_settings.HotKeyRouterSettings.Mappings);
+        }
+
+        public IReadOnlyList<HotkeyRegistrationResult> RefreshRouterHotkeys(IEnumerable<HotKeyRouterSettings.HotKeyRouterMap> mappings)
+        {
+                ClearRouterHotkeys();
+                return RegisterRouterHotkeys(mappings);
+        }
+
+        private void ClearRouterHotkeys()
         {
                 foreach (var id in _routerIds)
                 {
                         UnregisterHotKey(_hwnd, id);
                         _callbacks.Remove(id);
+                        if (_routerNormalizedHotkeys.TryGetValue(id, out var norm))
+                        {
+                                _routerNormalizedHotkeys.Remove(id);
+                                _registeredHotkeys.Remove(norm);
+                        }
                 }
 
                 _routerIds.Clear();
-                RegisterRouterHotkeys();
+                foreach (var previous in _routerFailedRegistrations)
+                        FailedRegistrations.Remove(previous);
+                _routerFailedRegistrations.Clear();
         }
 
-	public void UnregisterAll()
-	{
-		foreach (var kvp in _callbacks)
-			UnregisterHotKey(_hwnd, kvp.Key);
-		_callbacks.Clear();
-		_routerIds.Clear();
-		_registeredHotkeys.Clear();
-	}
+        public void UnregisterAll()
+        {
+                foreach (var kvp in _callbacks)
+                        UnregisterHotKey(_hwnd, kvp.Key);
+                _callbacks.Clear();
+                _routerIds.Clear();
+                _routerNormalizedHotkeys.Clear();
+                _registeredHotkeys.Clear();
+        }
 
 	private IntPtr WndProc(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam)
 	{


### PR DESCRIPTION
## Summary
- enhance the hotkey router entry model to normalize input, track validation state, highlight duplicates, and surface binding errors
- refresh the hotkey router UI with status icons, validation styling, and focus-loss sanitization so only healthy mappings persist and bind
- update hotkey parsing and manager registration logic to report structured results for bindings and skip saving invalid routes

## Testing
- `dotnet build` *(fails: proxy returned 403 while restoring packages)*

------
https://chatgpt.com/codex/tasks/task_e_68d8015c4240832fa4c820805db75fbb