### PR TITLE
Clean up hotkey parsing and microphone selection flow

### DIFF
--- a/Mutation.Ui/HotkeyRouterEntry.cs
+++ b/Mutation.Ui/HotkeyRouterEntry.cs
@@ -26,8 +26,6 @@ public sealed class HotkeyRouterEntry : INotifyPropertyChanged
         private static readonly Brush SuccessStatusBrush = ResolveThemeBrush("SystemFillColorSuccessBrush") ?? new SolidColorBrush(Color.FromArgb(0xFF, 0x0B, 0x8A, 0x00));
         private static readonly Brush FailureStatusBrush = ResolveThemeBrush("SystemFillColorCriticalBrush") ?? new SolidColorBrush(Color.FromArgb(0xFF, 0xD1, 0x42, 0x42));
 
-        private readonly char[] _separators = new[] { '+', '-', ',', '/', '\\', '|' , ';', ':' , ' ' };
-
         private string _fromHotkeyText = string.Empty;
         private string _toHotkeyText = string.Empty;
         private string? _formattedFrom;
@@ -272,7 +270,7 @@ public sealed class HotkeyRouterEntry : INotifyPropertyChanged
                         return string.Empty;
 
                 IEnumerable<string> parts = value
-                        .Split(_separators, StringSplitOptions.RemoveEmptyEntries)
+                        .Split(Hotkey.TokenSeparators, StringSplitOptions.RemoveEmptyEntries)
                         .Select(part => part.Trim())
                         .Where(part => !string.IsNullOrWhiteSpace(part))
                         .Select(part => part.ToUpperInvariant());

--- a/Mutation.Ui/MainWindow.xaml.cs
+++ b/Mutation.Ui/MainWindow.xaml.cs
@@ -866,7 +866,6 @@ public sealed partial class MainWindow : Window
                         if (_settings.AudioSettings != null)
                         {
                                 _settings.AudioSettings.ActiveCaptureDeviceFullName = device.FriendlyName;
-                                SyncHotkeyRouterSettings();
                                 _settingsManager.SaveSettingsToFile(_settings);
                         }
                 }

--- a/Mutation.Ui/Services/Hotkey.cs
+++ b/Mutation.Ui/Services/Hotkey.cs
@@ -5,11 +5,13 @@ namespace Mutation.Ui.Services;
 
 public class Hotkey
 {
-	public bool Alt { get; set; }
-	public bool Control { get; set; }
-	public bool Shift { get; set; }
-	public bool Win { get; set; }
-	public VirtualKey Key { get; set; }
+        internal static readonly char[] TokenSeparators = new[] { '+', '-', ' ', ',', '/', '\\', '|', ';', ':' };
+
+        public bool Alt { get; set; }
+        public bool Control { get; set; }
+        public bool Shift { get; set; }
+        public bool Win { get; set; }
+        public VirtualKey Key { get; set; }
 
 	public Hotkey Clone()
 	{
@@ -44,7 +46,7 @@ public class Hotkey
 		if (string.IsNullOrWhiteSpace(text))
 			throw new ArgumentException("Invalid hotkey", nameof(text));
 
-                var parts = text.Split(new[] { '+', '-', ' ', ',', '/', '\\', '|', ';', ':' }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+                var parts = text.Split(TokenSeparators, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
                 var hk = new Hotkey();
                 foreach (var p in parts)
                 {


### PR DESCRIPTION
## Summary
- remove the SyncHotkeyRouterSettings call from the microphone selection handler so the device change only updates audio settings
- centralize the hotkey token separators in Hotkey to keep parsing and formatting consistent across the UI

## Testing
- dotnet build *(fails: NU1301 unable to reach https://api.nuget.org/v3/index.json via proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68d858917f24832f83e5f649ff823b13