### PR TITLE
Move status info bar to header

### DIFF
--- a/Mutation.Ui/MainWindow.xaml
+++ b/Mutation.Ui/MainWindow.xaml
@@ -30,6 +30,18 @@
                 <TextBlock Text="Mutation Workspace" Style="{StaticResource TitleTextStyle}" AutomationProperties.Name="Application Title" />
                 <TextBlock Text="Capture ideas, format transcripts, and automate workflows from one polished surface." Style="{StaticResource SubtitleTextStyle}" />
             </StackPanel>
+
+            <InfoBar
+                x:Name="StatusInfoBar"
+                Grid.Column="2"
+                Margin="0,24,32,12"
+                HorizontalAlignment="Right"
+                VerticalAlignment="Top"
+                Title="Status"
+                IsOpen="False"
+                AutomationProperties.Name="Status notifications"
+                AutomationProperties.LiveSetting="Polite"
+                AutomationProperties.HelpText="Latest status messages for Mutation workspace" />
         </Grid>
 
         <Grid Grid.Row="1">
@@ -47,17 +59,7 @@
                 VerticalScrollBarVisibility="Auto"
                 VerticalScrollMode="Auto">
                 <StackPanel x:Name="ContentStack" Spacing="20">
-                <Grid x:Name="StatusRegion" MinHeight="72">
-                    <InfoBar
-                        x:Name="StatusInfoBar"
-                        Title="Status"
-                        IsOpen="False"
-                        AutomationProperties.Name="Status notifications"
-                        AutomationProperties.LiveSetting="Polite"
-                        AutomationProperties.HelpText="Latest status messages for Mutation workspace" />
-                </Grid>
-
-                <Grid x:Name="ContentGrid" ColumnSpacing="18" RowSpacing="18">
+                    <Grid x:Name="ContentGrid" ColumnSpacing="18" RowSpacing="18">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition x:Name="PrimaryColumn" Width="*" />
                         <ColumnDefinition x:Name="SecondaryColumn" Width="*" />


### PR DESCRIPTION
## Summary
- relocate the transcription status InfoBar from the scrollable content area into the fixed header
- align the InfoBar to the top-right of the window and remove the unused status spacer from the content stack

## Testing
- dotnet build *(fails: Duplicate 'Page' items were included for Views/RegionSelectionWindow.xaml)*

------
https://chatgpt.com/codex/tasks/task_e_68d8609ba720832f94d3089edaf3f421