### PR TITLE
Relocate status feedback to header overlay

### DIFF
--- a/Mutation.Ui/MainWindow.xaml
+++ b/Mutation.Ui/MainWindow.xaml
@@ -47,36 +47,26 @@
                 VerticalScrollBarVisibility="Auto"
                 VerticalScrollMode="Auto">
                 <StackPanel x:Name="ContentStack" Spacing="20">
-                <Grid x:Name="StatusRegion" MinHeight="72">
-                    <InfoBar
-                        x:Name="StatusInfoBar"
-                        Title="Status"
-                        IsOpen="False"
-                        AutomationProperties.Name="Status notifications"
-                        AutomationProperties.LiveSetting="Polite"
-                        AutomationProperties.HelpText="Latest status messages for Mutation workspace" />
-                </Grid>
+                    <Grid x:Name="ContentGrid" ColumnSpacing="18" RowSpacing="18">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition x:Name="PrimaryColumn" Width="*" />
+                            <ColumnDefinition x:Name="SecondaryColumn" Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
 
-                <Grid x:Name="ContentGrid" ColumnSpacing="18" RowSpacing="18">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition x:Name="PrimaryColumn" Width="*" />
-                        <ColumnDefinition x:Name="SecondaryColumn" Width="*" />
-                    </Grid.ColumnDefinitions>
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="Auto" />
-                    </Grid.RowDefinitions>
-
-                    <Grid.Transitions>
-                        <TransitionCollection>
-                            <EntranceThemeTransition FromHorizontalOffset="48" />
-                        </TransitionCollection>
-                    </Grid.Transitions>
+                        <Grid.Transitions>
+                            <TransitionCollection>
+                                <EntranceThemeTransition FromHorizontalOffset="48" />
+                            </TransitionCollection>
+                        </Grid.Transitions>
 
                     <!-- Microphone Management -->
                     <Border x:Name="MicrophoneCard" Style="{StaticResource CardStyle}" Grid.Row="0" Grid.Column="0">
@@ -717,6 +707,24 @@
                 </VisualStateManager.VisualStateGroups>
                 </StackPanel>
             </ScrollViewer>
+        </Grid>
+
+        <Grid
+            Grid.Row="0"
+            Grid.RowSpan="2"
+            HorizontalAlignment="Stretch"
+            VerticalAlignment="Stretch"
+            Panel.ZIndex="1">
+            <InfoBar
+                x:Name="StatusInfoBar"
+                Title="Status"
+                IsOpen="False"
+                HorizontalAlignment="Right"
+                VerticalAlignment="Top"
+                Margin="0,24,32,0"
+                AutomationProperties.Name="Status notifications"
+                AutomationProperties.LiveSetting="Polite"
+                AutomationProperties.HelpText="Latest status messages for Mutation workspace" />
         </Grid>
     </Grid>
 </Window>


### PR DESCRIPTION
## Summary
- move the status InfoBar out of the scrollable content stack and into a fixed overlay anchored to the header
- remove the placeholder grid from the scroll viewer so workspace content can use the freed space

## Testing
- `dotnet build` *(fails: error NETSDK1022 duplicate 'Page' items for Views/RegionSelectionWindow.xaml)*

------
https://chatgpt.com/codex/tasks/task_e_68d8fa695400832fa734c0dba4251965