### PR TITLE
Add microphone waveform visualization

### DIFF
--- a/CognitiveSupport/Settings.cs
+++ b/CognitiveSupport/Settings.cs
@@ -39,6 +39,8 @@ public class AudioSettings
 
 	public string? ActiveCaptureDeviceFullName { get; set; }
 	public string? MicrophoneToggleMuteHotKey { get; set; }
+        // Allows users to disable microphone visualization to save CPU
+        public bool EnableMicrophoneVisualization { get; set; } = true;
 	public CustomBeepSettingsData? CustomBeepSettings { get => customBeepSettings; set => customBeepSettings = value; }
 
 	public AudioSettings() { }

--- a/Mutation.Ui/Core/CaptureDeviceComboItem.cs
+++ b/Mutation.Ui/Core/CaptureDeviceComboItem.cs
@@ -4,12 +4,21 @@ namespace Mutation.Ui;
 
 internal class CaptureDeviceComboItem
 {
-	public MMDevice CaptureDevice { get; set; }
-	public string Display =>
-			  $"{CaptureDevice.FriendlyName}";
-
-	public override string ToString()
+	public MMDevice? CaptureDevice { get; set; }
+	public string Display
 	{
-		return this.Display;
+		get
+		{
+#pragma warning disable CS0618 // Support fallback if DeviceFriendlyName not populated
+			if (CaptureDevice == null)
+				return string.Empty;
+			var friendly = CaptureDevice.DeviceFriendlyName;
+			if (string.IsNullOrWhiteSpace(friendly))
+				friendly = CaptureDevice.FriendlyName;
+#pragma warning restore CS0618
+			return friendly ?? string.Empty;
+		}
 	}
+
+	public override string ToString() => Display;
 }

--- a/Mutation.Ui/MainWindow.xaml
+++ b/Mutation.Ui/MainWindow.xaml
@@ -71,7 +71,9 @@
 
                     <!-- Microphone Management -->
                     <Border x:Name="MicrophoneCard" Style="{StaticResource CardStyle}" Grid.Row="0" Grid.Column="0">
-                        <StackPanel Spacing="16">
+                        <Grid>
+                            <Rectangle x:Name="MicPulseOverlay" Fill="{ThemeResource PrimaryBrush}" Opacity="0" IsHitTestVisible="False" RadiusX="16" RadiusY="16" />
+                            <StackPanel Spacing="16">
                             <StackPanel Spacing="4">
                                 <TextBlock Text="Microphone" Style="{StaticResource SectionHeaderTextStyle}" />
                                 <TextBlock Text="Select your preferred capture device and control mute states instantly." Style="{StaticResource CaptionTextStyle}" />
@@ -172,12 +174,23 @@
                                 </Button>
                             </Grid>
 
+                            <StackPanel Orientation="Horizontal" Spacing="12" VerticalAlignment="Center">
+                                <ToggleSwitch x:Name="TglWaveform" Header="Waveform" OnContent="On" OffContent="Off" Toggled="TglWaveform_Toggled" />
+                                <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Bottom">
+                                    <Grid Width="110" Height="10" Background="{ThemeResource ControlFillColorDefaultBrush}" CornerRadius="5">
+                                        <Rectangle x:Name="RmsLevelBar" Height="10" HorizontalAlignment="Left" Fill="{ThemeResource PrimaryBrush}" Width="0" RadiusX="5" RadiusY="5" />
+                                    </Grid>
+                                    <TextBlock x:Name="LblLevels" Text="Peak: 0.00  RMS: 0.00" Style="{StaticResource CaptionTextStyle}" />
+                                </StackPanel>
+                            </StackPanel>
+
                             <ScottPlot:WinUIPlot
                                 x:Name="MicWaveformPlot"
                                 Height="120"
                                 Margin="0,4,0,0"
                                 IsHitTestVisible="False" />
-                        </StackPanel>
+                            </StackPanel>
+                        </Grid>
                     </Border>
 
                     <!-- Speech to Text -->

--- a/Mutation.Ui/MainWindow.xaml
+++ b/Mutation.Ui/MainWindow.xaml
@@ -4,6 +4,7 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:Mutation.Ui"
+    xmlns:ScottPlot="using:ScottPlot.WinUI"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
@@ -170,6 +171,12 @@
                                     </StackPanel>
                                 </Button>
                             </Grid>
+
+                            <ScottPlot:WinUIPlot
+                                x:Name="MicWaveformPlot"
+                                Height="120"
+                                Margin="0,4,0,0"
+                                IsHitTestVisible="False" />
                         </StackPanel>
                     </Border>
 

--- a/Mutation.Ui/MainWindow.xaml
+++ b/Mutation.Ui/MainWindow.xaml
@@ -174,21 +174,26 @@
                                 </Button>
                             </Grid>
 
-                            <StackPanel Orientation="Horizontal" Spacing="12" VerticalAlignment="Center">
-                                <ToggleSwitch x:Name="TglWaveform" Header="Waveform" OnContent="On" OffContent="Off" Toggled="TglWaveform_Toggled" />
-                                <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Bottom">
-                                    <Grid Width="110" Height="10" Background="{ThemeResource ControlFillColorDefaultBrush}" CornerRadius="5">
-                                        <Rectangle x:Name="RmsLevelBar" Height="10" HorizontalAlignment="Left" Fill="{ThemeResource PrimaryBrush}" Width="0" RadiusX="5" RadiusY="5" />
+                            <Grid Margin="0,4,0,0" x:Name="MicWaveContainer">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="Auto" />
+                                </Grid.ColumnDefinitions>
+                                <Grid x:Name="MicWaveArea" Grid.Column="0" PointerReleased="MicWaveArea_PointerReleased">
+                                    <ScottPlot:WinUIPlot
+                                        x:Name="MicWaveformPlot"
+                                        Height="120"
+                                        IsHitTestVisible="False" />
+                                    <TextBlock x:Name="MicWaveformOffLabel" Text="Off" FontSize="32" FontWeight="SemiBold" Foreground="{ThemeResource TextFillColorSecondaryBrush}" HorizontalAlignment="Center" VerticalAlignment="Center" Visibility="Collapsed" />
+                                </Grid>
+                                <StackPanel Grid.Column="1" Margin="12,0,0,0" Spacing="6" VerticalAlignment="Stretch">
+                                    <Grid Width="16" Height="120" Background="{ThemeResource ControlFillColorDefaultBrush}" CornerRadius="8">
+                                        <Rectangle x:Name="RmsLevelBar" Width="16" Height="0" Fill="{ThemeResource PrimaryBrush}" HorizontalAlignment="Center" VerticalAlignment="Bottom" RadiusX="8" RadiusY="8" />
                                     </Grid>
-                                    <TextBlock x:Name="LblLevels" Text="Peak: 0.00  RMS: 0.00" Style="{StaticResource CaptionTextStyle}" />
+                                    <TextBlock x:Name="LblPeak" Text="Peak: 0.00" Style="{StaticResource CaptionTextStyle}" />
+                                    <TextBlock x:Name="LblRms" Text="RMS: 0.00" Style="{StaticResource CaptionTextStyle}" />
                                 </StackPanel>
-                            </StackPanel>
-
-                            <ScottPlot:WinUIPlot
-                                x:Name="MicWaveformPlot"
-                                Height="120"
-                                Margin="0,4,0,0"
-                                IsHitTestVisible="False" />
+                            </Grid>
                             </StackPanel>
                         </Grid>
                     </Border>


### PR DESCRIPTION
## Summary
- add a ScottPlot waveform panel to the microphone card in the main window
- stream audio from the selected capture device into the plot using NAudio for a live visualization
- restart capture on device changes and dispose resources when the window closes

## Testing
- dotnet build *(fails: Duplicate 'Page' items were included in Mutation.Ui.csproj)*

------
https://chatgpt.com/codex/tasks/task_e_68dc1a58ab6c832fb11c882a9b3467f6