### PR TITLE
Add basic settings dialog entry

### DIFF
--- a/Mutation.Ui/MainWindow.xaml
+++ b/Mutation.Ui/MainWindow.xaml
@@ -10,6 +10,10 @@
     mc:Ignorable="d"
     Title="Mutation">
 
+    <Window.KeyboardAccelerators>
+        <KeyboardAccelerator Key="F" Modifiers="Menu" Invoked="SettingsPaneAccelerator_Invoked" />
+    </Window.KeyboardAccelerators>
+
     <Window.SystemBackdrop>
         <MicaBackdrop />
     </Window.SystemBackdrop>
@@ -31,6 +35,22 @@
                 <TextBlock Text="Mutation Workspace" Style="{StaticResource TitleTextStyle}" AutomationProperties.Name="Application Title" />
                 <TextBlock Text="Capture ideas, format transcripts, and automate workflows from one polished surface." Style="{StaticResource SubtitleTextStyle}" />
             </StackPanel>
+
+            <NavigationView
+                x:Name="HeaderNavigation"
+                Grid.Column="2"
+                Width="64"
+                PaneDisplayMode="LeftMinimal"
+                IsPaneOpen="False"
+                IsBackButtonVisible="Collapsed"
+                IsSettingsVisible="False"
+                IsPaneToggleButtonVisible="False"
+                AutomationProperties.Name="Main menu"
+                SelectionChanged="HeaderNavigation_SelectionChanged">
+                <NavigationView.MenuItems>
+                    <NavigationViewItem Content="Settings" Icon="Setting" Tag="Settings" />
+                </NavigationView.MenuItems>
+            </NavigationView>
         </Grid>
 
         <Grid Grid.Row="1">

--- a/Mutation.Ui/Mutation.Ui.csproj
+++ b/Mutation.Ui/Mutation.Ui.csproj
@@ -24,9 +24,13 @@
 		<Nullable>enable</Nullable>
 	</PropertyGroup>
 
-	<PropertyGroup>
-		<ActiveDebugProfile>Mutation.Ui</ActiveDebugProfile>
-	</PropertyGroup>
+        <PropertyGroup>
+                <ActiveDebugProfile>Mutation.Ui</ActiveDebugProfile>
+        </PropertyGroup>
+
+        <PropertyGroup>
+                <EnableDefaultPageItems>false</EnableDefaultPageItems>
+        </PropertyGroup>
 
 	<ItemGroup>
 		<None Update="CustomAudio\*.wav">
@@ -116,7 +120,8 @@
 		<PublishTrimmed Condition="'$(Configuration)' != 'Debug'">True</PublishTrimmed>
 	</PropertyGroup>
 
-	<ItemGroup>
-		<Page Include="Views/RegionSelectionWindow.xaml" />
-	</ItemGroup>
+        <ItemGroup>
+                <Page Include="Views/RegionSelectionWindow.xaml" />
+                <Page Include="Views/SettingsDialog.xaml" />
+        </ItemGroup>
 </Project>

--- a/Mutation.Ui/ViewModels/SettingsDialogViewModel.cs
+++ b/Mutation.Ui/ViewModels/SettingsDialogViewModel.cs
@@ -1,0 +1,370 @@
+using System;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Windows.Input;
+using CognitiveSupport;
+using Mutation.Ui.Services;
+
+namespace Mutation.Ui.ViewModels;
+
+public sealed class SettingsDialogViewModel : INotifyPropertyChanged
+{
+        private readonly Settings _settings;
+        private readonly ISettingsManager _settingsManager;
+        private readonly Action<Settings> _onSettingsSaved;
+        private CategoryViewModel? _selectedCategory;
+        private bool _isSaving;
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        public ObservableCollection<CategoryViewModel> Categories { get; }
+
+        public SettingsDialogViewModel(Settings settings, ISettingsManager settingsManager, Action<Settings> onSettingsSaved)
+        {
+                _settings = settings ?? throw new ArgumentNullException(nameof(settings));
+                _settingsManager = settingsManager ?? throw new ArgumentNullException(nameof(settingsManager));
+                _onSettingsSaved = onSettingsSaved ?? throw new ArgumentNullException(nameof(onSettingsSaved));
+
+                Categories = new ObservableCollection<CategoryViewModel>
+                {
+                        BuildGeneralCategory()
+                };
+
+                SelectedCategory = Categories.FirstOrDefault();
+
+                SaveCommand = new RelayCommand(ExecuteSave, CanExecuteSave);
+                CancelCommand = new RelayCommand(_ => { }, _ => true);
+                ResetDefaultsCommand = new RelayCommand(_ => ResetToDefaults(), _ => true);
+        }
+
+        public ICommand SaveCommand { get; }
+        public ICommand CancelCommand { get; }
+        public ICommand ResetDefaultsCommand { get; }
+
+        public CategoryViewModel? SelectedCategory
+        {
+                get => _selectedCategory;
+                set
+                {
+                        if (_selectedCategory != value)
+                        {
+                                _selectedCategory = value;
+                                OnPropertyChanged();
+                        }
+                }
+        }
+
+        public bool IsSaving
+        {
+                get => _isSaving;
+                private set
+                {
+                        if (_isSaving != value)
+                        {
+                                _isSaving = value;
+                                OnPropertyChanged();
+                        }
+                }
+        }
+
+        public bool HasValidationErrors => Categories.SelectMany(c => c.Rows).Any(r => r.ValidationState == ValidationState.Error);
+
+        public bool IsDirty => Categories.SelectMany(c => c.Rows).Any(r => r.IsDirty);
+
+        private bool CanExecuteSave(object? parameter) => !IsSaving && !HasValidationErrors;
+
+        private void ExecuteSave(object? parameter)
+        {
+                if (IsSaving)
+                        return;
+
+                try
+                {
+                        IsSaving = true;
+
+                        foreach (var row in Categories.SelectMany(c => c.Rows))
+                        {
+                                row.Commit();
+                        }
+
+                        _settingsManager.SaveSettingsToFile(_settings);
+                        _onSettingsSaved(_settings);
+                }
+                finally
+                {
+                        IsSaving = false;
+                }
+        }
+
+        private void ResetToDefaults()
+        {
+                foreach (var row in Categories.SelectMany(c => c.Rows))
+                {
+                        row.Reset();
+                }
+                OnPropertyChanged(nameof(IsDirty));
+        }
+
+        private CategoryViewModel BuildGeneralCategory()
+        {
+                var category = new CategoryViewModel("General");
+
+                category.Rows.Add(AttachRow(new SettingRowViewModel(
+                        key: nameof(Settings.UserInstructions),
+                        displayName: "User instructions",
+                        description: "Settings can now be edited within the application.",
+                        editorType: SettingEditorType.Info,
+                        originalValue: _settings.UserInstructions ?? string.Empty,
+                        apply: value => _settings.UserInstructions = value as string)
+                {
+                        IsReadOnly = true,
+                        Value = _settings.UserInstructions ?? string.Empty
+                }));
+
+                int maxLines = Math.Clamp(_settings.MainWindowUiSettings?.MaxTextBoxLineCount ?? 5, 1, 20);
+                var maxLinesRow = new SettingRowViewModel(
+                        key: nameof(MainWindowUiSettings.MaxTextBoxLineCount),
+                        displayName: "Maximum transcript lines",
+                        description: "Choose how many lines are visible in transcript editors.",
+                        editorType: SettingEditorType.Number,
+                        originalValue: maxLines,
+                        apply: value =>
+                        {
+                                if (_settings.MainWindowUiSettings == null)
+                                        _settings.MainWindowUiSettings = new MainWindowUiSettings();
+                                _settings.MainWindowUiSettings.MaxTextBoxLineCount = Convert.ToInt32(value);
+                        });
+                maxLinesRow.Value = maxLines;
+                maxLinesRow.SetValidationCallback(val =>
+                {
+                        if (val is double dbl)
+                        {
+                                if (dbl < 1 || dbl > 20)
+                                        return (ValidationState.Error, "Enter a value between 1 and 20.");
+
+                                return (ValidationState.Ok, string.Empty);
+                        }
+
+                        if (val is int lines)
+                        {
+                                if (lines < 1 || lines > 20)
+                                        return (ValidationState.Error, "Enter a value between 1 and 20.");
+
+                                return (ValidationState.Ok, string.Empty);
+                        }
+
+                        return (ValidationState.Error, "Value must be numeric.");
+                });
+                category.Rows.Add(AttachRow(maxLinesRow));
+
+                category.Rows.Add(AttachRow(new SettingRowViewModel(
+                        key: "ResetWindowLayout",
+                        displayName: "Reset window layout",
+                        description: "Re-center the window on next launch.",
+                        editorType: SettingEditorType.Action,
+                        originalValue: false,
+                        apply: value =>
+                        {
+                                if (_settings.MainWindowUiSettings != null)
+                                {
+                                        _settings.MainWindowUiSettings.WindowLocation = new System.Drawing.Point();
+                                        _settings.MainWindowUiSettings.WindowSize = new System.Drawing.Size();
+                                }
+                        })
+                {
+                        Value = false,
+                        ActionLabel = "Restore"
+                }));
+
+                return category;
+        }
+
+        private SettingRowViewModel AttachRow(SettingRowViewModel row)
+        {
+                row.PropertyChanged += Row_PropertyChanged;
+                return row;
+        }
+
+        private void Row_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+                if (e.PropertyName == nameof(SettingRowViewModel.ValidationState) || e.PropertyName == nameof(SettingRowViewModel.IsDirty))
+                {
+                        OnPropertyChanged(nameof(HasValidationErrors));
+                        OnPropertyChanged(nameof(IsDirty));
+                        (SaveCommand as RelayCommand)?.RaiseCanExecuteChanged();
+                }
+        }
+
+        private void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+        {
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+                if (propertyName == nameof(HasValidationErrors) || propertyName == nameof(IsDirty) || propertyName == nameof(IsSaving))
+                {
+                        (SaveCommand as RelayCommand)?.RaiseCanExecuteChanged();
+                }
+        }
+}
+
+public sealed class CategoryViewModel
+{
+        public string Name { get; }
+        public ObservableCollection<SettingRowViewModel> Rows { get; } = new();
+
+        public CategoryViewModel(string name)
+        {
+                Name = name;
+        }
+}
+
+public enum SettingEditorType
+{
+        Text,
+        Number,
+        Toggle,
+        Info,
+        Action
+}
+
+public enum ValidationState
+{
+        Ok,
+        Warning,
+        Error
+}
+
+public sealed class SettingRowViewModel : INotifyPropertyChanged
+{
+        private object? _value;
+        private ValidationState _validationState;
+        private string _validationMessage = string.Empty;
+        private Func<object?, (ValidationState State, string Message)>? _validationCallback;
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        public SettingRowViewModel(string key, string displayName, string description, SettingEditorType editorType, object? originalValue, Action<object?> apply)
+        {
+                Key = key;
+                DisplayName = displayName;
+                Description = description;
+                EditorType = editorType;
+                OriginalValue = originalValue;
+                ApplyValue = apply;
+                _validationState = ValidationState.Ok;
+        }
+
+        public string Key { get; }
+        public string DisplayName { get; }
+        public string Description { get; }
+        public SettingEditorType EditorType { get; }
+        public object? OriginalValue { get; }
+        public bool IsReadOnly { get; set; }
+        public string? ActionLabel { get; set; }
+        public Action<object?> ApplyValue { get; }
+
+        public ValidationState ValidationState
+        {
+                get => _validationState;
+                private set
+                {
+                        if (_validationState != value)
+                        {
+                                _validationState = value;
+                                OnPropertyChanged(nameof(ValidationState));
+                                OnPropertyChanged(nameof(IsValid));
+                        }
+                }
+        }
+
+        public string ValidationMessage
+        {
+                get => _validationMessage;
+                private set
+                {
+                        if (_validationMessage != value)
+                        {
+                                _validationMessage = value;
+                                OnPropertyChanged(nameof(ValidationMessage));
+                        }
+                }
+        }
+
+        public bool IsValid => ValidationState != ValidationState.Error;
+
+        public bool IsDirty => !Equals(Value, OriginalValue);
+
+        public object? Value
+        {
+                get => _value;
+                set
+                {
+                        if (!Equals(_value, value))
+                        {
+                                _value = value;
+                                Validate();
+                                OnPropertyChanged(nameof(Value));
+                                OnPropertyChanged(nameof(IsDirty));
+                        }
+                }
+        }
+
+        public void SetValidationCallback(Func<object?, (ValidationState State, string Message)> callback)
+        {
+                _validationCallback = callback;
+                Validate();
+        }
+
+        public void Commit()
+        {
+                if (!IsValid)
+                        throw new InvalidOperationException($"Setting '{DisplayName}' is invalid.");
+
+                ApplyValue(Value);
+        }
+
+        public void Reset()
+        {
+                Value = OriginalValue;
+                Validate();
+        }
+
+        private void Validate()
+        {
+                if (_validationCallback is null)
+                {
+                        ValidationState = ValidationState.Ok;
+                        ValidationMessage = string.Empty;
+                        return;
+                }
+
+                var result = _validationCallback(Value);
+                ValidationState = result.State;
+                ValidationMessage = result.Message;
+        }
+
+        private void OnPropertyChanged(string propertyName)
+        {
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+}
+
+internal sealed class RelayCommand : ICommand
+{
+        private readonly Action<object?> _execute;
+        private readonly Predicate<object?> _canExecute;
+
+        public RelayCommand(Action<object?> execute, Predicate<object?> canExecute)
+        {
+                _execute = execute ?? throw new ArgumentNullException(nameof(execute));
+                _canExecute = canExecute ?? throw new ArgumentNullException(nameof(canExecute));
+        }
+
+        public event EventHandler? CanExecuteChanged;
+
+        public bool CanExecute(object? parameter) => _canExecute(parameter);
+
+        public void Execute(object? parameter) => _execute(parameter);
+
+        public void RaiseCanExecuteChanged() => CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+}

--- a/Mutation.Ui/Views/SettingsDialog.xaml
+++ b/Mutation.Ui/Views/SettingsDialog.xaml
@@ -1,0 +1,139 @@
+<ContentDialog
+    x:Class="Mutation.Ui.Views.SettingsDialog"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Mutation.Ui.Views"
+    xmlns:vm="using:Mutation.Ui.ViewModels"
+    Title="Application Settings"
+    DefaultButton="Primary"
+    PrimaryButtonText="Save"
+    SecondaryButtonText="Cancel"
+    CloseButtonText="Reset"
+    PrimaryButtonClick="ContentDialog_PrimaryButtonClick"
+    SecondaryButtonClick="ContentDialog_SecondaryButtonClick"
+    CloseButtonClick="ContentDialog_CloseButtonClick"
+    Width="900"
+    MaxWidth="1000"
+    Height="640"
+    MaxHeight="800">
+
+    <ContentDialog.Resources>
+        <local:ValidationStateToVisibilityConverter x:Key="InvalidStateToVisibilityConverter" />
+
+        <DataTemplate x:Key="InfoTemplate" x:DataType="vm:SettingRowViewModel">
+            <Grid ColumnSpacing="16" RowSpacing="4">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="220" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+                <FontIcon
+                    FontFamily="Segoe Fluent Icons"
+                    Glyph="&#xE783;"
+                    Foreground="{ThemeResource SystemFillColorCriticalBrush}"
+                    Visibility="Collapsed" />
+                <StackPanel Grid.Column="1" Spacing="2">
+                    <TextBlock Text="{x:Bind DisplayName}" Style="{StaticResource CaptionTextStyle}" />
+                    <TextBlock Text="{x:Bind Description}" TextWrapping="Wrap" />
+                </StackPanel>
+                <TextBlock Grid.Column="2" Text="{x:Bind Value}" TextWrapping="Wrap" />
+            </Grid>
+        </DataTemplate>
+
+        <DataTemplate x:Key="NumberTemplate" x:DataType="vm:SettingRowViewModel">
+            <Grid ColumnSpacing="16" RowSpacing="4">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="220" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+                <FontIcon
+                    FontFamily="Segoe Fluent Icons"
+                    Glyph="&#xE783;"
+                    Foreground="{ThemeResource SystemFillColorCriticalBrush}"
+                    Visibility="{x:Bind ValidationState, Converter={StaticResource InvalidStateToVisibilityConverter}}" />
+                <StackPanel Grid.Column="1" Spacing="2">
+                    <TextBlock Text="{x:Bind DisplayName}" Style="{StaticResource CaptionTextStyle}" />
+                    <TextBlock Text="{x:Bind Description}" TextWrapping="Wrap" />
+                </StackPanel>
+                <NumberBox
+                    Grid.Column="2"
+                    Minimum="1"
+                    Maximum="20"
+                    SpinButtonPlacementMode="Compact"
+                    Value="{x:Bind Value, Mode=TwoWay}"
+                    HorizontalAlignment="Left"
+                    Width="140" />
+                <TextBlock Grid.Column="2" Margin="0,32,0,0" Text="{x:Bind ValidationMessage}" Foreground="{ThemeResource SystemFillColorCriticalBrush}" />
+            </Grid>
+        </DataTemplate>
+
+        <DataTemplate x:Key="ActionTemplate" x:DataType="vm:SettingRowViewModel">
+            <Grid ColumnSpacing="16" RowSpacing="4">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="220" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+                <FontIcon FontFamily="Segoe Fluent Icons" Glyph="&#xE783;" Opacity="0" />
+                <StackPanel Grid.Column="1" Spacing="2">
+                    <TextBlock Text="{x:Bind DisplayName}" Style="{StaticResource CaptionTextStyle}" />
+                    <TextBlock Text="{x:Bind Description}" TextWrapping="Wrap" />
+                </StackPanel>
+                <Button Grid.Column="3" Content="{x:Bind ActionLabel}" Click="ActionButton_Click" Tag="{x:Bind}" />
+            </Grid>
+        </DataTemplate>
+
+        <local:SettingTemplateSelector x:Key="SettingTemplateSelector"
+                                       InfoTemplate="{StaticResource InfoTemplate}"
+                                       NumberTemplate="{StaticResource NumberTemplate}"
+                                       ActionTemplate="{StaticResource ActionTemplate}" />
+    </ContentDialog.Resources>
+
+    <Grid RowSpacing="12">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <TextBlock Text="Fine-tune how Mutation behaves." Style="{StaticResource SubtitleTextStyle}" />
+
+        <Grid Grid.Row="1" ColumnSpacing="24">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="220" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+
+            <ListView
+                Grid.Column="0"
+                ItemsSource="{x:Bind ViewModel.Categories}"
+                SelectedItem="{x:Bind ViewModel.SelectedCategory, Mode=TwoWay}"
+                SelectionMode="Single"
+                IsItemClickEnabled="True">
+                <ListView.ItemTemplate>
+                    <DataTemplate x:DataType="vm:CategoryViewModel">
+                        <StackPanel Padding="12,8" Orientation="Vertical">
+                            <TextBlock Text="{x:Bind Name}" />
+                        </StackPanel>
+                    </DataTemplate>
+                </ListView.ItemTemplate>
+            </ListView>
+
+            <ItemsControl
+                Grid.Column="1"
+                ItemsSource="{x:Bind ViewModel.SelectedCategory?.Rows}">
+                <ItemsControl.ItemTemplateSelector>
+                    <StaticResource ResourceKey="SettingTemplateSelector" />
+                </ItemsControl.ItemTemplateSelector>
+                <ItemsControl.ItemContainerStyle>
+                    <Style TargetType="ContentPresenter">
+                        <Setter Property="Margin" Value="0,8,0,8" />
+                    </Style>
+                </ItemsControl.ItemContainerStyle>
+            </ItemsControl>
+        </Grid>
+    </Grid>
+</ContentDialog>

--- a/Mutation.Ui/Views/SettingsDialog.xaml.cs
+++ b/Mutation.Ui/Views/SettingsDialog.xaml.cs
@@ -1,0 +1,90 @@
+using System;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Data;
+using Mutation.Ui.ViewModels;
+
+namespace Mutation.Ui.Views;
+
+public sealed partial class SettingsDialog : ContentDialog
+{
+        public SettingsDialogViewModel ViewModel { get; }
+
+        public SettingsDialog(SettingsDialogViewModel viewModel)
+        {
+                this.InitializeComponent();
+                ViewModel = viewModel;
+                DataContext = this;
+        }
+
+        private void ContentDialog_PrimaryButtonClick(ContentDialog sender, ContentDialogButtonClickEventArgs args)
+        {
+                if (!ViewModel.SaveCommand.CanExecute(null))
+                {
+                        args.Cancel = true;
+                        return;
+                }
+
+                ViewModel.SaveCommand.Execute(null);
+                if (ViewModel.HasValidationErrors)
+                {
+                        args.Cancel = true;
+                }
+        }
+
+        private void ContentDialog_SecondaryButtonClick(ContentDialog sender, ContentDialogButtonClickEventArgs args)
+        {
+                ViewModel.CancelCommand.Execute(null);
+        }
+
+        private void ContentDialog_CloseButtonClick(ContentDialog sender, ContentDialogButtonClickEventArgs args)
+        {
+                ViewModel.ResetDefaultsCommand.Execute(null);
+                args.Cancel = true;
+        }
+
+        private void ActionButton_Click(object sender, RoutedEventArgs e)
+        {
+                if (sender is Button button && button.Tag is SettingRowViewModel row)
+                {
+                        row.ApplyValue(row.Value);
+                }
+        }
+}
+
+public sealed class SettingTemplateSelector : DataTemplateSelector
+{
+        public DataTemplate? InfoTemplate { get; set; }
+        public DataTemplate? NumberTemplate { get; set; }
+        public DataTemplate? ActionTemplate { get; set; }
+
+        protected override DataTemplate SelectTemplateCore(object item, DependencyObject container)
+        {
+                if (item is SettingRowViewModel row)
+                {
+                        return row.EditorType switch
+                        {
+                                SettingEditorType.Info => InfoTemplate!,
+                                SettingEditorType.Number => NumberTemplate!,
+                                SettingEditorType.Action => ActionTemplate!,
+                                _ => InfoTemplate!
+                        };
+                }
+
+                return base.SelectTemplateCore(item, container);
+        }
+}
+
+public sealed class ValidationStateToVisibilityConverter : IValueConverter
+{
+        public object Convert(object value, Type targetType, object parameter, string language)
+        {
+                if (value is ValidationState state)
+                        return state == ValidationState.Error ? Visibility.Visible : Visibility.Collapsed;
+
+                return Visibility.Collapsed;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, string language)
+            => throw new NotSupportedException();
+}


### PR DESCRIPTION
## Summary
- add a header navigation item and keyboard accelerator so the settings dialog can be opened from the main window
- introduce a `SettingsDialog` and supporting view models to edit general application preferences with validation and save plumbing
- update the WinUI project configuration to explicitly include XAML pages without duplicate item warnings

## Testing
- `dotnet build` *(fails: XamlCompiler.exe is not executable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de8bbb1670832fb79cfac79877093f