### PR TITLE
Add unit tests for document OCR preprocessing and rate limiter

### DIFF
--- a/CognitiveSupport/Settings.cs
+++ b/CognitiveSupport/Settings.cs
@@ -8,6 +8,7 @@ public class Settings
 
 	public AudioSettings? AudioSettings { get; set; }
 	public AzureComputerVisionSettings? AzureComputerVisionSettings { get; set; }
+	public AzureDocumentIntelligenceSettings? AzureDocumentIntelligenceSettings { get; set; }
         public SpeechToTextSettings? SpeechToTextSettings { get; set; }
 	public LlmSettings? LlmSettings { get; set; }
 	public TextToSpeechSettings? TextToSpeechSettings { get; set; }
@@ -20,11 +21,12 @@ public class Settings
 	{
 	}
 
-        public Settings(string? userInstructions, AudioSettings? audioSettings, AzureComputerVisionSettings? azureComputerVisionSettings, SpeechToTextSettings? speechToTextSettings, LlmSettings? llmSettings, TextToSpeechSettings? textToSpeechSettings, MainWindowUiSettings mainWindowUiSettings, HotKeyRouterSettings hotKeyRouterSettings)
+        public Settings(string? userInstructions, AudioSettings? audioSettings, AzureComputerVisionSettings? azureComputerVisionSettings, AzureDocumentIntelligenceSettings? azureDocumentIntelligenceSettings, SpeechToTextSettings? speechToTextSettings, LlmSettings? llmSettings, TextToSpeechSettings? textToSpeechSettings, MainWindowUiSettings mainWindowUiSettings, HotKeyRouterSettings hotKeyRouterSettings)
         {
                 UserInstructions = userInstructions;
                 AudioSettings = audioSettings;
                 AzureComputerVisionSettings = azureComputerVisionSettings;
+                AzureDocumentIntelligenceSettings = azureDocumentIntelligenceSettings;
                 SpeechToTextSettings = speechToTextSettings;
                 LlmSettings = llmSettings;
                 TextToSpeechSettings = textToSpeechSettings;
@@ -112,6 +114,22 @@ public class AzureComputerVisionSettings
 
 	public AzureComputerVisionSettings()
 	{
+	}
+}
+
+
+public class AzureDocumentIntelligenceSettings
+{
+	public string? Endpoint { get; set; }
+	public string? ApiKey { get; set; }
+	public bool UseFreeTier { get; set; } = true;
+	public int FreeTierPageLimit { get; set; } = 2;
+	public int MaxParallelDocuments { get; set; } = 2;
+	public int MaxParallelRequestsPerMinute { get; set; } = 20;
+	public long? MaxDocumentBytes { get; set; }
+	{
+		get;
+		set;
 	}
 }
 

--- a/Mutation.Tests/ApiRateLimiterTests.cs
+++ b/Mutation.Tests/ApiRateLimiterTests.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Mutation.Ui.Services.DocumentOcr;
+
+namespace Mutation.Tests;
+
+public class ApiRateLimiterTests
+{
+	[Fact]
+	public async Task AcquireAsync_DelaysWhenLimitExceeded()
+	{
+		var timeProvider = new TestTimeProvider(DateTimeOffset.UtcNow);
+		var delays = new List<TimeSpan>();
+		var limiter = new ApiRateLimiter(20, TimeSpan.FromMinutes(1), timeProvider, (span, token) =>
+		{
+			delays.Add(span);
+			timeProvider.Advance(span);
+			return Task.CompletedTask;
+		});
+
+		for (int i = 0; i < 20; i++)
+		{
+			await limiter.AcquireAsync(CancellationToken.None);
+		}
+
+		await limiter.AcquireAsync(CancellationToken.None);
+
+		Assert.Single(delays);
+		Assert.Equal(TimeSpan.FromMinutes(1), delays[0]);
+
+		await limiter.AcquireAsync(CancellationToken.None);
+		Assert.Single(delays);
+	}
+
+	private sealed class TestTimeProvider : TimeProvider
+	{
+		private DateTimeOffset _utcNow;
+
+		public TestTimeProvider(DateTimeOffset start)
+		{
+			_utcNow = start;
+		}
+
+		public override DateTimeOffset GetUtcNow() => _utcNow;
+
+		public void Advance(TimeSpan value) => _utcNow += value;
+
+		public override long GetTimestamp() => 0;
+		public override long GetTimestamp(DateTimeOffset utcDateTime) => 0;
+		public override TimeSpan GetElapsedTime(long startingTimestamp) => TimeSpan.Zero;
+		public override TimeSpan GetElapsedTime(long startingTimestamp, long endingTimestamp) => TimeSpan.Zero;
+
+		public override ITimer CreateTimer(TimerCallback callback, object? state, TimeSpan dueTime, TimeSpan period)
+		=> new NoopTimer();
+
+		private sealed class NoopTimer : ITimer
+		{
+			public void Dispose()
+			{
+			}
+
+			public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+			public bool Change(TimeSpan dueTime, TimeSpan period) => true;
+		}
+	}
+}

--- a/Mutation.Tests/DocumentFilePreprocessorTests.cs
+++ b/Mutation.Tests/DocumentFilePreprocessorTests.cs
@@ -1,0 +1,104 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Mutation.Ui.Services.DocumentOcr;
+using CognitiveSupport;
+using PdfSharp.Drawing;
+using PdfSharp.Pdf;
+
+namespace Mutation.Tests;
+
+public class DocumentFilePreprocessorTests
+{
+	[Fact]
+	public async Task PreprocessAsync_SplitsPdfRespectingFreeTierLimit()
+	{
+		var settings = new AzureDocumentIntelligenceSettings
+		{
+			UseFreeTier = true,
+			FreeTierPageLimit = 2
+		};
+		var preprocessor = new DocumentFilePreprocessor(settings);
+		byte[] pdfBytes = CreatePdfDocument(4);
+		var descriptor = DocumentSourceDescriptor.FromBytes("sample.pdf", pdfBytes);
+
+		DocumentOcrBatch batch = await preprocessor.PreprocessAsync(descriptor, CancellationToken.None);
+
+		Assert.Equal(2, batch.TotalJobs);
+		Assert.All(batch.Jobs, job => Assert.Equal(DocumentOcrContentType.Pdf, job.ContentType));
+		Assert.Equal(new[] { 1, 2 }, batch.Jobs.Select(job => job.PageNumber).ToArray());
+	}
+
+	[Fact]
+	public async Task PreprocessAsync_ProcessesAllPdfPagesWhenNotFreeTier()
+	{
+		var settings = new AzureDocumentIntelligenceSettings
+		{
+			UseFreeTier = false
+		};
+		var preprocessor = new DocumentFilePreprocessor(settings);
+		byte[] pdfBytes = CreatePdfDocument(3);
+		var descriptor = DocumentSourceDescriptor.FromBytes("contract.pdf", pdfBytes);
+
+		DocumentOcrBatch batch = await preprocessor.PreprocessAsync(descriptor, CancellationToken.None);
+
+		Assert.Equal(3, batch.TotalJobs);
+		Assert.Equal(new[] { 1, 2, 3 }, batch.Jobs.Select(job => job.PageNumber).ToArray());
+	}
+
+	[Fact]
+	public async Task PreprocessAsync_ThrowsForUnsupportedExtension()
+	{
+		var settings = new AzureDocumentIntelligenceSettings();
+		var preprocessor = new DocumentFilePreprocessor(settings);
+		var descriptor = DocumentSourceDescriptor.FromBytes("notes.txt", new byte[] { 1, 2, 3 });
+
+		await Assert.ThrowsAsync<NotSupportedException>(() => preprocessor.PreprocessAsync(descriptor, CancellationToken.None));
+	}
+
+	[Fact]
+	public async Task PreprocessAsync_RejectsDocumentsExceedingConfiguredSize()
+	{
+		var settings = new AzureDocumentIntelligenceSettings
+		{
+			MaxDocumentBytes = 2
+		};
+		var preprocessor = new DocumentFilePreprocessor(settings);
+		byte[] bytes = new byte[] { 0, 1, 2 };
+		var descriptor = DocumentSourceDescriptor.FromBytes("image.png", bytes);
+
+		await Assert.ThrowsAsync<InvalidOperationException>(() => preprocessor.PreprocessAsync(descriptor, CancellationToken.None));
+	}
+
+	[Fact]
+	public async Task PreprocessAsync_PreparesImageAsSingleJob()
+	{
+		var settings = new AzureDocumentIntelligenceSettings();
+		var preprocessor = new DocumentFilePreprocessor(settings);
+		byte[] imageBytes = Enumerable.Range(0, 32).Select(i => (byte)i).ToArray();
+		var descriptor = DocumentSourceDescriptor.FromBytes("photo.png", imageBytes);
+
+		DocumentOcrBatch batch = await preprocessor.PreprocessAsync(descriptor, CancellationToken.None);
+
+		var job = Assert.Single(batch.Jobs);
+		Assert.Equal(DocumentOcrContentType.Png, job.ContentType);
+		Assert.Equal(1, job.PageNumber);
+	}
+
+	private static byte[] CreatePdfDocument(int pageCount)
+	{
+		using PdfDocument document = new();
+		for (int i = 0; i < pageCount; i++)
+		{
+			PdfPage page = document.AddPage();
+			using XGraphics gfx = XGraphics.FromPdfPage(page);
+			gfx.DrawString($"Page {i + 1}", new XFont("Arial", 12), XBrushes.Black, new XPoint(20, 20));
+		}
+
+		using MemoryStream stream = new();
+		document.Save(stream, false);
+		return stream.ToArray();
+	}
+}

--- a/Mutation.Ui/Services/DocumentOcr/ApiRateLimiter.cs
+++ b/Mutation.Ui/Services/DocumentOcr/ApiRateLimiter.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Mutation.Ui.Services.DocumentOcr;
+
+/// <summary>
+/// Simple rate limiter used to throttle calls to the Document Intelligence service.
+/// </summary>
+public sealed class ApiRateLimiter
+{
+	private readonly TimeProvider _timeProvider;
+	private readonly Func<TimeSpan, CancellationToken, Task> _delayAsync;
+	private readonly Queue<DateTimeOffset> _invocations = new();
+	private readonly SemaphoreSlim _gate = new(1, 1);
+	private readonly int _maxCalls;
+	private readonly TimeSpan _window;
+
+	public ApiRateLimiter(
+		int maxCallsPerWindow,
+		TimeSpan window,
+		TimeProvider? timeProvider = null,
+		Func<TimeSpan, CancellationToken, Task>? delayAsync = null)
+	{
+		if (maxCallsPerWindow <= 0)
+		{
+			throw new ArgumentOutOfRangeException(nameof(maxCallsPerWindow));
+		}
+		if (window <= TimeSpan.Zero)
+		{
+			throw new ArgumentOutOfRangeException(nameof(window));
+		}
+
+		_maxCalls = maxCallsPerWindow;
+		_window = window;
+		_timeProvider = timeProvider ?? TimeProvider.System;
+		_delayAsync = delayAsync ?? ((delay, token) => Task.Delay(delay, token));
+	}
+
+	public async Task AcquireAsync(CancellationToken cancellationToken)
+	{
+		while (true)
+		{
+			TimeSpan? waitDuration = null;
+			await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+			try
+			{
+				TrimOldEntries();
+				if (_invocations.Count < _maxCalls)
+				{
+					_invocations.Enqueue(_timeProvider.GetUtcNow());
+					return;
+				}
+				DateTimeOffset oldest = _invocations.Peek();
+				DateTimeOffset now = _timeProvider.GetUtcNow();
+				TimeSpan elapsed = now - oldest;
+				TimeSpan remaining = _window - elapsed;
+				if (remaining < TimeSpan.Zero)
+				{
+					remaining = TimeSpan.Zero;
+				}
+				waitDuration = remaining;
+			}
+			finally
+			{
+				_gate.Release();
+			}
+
+			if (waitDuration.HasValue)
+			{
+				await _delayAsync(waitDuration.Value, cancellationToken).ConfigureAwait(false);
+			}
+		}
+	}
+
+	private void TrimOldEntries()
+	{
+		DateTimeOffset now = _timeProvider.GetUtcNow();
+		while (_invocations.Count > 0 && now - _invocations.Peek() >= _window)
+		{
+			_invocations.Dequeue();
+		}
+	}
+}

--- a/Mutation.Ui/Services/DocumentOcr/DocumentFilePreprocessor.cs
+++ b/Mutation.Ui/Services/DocumentOcr/DocumentFilePreprocessor.cs
@@ -1,0 +1,122 @@
+using CognitiveSupport;
+using System.Collections.Generic;
+using PdfSharp.Pdf;
+using PdfSharp.Pdf.IO;
+
+namespace Mutation.Ui.Services.DocumentOcr;
+
+/// <summary>
+/// Generates Azure Document Intelligence OCR jobs by splitting PDFs and preparing image files.
+/// </summary>
+public sealed class DocumentFilePreprocessor
+{
+	private static readonly HashSet<string> _supportedExtensions = new(StringComparer.OrdinalIgnoreCase)
+	{
+		".pdf",
+		".png",
+		".jpg",
+		".jpeg",
+		".tif",
+		".tiff",
+		".bmp"
+	};
+
+	private static readonly Dictionary<string, DocumentOcrContentType> _contentTypes = new(StringComparer.OrdinalIgnoreCase)
+	{
+		[".pdf"] = DocumentOcrContentType.Pdf,
+		[".png"] = DocumentOcrContentType.Png,
+		[".jpg"] = DocumentOcrContentType.Jpeg,
+		[".jpeg"] = DocumentOcrContentType.Jpeg,
+		[".tif"] = DocumentOcrContentType.Tiff,
+		[".tiff"] = DocumentOcrContentType.Tiff,
+		[".bmp"] = DocumentOcrContentType.Bmp
+	};
+
+	private readonly AzureDocumentIntelligenceSettings _settings;
+
+	public DocumentFilePreprocessor(AzureDocumentIntelligenceSettings settings)
+	{
+		_settings = settings ?? throw new ArgumentNullException(nameof(settings));
+	}
+
+	public async Task<DocumentOcrBatch> PreprocessAsync(DocumentSourceDescriptor descriptor, CancellationToken cancellationToken)
+	{
+		ArgumentNullException.ThrowIfNull(descriptor);
+		string extension = descriptor.Extension;
+		if (!_supportedExtensions.Contains(extension))
+		{
+			throw new NotSupportedException($"Unsupported document type: {extension}");
+		}
+		ValidateLength(descriptor);
+		return extension.Equals(".pdf", StringComparison.OrdinalIgnoreCase)
+			? await CreatePdfBatchAsync(descriptor, cancellationToken).ConfigureAwait(false)
+			: await CreateSinglePageBatchAsync(descriptor, cancellationToken).ConfigureAwait(false);
+	}
+
+	private void ValidateLength(DocumentSourceDescriptor descriptor)
+	{
+		if (_settings.MaxDocumentBytes is null || descriptor.LengthBytes is null)
+		{
+			return;
+		}
+		if (descriptor.LengthBytes.Value > _settings.MaxDocumentBytes.Value)
+		{
+			throw new InvalidOperationException($"Document '{descriptor.FileName}' exceeds the configured size limit of {_settings.MaxDocumentBytes.Value} bytes.");
+		}
+	}
+
+	private async Task<DocumentOcrBatch> CreatePdfBatchAsync(DocumentSourceDescriptor descriptor, CancellationToken cancellationToken)
+	{
+		await using Stream stream = await descriptor.OpenReadAsync(cancellationToken).ConfigureAwait(false);
+		using PdfDocument pdfDocument = PdfReader.Open(stream, PdfDocumentOpenMode.Import);
+		int totalPages = pdfDocument.PageCount;
+		int limit = _settings.UseFreeTier
+			? Math.Min(_settings.FreeTierPageLimit <= 0 ? 2 : _settings.FreeTierPageLimit, totalPages)
+			: totalPages;
+		var jobs = new List<DocumentOcrJobInput>(limit);
+		for (int i = 0; i < limit; i++)
+		{
+			cancellationToken.ThrowIfCancellationRequested();
+			byte[] payload = ExtractPdfPage(pdfDocument, i);
+			jobs.Add(new DocumentOcrJobInput(
+				descriptor.BaseName,
+				i + 1,
+				DocumentOcrContentType.Pdf,
+				_ => Task.FromResult<Stream>(new MemoryStream(payload, writable: false)),
+				payload.LongLength));
+		}
+		return new DocumentOcrBatch(descriptor.BaseName, descriptor.Extension, jobs);
+	}
+
+	private static byte[] ExtractPdfPage(PdfDocument sourceDocument, int pageIndex)
+	{
+		using PdfDocument pageDocument = new();
+		pageDocument.Version = sourceDocument.Version;
+		pageDocument.Options.CompressContentStreams = true;
+		pageDocument.AddPage(sourceDocument.Pages[pageIndex]);
+		using MemoryStream memoryStream = new();
+		pageDocument.Save(memoryStream, false);
+		return memoryStream.ToArray();
+	}
+
+	private async Task<DocumentOcrBatch> CreateSinglePageBatchAsync(DocumentSourceDescriptor descriptor, CancellationToken cancellationToken)
+	{
+		byte[] payload = await ReadAllBytesAsync(descriptor, cancellationToken).ConfigureAwait(false);
+		DocumentOcrContentType contentType = _contentTypes[descriptor.Extension];
+		var job = new DocumentOcrJobInput(
+			descriptor.BaseName,
+			1,
+			contentType,
+			_ => Task.FromResult<Stream>(new MemoryStream(payload, writable: false)),
+			payload.LongLength);
+		return new DocumentOcrBatch(descriptor.BaseName, descriptor.Extension, new[] { job });
+	}
+
+	private static async Task<byte[]> ReadAllBytesAsync(DocumentSourceDescriptor descriptor, CancellationToken cancellationToken)
+	{
+		await using Stream stream = await descriptor.OpenReadAsync(cancellationToken).ConfigureAwait(false);
+		using MemoryStream memoryStream = new();
+		await stream.CopyToAsync(memoryStream, cancellationToken).ConfigureAwait(false);
+		return memoryStream.ToArray();
+	}
+}

--- a/Mutation.Ui/Services/DocumentOcr/DocumentOcrModels.cs
+++ b/Mutation.Ui/Services/DocumentOcr/DocumentOcrModels.cs
@@ -1,0 +1,118 @@
+using CognitiveSupport;
+using System.Collections.Immutable;
+
+namespace Mutation.Ui.Services.DocumentOcr;
+
+/// <summary>
+/// Represents a batch of OCR jobs generated from a single source document.
+/// </summary>
+public sealed class DocumentOcrBatch
+{
+	public DocumentOcrBatch(string sourceName, string originalExtension, IReadOnlyList<DocumentOcrJobInput> jobs)
+	{
+		ArgumentException.ThrowIfNullOrWhiteSpace(sourceName);
+		SourceName = sourceName;
+		OriginalExtension = originalExtension ?? string.Empty;
+		Jobs = jobs?.ToImmutableArray() ?? throw new ArgumentNullException(nameof(jobs));
+	}
+
+	public string SourceName { get; }
+
+	public string OriginalExtension { get; }
+
+	public IReadOnlyList<DocumentOcrJobInput> Jobs { get; }
+
+	public int TotalJobs => Jobs.Count;
+}
+
+/// <summary>
+/// Describes a single OCR job to be sent to Azure Document Intelligence.
+/// </summary>
+public sealed class DocumentOcrJobInput
+{
+	private readonly Func<CancellationToken, Task<Stream>> _streamFactory;
+
+	public DocumentOcrJobInput(
+		string sourceName,
+		int pageNumber,
+		DocumentOcrContentType contentType,
+		Func<CancellationToken, Task<Stream>> streamFactory,
+		long? originalLength)
+	{
+		ArgumentException.ThrowIfNullOrWhiteSpace(sourceName);
+		if (pageNumber <= 0)
+		{
+			throw new ArgumentOutOfRangeException(nameof(pageNumber));
+		}
+
+		_streamFactory = streamFactory ?? throw new ArgumentNullException(nameof(streamFactory));
+
+		SourceName = sourceName;
+		PageNumber = pageNumber;
+		ContentType = contentType;
+		OriginalLength = originalLength;
+	}
+
+	public string SourceName { get; }
+
+	public int PageNumber { get; }
+
+	public DocumentOcrContentType ContentType { get; }
+
+	public long? OriginalLength { get; }
+
+	public Task<Stream> OpenStreamAsync(CancellationToken cancellationToken)
+		=> _streamFactory(cancellationToken);
+}
+
+/// <summary>
+/// Supported MIME groupings for Azure Document Intelligence submissions.
+/// </summary>
+public enum DocumentOcrContentType
+{
+	Pdf,
+	Jpeg,
+	Png,
+	Tiff,
+	Bmp
+}
+
+/// <summary>
+/// Descriptor representing a file selected by the user that will be preprocessed for OCR.
+/// </summary>
+public sealed class DocumentSourceDescriptor
+{
+	private readonly Func<CancellationToken, Task<Stream>> _streamFactory;
+
+	public DocumentSourceDescriptor(
+		string fileName,
+		Func<CancellationToken, Task<Stream>> streamFactory,
+		long? lengthBytes = null)
+	{
+		ArgumentException.ThrowIfNullOrWhiteSpace(fileName);
+		_streamFactory = streamFactory ?? throw new ArgumentNullException(nameof(streamFactory));
+
+		FileName = fileName;
+		LengthBytes = lengthBytes;
+	}
+
+	public string FileName { get; }
+
+	public string Extension => Path.GetExtension(FileName);
+
+	public string BaseName => Path.GetFileNameWithoutExtension(FileName);
+
+	public long? LengthBytes { get; }
+
+	public Task<Stream> OpenReadAsync(CancellationToken cancellationToken)
+		=> _streamFactory(cancellationToken);
+
+	public static DocumentSourceDescriptor FromBytes(string fileName, byte[] data)
+	{
+		ArgumentNullException.ThrowIfNull(data);
+		return new DocumentSourceDescriptor(
+			fileName,
+			_ => Task.FromResult<Stream>(new MemoryStream(data, writable: false)),
+			data.LongLength);
+	}
+}

--- a/Mutation.Ui/Services/SettingsManager.cs
+++ b/Mutation.Ui/Services/SettingsManager.cs
@@ -121,6 +121,45 @@ internal class SettingsManager : ISettingsManager
 		}
 
 
+		if (settings.AzureDocumentIntelligenceSettings is null)
+		{
+			settings.AzureDocumentIntelligenceSettings = new AzureDocumentIntelligenceSettings();
+			somethingWasMissing = true;
+		}
+		var azureDocumentIntelligenceSettings = settings.AzureDocumentIntelligenceSettings;
+
+		if (string.IsNullOrWhiteSpace(azureDocumentIntelligenceSettings.Endpoint))
+		{
+			azureDocumentIntelligenceSettings.Endpoint = PlaceholderUrl;
+			somethingWasMissing = true;
+		}
+		if (string.IsNullOrWhiteSpace(azureDocumentIntelligenceSettings.ApiKey))
+		{
+			azureDocumentIntelligenceSettings.ApiKey = PlaceholderValue;
+			somethingWasMissing = true;
+		}
+		if (azureDocumentIntelligenceSettings.FreeTierPageLimit <= 0)
+		{
+			azureDocumentIntelligenceSettings.FreeTierPageLimit = 2;
+			somethingWasMissing = true;
+		}
+		if (azureDocumentIntelligenceSettings.MaxParallelDocuments <= 0)
+		{
+			azureDocumentIntelligenceSettings.MaxParallelDocuments = 2;
+			somethingWasMissing = true;
+		}
+		if (azureDocumentIntelligenceSettings.MaxParallelRequestsPerMinute <= 0)
+		{
+			azureDocumentIntelligenceSettings.MaxParallelRequestsPerMinute = 20;
+			somethingWasMissing = true;
+		}
+		if (azureDocumentIntelligenceSettings.MaxDocumentBytes.HasValue && azureDocumentIntelligenceSettings.MaxDocumentBytes.Value <= 0)
+		{
+			azureDocumentIntelligenceSettings.MaxDocumentBytes = null;
+			somethingWasMissing = true;
+		}
+
+
 		if (settings.AudioSettings is null)
 		{
 			settings.AudioSettings = new AudioSettings();


### PR DESCRIPTION
## Summary
- introduce Document OCR preprocessing models, PDF/image batching utility, and API throttling helper
- extend shared settings to include Azure Document Intelligence configuration defaults
- add unit tests validating the preprocessor behaviors and rate limiter pacing logic

## Testing
- `dotnet test` *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fc8c900138832d911b7b7be81daf0f