### PR TITLE
Ensure OCR clipboard updates marshal to UI thread

### DIFF
--- a/Mutation.Tests/OcrManagerTests.cs
+++ b/Mutation.Tests/OcrManagerTests.cs
@@ -1,0 +1,126 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using CognitiveSupport;
+using Mutation.Ui.Services;
+
+namespace Mutation.Tests;
+
+public class OcrManagerTests
+{
+	[Fact]
+	public async Task ExtractTextFromFilesAsync_CopiesResult_WhenUiThread()
+	{
+		var settings = new Settings();
+		var clipboard = new TestClipboardManager();
+		var ocrService = new FakeOcrService("recognized text");
+		using var temp = new TempFile();
+		File.WriteAllText(temp.Path, "sample");
+		var manager = new TestableOcrManager(settings, ocrService, clipboard, () => true, _ => Task.CompletedTask);
+		var result = await manager.ExtractTextFromFilesAsync(new[] { temp.Path }, OcrReadingOrder.TopToBottomColumnAware, CancellationToken.None);
+		var expected = $"[{Path.GetFileName(temp.Path)}]{Environment.NewLine}recognized text{Environment.NewLine}";
+		Assert.True(result.Success);
+		Assert.Equal(expected, result.Text);
+		Assert.Equal(expected, clipboard.LastText);
+		Assert.Equal(1, clipboard.CallCount);
+		Assert.Equal(0, manager.RunOnDispatcherCalls);
+	}
+
+	[Fact]
+	public async Task ExtractTextFromFilesAsync_DispatchesClipboardUpdate_WhenOffUiThread()
+	{
+		var settings = new Settings();
+		var clipboard = new TestClipboardManager();
+		var ocrService = new FakeOcrService("batched result");
+		using var temp = new TempFile();
+		File.WriteAllText(temp.Path, "sample");
+		var dispatched = false;
+		var manager = new TestableOcrManager(settings, ocrService, clipboard, () => false, action =>
+		{
+			dispatched = true;
+			action();
+			return Task.CompletedTask;
+		});
+		var result = await manager.ExtractTextFromFilesAsync(new[] { temp.Path }, OcrReadingOrder.TopToBottomColumnAware, CancellationToken.None);
+		var expected = $"[{Path.GetFileName(temp.Path)}]{Environment.NewLine}batched result{Environment.NewLine}";
+		Assert.True(result.Success);
+		Assert.True(dispatched);
+		Assert.Equal(expected, clipboard.LastText);
+		Assert.Equal(1, clipboard.CallCount);
+		Assert.Equal(1, manager.RunOnDispatcherCalls);
+	}
+
+	private sealed class TestableOcrManager : OcrManager
+	{
+		private readonly Func<bool> _hasThreadAccess;
+		private readonly Func<Action, Task> _dispatcher;
+
+		public int RunOnDispatcherCalls { get; private set; }
+
+		public TestableOcrManager(Settings settings, IOcrService ocrService, ClipboardManager clipboard, Func<bool> hasThreadAccess, Func<Action, Task> dispatcher)
+			: base(settings, ocrService, clipboard)
+		{
+			_hasThreadAccess = hasThreadAccess;
+			_dispatcher = dispatcher;
+		}
+
+		protected override bool HasDispatcherThreadAccess() => _hasThreadAccess();
+
+		protected override Task RunOnDispatcherAsync(Action action)
+		{
+			RunOnDispatcherCalls++;
+			return _dispatcher(action);
+		}
+
+		protected override void PlayBeep(BeepType type)
+		{
+			// Suppress audio during tests
+		}
+	}
+
+	private sealed class TestClipboardManager : ClipboardManager
+	{
+		public string? LastText { get; private set; }
+		public int CallCount { get; private set; }
+
+		public override void SetText(string text)
+		{
+			CallCount++;
+			LastText = text;
+		}
+	}
+
+	private sealed class FakeOcrService : IOcrService
+	{
+		private readonly string _text;
+
+		public FakeOcrService(string text)
+		{
+			_text = text;
+		}
+
+		public Task<string> ExtractText(OcrReadingOrder ocrReadingOrder, Stream imageStream, CancellationToken overallCancellationToken)
+		{
+			return Task.FromResult(_text);
+		}
+	}
+
+	private sealed class TempFile : IDisposable
+	{
+		public string Path { get; }
+
+		public TempFile()
+		{
+			Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), System.IO.Path.GetRandomFileName());
+		}
+
+		public void Dispose()
+		{
+			if (File.Exists(Path))
+			{
+				File.Delete(Path);
+			}
+		}
+	}
+}

--- a/Mutation.Ui/MainWindow.xaml
+++ b/Mutation.Ui/MainWindow.xaml
@@ -605,6 +605,35 @@
                                         </StackPanel>
                                     </Grid>
                                 </Button>
+
+                                <Button
+                                    x:Name="BtnOcrDocuments"
+                                    Style="{StaticResource OutlinedButtonStyle}"
+                                    HorizontalAlignment="Stretch"
+                                    HorizontalContentAlignment="Stretch"
+                                    Click="BtnOcrDocuments_Click"
+                                    AccessKey="R"
+                                    AutomationProperties.Name="OCR documents"
+                                    ToolTipService.ToolTip="Select documents and extract their text in a single batch">
+                                    <Grid ColumnSpacing="12" VerticalAlignment="Stretch">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="32" />
+                                            <ColumnDefinition Width="*" />
+                                        </Grid.ColumnDefinitions>
+                                        <FontIcon
+                                            Glyph="&#xE8A5;"
+                                            FontFamily="Segoe Fluent Icons"
+                                            HorizontalAlignment="Left"
+                                            VerticalAlignment="Center" />
+                                        <StackPanel Grid.Column="1" Spacing="2" VerticalAlignment="Center">
+                                            <TextBlock Text="OCR documents" />
+                                            <TextBlock
+                                                Text="Batch PDFs and images into one result"
+                                                Style="{StaticResource CaptionTextStyle}"
+                                                Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                                        </StackPanel>
+                                    </Grid>
+                                </Button>
                             </StackPanel>
 
                             <TextBox
@@ -617,6 +646,20 @@
                                 ScrollViewer.HorizontalScrollMode="Auto"
                                 AutomationProperties.Name="OCR result"
                                 ToolTipService.ToolTip="Text extracted from captured images" />
+
+                            <Button
+                                x:Name="BtnDownloadOcrResults"
+                                Style="{StaticResource AccentButtonStyle}"
+                                HorizontalAlignment="Left"
+                                Click="BtnDownloadOcrResults_Click"
+                                IsEnabled="False"
+                                AutomationProperties.Name="Download OCR result"
+                                ToolTipService.ToolTip="Save the OCR output to a text document">
+                                <StackPanel Orientation="Horizontal" Spacing="8">
+                                    <FontIcon Glyph="&#xE118;" FontFamily="Segoe Fluent Icons" />
+                                    <TextBlock Text="Download OCR result" />
+                                </StackPanel>
+                            </Button>
                         </StackPanel>
                     </Border>
 

--- a/Mutation.Ui/MainWindow.xaml.cs
+++ b/Mutation.Ui/MainWindow.xaml.cs
@@ -961,6 +961,95 @@ public sealed partial class MainWindow : Window
 		}
 	}
 
+	private async void BtnOcrDocuments_Click(object sender, RoutedEventArgs e)
+	{
+		try
+		{
+			var picker = new FileOpenPicker
+			{
+				SuggestedStartLocation = PickerLocationId.DocumentsLibrary,
+				ViewMode = PickerViewMode.List
+			};
+			string[] extensions = new[] { ".pdf", ".png", ".jpg", ".jpeg", ".bmp", ".gif", ".tif", ".tiff", ".heic", ".webp" };
+			foreach (string extension in extensions)
+			{
+				picker.FileTypeFilter.Add(extension);
+			}
+
+			InitializeWithWindow.Initialize(picker, WindowNative.GetWindowHandle(this));
+			IReadOnlyList<StorageFile>? files = await picker.PickMultipleFilesAsync();
+			if (files == null || files.Count == 0)
+				return;
+
+			BtnOcrDocuments.IsEnabled = false;
+			ShowStatus("OCR documents", $"Processing {files.Count} document(s)...", InfoBarSeverity.Informational);
+
+			var paths = files.Select(file => file.Path).ToList();
+			var result = await _ocrManager.ExtractTextFromFilesAsync(paths, OcrReadingOrder.TopToBottomColumnAware, CancellationToken.None);
+			SetOcrText(result.Text);
+
+			if (result.SuccessCount == 0)
+			{
+				string failureDetails = result.Failures.Count > 0 ? string.Join("\n", result.Failures) : "Unable to extract text from the selected documents.";
+				ShowStatus("OCR documents", failureDetails, InfoBarSeverity.Error);
+			}
+			else if (result.Success)
+			{
+				ShowStatus("OCR documents", $"Processed {result.SuccessCount} document(s). Results copied to the clipboard.", InfoBarSeverity.Success);
+			}
+			else
+			{
+				string failureSummary = BuildFailureSummary(result.Failures);
+				string message = string.IsNullOrWhiteSpace(failureSummary)
+					? $"Processed {result.SuccessCount} of {result.TotalCount} document(s)."
+					: $"Processed {result.SuccessCount} of {result.TotalCount} document(s). Issues: {failuresummary}";
+				ShowStatus("OCR documents", message, InfoBarSeverity.Warning);
+			}
+		}
+		catch (Exception ex)
+		{
+			ShowStatus("OCR documents", ex.Message, InfoBarSeverity.Error);
+			await ShowErrorDialog("OCR Documents Error", ex);
+		}
+		finally
+		{
+			BtnOcrDocuments.IsEnabled = true;
+		}
+	}
+
+        private async void BtnDownloadOcrResults_Click(object sender, RoutedEventArgs e)
+        {
+                string text = TxtOcr.Text;
+                if (string.IsNullOrWhiteSpace(text))
+                {
+                        ShowStatus("OCR documents", "No OCR results available to download.", InfoBarSeverity.Warning);
+                        return;
+                }
+
+                try
+                {
+                        var picker = new FileSavePicker
+                        {
+                                SuggestedStartLocation = PickerLocationId.DocumentsLibrary,
+                                SuggestedFileName = $"ocr-results-{DateTime.Now:yyyyMMdd-HHmmss}"
+                        };
+                        picker.FileTypeChoices.Add("Text Document", new List<string> { ".txt" });
+
+                        InitializeWithWindow.Initialize(picker, WindowNative.GetWindowHandle(this));
+                        StorageFile? file = await picker.PickSaveFileAsync();
+                        if (file is null)
+                                return;
+
+                        await FileIO.WriteTextAsync(file, text);
+                        ShowStatus("OCR documents", $"Saved OCR results to {file.Name}.", InfoBarSeverity.Success);
+                }
+                catch (Exception ex)
+                {
+                        ShowStatus("OCR documents", ex.Message, InfoBarSeverity.Error);
+                        await ShowErrorDialog("Save OCR Result Error", ex);
+                }
+        }
+
 	public async void BtnSpeechToText_Click(object? sender, RoutedEventArgs? e)
 	{
 		try
@@ -1860,9 +1949,27 @@ public sealed partial class MainWindow : Window
 		catch (TaskCanceledException) { }
 	}
 
+	private static string BuildFailureSummary(IReadOnlyList<string> failures)
+	{
+		if (failures.Count == 0)
+			return string.Empty;
+
+		var sample = failures.Take(3).ToList();
+		string summary = string.Join("; ", sample);
+		if (failures.Count > sample.Count)
+			summary += "; ...";
+
+		return summary;
+	}
+
 	internal void SetOcrText(string message)
 	{
-		TxtOcr.Text = message;
+		string safeMessage = message ?? string.Empty;
+		TxtOcr.Text = safeMessage;
+		if (BtnDownloadOcrResults is not null)
+		{
+			BtnDownloadOcrResults.IsEnabled = !string.IsNullOrWhiteSpace(safeMessage);
+		}
 	}
 
 	private async void SettingsMenuItem_Click(object sender, RoutedEventArgs e)

--- a/Mutation.Ui/MainWindow.xaml.cs
+++ b/Mutation.Ui/MainWindow.xaml.cs
@@ -1002,7 +1002,7 @@ public sealed partial class MainWindow : Window
 				string failureSummary = BuildFailureSummary(result.Failures);
 				string message = string.IsNullOrWhiteSpace(failureSummary)
 					? $"Processed {result.SuccessCount} of {result.TotalCount} document(s)."
-					: $"Processed {result.SuccessCount} of {result.TotalCount} document(s). Issues: {failuresummary}";
+					: $"Processed {result.SuccessCount} of {result.TotalCount} document(s). Issues: {failureSummary}";
 				ShowStatus("OCR documents", message, InfoBarSeverity.Warning);
 			}
 		}

--- a/Mutation.Ui/Services/ClipboardManager.cs
+++ b/Mutation.Ui/Services/ClipboardManager.cs
@@ -29,7 +29,7 @@ public class ClipboardManager
 		return null;
 	}
 
-	public void SetText(string text)
+	public virtual void SetText(string text)
 	{
 		if (string.IsNullOrWhiteSpace(text))
 			return;


### PR DESCRIPTION
## Summary
- ensure batch OCR clipboard writes run on the UI thread by dispatching through the window dispatcher and exposing an overridable beep hook
- make the clipboard service extensible and cover the new threading behavior with unit tests

## Testing
- dotnet test --configuration Release --logger "trx;LogFileName=test-results.trx" *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68fcac3d6bb4832d99504345b9a597ff