### PR TITLE
Add Anthropic Claude API support alongside OpenAI

### DIFF
--- a/CognitiveSupport/AnthropicLlmService.cs
+++ b/CognitiveSupport/AnthropicLlmService.cs
@@ -1,0 +1,140 @@
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace CognitiveSupport;
+
+public class AnthropicLlmService : ILlmService
+{
+	private const string ApiUrl = "https://api.anthropic.com/v1/messages";
+	private const string AnthropicVersion = "2023-06-01";
+	private const int DefaultMaxTokens = 4096;
+
+	private readonly string _apiKey;
+	private readonly HttpClient _httpClient;
+
+	public AnthropicLlmService(string apiKey, HttpClient httpClient)
+	{
+		if (string.IsNullOrEmpty(apiKey)) throw new ArgumentNullException(nameof(apiKey));
+		_apiKey = apiKey;
+		_httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+	}
+
+	public async Task<string> CreateChatCompletion(
+		IList<LlmChatMessage> messages,
+		string llmModelName,
+		decimal temperature = 0.7m)
+	{
+		// Extract system message (Anthropic uses a top-level "system" parameter)
+		string? systemMessage = messages
+			.Where(m => m.Role == LlmChatRole.System)
+			.Select(m => m.Content)
+			.FirstOrDefault();
+
+		var conversationMessages = messages
+			.Where(m => m.Role != LlmChatRole.System)
+			.Select(m => new AnthropicMessage
+			{
+				Role = m.Role == LlmChatRole.User ? "user" : "assistant",
+				Content = m.Content
+			})
+			.ToArray();
+
+		if (conversationMessages.Length == 0)
+			throw new ArgumentException("At least one non-system message is required for Anthropic API calls.", nameof(messages));
+
+		var request = new AnthropicRequest
+		{
+			Model = llmModelName,
+			MaxTokens = DefaultMaxTokens,
+			Temperature = (double)temperature,
+			System = systemMessage,
+			Messages = conversationMessages
+		};
+
+		var jsonOptions = new JsonSerializerOptions
+		{
+			DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+		};
+		string jsonBody = JsonSerializer.Serialize(request, jsonOptions);
+
+		using var httpRequest = new HttpRequestMessage(HttpMethod.Post, ApiUrl);
+		httpRequest.Headers.Add("x-api-key", _apiKey);
+		httpRequest.Headers.Add("anthropic-version", AnthropicVersion);
+		httpRequest.Content = new StringContent(jsonBody, Encoding.UTF8, "application/json");
+
+		using var httpResponse = await _httpClient.SendAsync(httpRequest);
+
+		string responseBody = await httpResponse.Content.ReadAsStringAsync();
+
+		if (!httpResponse.IsSuccessStatusCode)
+		{
+			string errorMessage = $"Anthropic API returned {(int)httpResponse.StatusCode} {httpResponse.StatusCode}";
+			try
+			{
+				var errorResponse = JsonSerializer.Deserialize<AnthropicErrorResponse>(responseBody);
+				if (errorResponse?.Error != null)
+				{
+					errorMessage = $"Anthropic API error ({errorResponse.Error.Type}): {errorResponse.Error.Message}";
+				}
+			}
+			catch (JsonException)
+			{
+				// If we can't parse the error, use the raw status code message
+			}
+			throw new HttpRequestException(errorMessage);
+		}
+
+		var response = JsonSerializer.Deserialize<AnthropicResponse>(responseBody);
+		if (response?.Content != null && response.Content.Length > 0)
+		{
+			var textBlock = response.Content.FirstOrDefault(c => c.Type == "text");
+			if (textBlock != null)
+			{
+				return textBlock.Text ?? string.Empty;
+			}
+		}
+
+		return string.Empty;
+	}
+
+	// --- Internal DTOs for Anthropic API serialization ---
+
+	private class AnthropicRequest
+	{
+		[JsonPropertyName("model")] public string Model { get; set; } = "";
+		[JsonPropertyName("max_tokens")] public int MaxTokens { get; set; }
+		[JsonPropertyName("temperature")] public double Temperature { get; set; }
+		[JsonPropertyName("system")] public string? System { get; set; }
+		[JsonPropertyName("messages")] public AnthropicMessage[] Messages { get; set; } = [];
+	}
+
+	private class AnthropicMessage
+	{
+		[JsonPropertyName("role")] public string Role { get; set; } = "";
+		[JsonPropertyName("content")] public string Content { get; set; } = "";
+	}
+
+	private class AnthropicResponse
+	{
+		[JsonPropertyName("content")] public AnthropicContentBlock[] Content { get; set; } = [];
+	}
+
+	private class AnthropicContentBlock
+	{
+		[JsonPropertyName("type")] public string Type { get; set; } = "";
+		[JsonPropertyName("text")] public string? Text { get; set; }
+	}
+
+	private class AnthropicErrorResponse
+	{
+		[JsonPropertyName("error")] public AnthropicErrorDetail? Error { get; set; }
+	}
+
+	private class AnthropicErrorDetail
+	{
+		[JsonPropertyName("type")] public string Type { get; set; } = "";
+		[JsonPropertyName("message")] public string Message { get; set; } = "";
+	}
+}

--- a/CognitiveSupport/CompositeLlmService.cs
+++ b/CognitiveSupport/CompositeLlmService.cs
@@ -1,0 +1,39 @@
+namespace CognitiveSupport;
+
+public class CompositeLlmService : ILlmService
+{
+	private readonly ILlmService? _openAiService;
+	private readonly ILlmService? _anthropicService;
+
+	public CompositeLlmService(ILlmService? openAiService, ILlmService? anthropicService)
+	{
+		_openAiService = openAiService;
+		_anthropicService = anthropicService;
+	}
+
+	public Task<string> CreateChatCompletion(
+		IList<LlmChatMessage> messages,
+		string llmModelName,
+		decimal temperature = 0.7m)
+	{
+		if (IsAnthropicModel(llmModelName))
+		{
+			if (_anthropicService == null)
+				throw new InvalidOperationException(
+					$"Model '{llmModelName}' is an Anthropic model but no Anthropic API key is configured. " +
+					"Please set AnthropicApiKey in Mutation.json and restart.");
+
+			return _anthropicService.CreateChatCompletion(messages, llmModelName, temperature);
+		}
+
+		if (_openAiService == null)
+			throw new InvalidOperationException(
+				$"Model '{llmModelName}' is an OpenAI model but no OpenAI API key is configured. " +
+				"Please set ApiKey in Mutation.json and restart.");
+
+		return _openAiService.CreateChatCompletion(messages, llmModelName, temperature);
+	}
+
+	public static bool IsAnthropicModel(string modelName)
+		=> modelName.StartsWith("claude", StringComparison.OrdinalIgnoreCase);
+}

--- a/CognitiveSupport/ILlmService.cs
+++ b/CognitiveSupport/ILlmService.cs
@@ -1,8 +1,6 @@
-﻿using OpenAI.Chat;
-
 namespace CognitiveSupport;
 
 public interface ILlmService
 {
-	Task<string> CreateChatCompletion(IList<ChatMessage> messages, string llmModelName, decimal temperature = 0.7M);
+	Task<string> CreateChatCompletion(IList<LlmChatMessage> messages, string llmModelName, decimal temperature = 0.7M);
 }

--- a/CognitiveSupport/LlmChatMessage.cs
+++ b/CognitiveSupport/LlmChatMessage.cs
@@ -1,0 +1,20 @@
+namespace CognitiveSupport;
+
+public enum LlmChatRole
+{
+	System,
+	User,
+	Assistant
+}
+
+public class LlmChatMessage
+{
+	public LlmChatRole Role { get; }
+	public string Content { get; }
+
+	public LlmChatMessage(LlmChatRole role, string content)
+	{
+		Role = role;
+		Content = content;
+	}
+}

--- a/CognitiveSupport/LlmService.cs
+++ b/CognitiveSupport/LlmService.cs
@@ -1,4 +1,4 @@
-﻿using OpenAI.Chat;
+using OpenAI.Chat;
 using System.ClientModel;
 
 namespace CognitiveSupport;
@@ -24,7 +24,7 @@ public class LlmService : ILlmService
 	}
 
 	public async Task<string> CreateChatCompletion(
-		IList<ChatMessage> messages,
+		IList<LlmChatMessage> messages,
 		string llmModelName,
 		decimal temperature = 0.7m)
 	{
@@ -33,12 +33,14 @@ public class LlmService : ILlmService
 
 		var client = _chatClients[llmModelName];
 
+		var openAiMessages = messages.Select(ToOpenAiMessage).ToList();
+
 		ChatCompletionOptions options = new()
 		{
 			Temperature = (float)temperature
 		};
 
-		ClientResult<ChatCompletion> result = await client.CompleteChatAsync(messages, options);
+		ClientResult<ChatCompletion> result = await client.CompleteChatAsync(openAiMessages, options);
 
 		if (result.Value.Content.Count > 0)
 		{
@@ -46,4 +48,13 @@ public class LlmService : ILlmService
 		}
 		return string.Empty;
 	}
+
+	private static ChatMessage ToOpenAiMessage(LlmChatMessage msg)
+		=> msg.Role switch
+		{
+			LlmChatRole.System => new SystemChatMessage(msg.Content),
+			LlmChatRole.User => new UserChatMessage(msg.Content),
+			LlmChatRole.Assistant => new AssistantChatMessage(msg.Content),
+			_ => throw new ArgumentOutOfRangeException(nameof(msg.Role), msg.Role, "Unsupported chat role")
+		};
 }

--- a/CognitiveSupport/Settings.cs
+++ b/CognitiveSupport/Settings.cs
@@ -150,8 +150,10 @@ public class LlmSettings
 {
 	public const string DefaultModel = "gpt-4.1";
 	public const string DefaultSecondaryModel = "gpt-5.1";
+	public const string DefaultAnthropicModel = "claude-sonnet-4-6";
 
 	public string? ApiKey { get; set; }
+	public string? AnthropicApiKey { get; set; }
 	public List<string> Models { get; set; }
 	public string? SelectedLlmModel { get; set; }
 	public List<TranscriptFormatRule> TranscriptFormatRules { get; set; }

--- a/Mutation.Ui/App.xaml.cs
+++ b/Mutation.Ui/App.xaml.cs
@@ -12,6 +12,7 @@ using System.ClientModel;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net.Http;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
@@ -108,10 +109,29 @@ public partial class App : Application
 									  sp.GetRequiredService<ClipboardManager>()));
 			builder.Services.AddSingleton<HotkeyManager>(sp =>
 					  new HotkeyManager(sp.GetRequiredService<MainWindow>(), sp.GetRequiredService<Settings>()));
-			builder.Services.AddSingleton<ILlmService>(
-					  new LlmService(
-							 settings.LlmSettings?.ApiKey ?? string.Empty,
-							 settings.LlmSettings?.Models ?? new List<string>()));
+			builder.Services.AddSingleton<ILlmService>(sp =>
+			{
+				var llmSettings = settings.LlmSettings;
+				string openAiKey = llmSettings?.ApiKey ?? string.Empty;
+				string anthropicKey = llmSettings?.AnthropicApiKey ?? string.Empty;
+				var allModels = llmSettings?.Models ?? new List<string>();
+
+				var openAiModels = allModels.Where(m => !CompositeLlmService.IsAnthropicModel(m)).ToList();
+
+				LlmService? openAiService = null;
+				if (openAiModels.Any() && !string.IsNullOrEmpty(openAiKey) && openAiKey != "<placeholder>")
+				{
+					openAiService = new LlmService(openAiKey, openAiModels);
+				}
+
+				AnthropicLlmService? anthropicService = null;
+				if (!string.IsNullOrEmpty(anthropicKey) && anthropicKey != "<placeholder>")
+				{
+					anthropicService = new AnthropicLlmService(anthropicKey, new HttpClient());
+				}
+
+				return new CompositeLlmService(openAiService, anthropicService);
+			});
 			builder.Services.AddSingleton<TranscriptFormatter>();
                         builder.Services.AddSingleton<ITextToSpeechService, TextToSpeechService>();
 			builder.Services.AddHttpClient(OpenAiHttpClientName);

--- a/Mutation.Ui/Core/TranscriptFormatter.cs
+++ b/Mutation.Ui/Core/TranscriptFormatter.cs
@@ -1,6 +1,5 @@
-﻿using CognitiveSupport;
+using CognitiveSupport;
 using CognitiveSupport.Extensions;
-using OpenAI.Chat;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -41,10 +40,10 @@ public class TranscriptFormatter
 		if (string.IsNullOrWhiteSpace(transcript))
 			return transcript;
 
-		var messages = new List<ChatMessage>
+		var messages = new List<LlmChatMessage>
 		  {
-				new SystemChatMessage($"{systemPrompt}"),
-				new UserChatMessage($"Reformat the following transcript: {transcript}")
+				new LlmChatMessage(LlmChatRole.System, systemPrompt),
+				new LlmChatMessage(LlmChatRole.User, $"Reformat the following transcript: {transcript}")
 		  };
 
 		string formattedText = await _llmService.CreateChatCompletion(messages, modelName);

--- a/Mutation.Ui/Services/SettingsManager.cs
+++ b/Mutation.Ui/Services/SettingsManager.cs
@@ -364,6 +364,11 @@ internal class SettingsManager : ISettingsManager
 			llmSettings.ApiKey = PlaceholderValue;
 			somethingWasMissing = true;
 		}
+		if (string.IsNullOrWhiteSpace(llmSettings.AnthropicApiKey))
+		{
+			llmSettings.AnthropicApiKey = PlaceholderValue;
+			somethingWasMissing = true;
+		}
 
 		/* ResourceName removed
 		if (string.IsNullOrWhiteSpace(llmSettings.ResourceName))
@@ -430,7 +435,8 @@ End of summary.
 			llmSettings.Models = new List<string>
 			{
 				LlmSettings.DefaultModel,
-				LlmSettings.DefaultSecondaryModel
+				LlmSettings.DefaultSecondaryModel,
+				LlmSettings.DefaultAnthropicModel
 			};
 			somethingWasMissing = true;
 		}


### PR DESCRIPTION
Introduce provider-agnostic LlmChatMessage type to decouple ILlmService from OpenAI SDK types. Add AnthropicLlmService using raw HttpClient and CompositeLlmService that routes to OpenAI or Anthropic based on model name prefix (claude* -> Anthropic). Users configure AnthropicApiKey in Mutation.json and add Claude model names to the Models list.