### PR TITLE
Feature/tinkering

### DIFF
--- a/CognitiveSupport/AnthropicLlmService.cs
+++ b/CognitiveSupport/AnthropicLlmService.cs
@@ -13,21 +13,33 @@ public class AnthropicLlmService : ILlmService
 
 	private readonly string _apiKey;
 	private readonly HttpClient _httpClient;
+	private readonly Dictionary<string, LlmModelConfig> _modelConfigs;
 	private readonly int _timeoutSeconds;
 
-	public AnthropicLlmService(string apiKey, HttpClient httpClient, int timeoutSeconds = 60)
+	public AnthropicLlmService(
+		string apiKey,
+		IEnumerable<LlmModelConfig> models,
+		HttpClient httpClient,
+		int timeoutSeconds = 60)
 	{
 		if (string.IsNullOrEmpty(apiKey)) throw new ArgumentNullException(nameof(apiKey));
+		if (models is null) throw new ArgumentNullException(nameof(models));
+
 		_apiKey = apiKey;
 		_httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
 		_timeoutSeconds = timeoutSeconds > 0 ? timeoutSeconds : 60;
+		_modelConfigs = models.ToDictionary(m => m.Name, m => m, StringComparer.OrdinalIgnoreCase);
 	}
 
 	public async Task<string> CreateChatCompletion(
 		IList<LlmChatMessage> messages,
-		string llmModelName,
-		decimal temperature = 0.7m)
+		string llmModelName)
 	{
+		if (!_modelConfigs.TryGetValue(llmModelName, out var config))
+			throw new ArgumentException(
+				$"{llmModelName} is not one of the configured Anthropic models. Available: {string.Join(",", _modelConfigs.Keys)}",
+				nameof(llmModelName));
+
 		// Extract system message (Anthropic uses a top-level "system" parameter)
 		string? systemMessage = messages
 			.Where(m => m.Role == LlmChatRole.System)
@@ -50,7 +62,7 @@ public class AnthropicLlmService : ILlmService
 		{
 			Model = llmModelName,
 			MaxTokens = DefaultMaxTokens,
-			Temperature = (double)temperature,
+			Temperature = config.CustomTemperature.HasValue ? (double?)config.CustomTemperature.Value : null,
 			System = systemMessage,
 			Messages = conversationMessages
 		};
@@ -108,7 +120,7 @@ public class AnthropicLlmService : ILlmService
 	{
 		[JsonPropertyName("model")] public string Model { get; set; } = "";
 		[JsonPropertyName("max_tokens")] public int MaxTokens { get; set; }
-		[JsonPropertyName("temperature")] public double Temperature { get; set; }
+		[JsonPropertyName("temperature")] public double? Temperature { get; set; }
 		[JsonPropertyName("system")] public string? System { get; set; }
 		[JsonPropertyName("messages")] public AnthropicMessage[] Messages { get; set; } = [];
 	}

--- a/CognitiveSupport/AudioFileConverter.cs
+++ b/CognitiveSupport/AudioFileConverter.cs
@@ -57,12 +57,14 @@ public static class AudioFileConverter
 		resampler.ResamplerQuality = 60; // Reasonable quality
 
 		using var outStream = new FileStream(outputOggPath, FileMode.Create, FileAccess.Write, FileShare.None);
+#pragma warning disable CS0618 // Concentus.OggFile 1.0.6 still requires the concrete OpusEncoder type, not IOpusEncoder from OpusCodecFactory.
 		var encoder = new OpusEncoder(48000, 1, OpusApplication.OPUS_APPLICATION_VOIP)
 		{
 			Bitrate = 24000,
 			UseVBR = true,
 			UseDTX = false // DTX not supported in Ogg streams by Concentus.OggFile
 		};
+#pragma warning restore CS0618
 		var tags = new OpusTags();
 		var oggStream = new OpusOggWriteStream(encoder, outStream, tags);
 

--- a/CognitiveSupport/AudioPlayer.cs
+++ b/CognitiveSupport/AudioPlayer.cs
@@ -66,7 +66,9 @@ public class AudioPlayer : IDisposable
     {
         // Read and decode the entire OGG file to PCM
         using var fileStream = File.OpenRead(filePath);
+#pragma warning disable CS0618 // Concentus.OggFile 1.0.6 still requires the concrete OpusDecoder type, not IOpusDecoder from OpusCodecFactory.
         var oggReader = new OpusOggReadStream(_decoder = new OpusDecoder(SampleRate, Channels), fileStream);
+#pragma warning restore CS0618
 
         // Collect all decoded samples
         var allSamples = new List<short>();

--- a/CognitiveSupport/AudioRecorder.cs
+++ b/CognitiveSupport/AudioRecorder.cs
@@ -42,12 +42,14 @@ public class AudioRecorder : IDisposable
 
 				fileStream = new FileStream(outputFile, FileMode.Create, FileAccess.Write, FileShare.Read);
 
+#pragma warning disable CS0618 // Concentus.OggFile 1.0.6 still requires the concrete OpusEncoder type, not IOpusEncoder from OpusCodecFactory.
 				encoder = new OpusEncoder(SampleRate, Channels, OpusApplication.OPUS_APPLICATION_VOIP)
 				{
 					Bitrate = 24000,
 					UseVBR = true,
 					UseDTX = false // DTX not supported in Ogg streams by Concentus.OggFile
 				};
+#pragma warning restore CS0618
 
 				oggStream = new OpusOggWriteStream(encoder, fileStream, new OpusTags());
 

--- a/CognitiveSupport/BeepPlayer.cs
+++ b/CognitiveSupport/BeepPlayer.cs
@@ -39,12 +39,12 @@ public static class BeepPlayer
 			var custom = settings.AudioSettings?.CustomBeepSettings;
 			if (custom?.UseCustomBeeps == true)
 			{
-				_playerStart = LoadPlayer(custom.ResolveAudioFilePath(custom.BeepStartFile), fp => issues.Add($"Could not load start beep file: {fp}"));
-				_playerSuccess = LoadPlayer(custom.ResolveAudioFilePath(custom.BeepSuccessFile), fp => issues.Add($"Could not load success beep file: {fp}"));
-				_playerFailure = LoadPlayer(custom.ResolveAudioFilePath(custom.BeepFailureFile), fp => issues.Add($"Could not load failure beep file: {fp}"));
-				_playerEnd = LoadPlayer(custom.ResolveAudioFilePath(custom.BeepEndFile), fp => issues.Add($"Could not load end beep file: {fp}"));
-				_playerMute = LoadPlayer(custom.ResolveAudioFilePath(custom.BeepMuteFile), fp => issues.Add($"Could not load mute beep file: {fp}"));
-				_playerUnmute = LoadPlayer(custom.ResolveAudioFilePath(custom.BeepUnmuteFile), fp => issues.Add($"Could not load unmute beep file: {fp}"));
+				_playerStart = LoadPlayer(custom.ResolveAudioFilePath(custom.BeepStartFile ?? string.Empty), fp => issues.Add($"Could not load start beep file: {fp}"));
+				_playerSuccess = LoadPlayer(custom.ResolveAudioFilePath(custom.BeepSuccessFile ?? string.Empty), fp => issues.Add($"Could not load success beep file: {fp}"));
+				_playerFailure = LoadPlayer(custom.ResolveAudioFilePath(custom.BeepFailureFile ?? string.Empty), fp => issues.Add($"Could not load failure beep file: {fp}"));
+				_playerEnd = LoadPlayer(custom.ResolveAudioFilePath(custom.BeepEndFile ?? string.Empty), fp => issues.Add($"Could not load end beep file: {fp}"));
+				_playerMute = LoadPlayer(custom.ResolveAudioFilePath(custom.BeepMuteFile ?? string.Empty), fp => issues.Add($"Could not load mute beep file: {fp}"));
+				_playerUnmute = LoadPlayer(custom.ResolveAudioFilePath(custom.BeepUnmuteFile ?? string.Empty), fp => issues.Add($"Could not load unmute beep file: {fp}"));
 			}
 			LastInitializationIssues = issues;
 		}

--- a/CognitiveSupport/CognitiveSupport.csproj
+++ b/CognitiveSupport/CognitiveSupport.csproj
@@ -6,6 +6,9 @@
 		<Platforms>AnyCPU;x64</Platforms>
 	</PropertyGroup>
 	<ItemGroup>
+		<InternalsVisibleTo Include="Mutation.Tests" />
+	</ItemGroup>
+	<ItemGroup>
 		<PackageReference Include="Azure.AI.Vision.ImageAnalysis" Version="1.0.0" />
 		<PackageReference Include="Concentus" Version="2.2.2" />
 		<PackageReference Include="Concentus.Oggfile" Version="1.0.6" />

--- a/CognitiveSupport/CompositeLlmService.cs
+++ b/CognitiveSupport/CompositeLlmService.cs
@@ -4,36 +4,46 @@ public class CompositeLlmService : ILlmService
 {
 	private readonly ILlmService? _openAiService;
 	private readonly ILlmService? _anthropicService;
+	private readonly IReadOnlyDictionary<string, LlmProvider> _modelProviders;
 
-	public CompositeLlmService(ILlmService? openAiService, ILlmService? anthropicService)
+	public CompositeLlmService(
+		ILlmService? openAiService,
+		ILlmService? anthropicService,
+		IReadOnlyDictionary<string, LlmProvider> modelProviders)
 	{
 		_openAiService = openAiService;
 		_anthropicService = anthropicService;
+		_modelProviders = modelProviders ?? throw new ArgumentNullException(nameof(modelProviders));
 	}
 
 	public Task<string> CreateChatCompletion(
 		IList<LlmChatMessage> messages,
-		string llmModelName,
-		decimal temperature = 0.7m)
+		string llmModelName)
 	{
-		if (IsAnthropicModel(llmModelName))
-		{
-			if (_anthropicService == null)
-				throw new InvalidOperationException(
-					$"Model '{llmModelName}' is an Anthropic model but no Anthropic API key is configured. " +
-					"Please set AnthropicApiKey in Mutation.json and restart.");
-
-			return _anthropicService.CreateChatCompletion(messages, llmModelName, temperature);
-		}
-
-		if (_openAiService == null)
+		if (!_modelProviders.TryGetValue(llmModelName, out var provider))
 			throw new InvalidOperationException(
-				$"Model '{llmModelName}' is an OpenAI model but no OpenAI API key is configured. " +
-				"Please set ApiKey in Mutation.json and restart.");
+				$"Model '{llmModelName}' is not configured in LlmSettings.Models. " +
+				$"Add it (with an explicit Provider) to Mutation.json and restart.");
 
-		return _openAiService.CreateChatCompletion(messages, llmModelName, temperature);
+		switch (provider)
+		{
+			case LlmProvider.Anthropic:
+				if (_anthropicService == null)
+					throw new InvalidOperationException(
+						$"Model '{llmModelName}' is an Anthropic model but no Anthropic API key is configured. " +
+						"Please set AnthropicApiKey in Mutation.json and restart.");
+				return _anthropicService.CreateChatCompletion(messages, llmModelName);
+
+			case LlmProvider.OpenAI:
+				if (_openAiService == null)
+					throw new InvalidOperationException(
+						$"Model '{llmModelName}' is an OpenAI model but no OpenAI API key is configured. " +
+						"Please set ApiKey in Mutation.json and restart.");
+				return _openAiService.CreateChatCompletion(messages, llmModelName);
+
+			default:
+				throw new InvalidOperationException(
+					$"Unsupported LlmProvider '{provider}' for model '{llmModelName}'.");
+		}
 	}
-
-	public static bool IsAnthropicModel(string modelName)
-		=> modelName.StartsWith("claude", StringComparison.OrdinalIgnoreCase);
 }

--- a/CognitiveSupport/DeepgramSpeechToTextService.cs
+++ b/CognitiveSupport/DeepgramSpeechToTextService.cs
@@ -73,7 +73,7 @@ public class DeepgramSpeechToTextService : ISpeechToTextService
 			return await TranscribeViaDeepgram(keyterms, audioBytes, linkedCts).ConfigureAwait(false);
 		}, context, overallCancellationToken).ConfigureAwait(false);
 	
-		return response.Results.Channels?.FirstOrDefault()?.Alternatives?.FirstOrDefault().Transcript
+		return response?.Results?.Channels?.FirstOrDefault()?.Alternatives?.FirstOrDefault()?.Transcript
 			?? "(no transcript available)";
 
 
@@ -96,7 +96,7 @@ public class DeepgramSpeechToTextService : ISpeechToTextService
 			  FillerWords = false,
 			  Measurements = true,
 			  SmartFormat = true,
-		  }, cancellationTokenSource = cancellationTokenSource);
+		  }, cancellationTokenSource);
 		return response;
 	}
 

--- a/CognitiveSupport/Extensions/StringExtensions.cs
+++ b/CognitiveSupport/Extensions/StringExtensions.cs
@@ -5,7 +5,7 @@ public static class StringExtensions
 	public static string FixNewLines(
 		this string text)
 	{
-		if (text is null) return text;
+		if (text is null) return text!;
 
 		// Replace isolated "\r" with "\n"
 		text = text.Replace("\r\n", "\n");

--- a/CognitiveSupport/ILlmService.cs
+++ b/CognitiveSupport/ILlmService.cs
@@ -2,5 +2,5 @@ namespace CognitiveSupport;
 
 public interface ILlmService
 {
-	Task<string> CreateChatCompletion(IList<LlmChatMessage> messages, string llmModelName, decimal temperature = 0.7M);
+	Task<string> CreateChatCompletion(IList<LlmChatMessage> messages, string llmModelName);
 }

--- a/CognitiveSupport/LlmModelConfig.cs
+++ b/CognitiveSupport/LlmModelConfig.cs
@@ -1,0 +1,27 @@
+namespace CognitiveSupport;
+
+public enum LlmProvider
+{
+	OpenAI = 1,
+	Anthropic = 2,
+}
+
+public class LlmModelConfig
+{
+	public string Name { get; set; } = "";
+	public LlmProvider Provider { get; set; } = LlmProvider.OpenAI;
+
+	// Per-model temperature. Leave null (omit from JSON) for models that
+	// only accept the API default — the request will be sent without a
+	// temperature parameter.
+	public decimal? CustomTemperature { get; set; }
+
+	public LlmModelConfig() { }
+
+	public LlmModelConfig(string name, LlmProvider provider, decimal? customTemperature = null)
+	{
+		Name = name;
+		Provider = provider;
+		CustomTemperature = customTemperature;
+	}
+}

--- a/CognitiveSupport/LlmService.cs
+++ b/CognitiveSupport/LlmService.cs
@@ -6,42 +6,45 @@ namespace CognitiveSupport;
 public class LlmService : ILlmService
 {
 	private readonly Dictionary<string, ChatClient> _chatClients;
+	private readonly Dictionary<string, LlmModelConfig> _modelConfigs;
 	private readonly int _timeoutSeconds;
 
 	public LlmService(
 		string apiKey,
-		List<string> models,
+		IEnumerable<LlmModelConfig> models,
 		int timeoutSeconds = 60)
 	{
 		if (string.IsNullOrEmpty(apiKey)) throw new ArgumentNullException(nameof(apiKey));
-		if (models is null || !models.Any())
-			throw new ArgumentNullException(nameof(models));
+		if (models is null) throw new ArgumentNullException(nameof(models));
+
+		var modelList = models.ToList();
+		if (modelList.Count == 0)
+			throw new ArgumentException("At least one model must be configured.", nameof(models));
 
 		_chatClients = new Dictionary<string, ChatClient>();
+		_modelConfigs = new Dictionary<string, LlmModelConfig>();
 		_timeoutSeconds = timeoutSeconds > 0 ? timeoutSeconds : 60;
 
-		foreach (var model in models)
+		foreach (var model in modelList)
 		{
-			_chatClients[model] = new ChatClient(model, apiKey);
+			_chatClients[model.Name] = new ChatClient(model.Name, apiKey);
+			_modelConfigs[model.Name] = model;
 		}
 	}
 
 	public async Task<string> CreateChatCompletion(
 		IList<LlmChatMessage> messages,
-		string llmModelName,
-		decimal temperature = 0.7m)
+		string llmModelName)
 	{
 		if (!_chatClients.ContainsKey(llmModelName))
 			throw new ArgumentException($"{llmModelName} is not one of the configured models. The following are the available, configured models: {string.Join(",", _chatClients.Keys)}", nameof(llmModelName));
 
 		var client = _chatClients[llmModelName];
+		var config = _modelConfigs[llmModelName];
 
 		var openAiMessages = messages.Select(ToOpenAiMessage).ToList();
 
-		ChatCompletionOptions options = new()
-		{
-			Temperature = (float)temperature
-		};
+		ChatCompletionOptions options = BuildChatOptions(config);
 
 		using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(_timeoutSeconds));
 		ClientResult<ChatCompletion> result = await client.CompleteChatAsync(openAiMessages, options, timeoutCts.Token);
@@ -51,6 +54,16 @@ public class LlmService : ILlmService
 			return result.Value.Content[0].Text;
 		}
 		return string.Empty;
+	}
+
+	internal static ChatCompletionOptions BuildChatOptions(LlmModelConfig config)
+	{
+		var options = new ChatCompletionOptions();
+		if (config.CustomTemperature.HasValue)
+		{
+			options.Temperature = (float)config.CustomTemperature.Value;
+		}
+		return options;
 	}
 
 	private static ChatMessage ToOpenAiMessage(LlmChatMessage msg)

--- a/CognitiveSupport/Settings.cs
+++ b/CognitiveSupport/Settings.cs
@@ -176,13 +176,13 @@ public class SpeechToTextServiceSettings
 
 public class LlmSettings
 {
-	public const string DefaultModel = "gpt-4.1";
+	public const string DefaultModel = "chat-latest";
 	public const string DefaultSecondaryModel = "gpt-4.1";
 	public const string DefaultAnthropicModel = "claude-sonnet-4-6";
 
 	public string? ApiKey { get; set; }
 	public string? AnthropicApiKey { get; set; }
-	public List<string> Models { get; set; }
+	public List<LlmModelConfig> Models { get; set; }
 	public string? SelectedLlmModel { get; set; }
 	public List<TranscriptFormatRule> TranscriptFormatRules { get; set; }
 	public string? FormatTranscriptPrompt { get; set; }
@@ -193,12 +193,12 @@ public class LlmSettings
 
 	public LlmSettings()
 	{
-		Models = new List<string>();
+		Models = new List<LlmModelConfig>();
 		TranscriptFormatRules = new List<TranscriptFormatRule>();
 		Prompts = new List<LlmPrompt>();
 	}
 
-	public LlmSettings(string? apiKey, List<string> models, List<TranscriptFormatRule> transcriptFormatRules, string? formatTranscriptPrompt)
+	public LlmSettings(string? apiKey, List<LlmModelConfig> models, List<TranscriptFormatRule> transcriptFormatRules, string? formatTranscriptPrompt)
 	{
 		ApiKey = apiKey;
 		Models = models;

--- a/CognitiveSupport/Settings.cs
+++ b/CognitiveSupport/Settings.cs
@@ -183,7 +183,6 @@ public class LlmSettings
 	public string? ApiKey { get; set; }
 	public string? AnthropicApiKey { get; set; }
 	public List<LlmModelConfig> Models { get; set; }
-	public string? SelectedLlmModel { get; set; }
 	public List<TranscriptFormatRule> TranscriptFormatRules { get; set; }
 	public string? FormatTranscriptPrompt { get; set; }
 	public string? FormatWithLlmHotKey { get; set; }
@@ -214,6 +213,7 @@ public class LlmSettings
 		public string Content { get; set; } = "";
 		public string? Hotkey { get; set; }
 		public bool AutoRun { get; set; }
+		public string? ModelName { get; set; }
 
 		public LlmPrompt() { }
 	}

--- a/CognitiveSupport/TextFormatter.cs
+++ b/CognitiveSupport/TextFormatter.cs
@@ -11,7 +11,7 @@ public static class TextFormatter
 		this string text,
 		List<LlmSettings.TranscriptFormatRule> rules)
 	{
-		if (text is null) return text;
+		if (text is null) return text!;
 		if (rules is null) throw new ArgumentNullException(nameof(rules));
 
 		text = text.FixNewLines();
@@ -29,7 +29,7 @@ public static class TextFormatter
 	public static string CleanupPunctuation(
 		this string text)
 	{
-		if (text is null) return text;
+		if (text is null) return text!;
 
 		string[] deduplications = new[]
 		{
@@ -89,7 +89,7 @@ public static class TextFormatter
 		string line)
 	{
 		if (line is null)
-			return line;
+			return line!;
 
 		string output = line.Trim();
 
@@ -109,12 +109,16 @@ public static class TextFormatter
 		string text,
 		TranscriptFormatRule rule)
 	{
-		if (text is null) return text;
+		if (text is null) return text!;
 		if (rule is null) throw new ArgumentNullException(nameof(rule));
+		if (rule.Find is null) return text;
 
 		RegexOptions regexOptions = RegexOptions.None;
 		if (!rule.CaseSensitive)
 			regexOptions = RegexOptions.IgnoreCase;
+
+		string find = rule.Find;
+		string replaceWith = rule.ReplaceWith ?? string.Empty;
 
 		switch (rule.MatchType)
 		{
@@ -123,14 +127,14 @@ public static class TextFormatter
 				if (rule.CaseSensitive)
 					comparison = StringComparison.InvariantCulture;
 
-				text = text.Replace(rule.Find, rule.ReplaceWith, comparison);
+				text = text.Replace(find, replaceWith, comparison);
 				break;
 			case MatchTypeEnum.RegEx:
-				text = Regex.Replace(text, rule.Find, rule.ReplaceWith, regexOptions);
+				text = Regex.Replace(text, find, replaceWith, regexOptions);
 				break;
 			case MatchTypeEnum.Smart:
-				string pattern = $@"(\b|^)([.,]?)([ ]*{rule.Find}[.,]?[ ]*)(\b|$)";
-				string replacement = $"$1$2{rule.ReplaceWith}$4";
+				string pattern = $@"(\b|^)([.,]?)([ ]*{find}[.,]?[ ]*)(\b|$)";
+				string replacement = $"$1$2{replaceWith}$4";
 				text = Regex.Replace(text, pattern, replacement, regexOptions);
 
 				break;
@@ -145,7 +149,7 @@ public static class TextFormatter
 		this string text,
 		params string[] substringsToRemove)
 	{
-		if (text is null) return text;
+		if (text is null) return text!;
 		if (substringsToRemove is null || !substringsToRemove.Any())
 			throw new ArgumentNullException(nameof(substringsToRemove));
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,5 +2,6 @@
   <PropertyGroup>
     <!-- Allow Windows-targeted TFMs to build on non‑Windows hosts -->
     <EnableWindowsTargeting Condition="'$(OS)' != 'Windows_NT'">true</EnableWindowsTargeting>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 </Project>

--- a/Mutation.Tests/CompositeLlmServiceTests.cs
+++ b/Mutation.Tests/CompositeLlmServiceTests.cs
@@ -4,27 +4,16 @@ namespace Mutation.Tests;
 
 public class CompositeLlmServiceTests
 {
-	[Theory]
-	[InlineData("claude-sonnet-4-6", true)]
-	[InlineData("claude-3-opus", true)]
-	[InlineData("Claude-Sonnet", true)]
-	[InlineData("CLAUDE", true)]
-	[InlineData("gpt-4", false)]
-	[InlineData("gpt-4.1", false)]
-	[InlineData("o1-mini", false)]
-	[InlineData("", false)]
-	[InlineData("anthropic-claude", false)]
-	public void IsAnthropicModel_RecognizesPrefix(string model, bool expected)
-	{
-		Assert.Equal(expected, CompositeLlmService.IsAnthropicModel(model));
-	}
+	private static IReadOnlyDictionary<string, LlmProvider> Providers(params (string name, LlmProvider provider)[] entries)
+		=> entries.ToDictionary(e => e.name, e => e.provider, StringComparer.OrdinalIgnoreCase);
 
 	[Fact]
 	public async Task CreateChatCompletion_AnthropicModel_RoutesToAnthropicService()
 	{
 		var openAi = new StubLlmService("from-openai");
 		var anthropic = new StubLlmService("from-anthropic");
-		var composite = new CompositeLlmService(openAi, anthropic);
+		var providers = Providers(("claude-sonnet-4-6", LlmProvider.Anthropic));
+		var composite = new CompositeLlmService(openAi, anthropic, providers);
 
 		var messages = new List<LlmChatMessage>
 		{
@@ -44,7 +33,8 @@ public class CompositeLlmServiceTests
 	{
 		var openAi = new StubLlmService("from-openai");
 		var anthropic = new StubLlmService("from-anthropic");
-		var composite = new CompositeLlmService(openAi, anthropic);
+		var providers = Providers(("gpt-4.1", LlmProvider.OpenAI));
+		var composite = new CompositeLlmService(openAi, anthropic, providers);
 
 		var messages = new List<LlmChatMessage>
 		{
@@ -60,9 +50,48 @@ public class CompositeLlmServiceTests
 	}
 
 	[Fact]
+	public async Task CreateChatCompletion_RoutesByExplicitProvider_NotByNamePrefix()
+	{
+		// A model named "claude-via-openai-proxy" routed explicitly to OpenAI.
+		var openAi = new StubLlmService("from-openai");
+		var anthropic = new StubLlmService("from-anthropic");
+		var providers = Providers(("claude-via-openai-proxy", LlmProvider.OpenAI));
+		var composite = new CompositeLlmService(openAi, anthropic, providers);
+
+		string result = await composite.CreateChatCompletion(
+			new List<LlmChatMessage> { new(LlmChatRole.User, "hi") },
+			"claude-via-openai-proxy");
+
+		Assert.Equal("from-openai", result);
+		Assert.Equal(1, openAi.CallCount);
+		Assert.Equal(0, anthropic.CallCount);
+	}
+
+	[Fact]
+	public async Task CreateChatCompletion_UnknownModel_Throws()
+	{
+		var composite = new CompositeLlmService(
+			openAiService: new StubLlmService("openai"),
+			anthropicService: new StubLlmService("anthropic"),
+			Providers());
+
+		var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+			composite.CreateChatCompletion(
+				new List<LlmChatMessage> { new(LlmChatRole.User, "hi") },
+				"some-unknown-model"));
+
+		Assert.Contains("not configured", ex.Message, StringComparison.OrdinalIgnoreCase);
+		Assert.Contains("some-unknown-model", ex.Message);
+	}
+
+	[Fact]
 	public async Task CreateChatCompletion_AnthropicModelButServiceNull_ThrowsWithHelpfulMessage()
 	{
-		var composite = new CompositeLlmService(openAiService: new StubLlmService("openai"), anthropicService: null);
+		var providers = Providers(("claude-sonnet-4-6", LlmProvider.Anthropic));
+		var composite = new CompositeLlmService(
+			openAiService: new StubLlmService("openai"),
+			anthropicService: null,
+			providers);
 
 		var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
 			composite.CreateChatCompletion(
@@ -76,7 +105,11 @@ public class CompositeLlmServiceTests
 	[Fact]
 	public async Task CreateChatCompletion_OpenAiModelButServiceNull_ThrowsWithHelpfulMessage()
 	{
-		var composite = new CompositeLlmService(openAiService: null, anthropicService: new StubLlmService("anthropic"));
+		var providers = Providers(("gpt-4", LlmProvider.OpenAI));
+		var composite = new CompositeLlmService(
+			openAiService: null,
+			anthropicService: new StubLlmService("anthropic"),
+			providers);
 
 		var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
 			composite.CreateChatCompletion(
@@ -85,20 +118,6 @@ public class CompositeLlmServiceTests
 
 		Assert.Contains("OpenAI", ex.Message, StringComparison.OrdinalIgnoreCase);
 		Assert.Contains("ApiKey", ex.Message);
-	}
-
-	[Fact]
-	public async Task CreateChatCompletion_PassesTemperatureThrough()
-	{
-		var anthropic = new StubLlmService("ok");
-		var composite = new CompositeLlmService(openAiService: null, anthropicService: anthropic);
-
-		await composite.CreateChatCompletion(
-			new List<LlmChatMessage> { new(LlmChatRole.User, "hi") },
-			"claude-sonnet-4-6",
-			temperature: 0.2m);
-
-		Assert.Equal(0.2m, anthropic.LastTemperature);
 	}
 
 	private sealed class StubLlmService : ILlmService
@@ -113,14 +132,12 @@ public class CompositeLlmServiceTests
 		public int CallCount { get; private set; }
 		public IList<LlmChatMessage>? LastMessages { get; private set; }
 		public string? LastModel { get; private set; }
-		public decimal LastTemperature { get; private set; }
 
-		public Task<string> CreateChatCompletion(IList<LlmChatMessage> messages, string llmModelName, decimal temperature = 0.7M)
+		public Task<string> CreateChatCompletion(IList<LlmChatMessage> messages, string llmModelName)
 		{
 			CallCount++;
 			LastMessages = messages;
 			LastModel = llmModelName;
-			LastTemperature = temperature;
 			return Task.FromResult(_response);
 		}
 	}

--- a/Mutation.Tests/LlmServiceTemperatureTests.cs
+++ b/Mutation.Tests/LlmServiceTemperatureTests.cs
@@ -1,0 +1,27 @@
+using CognitiveSupport;
+
+namespace Mutation.Tests;
+
+public class LlmServiceTemperatureTests
+{
+	[Fact]
+	public void BuildChatOptions_SetsTemperature_WhenConfigured()
+	{
+		var config = new LlmModelConfig("gpt-4.1", LlmProvider.OpenAI, customTemperature: 0.42m);
+
+		var options = LlmService.BuildChatOptions(config);
+
+		Assert.NotNull(options.Temperature);
+		Assert.Equal(0.42f, options.Temperature.Value, precision: 4);
+	}
+
+	[Fact]
+	public void BuildChatOptions_OmitsTemperature_WhenNotConfigured()
+	{
+		var config = new LlmModelConfig("chat-latest", LlmProvider.OpenAI, customTemperature: null);
+
+		var options = LlmService.BuildChatOptions(config);
+
+		Assert.Null(options.Temperature);
+	}
+}

--- a/Mutation.Tests/OcrServiceTests.cs
+++ b/Mutation.Tests/OcrServiceTests.cs
@@ -27,11 +27,11 @@ public class OcrServiceTests
 		Assert.NotNull(waitAsync);
 
 		Task first = (Task)waitAsync!.Invoke(limiter, new object[] { CancellationToken.None })!;
-		await first.ConfigureAwait(false);
+		await first;
 
 		var stopwatch = Stopwatch.StartNew();
 		Task second = (Task)waitAsync.Invoke(limiter, new object[] { CancellationToken.None })!;
-		await second.ConfigureAwait(false);
+		await second;
 		stopwatch.Stop();
 
                 Assert.True(stopwatch.Elapsed >= TimeSpan.FromMilliseconds(85));
@@ -47,11 +47,11 @@ public class OcrServiceTests
 		MethodInfo? waitAsync = limiterType!.GetMethod("WaitAsync", BindingFlags.Public | BindingFlags.Instance);
 		Assert.NotNull(waitAsync);
 
-		await ((Task)waitAsync!.Invoke(limiter, new object[] { CancellationToken.None })!).ConfigureAwait(false);
-		await ((Task)waitAsync.Invoke(limiter, new object[] { CancellationToken.None })!).ConfigureAwait(false);
+		await ((Task)waitAsync!.Invoke(limiter, new object[] { CancellationToken.None })!);
+		await ((Task)waitAsync.Invoke(limiter, new object[] { CancellationToken.None })!);
 
 		var stopwatch = Stopwatch.StartNew();
-		await ((Task)waitAsync.Invoke(limiter, new object[] { CancellationToken.None })!).ConfigureAwait(false);
+		await ((Task)waitAsync.Invoke(limiter, new object[] { CancellationToken.None })!);
 		stopwatch.Stop();
 
 		Assert.True(stopwatch.Elapsed >= TimeSpan.FromMilliseconds(100));
@@ -67,15 +67,15 @@ public class OcrServiceTests
 		MethodInfo? waitAsync = limiterType!.GetMethod("WaitAsync", BindingFlags.Public | BindingFlags.Instance);
 		Assert.NotNull(waitAsync);
 
-		await ((Task)waitAsync!.Invoke(limiter, new object[] { CancellationToken.None })!).ConfigureAwait(false);
+		await ((Task)waitAsync!.Invoke(limiter, new object[] { CancellationToken.None })!);
 
 		using var cts = new CancellationTokenSource();
 		cts.CancelAfter(TimeSpan.FromMilliseconds(50));
 
 		await Assert.ThrowsAsync<TaskCanceledException>(async () =>
 		{
-			await ((Task)waitAsync.Invoke(limiter, new object[] { cts.Token })!).ConfigureAwait(false);
-		}).ConfigureAwait(false);
+			await ((Task)waitAsync.Invoke(limiter, new object[] { cts.Token })!);
+		});
 	}
 
 	[Fact]
@@ -88,13 +88,13 @@ public class OcrServiceTests
 		MethodInfo? waitAsync = limiterType!.GetMethod("WaitAsync", BindingFlags.Public | BindingFlags.Instance);
 		Assert.NotNull(waitAsync);
 
-		await ((Task)waitAsync!.Invoke(limiter, new object[] { CancellationToken.None })!).ConfigureAwait(false);
-		await ((Task)waitAsync.Invoke(limiter, new object[] { CancellationToken.None })!).ConfigureAwait(false);
+		await ((Task)waitAsync!.Invoke(limiter, new object[] { CancellationToken.None })!);
+		await ((Task)waitAsync.Invoke(limiter, new object[] { CancellationToken.None })!);
 
-		await Task.Delay(TimeSpan.FromMilliseconds(120)).ConfigureAwait(false);
+		await Task.Delay(TimeSpan.FromMilliseconds(120));
 
 		var stopwatch = Stopwatch.StartNew();
-		await ((Task)waitAsync.Invoke(limiter, new object[] { CancellationToken.None })!).ConfigureAwait(false);
+		await ((Task)waitAsync.Invoke(limiter, new object[] { CancellationToken.None })!);
 		stopwatch.Stop();
 
 		Assert.True(stopwatch.Elapsed < TimeSpan.FromMilliseconds(40));
@@ -115,8 +115,8 @@ public class OcrServiceTests
 		MethodInfo? waitAsync = limiterType.GetMethod("WaitAsync", BindingFlags.Public | BindingFlags.Instance);
 		Assert.NotNull(waitAsync);
 
-		await ((Task)waitAsync!.Invoke(limiter, new object[] { CancellationToken.None })!).ConfigureAwait(false);
-		await ((Task)waitAsync.Invoke(limiter, new object[] { CancellationToken.None })!).ConfigureAwait(false);
+		await ((Task)waitAsync!.Invoke(limiter, new object[] { CancellationToken.None })!);
+		await ((Task)waitAsync.Invoke(limiter, new object[] { CancellationToken.None })!);
 
 		OcrService.OcrRequestWindowState populated = OcrService.GetSharedRequestWindowState();
 		Assert.Equal(2, populated.RequestsInWindow);
@@ -148,7 +148,7 @@ public class OcrServiceTests
 
 		for (int i = 0; i < 3; i++)
 		{
-			await ((Task)waitAsync!.Invoke(limiter, new object[] { CancellationToken.None })!).ConfigureAwait(false);
+			await ((Task)waitAsync!.Invoke(limiter, new object[] { CancellationToken.None })!);
 		}
 
 		OcrService.OcrRequestWindowState state = OcrService.GetSharedRequestWindowState();
@@ -187,7 +187,7 @@ public class OcrServiceTests
 			var stopwatch = Stopwatch.StartNew();
 			for (int i = 0; i < 6; i++)
 			{
-				await ((Task)waitAsync!.Invoke(testLimiter, new object[] { CancellationToken.None })!).ConfigureAwait(false);
+				await ((Task)waitAsync!.Invoke(testLimiter, new object[] { CancellationToken.None })!);
 				OcrService.OcrRequestWindowState snapshot = OcrService.GetSharedRequestWindowState();
 				Assert.InRange(snapshot.RequestsInWindow, 1, 3);
 				Assert.True(snapshot.TotalRequestsGranted >= i + 1);
@@ -228,13 +228,13 @@ public class OcrServiceTests
 
 			for (int i = 0; i < 3; i++)
 			{
-				await ((Task)waitAsync!.Invoke(testLimiter, new object[] { CancellationToken.None })!).ConfigureAwait(false);
+				await ((Task)waitAsync!.Invoke(testLimiter, new object[] { CancellationToken.None })!);
 			}
 
 			OcrService.OcrRequestWindowState saturated = OcrService.GetSharedRequestWindowState();
 			Assert.Equal(3, saturated.RequestsInWindow);
 
-			await Task.Delay(TimeSpan.FromMilliseconds(120)).ConfigureAwait(false);
+			await Task.Delay(TimeSpan.FromMilliseconds(120));
 
 			OcrService.OcrRequestWindowState afterWait = OcrService.GetSharedRequestWindowState();
 			Assert.Equal(0, afterWait.RequestsInWindow);
@@ -242,7 +242,7 @@ public class OcrServiceTests
 			var stopwatch = Stopwatch.StartNew();
 			for (int i = 0; i < 3; i++)
 			{
-				await ((Task)waitAsync!.Invoke(testLimiter, new object[] { CancellationToken.None })!).ConfigureAwait(false);
+				await ((Task)waitAsync!.Invoke(testLimiter, new object[] { CancellationToken.None })!);
 			}
 			stopwatch.Stop();
 
@@ -282,7 +282,7 @@ public class OcrServiceTests
 			var stopwatch = Stopwatch.StartNew();
 			for (int i = 0; i < 10; i++)
 			{
-				await ((Task)waitAsync!.Invoke(testLimiter, new object[] { CancellationToken.None })!).ConfigureAwait(false);
+				await ((Task)waitAsync!.Invoke(testLimiter, new object[] { CancellationToken.None })!);
 				OcrService.OcrRequestWindowState snapshot = OcrService.GetSharedRequestWindowState();
 				Assert.InRange(snapshot.RequestsInWindow, 1, 4);
 				Assert.True(snapshot.TotalRequestsGranted >= i + 1);

--- a/Mutation.Tests/SettingsManagerMigrationTests.cs
+++ b/Mutation.Tests/SettingsManagerMigrationTests.cs
@@ -1,0 +1,115 @@
+using System;
+using System.IO;
+using CognitiveSupport;
+using Mutation.Ui.Services;
+using Newtonsoft.Json.Linq;
+
+namespace Mutation.Tests;
+
+public class SettingsManagerMigrationTests : IDisposable
+{
+	private readonly string _tempPath;
+
+	public SettingsManagerMigrationTests()
+	{
+		_tempPath = Path.Combine(Path.GetTempPath(), $"mutation-settings-{Guid.NewGuid():N}.json");
+	}
+
+	public void Dispose()
+	{
+		if (File.Exists(_tempPath))
+			File.Delete(_tempPath);
+	}
+
+	private JObject UpgradeAndReload(string json)
+	{
+		File.WriteAllText(_tempPath, json);
+		var manager = new SettingsManager(_tempPath);
+		manager.UpgradeSettings();
+		return JObject.Parse(File.ReadAllText(_tempPath));
+	}
+
+	[Fact]
+	public void UpgradeSettings_RemovesLegacySelectedLlmModel()
+	{
+		string json = """
+			{
+				"LlmSettings": {
+					"SelectedLlmModel": "gpt-4.1",
+					"Prompts": [
+						{ "Id": 1, "Name": "P1", "Content": "x", "ModelName": "claude-sonnet-4-6" }
+					]
+				}
+			}
+			""";
+
+		JObject result = UpgradeAndReload(json);
+
+		Assert.Null(result["LlmSettings"]?["SelectedLlmModel"]);
+	}
+
+	[Fact]
+	public void UpgradeSettings_BackfillsMissingModelNameWithDefault()
+	{
+		string json = """
+			{
+				"LlmSettings": {
+					"SelectedLlmModel": "gpt-4.1",
+					"Prompts": [
+						{ "Id": 1, "Name": "Translate", "Content": "translate" },
+						{ "Id": 2, "Name": "Summarize", "Content": "summarize", "ModelName": null },
+						{ "Id": 3, "Name": "Empty model", "Content": "x", "ModelName": "" }
+					]
+				}
+			}
+			""";
+
+		JObject result = UpgradeAndReload(json);
+		var prompts = (JArray)result["LlmSettings"]!["Prompts"]!;
+
+		foreach (var prompt in prompts)
+		{
+			Assert.Equal(LlmSettings.DefaultModel, prompt["ModelName"]?.ToString());
+		}
+	}
+
+	[Fact]
+	public void UpgradeSettings_PreservesExistingPerPromptModelName()
+	{
+		string json = """
+			{
+				"LlmSettings": {
+					"Prompts": [
+						{ "Id": 1, "Name": "Keep", "Content": "x", "ModelName": "claude-sonnet-4-6" }
+					]
+				}
+			}
+			""";
+
+		JObject result = UpgradeAndReload(json);
+
+		Assert.Equal("claude-sonnet-4-6", result["LlmSettings"]!["Prompts"]![0]!["ModelName"]?.ToString());
+	}
+
+	[Fact]
+	public void UpgradeSettings_AlreadyMigratedFile_IsIdempotent()
+	{
+		string json = """
+			{
+				"LlmSettings": {
+					"Prompts": [
+						{ "Id": 1, "Name": "P1", "Content": "x", "ModelName": "chat-latest" }
+					]
+				}
+			}
+			""";
+		File.WriteAllText(_tempPath, json);
+		var beforeMtime = File.GetLastWriteTimeUtc(_tempPath);
+
+		var manager = new SettingsManager(_tempPath);
+		manager.UpgradeSettings();
+
+		var afterMtime = File.GetLastWriteTimeUtc(_tempPath);
+		Assert.Equal(beforeMtime, afterMtime);
+	}
+}

--- a/Mutation.Tests/TranscriptFormatterTests.cs
+++ b/Mutation.Tests/TranscriptFormatterTests.cs
@@ -184,7 +184,7 @@ public class TranscriptFormatterTests
 		public IList<LlmChatMessage>? LastMessages { get; private set; }
 		public string? LastModel { get; private set; }
 
-		public Task<string> CreateChatCompletion(IList<LlmChatMessage> messages, string llmModelName, decimal temperature = 0.7M)
+		public Task<string> CreateChatCompletion(IList<LlmChatMessage> messages, string llmModelName)
 		{
 			CallCount++;
 			LastMessages = messages;

--- a/Mutation.Ui/App.xaml.cs
+++ b/Mutation.Ui/App.xaml.cs
@@ -246,9 +246,10 @@ public partial class App : Application
 				string openAiKey = llmSettings?.ApiKey ?? string.Empty;
 				string anthropicKey = llmSettings?.AnthropicApiKey ?? string.Empty;
 				int timeoutSeconds = llmSettings?.TimeoutSeconds > 0 ? llmSettings.TimeoutSeconds : 60;
-				var allModels = llmSettings?.Models ?? new List<string>();
+				var allModels = llmSettings?.Models ?? new List<LlmModelConfig>();
 
-				var openAiModels = allModels.Where(m => !CompositeLlmService.IsAnthropicModel(m)).ToList();
+				var openAiModels = allModels.Where(m => m.Provider == LlmProvider.OpenAI).ToList();
+				var anthropicModels = allModels.Where(m => m.Provider == LlmProvider.Anthropic).ToList();
 
 				LlmService? openAiService = null;
 				if (openAiModels.Any() && !string.IsNullOrEmpty(openAiKey) && openAiKey != "<placeholder>")
@@ -257,14 +258,18 @@ public partial class App : Application
 				}
 
 				AnthropicLlmService? anthropicService = null;
-				if (!string.IsNullOrEmpty(anthropicKey) && anthropicKey != "<placeholder>")
+				if (anthropicModels.Any() && !string.IsNullOrEmpty(anthropicKey) && anthropicKey != "<placeholder>")
 				{
 					var httpClientFactory = sp.GetRequiredService<IHttpClientFactory>();
 					var anthropicHttpClient = httpClientFactory.CreateClient(AnthropicHttpClientName);
-					anthropicService = new AnthropicLlmService(anthropicKey, anthropicHttpClient, timeoutSeconds);
+					anthropicService = new AnthropicLlmService(anthropicKey, anthropicModels, anthropicHttpClient, timeoutSeconds);
 				}
 
-				return new CompositeLlmService(openAiService, anthropicService);
+				var modelProviders = allModels
+					.GroupBy(m => m.Name, StringComparer.OrdinalIgnoreCase)
+					.ToDictionary(g => g.Key, g => g.First().Provider, StringComparer.OrdinalIgnoreCase);
+
+				return new CompositeLlmService(openAiService, anthropicService, modelProviders);
 			});
 			builder.Services.AddSingleton<TranscriptFormatter>();
 			builder.Services.AddSingleton<SpeechToTextManager>();

--- a/Mutation.Ui/Core/AudioDeviceManager.cs
+++ b/Mutation.Ui/Core/AudioDeviceManager.cs
@@ -28,7 +28,7 @@ public class AudioDeviceManager
 
         public int MicrophoneDeviceIndex => _microphoneDeviceIndex;
 
-        public bool IsMuted => _microphone != null && _microphone.AudioEndpointVolume.Mute;
+        public bool IsMuted => _microphone is { AudioEndpointVolume: { } volume } && volume.Mute;
 
         public void RefreshCaptureDevices()
         {
@@ -72,7 +72,7 @@ public class AudioDeviceManager
                 // the friendly name before comparison, preventing any matches and leaving the device
                 // index at -1 (so no waveform capture would occur). Use more flexible matching.
 		int deviceCount = WaveIn.DeviceCount;
-                string friendly = _microphone.FriendlyName;
+                string friendly = _microphone.DeviceFriendlyName;
                 int bestMatchIndex = -1;
                 for (int i = 0; i < deviceCount; i++)
                 {

--- a/Mutation.Ui/Core/AudioSessionManager.cs
+++ b/Mutation.Ui/Core/AudioSessionManager.cs
@@ -128,7 +128,7 @@ public class AudioSessionManager : IDisposable
         await PlaySelectedSessionAsync();
     }
 
-    public async Task StartStopRecordingAsync(ISpeechToTextService activeService, bool useLlmFormatting, string prompt, string llmPrompt = "", CancellationToken cancellationToken = default)
+    public async Task StartStopRecordingAsync(ISpeechToTextService activeService, bool useLlmFormatting, string prompt, LlmSettings.LlmPrompt? llmPrompt = null, CancellationToken cancellationToken = default)
     {
         try
         {
@@ -145,7 +145,7 @@ public class AudioSessionManager : IDisposable
             {
                 _currentRecordingUsesLlmFormatting = useLlmFormatting;
                 StopPlayback();
-                
+
                 StatusMessage?.Invoke(this, "Listening for audio...");
                 StateChanged?.Invoke(this, EventArgs.Empty); // Notify UI to update buttons (Stop)
 
@@ -257,20 +257,20 @@ public class AudioSessionManager : IDisposable
         }
     }
 
-    private async Task ProcessTranscriptAsync(string text, string llmPrompt)
+    private async Task ProcessTranscriptAsync(string text, LlmSettings.LlmPrompt? llmPrompt)
     {
         // Always run rules-based formatting first
         string rulesFormattedText = _transcriptFormatter.ApplyRules(text, false);
         string? llmFormattedText = null;
 
-        if (_currentRecordingUsesLlmFormatting)
+        if (_currentRecordingUsesLlmFormatting && llmPrompt != null)
         {
             try
             {
                 StatusMessage?.Invoke(this, "Formatting with LLM...");
-                string modelName = _settings.LlmSettings?.SelectedLlmModel ?? LlmSettings.DefaultModel;
+                string modelName = !string.IsNullOrWhiteSpace(llmPrompt.ModelName) ? llmPrompt.ModelName : LlmSettings.DefaultModel;
                 // Pass the rules-formatted text to the LLM
-                llmFormattedText = await _transcriptFormatter.FormatWithLlmAsync(rulesFormattedText, llmPrompt, modelName);
+                llmFormattedText = await _transcriptFormatter.FormatWithLlmAsync(rulesFormattedText, llmPrompt.Content, modelName);
             }
             catch (Exception ex)
             {

--- a/Mutation.Ui/Core/SpeechToTextServiceComboItem.cs
+++ b/Mutation.Ui/Core/SpeechToTextServiceComboItem.cs
@@ -4,8 +4,8 @@ namespace Mutation.Ui;
 
 internal class SpeechToTextServiceComboItem
 {
-        public SpeechToTextServiceSettings SpeechToTextServiceSettings { get; set; }
-        public ISpeechToTextService SpeechToTextService { get; set; }
+	public required SpeechToTextServiceSettings SpeechToTextServiceSettings { get; set; }
+	public required ISpeechToTextService SpeechToTextService { get; set; }
         public string Display =>
                 $"{SpeechToTextServiceSettings.Name}";
 

--- a/Mutation.Ui/Core/SpeechToTextState.cs
+++ b/Mutation.Ui/Core/SpeechToTextState.cs
@@ -11,7 +11,7 @@ internal class SpeechToTextState : IDisposable
 	private readonly object _ctsLock = new();
 	private CancellationTokenSource? _cts;
 
-	private Func<AudioRecorder> GetAudioRecorder;
+	private Func<AudioRecorder?> GetAudioRecorder;
 	internal bool RecordingAudio => GetAudioRecorder() != null;
 
 	internal bool TranscribingAudio
@@ -20,7 +20,7 @@ internal class SpeechToTextState : IDisposable
 	}
 
 	public SpeechToTextState(
-		Func<AudioRecorder> getAudioRecorder)
+		Func<AudioRecorder?> getAudioRecorder)
 	{
 		GetAudioRecorder = getAudioRecorder ?? throw new ArgumentNullException(nameof(getAudioRecorder));
 	}

--- a/Mutation.Ui/Core/TranscriptFormatter.cs
+++ b/Mutation.Ui/Core/TranscriptFormatter.cs
@@ -20,7 +20,7 @@ public class TranscriptFormatter
 	public string ApplyRules(string transcript, bool manualPunctuation)
 	{
 		if (transcript is null)
-			return transcript;
+			return transcript!;
 
 		string text = transcript;
 		if (manualPunctuation)

--- a/Mutation.Ui/MainWindow.xaml
+++ b/Mutation.Ui/MainWindow.xaml
@@ -382,48 +382,33 @@
                                 <Button x:Name="BtnAddPrompt" Grid.Column="1" Content="Add Prompt" Click="BtnAddPrompt_Click" />
                             </Grid>
 
-                            <Grid ColumnSpacing="16">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="*" />
-                                    <ColumnDefinition Width="Auto" />
-                                </Grid.ColumnDefinitions>
-                                
-                                <ListView x:Name="LstPrompts" Grid.Column="0" SelectionMode="None" MaxHeight="200">
-                                    <ListView.ItemTemplate>
-                                        <DataTemplate>
-                                            <Grid ColumnSpacing="12" Padding="0,8">
-                                                <Grid.ColumnDefinitions>
-                                                    <ColumnDefinition Width="*" />
-                                                    <ColumnDefinition Width="Auto" />
-                                                    <ColumnDefinition Width="Auto" />
-                                                    <ColumnDefinition Width="Auto" />
-                                                </Grid.ColumnDefinitions>
+                            <ListView x:Name="LstPrompts" SelectionMode="None" MaxHeight="200">
+                                <ListView.ItemTemplate>
+                                    <DataTemplate>
+                                        <Grid ColumnSpacing="12" Padding="0,8">
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="*" />
+                                                <ColumnDefinition Width="Auto" />
+                                                <ColumnDefinition Width="Auto" />
+                                                <ColumnDefinition Width="Auto" />
+                                            </Grid.ColumnDefinitions>
 
-                                                <StackPanel Grid.Column="0" VerticalAlignment="Center">
-                                                    <TextBlock Text="{Binding Name}" FontWeight="SemiBold" />
-                                                    <StackPanel Orientation="Horizontal" Spacing="8">
-                                                        <TextBlock Text="{Binding Hotkey}" FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
-                                                        <TextBlock Text="(Auto-Run)" FontSize="12" Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}" Visibility="{Binding AutoRun, Converter={StaticResource BoolToVisConverter}}" />
-                                                    </StackPanel>
+                                            <StackPanel Grid.Column="0" VerticalAlignment="Center">
+                                                <TextBlock Text="{Binding Name}" FontWeight="SemiBold" />
+                                                <StackPanel Orientation="Horizontal" Spacing="8">
+                                                    <TextBlock Text="{Binding Hotkey}" FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                                                    <TextBlock Text="(Auto-Run)" FontSize="12" Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}" Visibility="{Binding AutoRun, Converter={StaticResource BoolToVisConverter}}" />
                                                 </StackPanel>
+                                                <TextBlock Text="{Binding ModelName}" FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                                            </StackPanel>
 
-                                                <Button Grid.Column="1" Content="Run" Click="BtnRunPrompt_Click" Tag="{Binding}" Style="{StaticResource OutlinedButtonStyle}" />
-                                                <Button Grid.Column="2" Content="Edit" Click="BtnEditPrompt_Click" Tag="{Binding}" />
-                                                <Button Grid.Column="3" Content="Delete" Click="BtnDeletePrompt_Click" Tag="{Binding}" />
-                                            </Grid>
-                                        </DataTemplate>
-                                    </ListView.ItemTemplate>
-                                </ListView>
-
-                                <ComboBox
-                                    x:Name="CmbLlmModel"
-                                    Grid.Column="1"
-                                    Header="LLM Model"
-                                    PlaceholderText="Select a model"
-                                    HorizontalAlignment="Stretch"
-                                    VerticalAlignment="Top"
-                                    SelectionChanged="CmbLlmModel_SelectionChanged" />
-                            </Grid>
+                                            <Button Grid.Column="1" Content="Run" Click="BtnRunPrompt_Click" Tag="{Binding}" Style="{StaticResource OutlinedButtonStyle}" />
+                                            <Button Grid.Column="2" Content="Edit" Click="BtnEditPrompt_Click" Tag="{Binding}" />
+                                            <Button Grid.Column="3" Content="Delete" Click="BtnDeletePrompt_Click" Tag="{Binding}" />
+                                        </Grid>
+                                    </DataTemplate>
+                                </ListView.ItemTemplate>
+                            </ListView>
                         </StackPanel>
                     </Border>
 

--- a/Mutation.Ui/MainWindow.xaml.cs
+++ b/Mutation.Ui/MainWindow.xaml.cs
@@ -167,15 +167,16 @@ public sealed partial class MainWindow : Window, IDisposable
 
 		if (_settings.LlmSettings != null)
 		{
-			CmbLlmModel.ItemsSource = _settings.LlmSettings.Models;
-			if (!string.IsNullOrEmpty(_settings.LlmSettings.SelectedLlmModel) && _settings.LlmSettings.Models.Contains(_settings.LlmSettings.SelectedLlmModel))
+			var modelNames = _settings.LlmSettings.Models.Select(m => m.Name).ToList();
+			CmbLlmModel.ItemsSource = modelNames;
+			if (!string.IsNullOrEmpty(_settings.LlmSettings.SelectedLlmModel) && modelNames.Contains(_settings.LlmSettings.SelectedLlmModel))
 			{
 				CmbLlmModel.SelectedItem = _settings.LlmSettings.SelectedLlmModel;
 			}
-			else if (_settings.LlmSettings.Models.Any())
+			else if (modelNames.Any())
 			{
 				CmbLlmModel.SelectedIndex = 0;
-				_settings.LlmSettings.SelectedLlmModel = _settings.LlmSettings.Models[0];
+				_settings.LlmSettings.SelectedLlmModel = modelNames[0];
 			}
 		}
 

--- a/Mutation.Ui/MainWindow.xaml.cs
+++ b/Mutation.Ui/MainWindow.xaml.cs
@@ -165,21 +165,6 @@ public sealed partial class MainWindow : Window, IDisposable
 
 		// TxtFormatPrompt.Text = _settings.LlmSettings?.FormatTranscriptPrompt ?? string.Empty;
 
-		if (_settings.LlmSettings != null)
-		{
-			var modelNames = _settings.LlmSettings.Models.Select(m => m.Name).ToList();
-			CmbLlmModel.ItemsSource = modelNames;
-			if (!string.IsNullOrEmpty(_settings.LlmSettings.SelectedLlmModel) && modelNames.Contains(_settings.LlmSettings.SelectedLlmModel))
-			{
-				CmbLlmModel.SelectedItem = _settings.LlmSettings.SelectedLlmModel;
-			}
-			else if (modelNames.Any())
-			{
-				CmbLlmModel.SelectedIndex = 0;
-				_settings.LlmSettings.SelectedLlmModel = modelNames[0];
-			}
-		}
-
             _promptLibrary = new PromptLibraryController(
                 _settings,
                 _settingsManager,
@@ -693,8 +678,8 @@ public sealed partial class MainWindow : Window, IDisposable
 				return;
             }
             
-            string llmPromptContent = _promptLibrary?.GetAutoRunPromptContent() ?? string.Empty;
-            await _audioSessionManager.StartStopRecordingAsync(_activeSpeechService, useLlmFormatting, GetActivePrompt(), llmPromptContent, _shutdownCts.Token);
+            LlmSettings.LlmPrompt? autoRunPrompt = _promptLibrary?.GetAutoRunPrompt();
+            await _audioSessionManager.StartStopRecordingAsync(_activeSpeechService, useLlmFormatting, GetActivePrompt(), autoRunPrompt, _shutdownCts.Token);
 		}
 		catch (Exception ex)
 		{
@@ -782,7 +767,7 @@ public sealed partial class MainWindow : Window, IDisposable
 				return;
 			}
 
-			string modelName = _settings.LlmSettings?.SelectedLlmModel ?? LlmSettings.DefaultModel;
+			string modelName = !string.IsNullOrWhiteSpace(prompt.ModelName) ? prompt.ModelName : LlmSettings.DefaultModel;
 			string formatted = await _transcriptFormatter.FormatWithLlmAsync(raw, prompt.Content, modelName);
             
 			TxtFormatTranscript.Text = formatted;
@@ -1216,16 +1201,6 @@ public sealed partial class MainWindow : Window, IDisposable
 			}
 		}
 	}
-
-	private void CmbLlmModel_SelectionChanged(object sender, SelectionChangedEventArgs e)
-	{
-		if (_settings.LlmSettings != null && CmbLlmModel.SelectedItem is string selectedModel)
-		{
-			_settings.LlmSettings.SelectedLlmModel = selectedModel;
-			_settingsManager.SaveSettingsToFile(_settings);
-		}
-	}
-
 
 	private void UpdateThirdPartyExplanation(DictationInsertOption option)
 	{

--- a/Mutation.Ui/Services/HotkeyManager.cs
+++ b/Mutation.Ui/Services/HotkeyManager.cs
@@ -353,7 +353,7 @@ public class HotkeyManager : IDisposable
 		return CallWindowProc(_prevWndProc, hWnd, msg, wParam, lParam);
 	}
 
-	public static void SendHotkeyAfterDelay(string hotkey, int delayMs)
+	public static void SendHotkeyAfterDelay(string? hotkey, int delayMs)
 	{
 		if (string.IsNullOrWhiteSpace(hotkey))
 			return;

--- a/Mutation.Ui/Services/OcrManager.cs
+++ b/Mutation.Ui/Services/OcrManager.cs
@@ -552,7 +552,6 @@ public class OcrManager
 
             var bounds = new Rectangle(left, top, width, height);
 
-            FormWindowState? prevState = null;
             IntPtr? hwnd = null;
             try
             {

--- a/Mutation.Ui/Services/PromptLibraryController.cs
+++ b/Mutation.Ui/Services/PromptLibraryController.cs
@@ -2,6 +2,7 @@ using CognitiveSupport;
 using Microsoft.UI.Xaml.Controls;
 using Mutation.Ui.Views;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Mutation.Ui.Services;
@@ -43,10 +44,9 @@ internal sealed class PromptLibraryController
 			_hotkeyManager.RegisterPromptHotkeys(_settings.LlmSettings.Prompts, _executePrompt);
 	}
 
-	public string GetAutoRunPromptContent()
+	public LlmSettings.LlmPrompt? GetAutoRunPrompt()
 	{
-		var prompt = _settings.LlmSettings?.Prompts.FirstOrDefault(p => p.AutoRun);
-		return prompt?.Content ?? string.Empty;
+		return _settings.LlmSettings?.Prompts.FirstOrDefault(p => p.AutoRun);
 	}
 
 	public void OpenAddDialog()
@@ -54,7 +54,7 @@ internal sealed class PromptLibraryController
 		if (_settings.LlmSettings == null)
 			return;
 
-		var dialog = new PromptEditorWindow(null, _transcriptFormatter);
+		var dialog = new PromptEditorWindow(null, _transcriptFormatter, GetAvailableModelNames());
 		dialog.Activate();
 		dialog.Closed += (_, _) =>
 		{
@@ -76,7 +76,7 @@ internal sealed class PromptLibraryController
 		if (prompt == null || _settings.LlmSettings == null)
 			return;
 
-		var dialog = new PromptEditorWindow(prompt, _transcriptFormatter);
+		var dialog = new PromptEditorWindow(prompt, _transcriptFormatter, GetAvailableModelNames());
 		dialog.Activate();
 		dialog.Closed += (_, _) =>
 		{
@@ -102,6 +102,11 @@ internal sealed class PromptLibraryController
 
 		_settings.LlmSettings.Prompts.Remove(prompt);
 		SaveAndRefresh();
+	}
+
+	private IReadOnlyList<string> GetAvailableModelNames()
+	{
+		return _settings.LlmSettings?.Models?.Select(m => m.Name).ToList() ?? new List<string>();
 	}
 
 	private void SaveAndRefresh()

--- a/Mutation.Ui/Services/SettingsManager.cs
+++ b/Mutation.Ui/Services/SettingsManager.cs
@@ -440,14 +440,12 @@ End of summary.
 
 		if (llmSettings.Models == null || !llmSettings.Models.Any())
 		{
-			llmSettings.Models = new List<string>
+			llmSettings.Models = new List<LlmModelConfig>
 			{
-				LlmSettings.DefaultModel,
-				LlmSettings.DefaultSecondaryModel,
-				LlmSettings.DefaultAnthropicModel
-			}
-			.Distinct(StringComparer.OrdinalIgnoreCase)
-			.ToList();
+				new LlmModelConfig(LlmSettings.DefaultModel, LlmProvider.OpenAI, customTemperature: null),
+				new LlmModelConfig(LlmSettings.DefaultSecondaryModel, LlmProvider.OpenAI, customTemperature: 0.7m),
+				new LlmModelConfig(LlmSettings.DefaultAnthropicModel, LlmProvider.Anthropic, customTemperature: 0.7m),
+			};
 			somethingWasMissing = true;
 		}
 

--- a/Mutation.Ui/Services/SettingsManager.cs
+++ b/Mutation.Ui/Services/SettingsManager.cs
@@ -175,7 +175,7 @@ internal class SettingsManager : ISettingsManager
 			string[] allowedExtensions = new[] { ".wav" };
 			var beepIssues = new List<string>();
 
-			string successPath = audioSettings.CustomBeepSettings?.BeepSuccessFile ?? string.Empty;
+			string successPath = audioSettings.CustomBeepSettings.BeepSuccessFile ?? string.Empty;
 			string resolvedSuccessPath = audioSettings.CustomBeepSettings.ResolveAudioFilePath(successPath);
 			if (string.IsNullOrWhiteSpace(successPath) ||
 				!allowedExtensions.Contains(Path.GetExtension(successPath)?.ToLower()) ||
@@ -189,7 +189,7 @@ internal class SettingsManager : ISettingsManager
 					beepIssues.Add($"Could not load success beep file: {successPath}");
 			}
 
-			string failurePath = audioSettings.CustomBeepSettings?.BeepFailureFile ?? string.Empty;
+			string failurePath = audioSettings.CustomBeepSettings.BeepFailureFile ?? string.Empty;
 			string resolvedFailurePath = audioSettings.CustomBeepSettings.ResolveAudioFilePath(failurePath);
 			if (string.IsNullOrWhiteSpace(failurePath) ||
 				!allowedExtensions.Contains(Path.GetExtension(failurePath)?.ToLower()) ||
@@ -203,7 +203,7 @@ internal class SettingsManager : ISettingsManager
 					beepIssues.Add($"Could not load failure beep file: {failurePath}");
 			}
 
-			string startPath = audioSettings.CustomBeepSettings?.BeepStartFile ?? string.Empty;
+			string startPath = audioSettings.CustomBeepSettings.BeepStartFile ?? string.Empty;
 			string resolvedStartPath = audioSettings.CustomBeepSettings.ResolveAudioFilePath(startPath);
 			if (string.IsNullOrWhiteSpace(startPath) ||
 				!allowedExtensions.Contains(Path.GetExtension(startPath)?.ToLower()) ||
@@ -217,7 +217,7 @@ internal class SettingsManager : ISettingsManager
 					beepIssues.Add($"Could not load start beep file: {startPath}");
 			}
 
-			string endPath = audioSettings.CustomBeepSettings?.BeepEndFile ?? string.Empty;
+			string endPath = audioSettings.CustomBeepSettings.BeepEndFile ?? string.Empty;
 			string resolvedEndPath = audioSettings.CustomBeepSettings.ResolveAudioFilePath(endPath);
 			if (string.IsNullOrWhiteSpace(endPath) ||
 				!allowedExtensions.Contains(Path.GetExtension(endPath)?.ToLower()) ||
@@ -231,7 +231,7 @@ internal class SettingsManager : ISettingsManager
 					beepIssues.Add($"Could not load end beep file: {endPath}");
 			}
 
-			string mutePath = audioSettings.CustomBeepSettings?.BeepMuteFile ?? string.Empty;
+			string mutePath = audioSettings.CustomBeepSettings.BeepMuteFile ?? string.Empty;
 			string resolvedMutePath = audioSettings.CustomBeepSettings.ResolveAudioFilePath(mutePath);
 			if (string.IsNullOrWhiteSpace(mutePath) ||
 				!allowedExtensions.Contains(Path.GetExtension(mutePath)?.ToLower()) ||
@@ -245,7 +245,7 @@ internal class SettingsManager : ISettingsManager
 					beepIssues.Add($"Could not load mute beep file: {mutePath}");
 			}
 
-			string unmutePath = audioSettings.CustomBeepSettings?.BeepUnmuteFile ?? string.Empty;
+			string unmutePath = audioSettings.CustomBeepSettings.BeepUnmuteFile ?? string.Empty;
 			string resolvedUnmutePath = audioSettings.CustomBeepSettings.ResolveAudioFilePath(unmutePath);
 			if (string.IsNullOrWhiteSpace(unmutePath) ||
 				!allowedExtensions.Contains(Path.GetExtension(unmutePath)?.ToLower()) ||
@@ -394,8 +394,8 @@ internal class SettingsManager : ISettingsManager
 
 		if (!llmSettings.Prompts.Any())
 		{
-             string legacyPrompt = llmSettings.FormatTranscriptPrompt;
-             string legacyHotkey = llmSettings.FormatWithLlmHotKey;
+             string? legacyPrompt = llmSettings.FormatTranscriptPrompt;
+             string? legacyHotkey = llmSettings.FormatWithLlmHotKey;
              
              if (string.IsNullOrWhiteSpace(legacyPrompt))
              {
@@ -627,7 +627,7 @@ End of summary.
 
 		if (speechSettings is not null)
 		{
-			if (speechSettings["Services"] == null || speechSettings["Services"].Type != JTokenType.Array)
+			if (speechSettings["Services"] is not JToken servicesToken || servicesToken.Type != JTokenType.Array)
 			{
 				string providerName = speechSettings.Value<string>("Service") ?? string.Empty;
 

--- a/Mutation.Ui/Services/SettingsManager.cs
+++ b/Mutation.Ui/Services/SettingsManager.cs
@@ -433,7 +433,8 @@ End of summary.
                 Name = "Default",
                 Content = legacyPrompt,
                 Hotkey = legacyHotkey,
-                AutoRun = false
+                AutoRun = false,
+                ModelName = LlmSettings.DefaultModel
              });
 			 somethingWasMissing = true;
 		}
@@ -447,6 +448,15 @@ End of summary.
 				new LlmModelConfig(LlmSettings.DefaultAnthropicModel, LlmProvider.Anthropic, customTemperature: 0.7m),
 			};
 			somethingWasMissing = true;
+		}
+
+		foreach (var prompt in llmSettings.Prompts)
+		{
+			if (string.IsNullOrWhiteSpace(prompt.ModelName))
+			{
+				prompt.ModelName = LlmSettings.DefaultModel;
+				somethingWasMissing = true;
+			}
 		}
 
 		if (llmSettings.TranscriptFormatRules == null || !llmSettings.TranscriptFormatRules.Any())
@@ -678,6 +688,30 @@ End of summary.
 				visionSettings["SendHotkeyAfterOcrOperation"] = visionSettings["SendKotKeyAfterOcrOperation"];
 				visionSettings.Remove("SendKotKeyAfterOcrOperation");
 				saveRequired = true;
+			}
+		}
+
+		if (jObj["LlmSettings"] is JObject llmSettingsJObj)
+		{
+			if (llmSettingsJObj.Remove("SelectedLlmModel"))
+			{
+				saveRequired = true;
+			}
+
+			if (llmSettingsJObj["Prompts"] is JArray promptsArray)
+			{
+				foreach (var promptToken in promptsArray)
+				{
+					if (promptToken is JObject promptObj)
+					{
+						JToken? modelToken = promptObj["ModelName"];
+						if (modelToken == null || modelToken.Type == JTokenType.Null || string.IsNullOrWhiteSpace(modelToken.ToString()))
+						{
+							promptObj["ModelName"] = LlmSettings.DefaultModel;
+							saveRequired = true;
+						}
+					}
+				}
 			}
 		}
 

--- a/Mutation.Ui/Views/PromptEditorWindow.xaml
+++ b/Mutation.Ui/Views/PromptEditorWindow.xaml
@@ -26,12 +26,20 @@
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
 
             <TextBox x:Name="TxtName" Header="Name" PlaceholderText="e.g. Summarize" Grid.Column="0" />
             <TextBox x:Name="TxtHotkey" Header="Hotkey" PlaceholderText="e.g. CTRL+ALT+S" Grid.Column="1" />
-            
-            <CheckBox x:Name="ChkAutoRun" Content="Run automatically after transcription" Grid.Row="1" Grid.ColumnSpan="2" />
+
+            <ComboBox x:Name="CmbModel"
+                      Header="Model"
+                      PlaceholderText="Select a model"
+                      HorizontalAlignment="Stretch"
+                      Grid.Row="1"
+                      Grid.Column="0" />
+
+            <CheckBox x:Name="ChkAutoRun" Content="Run automatically after transcription" Grid.Row="2" Grid.ColumnSpan="2" />
         </Grid>
 
         <TextBox x:Name="TxtContent" 

--- a/Mutation.Ui/Views/PromptEditorWindow.xaml.cs
+++ b/Mutation.Ui/Views/PromptEditorWindow.xaml.cs
@@ -17,7 +17,7 @@ public sealed partial class PromptEditorWindow : Window
     public bool IsSaved { get; private set; }
     private readonly TranscriptFormatter _formatter;
 
-    public PromptEditorWindow(LlmSettings.LlmPrompt prompt, TranscriptFormatter formatter, IReadOnlyList<string> availableModels)
+    public PromptEditorWindow(LlmSettings.LlmPrompt? prompt, TranscriptFormatter formatter, IReadOnlyList<string> availableModels)
     {
         this.InitializeComponent();
         _formatter = formatter;
@@ -112,11 +112,6 @@ public sealed partial class PromptEditorWindow : Window
 
     private void BtnCancel_Click(object sender, RoutedEventArgs e)
     {
-         // If we don't save, we don't update potential output or we indicate failure?
-         // For a new prompt, we can return null? 
-         // But `Prompt` is a property.
-         // Let's add a `Confirmed` property.
-         Prompt = null; 
          this.Close();
     }
 

--- a/Mutation.Ui/Views/PromptEditorWindow.xaml.cs
+++ b/Mutation.Ui/Views/PromptEditorWindow.xaml.cs
@@ -2,6 +2,8 @@ using CognitiveSupport;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Windows.ApplicationModel.DataTransfer;
 using Microsoft.UI.Windowing;
 using WinRT.Interop;
@@ -15,23 +17,23 @@ public sealed partial class PromptEditorWindow : Window
     public bool IsSaved { get; private set; }
     private readonly TranscriptFormatter _formatter;
 
-    public PromptEditorWindow(LlmSettings.LlmPrompt prompt, TranscriptFormatter formatter)
+    public PromptEditorWindow(LlmSettings.LlmPrompt prompt, TranscriptFormatter formatter, IReadOnlyList<string> availableModels)
     {
         this.InitializeComponent();
         _formatter = formatter;
-        
+
         // Set window size
         IntPtr hWnd = WindowNative.GetWindowHandle(this);
         WindowId windowId = Win32Interop.GetWindowIdFromWindow(hWnd);
         AppWindow appWindow = AppWindow.GetFromWindowId(windowId);
-        appWindow.Resize(new Windows.Graphics.SizeInt32(600, 500));
-        
+        appWindow.Resize(new Windows.Graphics.SizeInt32(600, 540));
+
         // Center the window
         var displayArea = DisplayArea.GetFromWindowId(windowId, DisplayAreaFallback.Primary);
         if (displayArea != null)
         {
             var centeredX = (displayArea.WorkArea.Width - 600) / 2;
-            var centeredY = (displayArea.WorkArea.Height - 500) / 2;
+            var centeredY = (displayArea.WorkArea.Height - 540) / 2;
             appWindow.Move(new Windows.Graphics.PointInt32(displayArea.WorkArea.X + centeredX, displayArea.WorkArea.Y + centeredY));
         }
 
@@ -42,23 +44,37 @@ public sealed partial class PromptEditorWindow : Window
             // presenter.IsModal = true; // CRASH FIX: IsModal requires an owner to be set via P/Invoke, which we aren't doing accurately enough. checking IsAlwaysOnTop is sufficient.
         }
 
+        var modelList = (availableModels ?? Array.Empty<string>()).ToList();
+        if (!modelList.Contains(LlmSettings.DefaultModel))
+        {
+            modelList.Insert(0, LlmSettings.DefaultModel);
+        }
+        CmbModel.ItemsSource = modelList;
+
         if (prompt == null)
         {
-            Prompt = new LlmSettings.LlmPrompt();
-            Prompt = new LlmSettings.LlmPrompt();
+            Prompt = new LlmSettings.LlmPrompt { ModelName = LlmSettings.DefaultModel };
             Title = "Add New Prompt";
+            CmbModel.SelectedItem = LlmSettings.DefaultModel;
         }
         else
         {
             Prompt = prompt;
-            Prompt = prompt;
             Title = "Edit Prompt";
-            
+
             // Populate fields
             TxtName.Text = Prompt.Name;
             TxtHotkey.Text = Prompt.Hotkey;
             TxtContent.Text = Prompt.Content;
             ChkAutoRun.IsChecked = Prompt.AutoRun;
+
+            string desiredModel = !string.IsNullOrWhiteSpace(Prompt.ModelName) ? Prompt.ModelName : LlmSettings.DefaultModel;
+            if (!modelList.Contains(desiredModel))
+            {
+                modelList.Insert(0, desiredModel);
+                CmbModel.ItemsSource = modelList;
+            }
+            CmbModel.SelectedItem = desiredModel;
         }
     }
 
@@ -76,6 +92,7 @@ public sealed partial class PromptEditorWindow : Window
         Prompt.Hotkey = TxtHotkey.Text; // Basic text for now, could implement validation later
         Prompt.Content = TxtContent.Text;
         Prompt.AutoRun = ChkAutoRun.IsChecked ?? false;
+        Prompt.ModelName = CmbModel.SelectedItem as string ?? LlmSettings.DefaultModel;
 
         IsSaved = true;
 
@@ -115,7 +132,8 @@ public sealed partial class PromptEditorWindow : Window
                 {
                     // Use the CURRENT text in the content box, not the saved one
                     string currentContent = TxtContent.Text;
-                    string result = await _formatter.FormatWithLlmAsync(text, currentContent, LlmSettings.DefaultModel); // Using default model for test
+                    string testModel = CmbModel.SelectedItem as string ?? LlmSettings.DefaultModel;
+                    string result = await _formatter.FormatWithLlmAsync(text, currentContent, testModel);
                     
                     // Show result in a dialog or just a message box?
                     // WinUI 3 MessageDialog or ContentDialog requires XamlRoot.


### PR DESCRIPTION
This pull request introduces several important changes to support per-model configuration for language models, improves null handling, and addresses compatibility issues with external libraries. The most significant update is the introduction of the `LlmModelConfig` class, which enables specifying provider and temperature for each model, and the refactoring of services to use these configurations. Additionally, several methods now handle null values more robustly, and there are minor code quality improvements.

**Language Model Configuration and Service Refactoring**
- Introduced the `LlmModelConfig` class and `LlmProvider` enum, allowing each model to specify its provider (OpenAI or Anthropic) and an optional custom temperature. (`CognitiveSupport/LlmModelConfig.cs`)
- Refactored `LlmService`, `AnthropicLlmService`, and `CompositeLlmService` to accept and utilize a list of `LlmModelConfig` instead of plain model names, enforcing configuration and enabling per-model settings. (`CognitiveSupport/LlmService.cs`, `CognitiveSupport/AnthropicLlmService.cs`, `CognitiveSupport/CompositeLlmService.cs`, `CognitiveSupport/Settings.cs`) [[1]](diffhunk://#diff-e7035a116f4c5124c9899c89dd82784065cca9dc91501ff4406962479a6c068aR9-R47) [[2]](diffhunk://#diff-def5740900992f0b236fb9388422eced1ac8dd4db015470bbafab03ccf8138ebR16-R42) [[3]](diffhunk://#diff-2d272791a17e01834b56a643030b9e9f390467a9f686376d00948425a08b6eadR7-L38) [[4]](diffhunk://#diff-4088b7d8fa5cd9d04709561c7346f8eb3d16b5ef8515e449a582091b718e1e27L179-R185)
- Updated the `ILlmService` interface and related methods to remove the `temperature` parameter, relying on the per-model configuration instead. (`CognitiveSupport/ILlmService.cs`, `CognitiveSupport/LlmService.cs`, `CognitiveSupport/AnthropicLlmService.cs`, `CognitiveSupport/CompositeLlmService.cs`) [[1]](diffhunk://#diff-2f72d461420dc8d286f3fe4dff4893769e4b693e4e7ef064423991b84e445b37L5-R5) [[2]](diffhunk://#diff-e7035a116f4c5124c9899c89dd82784065cca9dc91501ff4406962479a6c068aR9-R47) [[3]](diffhunk://#diff-def5740900992f0b236fb9388422eced1ac8dd4db015470bbafab03ccf8138ebR16-R42) [[4]](diffhunk://#diff-2d272791a17e01834b56a643030b9e9f390467a9f686376d00948425a08b6eadR7-L38)

**Null Handling and Defensive Coding**
- Improved null handling in various string-processing extension methods and text formatting utilities, ensuring that methods return a non-null string even if the input is null. (`CognitiveSupport/Extensions/StringExtensions.cs`, `CognitiveSupport/TextFormatter.cs`) [[1]](diffhunk://#diff-4a263039ba55597f0df717a6af3e1d96a482ba3f2880d8ae9473b7bf5b41451eL8-R8) [[2]](diffhunk://#diff-bd873d77376ee191643cd76fce2e06c5ac1f8cd9a76b892adeacd150667d64fdL14-R14) [[3]](diffhunk://#diff-bd873d77376ee191643cd76fce2e06c5ac1f8cd9a76b892adeacd150667d64fdL32-R32) [[4]](diffhunk://#diff-bd873d77376ee191643cd76fce2e06c5ac1f8cd9a76b892adeacd150667d64fdL92-R92) [[5]](diffhunk://#diff-bd873d77376ee191643cd76fce2e06c5ac1f8cd9a76b892adeacd150667d64fdL112-R137) [[6]](diffhunk://#diff-bd873d77376ee191643cd76fce2e06c5ac1f8cd9a76b892adeacd150667d64fdL148-R152)
- Updated the beep player to handle potentially null custom beep file paths safely. (`CognitiveSupport/BeepPlayer.cs`)

**Audio and External Library Compatibility**
- Added pragma directives to suppress warnings about deprecated types in the Concentus audio library, maintaining compatibility until the library is updated. (`CognitiveSupport/AudioFileConverter.cs`, `CognitiveSupport/AudioRecorder.cs`, `CognitiveSupport/AudioPlayer.cs`) [[1]](diffhunk://#diff-18d6f314bbc5091ca7df64ea4db8c8d871de18ed4991b313cedfed90a0d0e86eR60-R67) [[2]](diffhunk://#diff-bd9f9f2bcf1838f557807e28ed1ce01ddc38da06df903e42033bed139ed4d26aR45-R52) [[3]](diffhunk://#diff-12c1d227f8a3aa2fb8b88a222d9cc4c720498e0aa5e82b4f5143d8119538c608R69-R71)

**Other Improvements**
- Made minor bug fixes, such as correcting null-conditional access in the Deepgram speech-to-text service and fixing a parameter assignment typo. (`CognitiveSupport/DeepgramSpeechToTextService.cs`) [[1]](diffhunk://#diff-f7f96ad283ea16dc9e47b29b0423a10255550d57ca401b79ac6747c44b878423L76-R76) [[2]](diffhunk://#diff-f7f96ad283ea16dc9e47b29b0423a10255550d57ca401b79ac6747c44b878423L99-R99)
- Exposed internals for testing by adding `InternalsVisibleTo` for the test project. (`CognitiveSupport/CognitiveSupport.csproj`)
- Updated the default model name in settings to `chat-latest` for improved out-of-the-box experience. (`CognitiveSupport/Settings.cs`)

These changes collectively make the language model integration more robust, configurable, and maintainable.