### PR TITLE
Add configurable silence stripping to speech-to-text

### DIFF
--- a/CognitiveSupport/AudioFileConverter.cs
+++ b/CognitiveSupport/AudioFileConverter.cs
@@ -14,12 +14,12 @@ public static class AudioFileConverter
 	/// </summary>
 	/// <param name="inputPath">Path to the input file (MP4, AVI, etc.)</param>
 	/// <returns>Path to the temporary OGG file. Caller is responsible for cleanup.</returns>
-	public static string ConvertMp4ToOgg(string inputPath)
+	public static string ConvertMp4ToOgg(string inputPath, SilenceTrimmerOptions? silenceOptions = null)
 	{
 		string tempOggPath = Path.ChangeExtension(Path.GetTempFileName(), ".ogg");
 		try
 		{
-			ConvertMp4ToOgg(inputPath, tempOggPath);
+			ConvertMp4ToOgg(inputPath, tempOggPath, silenceOptions);
 			return tempOggPath;
 		}
 		catch
@@ -37,7 +37,7 @@ public static class AudioFileConverter
 	/// </summary>
 	/// <param name="inputPath">Path to the input file (MP4, AVI, etc.)</param>
 	/// <param name="outputOggPath">Path where the OGG file will be written.</param>
-	public static void ConvertMp4ToOgg(string inputPath, string outputOggPath)
+	public static void ConvertMp4ToOgg(string inputPath, string outputOggPath, SilenceTrimmerOptions? silenceOptions = null)
 	{
 		if (string.IsNullOrWhiteSpace(inputPath))
 			throw new ArgumentException("Input path cannot be empty", nameof(inputPath));
@@ -78,6 +78,18 @@ public static class AudioFileConverter
 		int bytesPerFrame = samplesPerFrame * 2;
 		List<byte> accumulationBuffer = new List<byte>();
 
+		var trimmer = silenceOptions is null
+			? null
+			: new SilenceTrimmer(48000, samplesPerFrame, silenceOptions);
+
+		void WriteFrame(short[] pcmSamples)
+		{
+			if (trimmer is null)
+				oggStream.WriteSamples(pcmSamples, 0, pcmSamples.Length);
+			else
+				trimmer.ProcessFrame(pcmSamples, f => oggStream.WriteSamples(f, 0, f.Length));
+		}
+
 		while ((bytesRead = resampler.Read(buffer, 0, buffer.Length)) > 0)
 		{
 			for (int i = 0; i < bytesRead; i++)
@@ -94,13 +106,13 @@ public static class AudioFileConverter
 				short[] pcmSamples = new short[samplesPerFrame];
 				Buffer.BlockCopy(frameBytes, 0, pcmSamples, 0, bytesPerFrame);
 
-				oggStream.WriteSamples(pcmSamples, 0, samplesPerFrame);
+				WriteFrame(pcmSamples);
 			}
 		}
 
 		// Handle remaining bytes (pad with silence if needed, or just finish)
-		// For speech, we can probably drop the last partial frame if it's very short, 
-		// or pad it. 
+		// For speech, we can probably drop the last partial frame if it's very short,
+		// or pad it.
 		if (accumulationBuffer.Count > 0)
 		{
 			// Padding with silence to reach frame size
@@ -108,12 +120,14 @@ public static class AudioFileConverter
 			{
 				accumulationBuffer.Add(0);
 			}
-			
+
 			byte[] frameBytes = accumulationBuffer.ToArray();
 			short[] pcmSamples = new short[samplesPerFrame];
 			Buffer.BlockCopy(frameBytes, 0, pcmSamples, 0, bytesPerFrame);
-			oggStream.WriteSamples(pcmSamples, 0, samplesPerFrame);
+			WriteFrame(pcmSamples);
 		}
+
+		trimmer?.Flush(f => oggStream.WriteSamples(f, 0, f.Length));
 
 		oggStream.Finish();
 	}

--- a/CognitiveSupport/AudioRecorder.cs
+++ b/CognitiveSupport/AudioRecorder.cs
@@ -12,7 +12,12 @@ public class AudioRecorder : IDisposable
 	private OpusEncoder? _encoder;
 	private OpusOggWriteStream? _oggStream;
 	private Stream? _fileStream;
+	private SilenceTrimmer? _silenceTrimmer;
 	private readonly object _writeLock = new();
+
+	// After StopRecording, the trimmed speech duration in seconds when silence stripping was
+	// active; null when stripping was disabled (so callers leave the recording untouched).
+	public double? TrimmedSpeechSeconds { get; private set; }
 
 	// Opus requires specific frame sizes. 20ms at 48kHz = 960 samples.
 	private const int SampleRate = 48000;
@@ -23,10 +28,15 @@ public class AudioRecorder : IDisposable
 	// Buffer for incoming PCM data
 	private readonly List<short> _pcmBuffer = new();
 
-	public void StartRecording(int captureDeviceIndex, string outputFile)
+	public void StartRecording(int captureDeviceIndex, string outputFile, SilenceTrimmerOptions? silenceOptions = null)
 	{
 		lock (_writeLock)
 		{
+			_silenceTrimmer = silenceOptions is null
+				? null
+				: new SilenceTrimmer(SampleRate, SamplesPerFrame, silenceOptions);
+			TrimmedSpeechSeconds = null;
+
 			WaveInEvent? waveIn = null;
 			Stream? fileStream = null;
 			OpusEncoder? encoder = null;
@@ -107,11 +117,16 @@ public class AudioRecorder : IDisposable
 			{
 				var frame = _pcmBuffer.GetRange(0, SamplesPerFrame).ToArray();
 				_pcmBuffer.RemoveRange(0, SamplesPerFrame);
-				
-				_oggStream.WriteSamples(frame, 0, SamplesPerFrame);
+
+				if (_silenceTrimmer is null)
+					_oggStream.WriteSamples(frame, 0, SamplesPerFrame);
+				else
+					_silenceTrimmer.ProcessFrame(frame, WriteFrame);
 			}
 		}
 	}
+
+	private void WriteFrame(short[] frame) => _oggStream?.WriteSamples(frame, 0, frame.Length);
 
 	private void OnRecordingStopped(object? sender, StoppedEventArgs e)
 	{
@@ -128,16 +143,23 @@ public class AudioRecorder : IDisposable
 			{
 				try
 				{
-					// Flush remaining samples if needed? 
+					// Flush remaining samples if needed?
 					// Opus generally works on whole frames. If we have leftover samples < 20ms,
 					// we could pad with silence or just discard.
 					// For voice, discarding < 20ms at the end is usually fine.
-					
+
+					if (_silenceTrimmer is not null)
+					{
+						_silenceTrimmer.Flush(WriteFrame);
+						TrimmedSpeechSeconds = _silenceTrimmer.SpeechFrameCount * SamplesPerFrame / (double)SampleRate;
+					}
+
 					_oggStream.Finish();
 				}
 				finally
 				{
 					_oggStream = null;
+					_silenceTrimmer = null;
 				}
 			}
 		}

--- a/CognitiveSupport/NoSpeechDetectedException.cs
+++ b/CognitiveSupport/NoSpeechDetectedException.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace CognitiveSupport;
+
+/// <summary>
+/// Thrown when silence stripping reduces a recording to less than the minimum amount of
+/// speech worth transcribing, so the API call is skipped.
+/// </summary>
+public sealed class NoSpeechDetectedException : Exception
+{
+	public NoSpeechDetectedException(string message) : base(message)
+	{
+	}
+}

--- a/CognitiveSupport/Settings.cs
+++ b/CognitiveSupport/Settings.cs
@@ -140,6 +140,18 @@ public class SpeechToTextSettings
         public string? ActiveSpeechToTextService { get; set; }
 
         public int FileTranscriptionTimeoutSeconds { get; set; } = 300;
+
+        // Strip silent gaps from recorded/imported audio before transcription.
+        public bool EnableSilenceStripping { get; set; } = true;
+
+        // RMS loudness floor (dBFS); audio at or below this counts as silence.
+        public double SilenceThresholdDbFs { get; set; } = -40.0;
+
+        // Inter-speech gaps longer than this are trimmed down to this length (seconds).
+        public double MinSilenceSeconds { get; set; } = 1.0;
+
+        // Audio preserved on each side of speech to avoid clipping word edges (milliseconds).
+        public double SilenceGuardMilliseconds { get; set; } = 200.0;
 }
 
 public class SpeechToTextServiceSettings

--- a/CognitiveSupport/SilenceTrimmer.cs
+++ b/CognitiveSupport/SilenceTrimmer.cs
@@ -1,0 +1,148 @@
+using System;
+using System.Collections.Generic;
+
+namespace CognitiveSupport;
+
+/// <summary>
+/// Streaming voice-activity trimmer that operates on fixed-size 16-bit PCM frames.
+/// Feed frames in order via <see cref="ProcessFrame"/>; kept frames are handed back
+/// through the supplied callback. Call <see cref="Flush"/> once the stream ends.
+///
+/// Rules:
+///  - Leading/trailing silence is removed entirely except for a guard (pre-roll/hang-time).
+///  - Silence between speech longer than the threshold is trimmed down to the threshold.
+///  - Shorter inter-speech gaps are left untouched.
+///  - The guard is always preserved around speech to avoid clipping word edges.
+///
+/// Not thread-safe; the caller must serialize access.
+/// </summary>
+public sealed class SilenceTrimmer
+{
+	private readonly int _thresholdFrames;
+	private readonly int _guardFrames;
+	private readonly double _meanSquareThreshold;
+	private readonly int _capFrames;
+
+	// First and last frames of the current silence gap. Bounded to _capFrames each so a
+	// long pause does not grow memory without bound; we only ever keep frames adjacent to
+	// speech (the acoustically important guard regions) plus up to the threshold budget.
+	private readonly List<short[]> _head = new();
+	private readonly List<short[]> _tail = new();
+	private long _silenceCount;
+
+	private bool _hasEmittedSpeech;
+
+	/// <summary>Number of speech (non-silent) frames seen so far.</summary>
+	public long SpeechFrameCount { get; private set; }
+
+	public SilenceTrimmer(int sampleRate, int frameSize, SilenceTrimmerOptions options)
+	{
+		if (sampleRate <= 0) throw new ArgumentOutOfRangeException(nameof(sampleRate));
+		if (frameSize <= 0) throw new ArgumentOutOfRangeException(nameof(frameSize));
+		if (options is null) throw new ArgumentNullException(nameof(options));
+
+		double frameMs = frameSize * 1000.0 / sampleRate;
+
+		_thresholdFrames = Math.Max(0, (int)Math.Round(options.MinSilenceSeconds * 1000.0 / frameMs));
+		_guardFrames = Math.Max(0, (int)Math.Round(options.GuardMilliseconds / frameMs));
+		_capFrames = Math.Max(_thresholdFrames, 2 * _guardFrames);
+
+		// Convert the dBFS floor to a mean-square threshold so detection avoids sqrt/log per frame.
+		double linearRms = Math.Pow(10.0, options.SilenceThresholdDbFs / 20.0) * 32768.0;
+		_meanSquareThreshold = linearRms * linearRms;
+	}
+
+	public void ProcessFrame(short[] frame, Action<short[]> emit)
+	{
+		if (frame is null) throw new ArgumentNullException(nameof(frame));
+		if (emit is null) throw new ArgumentNullException(nameof(emit));
+
+		if (IsSilent(frame))
+		{
+			BufferSilence(frame);
+			return;
+		}
+
+		if (_silenceCount > 0)
+			FlushGap(hasLeftSpeech: _hasEmittedSpeech, hasRightSpeech: true, emit);
+
+		emit(frame);
+		_hasEmittedSpeech = true;
+		SpeechFrameCount++;
+	}
+
+	/// <summary>Flush trailing silence. Call once after the final frame.</summary>
+	public void Flush(Action<short[]> emit)
+	{
+		if (emit is null) throw new ArgumentNullException(nameof(emit));
+		if (_silenceCount > 0)
+			FlushGap(hasLeftSpeech: _hasEmittedSpeech, hasRightSpeech: false, emit);
+	}
+
+	private bool IsSilent(short[] frame)
+	{
+		double sumSquares = 0;
+		for (int i = 0; i < frame.Length; i++)
+		{
+			double s = frame[i];
+			sumSquares += s * s;
+		}
+		double meanSquare = sumSquares / frame.Length;
+		return meanSquare <= _meanSquareThreshold;
+	}
+
+	private void BufferSilence(short[] frame)
+	{
+		_silenceCount++;
+		if (_head.Count < _capFrames)
+			_head.Add(frame);
+		_tail.Add(frame);
+		if (_tail.Count > _capFrames)
+			_tail.RemoveAt(0);
+	}
+
+	private void FlushGap(bool hasLeftSpeech, bool hasRightSpeech, Action<short[]> emit)
+	{
+		long length = _silenceCount;
+		int leftGuard = hasLeftSpeech ? _guardFrames : 0;
+		int rightGuard = hasRightSpeech ? _guardFrames : 0;
+
+		int keepStart;
+		int keepEnd;
+
+		if (!hasLeftSpeech && !hasRightSpeech)
+		{
+			// Entire stream was silence: keep nothing.
+			keepStart = 0;
+			keepEnd = 0;
+		}
+		else if (hasLeftSpeech && hasRightSpeech)
+		{
+			// Interior gap: trim down to the threshold, but never below the guard regions.
+			int budget = (int)Math.Min(length, Math.Max(_thresholdFrames, leftGuard + rightGuard));
+			keepEnd = Math.Min(rightGuard, budget);
+			keepStart = budget - keepEnd; // any slack beyond the guards stays as hang-time after speech
+		}
+		else if (hasRightSpeech)
+		{
+			// Leading silence: keep only the pre-roll guard before the first speech.
+			keepStart = 0;
+			keepEnd = (int)Math.Min(length, rightGuard);
+		}
+		else
+		{
+			// Trailing silence: keep only the hang-time guard after the last speech.
+			keepStart = (int)Math.Min(length, leftGuard);
+			keepEnd = 0;
+		}
+
+		for (int i = 0; i < keepStart; i++)
+			emit(_head[i]);
+		for (int i = _tail.Count - keepEnd; i < _tail.Count; i++)
+			emit(_tail[i]);
+
+		_head.Clear();
+		_tail.Clear();
+		_silenceCount = 0;
+	}
+}

--- a/CognitiveSupport/SilenceTrimmerOptions.cs
+++ b/CognitiveSupport/SilenceTrimmerOptions.cs
@@ -1,0 +1,24 @@
+namespace CognitiveSupport;
+
+/// <summary>
+/// Configuration for <see cref="SilenceTrimmer"/>. All durations are wall-clock,
+/// independent of frame size.
+/// </summary>
+/// <param name="SilenceThresholdDbFs">
+/// RMS loudness floor in dBFS. A 20ms frame at or below this level counts as silence.
+/// Lower (more negative) = stricter (only quieter audio is treated as silence).
+/// </param>
+/// <param name="MinSilenceSeconds">
+/// Silence gaps between speech longer than this are trimmed down to this length.
+/// Gaps shorter than this are left untouched. 0 removes all inter-speech silence
+/// (subject to the guard below).
+/// </param>
+/// <param name="GuardMilliseconds">
+/// Audio kept on each side of a speech segment (hang-time after, pre-roll before)
+/// so soft consonants, breaths, and word decay are not clipped. Acts as a floor
+/// that is preserved even when <paramref name="MinSilenceSeconds"/> is very small.
+/// </param>
+public sealed record SilenceTrimmerOptions(
+	double SilenceThresholdDbFs,
+	double MinSilenceSeconds,
+	double GuardMilliseconds);

--- a/Mutation.Tests/SettingsDefaultsParityTests.cs
+++ b/Mutation.Tests/SettingsDefaultsParityTests.cs
@@ -70,6 +70,10 @@ public class SettingsDefaultsParityTests : IDisposable
 		Assert.Equal(SettingsDefaults.Speech.SpeechToTextWithLlmProcessingHotKey, stt.SpeechToTextWithLlmProcessingHotKey);
 		Assert.Equal(SettingsDefaults.Speech.TempDirectory, stt.TempDirectory);
 		Assert.Equal(SettingsDefaults.Speech.FileTranscriptionTimeoutSeconds, stt.FileTranscriptionTimeoutSeconds);
+		Assert.Equal(SettingsDefaults.Speech.EnableSilenceStripping, stt.EnableSilenceStripping);
+		Assert.Equal(SettingsDefaults.Speech.SilenceThresholdDbFs, stt.SilenceThresholdDbFs);
+		Assert.Equal(SettingsDefaults.Speech.MinSilenceSeconds, stt.MinSilenceSeconds);
+		Assert.Equal(SettingsDefaults.Speech.SilenceGuardMilliseconds, stt.SilenceGuardMilliseconds);
 
 		Assert.NotNull(stt.Services);
 		Assert.NotEmpty(stt.Services!);

--- a/Mutation.Tests/SilenceTrimmerTests.cs
+++ b/Mutation.Tests/SilenceTrimmerTests.cs
@@ -1,0 +1,106 @@
+using System.Collections.Generic;
+using CognitiveSupport;
+
+namespace Mutation.Tests;
+
+public class SilenceTrimmerTests
+{
+	private const int SampleRate = 48000;
+	private const int FrameSize = 960; // 20ms
+
+	// threshold 0.2s = 10 frames; guard 40ms = 2 frames.
+	private static SilenceTrimmer NewTrimmer() =>
+		new(SampleRate, FrameSize, new SilenceTrimmerOptions(
+			SilenceThresholdDbFs: -40.0,
+			MinSilenceSeconds: 0.2,
+			GuardMilliseconds: 40.0));
+
+	private static short[] Silent() => new short[FrameSize];
+
+	private static short[] Loud()
+	{
+		var f = new short[FrameSize];
+		for (int i = 0; i < f.Length; i++) f[i] = 8000;
+		return f;
+	}
+
+	private static List<short[]> Run(SilenceTrimmer trimmer, IEnumerable<short[]> frames)
+	{
+		var emitted = new List<short[]>();
+		foreach (var f in frames)
+			trimmer.ProcessFrame(f, emitted.Add);
+		trimmer.Flush(emitted.Add);
+		return emitted;
+	}
+
+	private static IEnumerable<short[]> Repeat(short[] frame, int count)
+	{
+		for (int i = 0; i < count; i++) yield return frame;
+	}
+
+	[Fact]
+	public void AllSilence_EmitsNothing()
+	{
+		var trimmer = NewTrimmer();
+		var emitted = Run(trimmer, Repeat(Silent(), 15));
+
+		Assert.Empty(emitted);
+		Assert.Equal(0, trimmer.SpeechFrameCount);
+	}
+
+	[Fact]
+	public void InteriorGap_TrimmedToThreshold()
+	{
+		var trimmer = NewTrimmer();
+		var frames = new List<short[]>();
+		frames.AddRange(Repeat(Loud(), 5));
+		frames.AddRange(Repeat(Silent(), 30)); // > threshold (10)
+		frames.AddRange(Repeat(Loud(), 5));
+
+		var emitted = Run(trimmer, frames);
+
+		// 5 speech + 10 kept silence + 5 speech
+		Assert.Equal(20, emitted.Count);
+		Assert.Equal(10, trimmer.SpeechFrameCount);
+	}
+
+	[Fact]
+	public void ShortGap_LeftUntouched()
+	{
+		var trimmer = NewTrimmer();
+		var frames = new List<short[]>();
+		frames.AddRange(Repeat(Loud(), 5));
+		frames.AddRange(Repeat(Silent(), 6)); // <= threshold (10)
+		frames.AddRange(Repeat(Loud(), 5));
+
+		var emitted = Run(trimmer, frames);
+
+		Assert.Equal(16, emitted.Count); // nothing stripped
+	}
+
+	[Fact]
+	public void LeadingAndTrailingSilence_TrimmedToGuard()
+	{
+		var trimmer = NewTrimmer();
+		var frames = new List<short[]>();
+		frames.AddRange(Repeat(Silent(), 20));
+		frames.AddRange(Repeat(Loud(), 5));
+		frames.AddRange(Repeat(Silent(), 20));
+
+		var emitted = Run(trimmer, frames);
+
+		// 2 guard (pre-roll) + 5 speech + 2 guard (hang-time)
+		Assert.Equal(9, emitted.Count);
+		Assert.Equal(5, trimmer.SpeechFrameCount);
+	}
+
+	[Fact]
+	public void ContinuousSpeech_PassesThrough()
+	{
+		var trimmer = NewTrimmer();
+		var emitted = Run(trimmer, Repeat(Loud(), 12));
+
+		Assert.Equal(12, emitted.Count);
+		Assert.Equal(12, trimmer.SpeechFrameCount);
+	}
+}

--- a/Mutation.Ui/Core/AudioSessionManager.cs
+++ b/Mutation.Ui/Core/AudioSessionManager.cs
@@ -169,6 +169,11 @@ public class AudioSessionManager : IDisposable
                 {
                     StatusMessage?.Invoke(this, "Transcription cancelled.");
                 }
+                catch (NoSpeechDetectedException)
+                {
+                    BeepPlayer.Play(BeepType.Failure);
+                    StatusMessage?.Invoke(this, "No speech detected — nothing to transcribe.");
+                }
                 finally
                 {
                     StateChanged?.Invoke(this, EventArgs.Empty);

--- a/Mutation.Ui/Core/SpeechToTextManager.cs
+++ b/Mutation.Ui/Core/SpeechToTextManager.cs
@@ -49,6 +49,21 @@ public class SpeechToTextManager : IDisposable
 
 	private string SessionsDirectory => Path.Combine(_settings.SpeechToTextSettings!.TempDirectory!, Constants.SessionsDirectoryName);
 
+	// Minimum trimmed speech below which we treat a recording as "no speech detected".
+	private const double MinSpeechSecondsForTranscription = 0.25;
+
+	private SilenceTrimmerOptions? BuildSilenceOptions()
+	{
+		var stt = _settings.SpeechToTextSettings;
+		if (stt is null || !stt.EnableSilenceStripping)
+			return null;
+
+		return new SilenceTrimmerOptions(
+			stt.SilenceThresholdDbFs,
+			stt.MinSilenceSeconds,
+			stt.SilenceGuardMilliseconds);
+	}
+
 	public bool HasRecordedAudio()
 	{
 		foreach (var session in GetSessions())
@@ -134,7 +149,7 @@ public class SpeechToTextManager : IDisposable
 			}
 
 			_audioRecorder = new CognitiveSupport.AudioRecorder();
-			_audioRecorder.StartRecording(microphoneDeviceIndex, path);
+			_audioRecorder.StartRecording(microphoneDeviceIndex, path, BuildSilenceOptions());
 		}
 		finally
 		{
@@ -165,10 +180,15 @@ public class SpeechToTextManager : IDisposable
 			try
 			{
 				_audioRecorder?.StopRecording();
+				double? trimmedSpeechSeconds = _audioRecorder?.TrimmedSpeechSeconds;
 				_audioRecorder?.Dispose();
 				_audioRecorder = null;
 
 				transcribeToken.ThrowIfCancellationRequested();
+
+				// When silence stripping ran and left almost no speech, skip the API call.
+				if (trimmedSpeechSeconds is double seconds && seconds < MinSpeechSecondsForTranscription)
+					throw new NoSpeechDetectedException("No speech detected after trimming silence.");
 
 				return await service.ConvertAudioToText(prompt, recordingSession.FilePath, transcribeToken).ConfigureAwait(false);
 			}
@@ -260,11 +280,14 @@ public class SpeechToTextManager : IDisposable
 		if (string.IsNullOrWhiteSpace(extension))
 			throw new InvalidOperationException("Uploaded audio must have a file extension.");
 
-		// If this is a video file, convert to OGG Opus format
-		if (AudioFileConverter.IsVideoFile(sourcePath))
+		var silenceOptions = BuildSilenceOptions();
+
+		// Video files always need decoding; audio files are decoded too when silence
+		// stripping is enabled so their silent gaps get trimmed (otherwise copied as-is).
+		if (AudioFileConverter.IsVideoFile(sourcePath) || silenceOptions is not null)
 		{
 			string destinationPath = await CreateSessionFileAsync(".ogg").ConfigureAwait(false);
-			await Task.Run(() => AudioFileConverter.ConvertMp4ToOgg(sourcePath, destinationPath), token).ConfigureAwait(false);
+			await Task.Run(() => AudioFileConverter.ConvertMp4ToOgg(sourcePath, destinationPath, silenceOptions), token).ConfigureAwait(false);
 
 			if (!TryCreateSession(destinationPath, out var convertedSession))
 				throw new InvalidOperationException($"Unable to parse converted session '{Path.GetFileName(destinationPath)}'.");

--- a/Mutation.Ui/Resources/HelpText.xaml
+++ b/Mutation.Ui/Resources/HelpText.xaml
@@ -30,6 +30,10 @@
 	<x:String x:Key="Help.Speech.FileTimeout">How long to wait for a file transcription to finish before giving up.</x:String>
 	<x:String x:Key="Help.Speech.TempDir">Folder where temporary audio files are written during recording and transcription.</x:String>
 	<x:String x:Key="Help.Speech.SendHotkeyAfter">Optional keystrokes sent to the active app after a transcript is delivered, for example CTRL+V to paste.</x:String>
+	<x:String x:Key="Help.Speech.StripSilence">Remove long silent gaps from audio before transcription, so pauses while you think do not bloat the recording. Applies to live recordings and imported files.</x:String>
+	<x:String x:Key="Help.Speech.SilenceThreshold">Loudness floor in dBFS. Audio at or below this level counts as silence. Lower (more negative) values are stricter, treating only quieter sounds as silence. Default -40.</x:String>
+	<x:String x:Key="Help.Speech.MinSilence">Shortest silence to keep, in seconds. Pauses shorter than this are left untouched; longer pauses are trimmed down to this length. Default 1.0.</x:String>
+	<x:String x:Key="Help.Speech.SilenceGuard">Audio kept on each side of speech, in milliseconds, so soft word starts, breaths, and word endings are not clipped. Default 200.</x:String>
 
 	<!-- Audio -->
 	<x:String x:Key="Help.Audio.MicVisualization">Show a live waveform of the microphone input while recording.</x:String>

--- a/Mutation.Ui/Services/SettingsManager.cs
+++ b/Mutation.Ui/Services/SettingsManager.cs
@@ -333,6 +333,26 @@ internal class SettingsManager : ISettingsManager
 			somethingWasMissing = true;
 		}
 
+		// Clamp silence-stripping values to sane ranges in case the file was hand-edited.
+		double clampedDbFs = Math.Clamp(speechToTextSettings.SilenceThresholdDbFs, -80.0, 0.0);
+		if (clampedDbFs != speechToTextSettings.SilenceThresholdDbFs)
+		{
+			speechToTextSettings.SilenceThresholdDbFs = clampedDbFs;
+			somethingWasMissing = true;
+		}
+		double clampedMinSilence = Math.Clamp(speechToTextSettings.MinSilenceSeconds, 0.0, 30.0);
+		if (clampedMinSilence != speechToTextSettings.MinSilenceSeconds)
+		{
+			speechToTextSettings.MinSilenceSeconds = clampedMinSilence;
+			somethingWasMissing = true;
+		}
+		double clampedGuard = Math.Clamp(speechToTextSettings.SilenceGuardMilliseconds, 0.0, 2000.0);
+		if (clampedGuard != speechToTextSettings.SilenceGuardMilliseconds)
+		{
+			speechToTextSettings.SilenceGuardMilliseconds = clampedGuard;
+			somethingWasMissing = true;
+		}
+
 		var duplicateGroups = speechToTextSettings.Services
 			 .GroupBy(s => s.Name, StringComparer.OrdinalIgnoreCase)
 			 .Where(g => g.Count() > 1)

--- a/Mutation.Ui/Views/Settings/Pages/SpeechSettingsPage.xaml
+++ b/Mutation.Ui/Views/Settings/Pages/SpeechSettingsPage.xaml
@@ -73,5 +73,79 @@
 							   HelpText="{StaticResource Help.Speech.SendHotkeyAfter}"
 							   AllowEmpty="True"
 							   AllowSendKeysSyntax="True" />
+
+		<TextBlock Text="Silence stripping" Style="{StaticResource SubtitleTextBlockStyle}" />
+
+		<StackPanel Spacing="4">
+			<StackPanel Orientation="Horizontal" Spacing="6">
+				<CheckBox x:Name="ChkStripSilence"
+						  Content="Strip silent gaps from audio"
+						  AutomationProperties.Name="Strip silent gaps from audio"
+						  AutomationProperties.HelpText="{StaticResource Help.Speech.StripSilence}"
+						  Checked="ChkStripSilence_Changed"
+						  Unchecked="ChkStripSilence_Changed" />
+				<controls:InfoHint Text="{StaticResource Help.Speech.StripSilence}" VerticalAlignment="Center" />
+			</StackPanel>
+		</StackPanel>
+
+		<StackPanel Spacing="4">
+			<StackPanel Orientation="Horizontal" Spacing="6">
+				<TextBlock Text="Minimum silence to keep (seconds)" VerticalAlignment="Center" Style="{StaticResource BodyStrongTextBlockStyle}" />
+				<controls:InfoHint Text="{StaticResource Help.Speech.MinSilence}" VerticalAlignment="Center" />
+			</StackPanel>
+			<StackPanel Orientation="Horizontal" Spacing="6">
+				<NumberBox x:Name="NbMinSilence"
+						   AutomationProperties.Name="Minimum silence to keep (seconds)"
+						   AutomationProperties.HelpText="{StaticResource Help.Speech.MinSilence}"
+						   Minimum="0" Maximum="5"
+						   SmallChange="0.1" LargeChange="0.5"
+						   SpinButtonPlacementMode="Inline"
+						   Width="220"
+						   ValueChanged="NbMinSilence_ValueChanged" />
+				<Button Click="BtnResetMinSilence_Click" ToolTipService.ToolTip="Reset to default" AutomationProperties.Name="Reset minimum silence to keep">
+					<FontIcon Glyph="&#xE72C;" FontFamily="Segoe Fluent Icons" FontSize="12" AutomationProperties.AccessibilityView="Raw" />
+				</Button>
+			</StackPanel>
+		</StackPanel>
+
+		<StackPanel Spacing="4">
+			<StackPanel Orientation="Horizontal" Spacing="6">
+				<TextBlock Text="Silence threshold (dBFS)" VerticalAlignment="Center" Style="{StaticResource BodyStrongTextBlockStyle}" />
+				<controls:InfoHint Text="{StaticResource Help.Speech.SilenceThreshold}" VerticalAlignment="Center" />
+			</StackPanel>
+			<StackPanel Orientation="Horizontal" Spacing="6">
+				<NumberBox x:Name="NbSilenceThreshold"
+						   AutomationProperties.Name="Silence threshold (dBFS)"
+						   AutomationProperties.HelpText="{StaticResource Help.Speech.SilenceThreshold}"
+						   Minimum="-60" Maximum="-20"
+						   SmallChange="1" LargeChange="5"
+						   SpinButtonPlacementMode="Inline"
+						   Width="220"
+						   ValueChanged="NbSilenceThreshold_ValueChanged" />
+				<Button Click="BtnResetSilenceThreshold_Click" ToolTipService.ToolTip="Reset to default" AutomationProperties.Name="Reset silence threshold">
+					<FontIcon Glyph="&#xE72C;" FontFamily="Segoe Fluent Icons" FontSize="12" AutomationProperties.AccessibilityView="Raw" />
+				</Button>
+			</StackPanel>
+		</StackPanel>
+
+		<StackPanel Spacing="4">
+			<StackPanel Orientation="Horizontal" Spacing="6">
+				<TextBlock Text="Edge guard (milliseconds)" VerticalAlignment="Center" Style="{StaticResource BodyStrongTextBlockStyle}" />
+				<controls:InfoHint Text="{StaticResource Help.Speech.SilenceGuard}" VerticalAlignment="Center" />
+			</StackPanel>
+			<StackPanel Orientation="Horizontal" Spacing="6">
+				<NumberBox x:Name="NbSilenceGuard"
+						   AutomationProperties.Name="Edge guard (milliseconds)"
+						   AutomationProperties.HelpText="{StaticResource Help.Speech.SilenceGuard}"
+						   Minimum="0" Maximum="500"
+						   SmallChange="10" LargeChange="50"
+						   SpinButtonPlacementMode="Inline"
+						   Width="220"
+						   ValueChanged="NbSilenceGuard_ValueChanged" />
+				<Button Click="BtnResetSilenceGuard_Click" ToolTipService.ToolTip="Reset to default" AutomationProperties.Name="Reset edge guard">
+					<FontIcon Glyph="&#xE72C;" FontFamily="Segoe Fluent Icons" FontSize="12" AutomationProperties.AccessibilityView="Raw" />
+				</Button>
+			</StackPanel>
+		</StackPanel>
 	</StackPanel>
 </UserControl>

--- a/Mutation.Ui/Views/Settings/Pages/SpeechSettingsPage.xaml.cs
+++ b/Mutation.Ui/Views/Settings/Pages/SpeechSettingsPage.xaml.cs
@@ -47,6 +47,11 @@ public sealed partial class SpeechSettingsPage : UserControl
 				: SettingsDefaults.Speech.FileTranscriptionTimeoutSeconds;
 			TxtTempDir.Text = stt.TempDirectory ?? string.Empty;
 			HkSendAfterTranscription.Hotkey = stt.SendHotkeyAfterTranscriptionOperation ?? string.Empty;
+
+			ChkStripSilence.IsChecked = stt.EnableSilenceStripping;
+			NbMinSilence.Value = stt.MinSilenceSeconds;
+			NbSilenceThreshold.Value = stt.SilenceThresholdDbFs;
+			NbSilenceGuard.Value = stt.SilenceGuardMilliseconds;
 		}
 		finally { _suppressEvents = false; }
 	}
@@ -72,6 +77,42 @@ public sealed partial class SpeechSettingsPage : UserControl
 
 	private void BtnResetFileTimeout_Click(object sender, RoutedEventArgs e) =>
 		NbFileTimeout.Value = SettingsDefaults.Speech.FileTranscriptionTimeoutSeconds;
+
+	private void ChkStripSilence_Changed(object sender, RoutedEventArgs e)
+	{
+		if (_suppressEvents) return;
+		(_settings.SpeechToTextSettings ??= new SpeechToTextSettings()).EnableSilenceStripping = ChkStripSilence.IsChecked == true;
+	}
+
+	private void NbMinSilence_ValueChanged(NumberBox sender, NumberBoxValueChangedEventArgs args)
+	{
+		if (_suppressEvents) return;
+		if (double.IsNaN(args.NewValue)) return;
+		(_settings.SpeechToTextSettings ??= new SpeechToTextSettings()).MinSilenceSeconds = args.NewValue;
+	}
+
+	private void NbSilenceThreshold_ValueChanged(NumberBox sender, NumberBoxValueChangedEventArgs args)
+	{
+		if (_suppressEvents) return;
+		if (double.IsNaN(args.NewValue)) return;
+		(_settings.SpeechToTextSettings ??= new SpeechToTextSettings()).SilenceThresholdDbFs = args.NewValue;
+	}
+
+	private void NbSilenceGuard_ValueChanged(NumberBox sender, NumberBoxValueChangedEventArgs args)
+	{
+		if (_suppressEvents) return;
+		if (double.IsNaN(args.NewValue)) return;
+		(_settings.SpeechToTextSettings ??= new SpeechToTextSettings()).SilenceGuardMilliseconds = args.NewValue;
+	}
+
+	private void BtnResetMinSilence_Click(object sender, RoutedEventArgs e) =>
+		NbMinSilence.Value = SettingsDefaults.Speech.MinSilenceSeconds;
+
+	private void BtnResetSilenceThreshold_Click(object sender, RoutedEventArgs e) =>
+		NbSilenceThreshold.Value = SettingsDefaults.Speech.SilenceThresholdDbFs;
+
+	private void BtnResetSilenceGuard_Click(object sender, RoutedEventArgs e) =>
+		NbSilenceGuard.Value = SettingsDefaults.Speech.SilenceGuardMilliseconds;
 
 	private void BtnResetTempDir_Click(object sender, RoutedEventArgs e) =>
 		TxtTempDir.Text = SettingsDefaults.Speech.TempDirectory;

--- a/Mutation.Ui/Views/Settings/SettingsDefaults.cs
+++ b/Mutation.Ui/Views/Settings/SettingsDefaults.cs
@@ -41,6 +41,10 @@ internal static class SettingsDefaults
 		public const string DefaultServiceModelId = "whisper-1";
 		public const string DefaultServiceBaseDomain = "https://api.openai.com/";
 		public const string DefaultServicePrompt = "Hello, let's use punctuation. Names: Kobus, Piro.";
+		public const bool EnableSilenceStripping = true;
+		public const double SilenceThresholdDbFs = -40.0;
+		public const double MinSilenceSeconds = 1.0;
+		public const double SilenceGuardMilliseconds = 200.0;
 	}
 
 	public static class Tts

--- a/Mutation.Ui/Views/Settings/SettingsWorkingCopy.cs
+++ b/Mutation.Ui/Views/Settings/SettingsWorkingCopy.cs
@@ -70,6 +70,10 @@ internal static class SettingsWorkingCopy
 			dst.Services = src.Services;
 			dst.ActiveSpeechToTextService = src.ActiveSpeechToTextService;
 			dst.FileTranscriptionTimeoutSeconds = src.FileTranscriptionTimeoutSeconds;
+			dst.EnableSilenceStripping = src.EnableSilenceStripping;
+			dst.SilenceThresholdDbFs = src.SilenceThresholdDbFs;
+			dst.MinSilenceSeconds = src.MinSilenceSeconds;
+			dst.SilenceGuardMilliseconds = src.SilenceGuardMilliseconds;
 		}
 
 		live.LlmSettings ??= new LlmSettings();


### PR DESCRIPTION
Strip silent gaps from recorded and imported audio before transcription so thinking pauses do not bloat the clip. A streaming SilenceTrimmer detects silence per 20ms PCM frame (RMS vs a dBFS floor), removes leading/trailing silence, trims inter-speech gaps down to a configurable minimum, and keeps a guard around speech to avoid clipping word edges.

Exposed on the Speech settings page (enabled by default): on/off toggle, minimum silence (s), silence threshold (dBFS), and edge guard (ms), all with accessible automation properties and help text. When trimming leaves under 250ms of speech, the API call is skipped with a "no speech detected" status.