### PR TITLE
Gitignore deploy scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,10 @@ src/Positron.Website/wwwroot/app/1.2/
 src/Positron.Website/appsettings.Development.json
 /src/Positron.Website/wwwroot/internal
 
+# Deploy scripts
+deploy.cmd
+deploy.ps1
+
 # Logs
 logs/
 


### PR DESCRIPTION
## Summary
- Add `deploy.cmd` and `deploy.ps1` to `.gitignore` so the local deployment scripts stay machine-specific and out of version control.

## Test plan
- [ ] Verify deploy scripts are not tracked by git after merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)