### PR TITLE
Fix/crashing

### DIFF
--- a/CRASH_INVESTIGATION.md
+++ b/CRASH_INVESTIGATION.md
@@ -1,0 +1,127 @@
+# Cold-start "process with LLM" crash — fix summary
+
+## Root cause (already diagnosed; recorded here for posterity)
+1. **No retry on the LLM path.** `LlmService` (OpenAI) and `AnthropicLlmService` issued a single
+   request with one timeout. The transcription path already wraps its call in a Polly
+   linear-backoff retry (`OpenAiSpeechToTextService.cs`). On the FIRST launch after a reboot,
+   cold-start latency (cold DNS/TLS/cert-chain + cold JIT warmup) makes the first network call
+   slow or fail. With no retry, that failure propagated unhandled during "process with LLM"
+   right after transcription. The second launch was fine because everything was already warm.
+2. **Crash logs silently vanished.** `App.xaml.cs` wrote `Mutation_Errors.log` / `CrashLog_*.txt`
+   to `AppDomain.CurrentDomain.BaseDirectory` (the EXE folder). When Mutation is installed under
+   Program Files that folder is not writable, so the writes threw (and were swallowed) — no log
+   ever appeared. Additionally, when the LLM call failed inside
+   `AudioSessionManager.ProcessTranscriptAsync`, the exception was caught but only shown as a
+   transient status message; it was never written to any log.
+
+## Deliverable 1 — Bulletproof, dual-location crash logging
+
+- **`CognitiveSupport/ErrorLogger.cs`** (was an untracked, single-location logger; extended in place):
+  - `Write()` now appends each entry to BOTH locations, each in its own try/catch (best-effort,
+    never throws): (a) `%LOCALAPPDATA%\Mutation\logs\Mutation_Errors.log` (dir created with
+    `Directory.CreateDirectory`), and (b) `AppContext.BaseDirectory\Mutation_Errors.log`. One
+    location failing (e.g. Program Files not writable) never stops the other.
+  - Added `public static string PrimaryLogPath` — returns the user-writable `%LOCALAPPDATA%`
+    path for surfacing in dialogs; computing it never throws (falls back to BaseDirectory, then
+    to the bare file name).
+  - Kept the existing public API (`LogError`, `LogInfo`, `SanitizeException`, `RedactSecrets`)
+    and the never-throw guarantee and secret redaction.
+- **`Mutation.Ui/App.xaml.cs`** — routed ALL exception logging through `ErrorLogger` (single
+  source of truth):
+  - `OnUnhandledException` / `OnAppDomainUnhandledException` / `OnUnobservedTaskException`: same
+    control flow (`e.Handled = true` / `e.SetObserved()`), body now calls
+    `ErrorLogger.LogError("<same source string>", ...)`.
+  - `OnLaunched` catch: replaced the `File.WriteAllText(CrashLog_*.txt, SanitizeException(ex))`
+    block with `ErrorLogger.LogError("Startup Error", ex);` and pointed the user-facing
+    dialog/MessageBox at `ErrorLogger.PrimaryLogPath`. Dialog + MessageBox fallback +
+    `ShutdownAsync()` behavior unchanged.
+  - Removed the now-divergent private `LogBackgroundException`, `SanitizeException`, and
+    `RedactSecrets` (logic lives in `ErrorLogger`). `TryRecoverSettings` does not use them.
+  - Added a startup breadcrumb near the top of `OnLaunched`:
+    `ErrorLogger.LogInfo("Startup", "OnLaunched starting");` — confirms the log path works on
+    every launch.
+- **`Mutation.Ui/Core/AudioSessionManager.cs`** `ProcessTranscriptAsync`: added
+  `ErrorLogger.LogInfo("LLM", $"LLM processing starting (model={modelName}).")` right before the
+  `ProcessWithLlmAsync` call, and `ErrorLogger.LogError("LLM processing failed", ex)` in the catch
+  (existing StatusMessage line kept). `using CognitiveSupport;` was already present.
+- **`Mutation.Ui/MainWindow.xaml.cs`**: added `ErrorLogger.LogError("Process with LLM", ex)` in
+  both `ExecutePrompt`'s catch and `BtnProcessLlm_Click`'s catch, before the existing dialog calls.
+  `using CognitiveSupport;` was already present.
+
+### Crash-log locations & format
+- Primary (user-writable, shown in dialogs): `%LOCALAPPDATA%\Mutation\logs\Mutation_Errors.log`
+- Secondary (best-effort): `<EXE folder>\Mutation_Errors.log`
+- Entry format (per write):
+  `[yyyy-MM-dd HH:mm:ss.fff zzz] [Source]\n<redacted body>\n\n`
+  Secrets (`sk-…`, `Bearer …`) are redacted before writing.
+
+## Deliverable 2 — Cold-start LLM hardening + configurable retry knob
+
+- **`CognitiveSupport/CognitiveSupport.csproj`**: added explicit
+  `<PackageReference Include="Polly" Version="7.2.4" />` and
+  `<PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />` (previously only
+  transitive via Deepgram).
+- **`CognitiveSupport/LlmService.cs`** (OpenAI): added `int retryCount = 3` ctor param
+  (stored as `_retryCount`, clamped `< 0` → 0). Wrapped `client.CompleteChatAsync(...)` in a
+  Polly `WaitAndRetryAsync` mirroring the transcription pattern: handles `HttpRequestException`,
+  `Polly.Timeout.TimeoutRejectedException`, `TaskCanceledException`;
+  `Backoff.LinearBackoff(500ms, retryCount: _retryCount, factor: 1)`; per-attempt
+  `CancellationTokenSource` timeout = `_timeoutSeconds * attempt` (escalating). With
+  `_retryCount == 0` the body still executes once.
+- **`CognitiveSupport/AnthropicLlmService.cs`**: same `retryCount` ctor param + Polly policy
+  wrapping `_httpClient.SendAsync(...)` and the response read, with escalating per-attempt
+  timeout. The `HttpRequestMessage` is rebuilt inside each attempt (it is single-use). Existing
+  error parsing kept. NOTE comment added: a non-success status (incl. 4xx like 401) is surfaced
+  as `HttpRequestException`, so it WILL be retried — this matches the existing transcription
+  behavior; not retrying 4xx is a sensible follow-up.
+- **`CognitiveSupport/Settings.cs`** — `LlmSettings`: added `public int RetryCount { get; set; } = 3;`
+  next to `TimeoutSeconds`.
+- **`Mutation.Ui/Views/Settings/SettingsDefaults.cs`** — `static class Llm`: added
+  `public const int RetryCount = 3;`.
+- **`Mutation.Ui/Services/SettingsManager.cs`** `EnsureSettings`: after the LLM section, added a
+  guard that corrects hand-edited values — `RetryCount < 0` → 3, `RetryCount > 10` → 10, each
+  setting `somethingWasMissing = true`. A clean object (field-init 3) is unchanged, so parity holds.
+- **`Mutation.Ui/Views/Settings/SettingsWorkingCopy.cs`** `CommitInto`: added
+  `dst.RetryCount = src.RetryCount;` in the LlmSettings block.
+- **`Mutation.Ui/App.xaml.cs`** DI of `ILlmService`: reads
+  `int retryCount = llmSettings?.RetryCount ?? SettingsDefaults.Llm.RetryCount;` then
+  `if (retryCount < 0) retryCount = SettingsDefaults.Llm.RetryCount;`, and passes `retryCount`
+  as the new last arg to both `new LlmService(...)` and `new AnthropicLlmService(...)`.
+
+### Accessible UI knob (hard requirement — user is blind, uses ZoomText)
+- **`Mutation.Ui/Resources/HelpText.xaml`**: added `Help.Llm.RetryCount` next to
+  `Help.Llm.RequestTimeout` (no duplicate keys). Text: "How many times to retry a failed
+  language-model request before giving up. Retries help the first request after a reboot succeed
+  while the network warms up. Default 3."
+- **`Mutation.Ui/Views/Settings/Pages/LlmSettingsPage.xaml`**: added a "Retries" block modeled
+  exactly on the "Request timeout (seconds)" block — label + `InfoHint` (Help.Llm.RetryCount),
+  a `NumberBox x:Name="NbRetryCount"` Minimum="0" Maximum="10" SmallChange="1"
+  SpinButtonPlacementMode="Inline" with `AutomationProperties.Name="Retry count"` and
+  `AutomationProperties.HelpText="{StaticResource Help.Llm.RetryCount}"`, plus a reset Button
+  with `AutomationProperties.Name="Reset retry count"`. Placed right after the timeout block.
+- **`Mutation.Ui/Views/Settings/Pages/LlmSettingsPage.xaml.cs`**: `LoadValues` sets
+  `NbRetryCount.Value = llm.RetryCount >= 0 ? llm.RetryCount : SettingsDefaults.Llm.RetryCount;`;
+  added `NbRetryCount_ValueChanged` (writes `RetryCount`, guarded by `_suppressEvents` + NaN
+  check) and `BtnResetRetryCount_Click` (sets default), mirroring the timeout equivalents.
+
+### Test
+- **`Mutation.Tests/SettingsDefaultsParityTests.cs`**: added
+  `[Fact] public void Llm_Defaults_Match()` asserting
+  `Assert.Equal(SettingsDefaults.Llm.RetryCount, s.LlmSettings!.RetryCount)` after `ApplyDefaults()`.
+
+## How to verify
+- Build: `dotnet build Mutation.slnx -c Debug` → Build succeeded, 0 warnings, 0 errors.
+- Test: `dotnet test Mutation.Tests/Mutation.Tests.csproj -c Debug` → Passed! 308/308, 0 failed.
+- Runtime: launch the app; `%LOCALAPPDATA%\Mutation\logs\Mutation_Errors.log` should receive a
+  `[Startup] OnLaunched starting` breadcrumb on every launch. The "Retries" NumberBox appears on
+  the LLM settings page with full screen-reader name/help text.
+
+## Remaining follow-ups
+- **Anthropic retries 4xx (e.g. 401 Unauthorized).** Because a non-success status is surfaced as
+  `HttpRequestException`, the Polly policy retries it. This matches existing transcription
+  behavior but wastes attempts on permanent failures; consider not retrying 4xx (parse status,
+  rethrow non-retryable as a distinct type the policy doesn't handle).
+- **Consider escalating the transcription-style timeout** consistently across all network paths,
+  and surfacing per-attempt diagnostics to the log.
+- The OpenAI SDK's `CompleteChatAsync` may apply its own internal retry/timeout; the added Polly
+  layer is additive. Worth confirming the combined behavior is acceptable under sustained outage.

--- a/CRASH_INVESTIGATION.md
+++ b/CRASH_INVESTIGATION.md
@@ -116,11 +116,15 @@
   `[Startup] OnLaunched starting` breadcrumb on every launch. The "Retries" NumberBox appears on
   the LLM settings page with full screen-reader name/help text.
 
+## Resolved follow-ups
+- **~~Anthropic retries 4xx (e.g. 401 Unauthorized).~~ Resolved.** Both LLM services now classify
+  HTTP statuses via `LlmHttpStatus.IsTransient` (`CognitiveSupport/LlmHttpStatus.cs`): only
+  connection failures, 408, 429 and 5xx are retried. Permanent 4xx (401/403/400/404/422) throw
+  `NonTransientLlmException` (Anthropic) or are detected via `ClientResultException.Status` (OpenAI
+  SDK), so a bad API key fails fast instead of retrying. Covered by
+  `Mutation.Tests/LlmHttpStatusTests.cs`.
+
 ## Remaining follow-ups
-- **Anthropic retries 4xx (e.g. 401 Unauthorized).** Because a non-success status is surfaced as
-  `HttpRequestException`, the Polly policy retries it. This matches existing transcription
-  behavior but wastes attempts on permanent failures; consider not retrying 4xx (parse status,
-  rethrow non-retryable as a distinct type the policy doesn't handle).
 - **Consider escalating the transcription-style timeout** consistently across all network paths,
   and surfacing per-attempt diagnostics to the log.
 - The OpenAI SDK's `CompleteChatAsync` may apply its own internal retry/timeout; the added Polly

--- a/CognitiveSupport/AnthropicLlmService.cs
+++ b/CognitiveSupport/AnthropicLlmService.cs
@@ -1,3 +1,6 @@
+using Polly;
+using Polly.Contrib.WaitAndRetry;
+using Polly.Timeout;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
@@ -15,12 +18,14 @@ public class AnthropicLlmService : ILlmService
 	private readonly HttpClient _httpClient;
 	private readonly Dictionary<string, LlmModelConfig> _modelConfigs;
 	private readonly int _timeoutSeconds;
+	private readonly int _retryCount;
 
 	public AnthropicLlmService(
 		string apiKey,
 		IEnumerable<LlmModelConfig> models,
 		HttpClient httpClient,
-		int timeoutSeconds = 60)
+		int timeoutSeconds = 60,
+		int retryCount = 3)
 	{
 		if (string.IsNullOrEmpty(apiKey)) throw new ArgumentNullException(nameof(apiKey));
 		if (models is null) throw new ArgumentNullException(nameof(models));
@@ -28,6 +33,7 @@ public class AnthropicLlmService : ILlmService
 		_apiKey = apiKey;
 		_httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
 		_timeoutSeconds = timeoutSeconds > 0 ? timeoutSeconds : 60;
+		_retryCount = retryCount < 0 ? 0 : retryCount;
 		_modelConfigs = models.ToDictionary(m => m.Name, m => m, StringComparer.OrdinalIgnoreCase);
 	}
 
@@ -73,33 +79,74 @@ public class AnthropicLlmService : ILlmService
 		};
 		string jsonBody = JsonSerializer.Serialize(request, jsonOptions);
 
-		using var httpRequest = new HttpRequestMessage(HttpMethod.Post, ApiUrl);
-		httpRequest.Headers.Add("x-api-key", _apiKey);
-		httpRequest.Headers.Add("anthropic-version", AnthropicVersion);
-		httpRequest.Content = new StringContent(jsonBody, Encoding.UTF8, "application/json");
+		// Retry policy mirrors OpenAiSpeechToTextService.cs so the cold-start path (slow
+		// DNS/TLS/JIT warmup on the first call after a reboot) gets a few escalating-timeout
+		// attempts instead of an unhandled failure.
+		// Only transient failures (network/timeout, 429, 5xx) are surfaced as the
+		// retryable HttpRequestException; permanent 4xx errors such as 401 Unauthorized
+		// throw NonTransientLlmException, which the policy does not handle, so a bad API
+		// key fails fast instead of after every retry.
+		const string AttemptKey = "Attempt";
 
-		using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(_timeoutSeconds));
-		using var httpResponse = await _httpClient.SendAsync(httpRequest, timeoutCts.Token);
+		var delay = Backoff.LinearBackoff(TimeSpan.FromMilliseconds(500), retryCount: _retryCount, factor: 1);
+		var retryPolicy = Policy
+			.Handle<HttpRequestException>()
+			.Or<TimeoutRejectedException>()
+			.Or<TaskCanceledException>()
+				.WaitAndRetryAsync(
+					delay,
+					onRetry: (exception, timeSpan, attemptNumber, context) =>
+					{
+						int attempt = context.ContainsKey(AttemptKey) ? (int)context[AttemptKey] : 1;
+						context[AttemptKey] = ++attempt;
+					}
+				);
 
-		string responseBody = await httpResponse.Content.ReadAsStringAsync(timeoutCts.Token);
+		var pollyContext = new Context();
+		pollyContext[AttemptKey] = 1;
 
-		if (!httpResponse.IsSuccessStatusCode)
+		string responseBody = await retryPolicy.ExecuteAsync(async (ctx) =>
 		{
-			string errorMessage = $"Anthropic API returned {(int)httpResponse.StatusCode} {httpResponse.StatusCode}";
-			try
+			int attempt = ctx.ContainsKey(AttemptKey) ? (int)ctx[AttemptKey] : 1;
+			int timeout = _timeoutSeconds * attempt;
+			using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(timeout));
+
+			// HttpRequestMessage is single-use; rebuild it for each attempt.
+			using var httpRequest = new HttpRequestMessage(HttpMethod.Post, ApiUrl);
+			httpRequest.Headers.Add("x-api-key", _apiKey);
+			httpRequest.Headers.Add("anthropic-version", AnthropicVersion);
+			httpRequest.Content = new StringContent(jsonBody, Encoding.UTF8, "application/json");
+
+			using var httpResponse = await _httpClient.SendAsync(httpRequest, timeoutCts.Token).ConfigureAwait(false);
+
+			string body = await httpResponse.Content.ReadAsStringAsync(timeoutCts.Token).ConfigureAwait(false);
+
+			if (!httpResponse.IsSuccessStatusCode)
 			{
-				var errorResponse = JsonSerializer.Deserialize<AnthropicErrorResponse>(responseBody);
-				if (errorResponse?.Error != null)
+				int statusCode = (int)httpResponse.StatusCode;
+				string errorMessage = $"Anthropic API returned {statusCode} {httpResponse.StatusCode}";
+				try
 				{
-					errorMessage = $"Anthropic API error ({errorResponse.Error.Type}): {errorResponse.Error.Message}";
+					var errorResponse = JsonSerializer.Deserialize<AnthropicErrorResponse>(body);
+					if (errorResponse?.Error != null)
+					{
+						errorMessage = $"Anthropic API error ({errorResponse.Error.Type}): {errorResponse.Error.Message}";
+					}
 				}
+				catch (JsonException)
+				{
+					// If we can't parse the error, use the raw status code message
+				}
+
+				// Retry only transient failures (429, 5xx); fail fast on permanent
+				// 4xx errors like 401 Unauthorized so a bad API key is reported at once.
+				if (LlmHttpStatus.IsTransient(statusCode))
+					throw new HttpRequestException(errorMessage);
+				throw new NonTransientLlmException(errorMessage, statusCode);
 			}
-			catch (JsonException)
-			{
-				// If we can't parse the error, use the raw status code message
-			}
-			throw new HttpRequestException(errorMessage);
-		}
+
+			return body;
+		}, pollyContext).ConfigureAwait(false);
 
 		var response = JsonSerializer.Deserialize<AnthropicResponse>(responseBody);
 		if (response?.Content != null && response.Content.Length > 0)

--- a/CognitiveSupport/CognitiveSupport.csproj
+++ b/CognitiveSupport/CognitiveSupport.csproj
@@ -14,6 +14,8 @@
 		<PackageReference Include="Concentus.Oggfile" Version="1.0.6" />
 		<PackageReference Include="Deepgram" Version="6.6.1" />
 		<PackageReference Include="OpenAI" Version="2.7.0" />
+		<PackageReference Include="Polly" Version="7.2.4" />
+		<PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
 		<PackageReference Include="NAudio" Version="2.2.1" />
 		<PackageReference Include="System.Speech" Version="10.0.0" />
 	</ItemGroup>

--- a/CognitiveSupport/ErrorLogger.cs
+++ b/CognitiveSupport/ErrorLogger.cs
@@ -1,0 +1,133 @@
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace CognitiveSupport;
+
+/// <summary>
+/// Shared, never-throwing file logger that appends redacted, timestamped entries to
+/// <c>Mutation_Errors.log</c> in BOTH a user-writable location
+/// (<c>%LOCALAPPDATA%\Mutation\logs</c>) and next to the EXE
+/// (<see cref="AppContext.BaseDirectory"/>).
+///
+/// Writing to both locations (each best-effort, in its own try/catch) means a crash
+/// log still lands somewhere even when the EXE folder is not writable (e.g. an install
+/// under Program Files) — the historical reason cold-start crash logs silently vanished.
+///
+/// This is the single source of truth for error-file logging so that non-UI code
+/// (e.g. the LLM services and call sites) can write to the SAME log the global
+/// crash handlers in App.xaml.cs use, without divergent copies of the redaction logic.
+/// Philosophy (matching commit 07019f6): log and keep the app alive; never throw from logging.
+/// </summary>
+public static class ErrorLogger
+{
+	private const string ErrorLogFileName = "Mutation_Errors.log";
+
+	/// <summary>
+	/// The user-writable log path (<c>%LOCALAPPDATA%\Mutation\logs\Mutation_Errors.log</c>),
+	/// suitable for surfacing in dialogs so the user knows where to find the log.
+	/// Never throws; falls back to the EXE-folder path if the local-app-data path
+	/// cannot be computed.
+	/// </summary>
+	public static string PrimaryLogPath
+	{
+		get
+		{
+			try
+			{
+				string localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+				return Path.Combine(localAppData, "Mutation", "logs", ErrorLogFileName);
+			}
+			catch
+			{
+				try
+				{
+					return Path.Combine(AppContext.BaseDirectory, ErrorLogFileName);
+				}
+				catch
+				{
+					return ErrorLogFileName;
+				}
+			}
+		}
+	}
+
+	/// <summary>
+	/// Appends a redacted, timestamped entry describing an exception. Never throws.
+	/// </summary>
+	public static void LogError(string source, Exception? exception)
+	{
+		Write(source, SanitizeException(exception));
+	}
+
+	/// <summary>
+	/// Appends a redacted, timestamped free-text breadcrumb (e.g. "LLM processing starting").
+	/// Never throws.
+	/// </summary>
+	public static void LogInfo(string source, string message)
+	{
+		Write(source, RedactSecrets(message ?? string.Empty));
+	}
+
+	private static void Write(string source, string body)
+	{
+		string timestamp = DateTimeOffset.Now.ToString("yyyy-MM-dd HH:mm:ss.fff zzz");
+		string entry = $"[{timestamp}] [{source}]{Environment.NewLine}{body}{Environment.NewLine}{Environment.NewLine}";
+
+		// (a) User-writable location: %LOCALAPPDATA%\Mutation\logs. Created if missing.
+		try
+		{
+			string localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+			string logDir = Path.Combine(localAppData, "Mutation", "logs");
+			Directory.CreateDirectory(logDir);
+			string logPath = Path.Combine(logDir, ErrorLogFileName);
+			File.AppendAllText(logPath, entry, Encoding.UTF8);
+		}
+		catch
+		{
+			// Never let logging throw — callers may already be in a failure path.
+		}
+
+		// (b) EXE folder. May fail if installed under a non-writable directory
+		// (e.g. Program Files); that must not stop the user-writable write above.
+		try
+		{
+			string logPath = Path.Combine(AppContext.BaseDirectory, ErrorLogFileName);
+			File.AppendAllText(logPath, entry, Encoding.UTF8);
+		}
+		catch
+		{
+			// Never let logging throw — callers may already be in a failure path.
+		}
+	}
+
+	public static string SanitizeException(Exception? exception)
+	{
+		if (exception is null)
+		{
+			return "(no exception object)";
+		}
+
+		return RedactSecrets(exception.ToString());
+	}
+
+	public static string RedactSecrets(string text)
+	{
+		if (string.IsNullOrEmpty(text))
+		{
+			return text;
+		}
+
+		// Redact common secret patterns (API keys) so they never land in the log file.
+		text = Regex.Replace(
+			text,
+			@"sk-[A-Za-z0-9_\-]{10,}",
+			"sk-***REDACTED***");
+
+		text = Regex.Replace(
+			text,
+			@"Bearer\s+[A-Za-z0-9_\-\.]{10,}",
+			"Bearer ***REDACTED***");
+
+		return text;
+	}
+}

--- a/CognitiveSupport/LlmHttpStatus.cs
+++ b/CognitiveSupport/LlmHttpStatus.cs
@@ -1,0 +1,35 @@
+namespace CognitiveSupport;
+
+/// <summary>
+/// Thrown for language-model API failures that are NOT worth retrying — chiefly 4xx
+/// client errors such as 401 Unauthorized / 403 Forbidden (bad or missing API key),
+/// 400 Bad Request, or 404 Not Found. The retry policies deliberately do not handle
+/// this exception type, so it surfaces immediately instead of after several pointless
+/// retries (which, with escalating timeouts, could otherwise make a simple bad-key
+/// error take a minute or more to report).
+/// </summary>
+public class NonTransientLlmException : Exception
+{
+	public int StatusCode { get; }
+
+	public NonTransientLlmException(string message, int statusCode)
+		: base(message)
+	{
+		StatusCode = statusCode;
+	}
+}
+
+internal static class LlmHttpStatus
+{
+	/// <summary>
+	/// True for HTTP statuses worth retrying on cold start: connection failures (0,
+	/// i.e. no response received), request timeout (408), rate limiting (429), and any
+	/// 5xx server error. Other 4xx statuses (401/403 auth, 400 bad request, 404) are
+	/// permanent for a given request and must not be retried.
+	/// </summary>
+	public static bool IsTransient(int statusCode)
+		=> statusCode == 0
+		|| statusCode == 408
+		|| statusCode == 429
+		|| statusCode >= 500;
+}

--- a/CognitiveSupport/LlmService.cs
+++ b/CognitiveSupport/LlmService.cs
@@ -1,4 +1,7 @@
 using OpenAI.Chat;
+using Polly;
+using Polly.Contrib.WaitAndRetry;
+using Polly.Timeout;
 using System.ClientModel;
 
 namespace CognitiveSupport;
@@ -8,11 +11,13 @@ public class LlmService : ILlmService
 	private readonly Dictionary<string, ChatClient> _chatClients;
 	private readonly Dictionary<string, LlmModelConfig> _modelConfigs;
 	private readonly int _timeoutSeconds;
+	private readonly int _retryCount;
 
 	public LlmService(
 		string apiKey,
 		IEnumerable<LlmModelConfig> models,
-		int timeoutSeconds = 60)
+		int timeoutSeconds = 60,
+		int retryCount = 3)
 	{
 		if (string.IsNullOrEmpty(apiKey)) throw new ArgumentNullException(nameof(apiKey));
 		if (models is null) throw new ArgumentNullException(nameof(models));
@@ -24,6 +29,7 @@ public class LlmService : ILlmService
 		_chatClients = new Dictionary<string, ChatClient>();
 		_modelConfigs = new Dictionary<string, LlmModelConfig>();
 		_timeoutSeconds = timeoutSeconds > 0 ? timeoutSeconds : 60;
+		_retryCount = retryCount < 0 ? 0 : retryCount;
 
 		foreach (var model in modelList)
 		{
@@ -46,8 +52,39 @@ public class LlmService : ILlmService
 
 		ChatCompletionOptions options = BuildChatOptions(config);
 
-		using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(_timeoutSeconds));
-		ClientResult<ChatCompletion> result = await client.CompleteChatAsync(openAiMessages, options, timeoutCts.Token);
+		// Retry policy mirrors OpenAiSpeechToTextService.cs so the cold-start path (slow
+		// DNS/TLS/JIT warmup on the first call after a reboot) gets a few escalating-timeout
+		// attempts instead of an unhandled failure. If _retryCount == 0 the body still runs once.
+		// The OpenAI SDK reports API errors as ClientResultException; only transient statuses
+		// (429, 5xx, connection failures) are retried, so a permanent 4xx such as 401
+		// Unauthorized (bad API key) fails fast instead of after every retry.
+		const string AttemptKey = "Attempt";
+
+		var delay = Backoff.LinearBackoff(TimeSpan.FromMilliseconds(500), retryCount: _retryCount, factor: 1);
+		var retryPolicy = Policy
+			.Handle<HttpRequestException>()
+			.Or<TimeoutRejectedException>()
+			.Or<TaskCanceledException>()
+			.Or<ClientResultException>(ex => LlmHttpStatus.IsTransient(ex.Status))
+				.WaitAndRetryAsync(
+					delay,
+					onRetry: (exception, timeSpan, attemptNumber, context) =>
+					{
+						int attempt = context.ContainsKey(AttemptKey) ? (int)context[AttemptKey] : 1;
+						context[AttemptKey] = ++attempt;
+					}
+				);
+
+		var pollyContext = new Context();
+		pollyContext[AttemptKey] = 1;
+
+		ClientResult<ChatCompletion> result = await retryPolicy.ExecuteAsync(async (ctx) =>
+		{
+			int attempt = ctx.ContainsKey(AttemptKey) ? (int)ctx[AttemptKey] : 1;
+			int timeout = _timeoutSeconds * attempt;
+			using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(timeout));
+			return await client.CompleteChatAsync(openAiMessages, options, timeoutCts.Token).ConfigureAwait(false);
+		}, pollyContext).ConfigureAwait(false);
 
 		if (result.Value.Content.Count > 0)
 		{

--- a/CognitiveSupport/Settings.cs
+++ b/CognitiveSupport/Settings.cs
@@ -182,6 +182,7 @@ public class LlmSettings
 	public string? ProcessWithLlmHotKey { get; set; }
 	public List<LlmPrompt> Prompts { get; set; } = new List<LlmPrompt>();
 	public int TimeoutSeconds { get; set; } = 60;
+	public int RetryCount { get; set; } = 3;
 
 
 	public LlmSettings()

--- a/Mutation.Tests/LlmHttpStatusTests.cs
+++ b/Mutation.Tests/LlmHttpStatusTests.cs
@@ -1,0 +1,31 @@
+using CognitiveSupport;
+
+namespace Mutation.Tests;
+
+// Verifies the transient/non-transient classification that decides whether the LLM
+// retry policies retry a failed request. Permanent 4xx errors (esp. 401 bad API key)
+// must NOT be retried; rate limiting and server errors must be.
+public class LlmHttpStatusTests
+{
+	[Theory]
+	[InlineData(0)]    // connection failure / no response
+	[InlineData(408)]  // request timeout
+	[InlineData(429)]  // rate limited
+	[InlineData(500)]  // server error
+	[InlineData(503)]  // service unavailable
+	public void Transient_StatusCodes_AreRetryable(int statusCode)
+	{
+		Assert.True(LlmHttpStatus.IsTransient(statusCode));
+	}
+
+	[Theory]
+	[InlineData(400)]  // bad request
+	[InlineData(401)]  // unauthorized (bad/missing API key)
+	[InlineData(403)]  // forbidden
+	[InlineData(404)]  // not found
+	[InlineData(422)]  // unprocessable entity
+	public void Permanent_ClientErrors_AreNotRetryable(int statusCode)
+	{
+		Assert.False(LlmHttpStatus.IsTransient(statusCode));
+	}
+}

--- a/Mutation.Tests/SettingsDefaultsParityTests.cs
+++ b/Mutation.Tests/SettingsDefaultsParityTests.cs
@@ -101,6 +101,13 @@ public class SettingsDefaultsParityTests : IDisposable
 	}
 
 	[Fact]
+	public void Llm_Defaults_Match()
+	{
+		var s = ApplyDefaults();
+		Assert.Equal(SettingsDefaults.Llm.RetryCount, s.LlmSettings!.RetryCount);
+	}
+
+	[Fact]
 	public void MainWindowUi_Defaults_Match()
 	{
 		var s = ApplyDefaults();

--- a/Mutation.Ui/App.xaml.cs
+++ b/Mutation.Ui/App.xaml.cs
@@ -46,14 +46,14 @@ public partial class App : Application
 		// Keep the app alive; a faulting UI handler/async-void should not kill the
 		// process. The error is logged and surfaced through normal in-app paths.
 		e.Handled = true;
-		LogBackgroundException("Unhandled UI Exception", e.Exception);
+		ErrorLogger.LogError("Unhandled UI Exception", e.Exception);
 	}
 
 	private void OnAppDomainUnhandledException(object sender, System.UnhandledExceptionEventArgs e)
 	{
 		// By the time this fires the runtime is already tearing the process down and
 		// there is nothing to prevent. Record what happened for diagnostics only.
-		LogBackgroundException("Unhandled AppDomain Exception", e.ExceptionObject as Exception);
+		ErrorLogger.LogError("Unhandled AppDomain Exception", e.ExceptionObject as Exception);
 	}
 
 	private void OnUnobservedTaskException(object? sender, UnobservedTaskExceptionEventArgs e)
@@ -62,43 +62,7 @@ public partial class App : Application
 		// timeouts trigger retries that abandon their in-flight requests. This is
 		// non-fatal: observe it so the runtime does not escalate, then log it.
 		e.SetObserved();
-		LogBackgroundException("Unobserved Task Exception", e.Exception);
-	}
-
-	// Appends a redacted, non-fatal exception record to a rolling log next to the exe.
-	// Never throws and never terminates the process.
-	private static void LogBackgroundException(string source, Exception? exception)
-	{
-		string details = SanitizeException(exception);
-		System.Diagnostics.Debug.WriteLine($"{source}: {details}");
-		try
-		{
-			string logPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Mutation_Errors.log");
-			string entry = $"[{DateTime.Now:yyyy-MM-dd HH:mm:ss}] {source}\n{details}\n----\n";
-			File.AppendAllText(logPath, entry);
-		}
-		catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"Error log write failed: {ex.Message}"); }
-	}
-
-	private static string SanitizeException(Exception? exception)
-	{
-		if (exception is null) return "(no exception details)";
-
-		var sb = new System.Text.StringBuilder();
-		Exception? current = exception;
-		int depth = 0;
-		while (current is not null && depth < 8)
-		{
-			sb.Append(current.GetType().FullName);
-			sb.Append(": ");
-			sb.AppendLine(RedactSecrets(current.Message));
-			if (!string.IsNullOrEmpty(current.StackTrace))
-				sb.AppendLine(current.StackTrace);
-			current = current.InnerException;
-			if (current is not null) sb.AppendLine("---- inner exception ----");
-			depth++;
-		}
-		return sb.ToString();
+		ErrorLogger.LogError("Unobserved Task Exception", e.Exception);
 	}
 
 	private static Settings? TryRecoverSettings(string filePath, SettingsManager manager, Exception originalException)
@@ -183,17 +147,6 @@ public partial class App : Application
 		return null;
 	}
 
-	private static string RedactSecrets(string message)
-	{
-		if (string.IsNullOrEmpty(message)) return string.Empty;
-		// Common API key shapes: long alphanumeric runs (>=24) and OpenAI/Anthropic-style prefixes.
-		message = System.Text.RegularExpressions.Regex.Replace(
-			message, @"\b(sk-[A-Za-z0-9_\-]{20,}|sk-ant-[A-Za-z0-9_\-]{20,})\b", "[REDACTED-KEY]");
-		message = System.Text.RegularExpressions.Regex.Replace(
-			message, @"\b[A-Fa-f0-9]{32,}\b", "[REDACTED-HEX]");
-		return message;
-	}
-
 	// First-run setup is needed while no LLM provider key is configured. This
 	// covers a brand-new Mutation.json (keys are "<placeholder>") and any later
 	// launch where the user dismissed onboarding without adding a key. Optional
@@ -211,6 +164,7 @@ public partial class App : Application
         {
                 try
 		{
+			ErrorLogger.LogInfo("Startup", "OnLaunched starting");
 			HostApplicationBuilder builder = Host.CreateApplicationBuilder();
 
 			string exeDir = AppDomain.CurrentDomain.BaseDirectory;
@@ -254,6 +208,8 @@ public partial class App : Application
 				string openAiKey = llmSettings?.OpenAiApiKey ?? string.Empty;
 				string anthropicKey = llmSettings?.AnthropicApiKey ?? string.Empty;
 				int timeoutSeconds = llmSettings?.TimeoutSeconds > 0 ? llmSettings.TimeoutSeconds : 60;
+				int retryCount = llmSettings?.RetryCount ?? SettingsDefaults.Llm.RetryCount;
+				if (retryCount < 0) retryCount = SettingsDefaults.Llm.RetryCount;
 				var allModels = llmSettings?.Models ?? new List<LlmModelConfig>();
 
 				var openAiModels = allModels.Where(m => m.Provider == LlmProvider.OpenAI).ToList();
@@ -262,7 +218,7 @@ public partial class App : Application
 				LlmService? openAiService = null;
 				if (openAiModels.Any() && !string.IsNullOrEmpty(openAiKey) && openAiKey != SettingsDefaults.PlaceholderValue)
 				{
-					openAiService = new LlmService(openAiKey, openAiModels, timeoutSeconds);
+					openAiService = new LlmService(openAiKey, openAiModels, timeoutSeconds, retryCount);
 				}
 
 				AnthropicLlmService? anthropicService = null;
@@ -270,7 +226,7 @@ public partial class App : Application
 				{
 					var httpClientFactory = sp.GetRequiredService<IHttpClientFactory>();
 					var anthropicHttpClient = httpClientFactory.CreateClient(AnthropicHttpClientName);
-					anthropicService = new AnthropicLlmService(anthropicKey, anthropicModels, anthropicHttpClient, timeoutSeconds);
+					anthropicService = new AnthropicLlmService(anthropicKey, anthropicModels, anthropicHttpClient, timeoutSeconds, retryCount);
 				}
 
 				var modelProviders = allModels
@@ -417,17 +373,11 @@ public partial class App : Application
 		}
 		catch (Exception ex)
 		{
-			string? logPath = null;
-			try
-			{
-				logPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, $"CrashLog_{DateTime.Now:yyyyMMdd_HHmmss}.txt");
-				File.WriteAllText(logPath, $"[{DateTime.Now:yyyy-MM-dd HH:mm:ss}] Startup Error\n\n{SanitizeException(ex)}");
-			}
-			catch (Exception logEx) { System.Diagnostics.Debug.WriteLine($"Startup crash log write failed: {logEx.Message}"); }
+			ErrorLogger.LogError("Startup Error", ex);
+			string logPath = ErrorLogger.PrimaryLogPath;
 
-			string userMessage = logPath is null
-				? $"An error occurred during startup: {ex.GetType().Name}."
-				: $"An error occurred during startup: {ex.GetType().Name}.\n\nDetails were written to:\n{logPath}";
+			string userMessage =
+				$"An error occurred during startup: {ex.GetType().Name}.\n\nDetails were written to:\n{logPath}";
 
 			bool dialogShown = false;
 			try

--- a/Mutation.Ui/Core/AudioSessionManager.cs
+++ b/Mutation.Ui/Core/AudioSessionManager.cs
@@ -274,11 +274,13 @@ public class AudioSessionManager : IDisposable
             {
                 StatusMessage?.Invoke(this, "Processing with LLM...");
                 string modelName = !string.IsNullOrWhiteSpace(llmPrompt.ModelName) ? llmPrompt.ModelName : LlmSettings.DefaultModel;
+                ErrorLogger.LogInfo("LLM", $"LLM processing starting (model={modelName}).");
                 // Pass the rules-formatted text to the LLM
                 llmProcessedText = await _transcriptFormatter.ProcessWithLlmAsync(rulesFormattedText, llmPrompt.Content, modelName);
             }
             catch (Exception ex)
             {
+                ErrorLogger.LogError("LLM processing failed", ex);
                 StatusMessage?.Invoke(this, $"LLM processing failed: {ex.Message}. Using rules-formatted transcript.");
                 // llmProcessedText remains null — FinalizeTranscript will fall back to rules-only
             }

--- a/Mutation.Ui/MainWindow.xaml.cs
+++ b/Mutation.Ui/MainWindow.xaml.cs
@@ -1032,6 +1032,7 @@ public sealed partial class MainWindow : Window, IDisposable
 		}
 		catch (Exception ex)
 		{
+			ErrorLogger.LogError("Process with LLM", ex);
 			ShowStatus("Processing", ex.Message, InfoBarSeverity.Error);
 			await ShowErrorDialog("Process with LLM Error", ex);
 		}
@@ -1070,6 +1071,7 @@ public sealed partial class MainWindow : Window, IDisposable
         }
         catch (Exception ex)
         {
+             ErrorLogger.LogError("Process with LLM", ex);
              ShowStatus("Processing Failed", ex.Message, InfoBarSeverity.Error);
              await ShowErrorDialog($"Error executing prompt '{prompt.Name}'", ex);
         }

--- a/Mutation.Ui/Resources/HelpText.xaml
+++ b/Mutation.Ui/Resources/HelpText.xaml
@@ -43,6 +43,7 @@
 	<x:String x:Key="Help.Llm.OpenAiKey">API key used to authenticate requests to OpenAI models.</x:String>
 	<x:String x:Key="Help.Llm.AnthropicKey">API key used to authenticate requests to Anthropic (Claude) models.</x:String>
 	<x:String x:Key="Help.Llm.RequestTimeout">How long to wait for the language model to respond before giving up.</x:String>
+	<x:String x:Key="Help.Llm.RetryCount">How many times to retry a failed language-model request before giving up. Retries help the first request after a reboot succeed while the network warms up. Default 3.</x:String>
 	<x:String x:Key="Help.Llm.Temperature">Controls how random responses are; leave empty to use the provider default.</x:String>
 
 	<!-- Hotkeys -->

--- a/Mutation.Ui/Services/SettingsManager.cs
+++ b/Mutation.Ui/Services/SettingsManager.cs
@@ -395,6 +395,19 @@ internal class SettingsManager : ISettingsManager
 			somethingWasMissing = true;
 		}
 
+		// Correct hand-edited invalid retry counts. A fresh LlmSettings already has
+		// RetryCount = 3 via field init, so a clean object is unchanged (parity holds).
+		if (llmSettings.RetryCount < 0)
+		{
+			llmSettings.RetryCount = 3;
+			somethingWasMissing = true;
+		}
+		if (llmSettings.RetryCount > 10)
+		{
+			llmSettings.RetryCount = 10;
+			somethingWasMissing = true;
+		}
+
 		/* ResourceName removed
 		if (string.IsNullOrWhiteSpace(llmSettings.ResourceName))
 		{

--- a/Mutation.Ui/Views/Settings/Pages/LlmSettingsPage.xaml
+++ b/Mutation.Ui/Views/Settings/Pages/LlmSettingsPage.xaml
@@ -37,6 +37,28 @@
 			</StackPanel>
 		</StackPanel>
 
+		<StackPanel Spacing="4">
+			<StackPanel Orientation="Horizontal" Spacing="6">
+				<TextBlock Text="Retries" VerticalAlignment="Center" Style="{StaticResource BodyStrongTextBlockStyle}" />
+				<controls:InfoHint Text="{StaticResource Help.Llm.RetryCount}" VerticalAlignment="Center" />
+			</StackPanel>
+			<StackPanel Orientation="Horizontal" Spacing="6">
+				<NumberBox x:Name="NbRetryCount"
+						   AutomationProperties.Name="Retry count"
+						   AutomationProperties.HelpText="{StaticResource Help.Llm.RetryCount}"
+						   Minimum="0" Maximum="10"
+						   SmallChange="1"
+						   Width="180"
+						   SpinButtonPlacementMode="Inline"
+						   ValueChanged="NbRetryCount_ValueChanged" />
+				<Button Click="BtnResetRetryCount_Click" ToolTipService.ToolTip="Reset to default"
+						AutomationProperties.Name="Reset retry count">
+					<FontIcon Glyph="&#xE72C;" FontFamily="Segoe Fluent Icons" FontSize="12"
+							  AutomationProperties.AccessibilityView="Raw" />
+				</Button>
+			</StackPanel>
+		</StackPanel>
+
 		<StackPanel Spacing="8">
 			<TextBlock Text="Models" Style="{StaticResource BodyStrongTextBlockStyle}" />
 

--- a/Mutation.Ui/Views/Settings/Pages/LlmSettingsPage.xaml.cs
+++ b/Mutation.Ui/Views/Settings/Pages/LlmSettingsPage.xaml.cs
@@ -40,6 +40,7 @@ public sealed partial class LlmSettingsPage : UserControl
 			TxtOpenAiKey.Secret = llm.OpenAiApiKey ?? string.Empty;
 			TxtAnthropicKey.Secret = llm.AnthropicApiKey ?? string.Empty;
 			NbTimeout.Value = llm.TimeoutSeconds > 0 ? llm.TimeoutSeconds : SettingsDefaults.Llm.TimeoutSeconds;
+			NbRetryCount.Value = llm.RetryCount >= 0 ? llm.RetryCount : SettingsDefaults.Llm.RetryCount;
 
 			ModelEntries.Clear();
 			foreach (var model in llm.Models)
@@ -69,6 +70,16 @@ public sealed partial class LlmSettingsPage : UserControl
 		(_settings.LlmSettings ??= new LlmSettings()).TimeoutSeconds = (int)args.NewValue;
 	}
 
+	private void NbRetryCount_ValueChanged(NumberBox sender, NumberBoxValueChangedEventArgs args)
+	{
+		if (_suppressEvents) return;
+		if (double.IsNaN(args.NewValue)) return;
+		(_settings.LlmSettings ??= new LlmSettings()).RetryCount = (int)args.NewValue;
+	}
+
 	private void BtnResetTimeout_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e) =>
 		NbTimeout.Value = SettingsDefaults.Llm.TimeoutSeconds;
+
+	private void BtnResetRetryCount_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e) =>
+		NbRetryCount.Value = SettingsDefaults.Llm.RetryCount;
 }

--- a/Mutation.Ui/Views/Settings/SettingsDefaults.cs
+++ b/Mutation.Ui/Views/Settings/SettingsDefaults.cs
@@ -62,6 +62,7 @@ internal static class SettingsDefaults
 	public static class Llm
 	{
 		public const int TimeoutSeconds = 60;
+		public const int RetryCount = 3;
 		public const string ProcessPromptHotKey = "ALT+SHIFT+P";
 	}
 

--- a/Mutation.Ui/Views/Settings/SettingsWorkingCopy.cs
+++ b/Mutation.Ui/Views/Settings/SettingsWorkingCopy.cs
@@ -87,6 +87,7 @@ internal static class SettingsWorkingCopy
 			dst.ProcessWithLlmHotKey = src.ProcessWithLlmHotKey;
 			dst.Prompts = src.Prompts;
 			dst.TimeoutSeconds = src.TimeoutSeconds;
+			dst.RetryCount = src.RetryCount;
 		}
 
 		live.TranscriptFormatRules = workingCopy.TranscriptFormatRules ?? new List<TranscriptFormatRule>();


### PR DESCRIPTION
This pull request introduces robust crash logging and cold-start reliability improvements for LLM (language model) requests, plus a user-configurable retry knob. It ensures all exceptions are consistently logged to both a user-writable and fallback location, and hardens the LLM service paths with Polly-based retry logic that only retries transient failures (network, 429, 5xx). The retry count is now user-configurable via the settings UI, with validation and full accessibility support.

**Crash logging improvements:**

- Dual-location crash logging: All errors are now logged to both `%LOCALAPPDATA%\Mutation\logs\Mutation_Errors.log` (user-writable, primary) and the EXE folder (secondary), each in its own try/catch for best-effort reliability. The logging logic is centralized in the new static `ErrorLogger` class, which also redacts secrets and is the single source of truth for all error logging. (`CognitiveSupport/ErrorLogger.cs`, `Mutation.Ui/App.xaml.cs`) [[1]](diffhunk://#diff-dd6e29a5a54f9c14dd1a841f46a470e12c3b1997b6190b5e7933ef79c7f058c5R1-R133) [[2]](diffhunk://#diff-236759a18b08c57a3ee1bd40f1e55f42a4b2f81dfffc014cc4c3d94fc1e35ce8R1-R131)
- The log path is surfaced in dialogs, and a startup breadcrumb confirms logging works on every launch. (`ErrorLogger.PrimaryLogPath`, `Mutation.Ui/App.xaml.cs`) [[1]](diffhunk://#diff-dd6e29a5a54f9c14dd1a841f46a470e12c3b1997b6190b5e7933ef79c7f058c5R1-R133) [[2]](diffhunk://#diff-236759a18b08c57a3ee1bd40f1e55f42a4b2f81dfffc014cc4c3d94fc1e35ce8R1-R131)

**LLM cold-start reliability and retry logic:**

- Both `LlmService` (OpenAI) and `AnthropicLlmService` now wrap their network calls in a Polly-based retry policy, retrying only on transient failures (network, 408, 429, 5xx). Permanent 4xx errors (e.g., 401 Unauthorized) fail fast, not retried, using a new `NonTransientLlmException` and helper logic in `LlmHttpStatus`. Retry attempts use escalating timeouts. (`CognitiveSupport/LlmService.cs`, `CognitiveSupport/AnthropicLlmService.cs`, `CognitiveSupport/LlmHttpStatus.cs`) [[1]](diffhunk://#diff-e7035a116f4c5124c9899c89dd82784065cca9dc91501ff4406962479a6c068aL49-R87) [[2]](diffhunk://#diff-def5740900992f0b236fb9388422eced1ac8dd4db015470bbafab03ccf8138ebR82-R130) [[3]](diffhunk://#diff-def5740900992f0b236fb9388422eced1ac8dd4db015470bbafab03ccf8138ebR140-R150) [[4]](diffhunk://#diff-44bbc17daf575bef48f085685cf268fc42b6c991c8e5fa23851d05804a8d5ed5R1-R35)
- Polly and Polly.Contrib.WaitAndRetry are now explicit dependencies. (`CognitiveSupport/CognitiveSupport.csproj`)

**Configurable retry knob and settings UI:**

- The number of LLM retries is now user-configurable via the settings UI, with validation (min 0, max 10), accessibility support, and parity with defaults. The value is persisted and passed to both LLM services. (`Mutation.Ui/Views/Settings/Pages/LlmSettingsPage.xaml`, `Mutation.Ui/Views/Settings/Pages/LlmSettingsPage.xaml.cs`, `Mutation.Ui/Views/Settings/SettingsDefaults.cs`, `CognitiveSupport/Settings.cs`, `Mutation.Ui/Services/SettingsManager.cs`)
- Help text and reset functionality are provided for the retry knob. (`Mutation.Ui/Resources/HelpText.xaml`)

**Testing and validation:**

- A test asserts that the retry count default in settings matches the UI default. (`Mutation.Tests/SettingsDefaultsParityTests.cs`)

**Resolved follow-up:**

- 4xx errors are now properly classified as non-transient and do not trigger retries, ensuring bad API keys fail fast. (`CognitiveSupport/LlmHttpStatus.cs`, `CognitiveSupport/AnthropicLlmService.cs`, `CognitiveSupport/LlmService.cs`) [[1]](diffhunk://#diff-44bbc17daf575bef48f085685cf268fc42b6c991c8e5fa23851d05804a8d5ed5R1-R35) [[2]](diffhunk://#diff-def5740900992f0b236fb9388422eced1ac8dd4db015470bbafab03ccf8138ebR140-R150) [[3]](diffhunk://#diff-e7035a116f4c5124c9899c89dd82784065cca9dc91501ff4406962479a6c068aL49-R87)

These changes collectively make the app more reliable, especially on first launch after reboot, and ensure users and support can always find crash logs.