### PR TITLE
Fix TTS sentence navigation: boundary announcements and skip-back grace window

### DIFF
--- a/CognitiveSupport/ITextToSpeechService.cs
+++ b/CognitiveSupport/ITextToSpeechService.cs
@@ -6,7 +6,7 @@ public interface ITextToSpeechService : IDisposable
 	string? CurrentText { get; }
 	IReadOnlyList<string> GetVoiceNames();
 	void Speak(string text, int rate, int volume, string? voiceName, bool resumeIfSame, bool preprocess);
-	void SkipSentence(int direction, int rate, int volume, string? voiceName);
+	void SkipSentence(int direction, int rate, int volume, string? voiceName, int graceWindowMs);
 	void SpeakAnnouncement(string text, int rate, int volume, string? voiceName);
 	void Stop();
 }

--- a/CognitiveSupport/Settings.cs
+++ b/CognitiveSupport/Settings.cs
@@ -243,6 +243,13 @@ public class TextToSpeechSettings
 	public bool EnableSpeechPreprocessing { get; set; } = true;
 	public string? VoiceName { get; set; }
 
+	// How long (milliseconds) after a sentence starts that a "skip backward" press
+	// counts as "still at the start" and therefore steps to the previous sentence.
+	// After this window a back-press restarts the current sentence (media-player
+	// style). A larger value makes stepping back easier; a smaller value favours
+	// re-reading the current sentence.
+	public int SkipSentenceGraceWindowMs { get; set; } = 1500;
+
 	public TextToSpeechSettings()
 	{
 	}

--- a/CognitiveSupport/TextToSpeechService.cs
+++ b/CognitiveSupport/TextToSpeechService.cs
@@ -29,6 +29,16 @@ namespace CognitiveSupport
 		// Events from a cancelled prompt are ignored so stale callbacks can't corrupt
 		// the cursor after a rapid skip.
 		private Prompt? _currentPrompt;
+		// Skip-burst tracking. Consecutive skip presses within the grace window form a
+		// "burst" and step relative to the last skip target (_pendingSkipIndex) rather
+		// than the playback position. This lets the user hold the modifiers and tap the
+		// hotkey, stepping one sentence per tap, even when playback advances between taps
+		// (which would otherwise move _navIndex out from under them and cause ping-pong).
+		// Half of MinValue (not MinValue itself) so `now - _lastSkipTick` stays well
+		// within long range — MinValue would overflow and wrongly report a burst.
+		private const long NoRecentSkipTick = long.MinValue / 2;
+		private long _lastSkipTick = NoRecentSkipTick;
+		private int _pendingSkipIndex;
 		private bool _speakingAnnouncement;
 		private bool _disposed;
 		private CancellationTokenSource? _opCts;
@@ -112,6 +122,7 @@ namespace CognitiveSupport
 					_lastInputText = text;
 					_spokenToCurrentDelta = _currentPosition;
 					EnterSentence(FindSentenceIndex(_currentPosition));
+					ResetSkipBurst();
 					_currentPrompt = _synth.SpeakAsync(processed.Substring(_currentPosition));
 				}
 				else
@@ -121,6 +132,7 @@ namespace CognitiveSupport
 					_currentPosition = 0;
 					_sentenceStarts = FindSentenceStarts(processed);
 					EnterSentence(0);
+					ResetSkipBurst();
 
 					string warning = ShouldAnnounceLength(processed)
 						? BuildLengthAnnouncement(processed)
@@ -154,41 +166,30 @@ namespace CognitiveSupport
 				ApplyVoiceParams(rate, volume, voiceName);
 
 				int lastIndex = _sentenceStarts.Count - 1;
-				int currentIndex = Math.Clamp(_navIndex, 0, lastIndex);
+				long now = Environment.TickCount64;
+				int desiredIndex = ComputeSkipTarget(
+					direction, now, _lastSkipTick, _pendingSkipIndex,
+					_navIndex, _sentenceEnteredAtTick, lastIndex, graceWindowMs);
 
-				int targetIndex = currentIndex;
-				string? boundaryAnnouncement = null;
-				if (direction < 0)
-				{
-					// Media-player semantics: if we have only just entered the current
-					// sentence (within the grace window) a back-press steps to the
-					// previous sentence; otherwise it restarts the current one. Because
-					// the grace timer resets on every entry, a rapid burst of presses
-					// keeps stepping back one sentence at a time.
-					long elapsedMs = Environment.TickCount64 - _sentenceEnteredAtTick;
-					bool atSentenceStart = elapsedMs < graceWindowMs;
-					if (atSentenceStart && currentIndex == 0)
-						boundaryAnnouncement = BeginningOfTextAnnouncement; // nothing before the first sentence
-					else
-						targetIndex = atSentenceStart ? currentIndex - 1 : currentIndex;
-				}
-				else
-				{
-					if (currentIndex >= lastIndex)
-						boundaryAnnouncement = EndOfTextAnnouncement; // nothing after the final sentence
-					else
-						targetIndex = currentIndex + 1;
-				}
+				_lastSkipTick = now;
 
-				if (boundaryAnnouncement is not null)
+				if (desiredIndex < 0)
 				{
+					_pendingSkipIndex = 0;
 					_speakingAnnouncement = true;
-					_currentPrompt = _synth!.SpeakAsync(boundaryAnnouncement);
+					_currentPrompt = _synth!.SpeakAsync(BeginningOfTextAnnouncement);
+				}
+				else if (desiredIndex > lastIndex)
+				{
+					_pendingSkipIndex = lastIndex;
+					_speakingAnnouncement = true;
+					_currentPrompt = _synth!.SpeakAsync(EndOfTextAnnouncement);
 				}
 				else
 				{
-					int targetPos = _sentenceStarts[targetIndex];
-					EnterSentence(targetIndex);
+					_pendingSkipIndex = desiredIndex;
+					int targetPos = _sentenceStarts[desiredIndex];
+					EnterSentence(desiredIndex);
 					_currentPosition = targetPos;
 					_spokenToCurrentDelta = targetPos;
 					_currentPrompt = _synth!.SpeakAsync(_currentText.Substring(targetPos));
@@ -203,6 +204,45 @@ namespace CognitiveSupport
 		{
 			_navIndex = index;
 			_sentenceEnteredAtTick = Environment.TickCount64;
+		}
+
+		// Clear any in-progress skip burst so the next skip press is treated as fresh
+		// (media-player semantics) and anchored to the current sentence.
+		private void ResetSkipBurst()
+		{
+			_lastSkipTick = NoRecentSkipTick;
+			_pendingSkipIndex = _navIndex;
+		}
+
+		// Pure decision for which sentence index a skip press targets. Returns a value
+		// in [-1, lastIndex+1]; -1 means "before the first sentence" (beginning-of-text)
+		// and lastIndex+1 means "past the last sentence" (end-of-text). Kept side-effect
+		// free and static so the navigation rules can be unit-tested without a synthesizer.
+		//
+		//  - A press within graceWindowMs of the PREVIOUS press continues a "burst" and
+		//    steps one sentence from the last target (pendingSkipIndex), which playback
+		//    never moves — so repeated taps keep marching even if playback advances.
+		//  - The first press after a gap uses media-player semantics for backward: step
+		//    to the previous sentence only if we just entered the current one, otherwise
+		//    restart the current sentence. Forward always advances.
+		internal static int ComputeSkipTarget(
+			int direction, long now, long lastSkipTick, int pendingSkipIndex,
+			int navIndex, long sentenceEnteredAtTick, int lastIndex, int graceWindowMs)
+		{
+			bool inBurst = now - lastSkipTick < graceWindowMs;
+			if (inBurst)
+			{
+				int anchor = Math.Clamp(pendingSkipIndex, 0, lastIndex);
+				return anchor + (direction < 0 ? -1 : 1);
+			}
+
+			int currentIndex = Math.Clamp(navIndex, 0, lastIndex);
+			if (direction < 0)
+			{
+				bool justEnteredSentence = now - sentenceEnteredAtTick < graceWindowMs;
+				return justEnteredSentence ? currentIndex - 1 : currentIndex;
+			}
+			return currentIndex + 1;
 		}
 
 		public void SpeakAnnouncement(string text, int rate, int volume, string? voiceName)

--- a/CognitiveSupport/TextToSpeechService.cs
+++ b/CognitiveSupport/TextToSpeechService.cs
@@ -219,30 +219,37 @@ namespace CognitiveSupport
 		// and lastIndex+1 means "past the last sentence" (end-of-text). Kept side-effect
 		// free and static so the navigation rules can be unit-tested without a synthesizer.
 		//
-		//  - A press within graceWindowMs of the PREVIOUS press continues a "burst" and
-		//    steps one sentence from the last target (pendingSkipIndex), which playback
-		//    never moves — so repeated taps keep marching even if playback advances.
-		//  - The first press after a gap uses media-player semantics for backward: step
-		//    to the previous sentence only if we just entered the current one, otherwise
-		//    restart the current sentence. Forward always advances.
+		// The handling is asymmetric because playback only ever drifts FORWARD:
+		//
+		//  - Forward always steps from the LIVE playback position (navIndex + 1). It can
+		//    therefore never re-read the sentence currently playing and reliably reaches
+		//    end-of-text — even if you navigated earlier and then listened on. (A frozen
+		//    anchor would go stale here and re-read the last sentence instead of ending.)
+		//  - Backward, in a "burst" (a press within graceWindowMs of the PREVIOUS press),
+		//    steps from the last target (pendingSkipIndex), which playback never moves —
+		//    so rapid back-taps keep marching even as playback drifts forward between taps
+		//    (otherwise they'd ping-pong). Reaching before the first sentence -> -1.
+		//  - The first backward press after a gap uses media-player semantics: at the
+		//    first sentence there is nothing before it, so announce beginning-of-text;
+		//    otherwise step to the previous sentence if we only just entered the current
+		//    one, else restart the current sentence.
 		internal static int ComputeSkipTarget(
 			int direction, long now, long lastSkipTick, int pendingSkipIndex,
 			int navIndex, long sentenceEnteredAtTick, int lastIndex, int graceWindowMs)
 		{
+			if (direction >= 0)
+				return Math.Clamp(navIndex, 0, lastIndex) + 1;
+
 			bool inBurst = now - lastSkipTick < graceWindowMs;
 			if (inBurst)
-			{
-				int anchor = Math.Clamp(pendingSkipIndex, 0, lastIndex);
-				return anchor + (direction < 0 ? -1 : 1);
-			}
+				return Math.Clamp(pendingSkipIndex, 0, lastIndex) - 1;
 
 			int currentIndex = Math.Clamp(navIndex, 0, lastIndex);
-			if (direction < 0)
-			{
-				bool justEnteredSentence = now - sentenceEnteredAtTick < graceWindowMs;
-				return justEnteredSentence ? currentIndex - 1 : currentIndex;
-			}
-			return currentIndex + 1;
+			if (currentIndex == 0)
+				return -1; // already at the first sentence -> beginning of text
+
+			bool justEnteredSentence = now - sentenceEnteredAtTick < graceWindowMs;
+			return justEnteredSentence ? currentIndex - 1 : currentIndex;
 		}
 
 		public void SpeakAnnouncement(string text, int rate, int volume, string? voiceName)

--- a/CognitiveSupport/TextToSpeechService.cs
+++ b/CognitiveSupport/TextToSpeechService.cs
@@ -7,6 +7,8 @@ namespace CognitiveSupport
 	public class TextToSpeechService : ITextToSpeechService
 	{
 		private const int LengthWarningThresholdChars = 5000;
+		private const string EndOfTextAnnouncement = "End of text.";
+		private const string BeginningOfTextAnnouncement = "Beginning of text.";
 
 		private readonly object _gate = new object();
 		private SpeechSynthesizer? _synth;
@@ -15,6 +17,18 @@ namespace CognitiveSupport
 		private int _currentPosition;
 		private int _spokenToCurrentDelta;
 		private List<int>? _sentenceStarts;
+		// Authoritative navigation cursor: which sentence index we are on. Driven
+		// explicitly by SkipSentence and nudged forward by playback progress, so
+		// skip presses never race against the continuously-moving spoken position.
+		private int _navIndex;
+		// Monotonic timestamp (Environment.TickCount64) of when the cursor entered
+		// the current sentence. Backward-skip uses this for the "am I at the start?"
+		// grace window instead of the spoken character position.
+		private long _sentenceEnteredAtTick;
+		// The Prompt of the utterance currently owning progress/completion events.
+		// Events from a cancelled prompt are ignored so stale callbacks can't corrupt
+		// the cursor after a rapid skip.
+		private Prompt? _currentPrompt;
 		private bool _speakingAnnouncement;
 		private bool _disposed;
 		private CancellationTokenSource? _opCts;
@@ -97,7 +111,8 @@ namespace CognitiveSupport
 				{
 					_lastInputText = text;
 					_spokenToCurrentDelta = _currentPosition;
-					_synth.SpeakAsync(processed.Substring(_currentPosition));
+					EnterSentence(FindSentenceIndex(_currentPosition));
+					_currentPrompt = _synth.SpeakAsync(processed.Substring(_currentPosition));
 				}
 				else
 				{
@@ -105,18 +120,19 @@ namespace CognitiveSupport
 					_lastInputText = text;
 					_currentPosition = 0;
 					_sentenceStarts = FindSentenceStarts(processed);
+					EnterSentence(0);
 
 					string warning = ShouldAnnounceLength(processed)
 						? BuildLengthAnnouncement(processed)
 						: string.Empty;
 					string spoken = warning + processed;
 					_spokenToCurrentDelta = -warning.Length;
-					_synth.SpeakAsync(spoken);
+					_currentPrompt = _synth.SpeakAsync(spoken);
 				}
 			}
 		}
 
-		public void SkipSentence(int direction, int rate, int volume, string? voiceName)
+		public void SkipSentence(int direction, int rate, int volume, string? voiceName, int graceWindowMs)
 		{
 			CancellationTokenSource? oldCts;
 			CancellationTokenSource newCts = new();
@@ -137,30 +153,56 @@ namespace CognitiveSupport
 
 				ApplyVoiceParams(rate, volume, voiceName);
 
-				int currentIndex = FindSentenceIndex(_currentPosition);
-				int targetIndex;
+				int lastIndex = _sentenceStarts.Count - 1;
+				int currentIndex = Math.Clamp(_navIndex, 0, lastIndex);
+
+				int targetIndex = currentIndex;
+				string? boundaryAnnouncement = null;
 				if (direction < 0)
 				{
-					if (_currentPosition > _sentenceStarts[currentIndex])
-						targetIndex = currentIndex;
+					// Media-player semantics: if we have only just entered the current
+					// sentence (within the grace window) a back-press steps to the
+					// previous sentence; otherwise it restarts the current one. Because
+					// the grace timer resets on every entry, a rapid burst of presses
+					// keeps stepping back one sentence at a time.
+					long elapsedMs = Environment.TickCount64 - _sentenceEnteredAtTick;
+					bool atSentenceStart = elapsedMs < graceWindowMs;
+					if (atSentenceStart && currentIndex == 0)
+						boundaryAnnouncement = BeginningOfTextAnnouncement; // nothing before the first sentence
 					else
-						targetIndex = Math.Max(0, currentIndex - 1);
+						targetIndex = atSentenceStart ? currentIndex - 1 : currentIndex;
 				}
 				else
 				{
-					targetIndex = Math.Min(_sentenceStarts.Count - 1, currentIndex + 1);
+					if (currentIndex >= lastIndex)
+						boundaryAnnouncement = EndOfTextAnnouncement; // nothing after the final sentence
+					else
+						targetIndex = currentIndex + 1;
 				}
 
-				int targetPos = _sentenceStarts[targetIndex];
-				if (targetPos < _currentText.Length)
+				if (boundaryAnnouncement is not null)
 				{
+					_speakingAnnouncement = true;
+					_currentPrompt = _synth!.SpeakAsync(boundaryAnnouncement);
+				}
+				else
+				{
+					int targetPos = _sentenceStarts[targetIndex];
+					EnterSentence(targetIndex);
 					_currentPosition = targetPos;
 					_spokenToCurrentDelta = targetPos;
-					_synth!.SpeakAsync(_currentText.Substring(targetPos));
+					_currentPrompt = _synth!.SpeakAsync(_currentText.Substring(targetPos));
 				}
 			}
 			oldCts?.Cancel();
 			oldCts?.Dispose();
+		}
+
+		// Move the navigation cursor onto a sentence and reset the grace-window timer.
+		private void EnterSentence(int index)
+		{
+			_navIndex = index;
+			_sentenceEnteredAtTick = Environment.TickCount64;
 		}
 
 		public void SpeakAnnouncement(string text, int rate, int volume, string? voiceName)
@@ -179,7 +221,7 @@ namespace CognitiveSupport
 
 				ApplyVoiceParams(rate, volume, voiceName);
 				_speakingAnnouncement = true;
-				_synth!.SpeakAsync(text);
+				_currentPrompt = _synth!.SpeakAsync(text);
 			}
 			oldCts?.Cancel();
 			oldCts?.Dispose();
@@ -195,6 +237,7 @@ namespace CognitiveSupport
 				if (_synth is null) return;
 				try { _synth.SpeakAsyncCancelAll(); } catch { }
 				_speakingAnnouncement = false;
+				_currentPrompt = null;
 			}
 			oldCts?.Cancel();
 			oldCts?.Dispose();
@@ -230,12 +273,21 @@ namespace CognitiveSupport
 		{
 			lock (_gate)
 			{
+				// Ignore stragglers from a cancelled/superseded utterance.
+				if (!ReferenceEquals(e.Prompt, _currentPrompt)) return;
 				if (_speakingAnnouncement) return;
 				if (_currentText is null) return;
 				int mapped = e.CharacterPosition + _spokenToCurrentDelta;
 				if (mapped < 0) mapped = 0;
 				if (mapped > _currentText.Length) mapped = _currentText.Length;
 				_currentPosition = mapped;
+
+				// Keep the navigation cursor in step with natural playback so a skip
+				// after the reader has crossed into a new sentence acts from there.
+				// Re-entering a sentence also restarts the back-skip grace window.
+				int sentenceIndex = FindSentenceIndex(mapped);
+				if (sentenceIndex != _navIndex)
+					EnterSentence(sentenceIndex);
 			}
 		}
 
@@ -243,6 +295,7 @@ namespace CognitiveSupport
 		{
 			lock (_gate)
 			{
+				if (!ReferenceEquals(e.Prompt, _currentPrompt)) return;
 				if (_speakingAnnouncement)
 				{
 					_speakingAnnouncement = false;
@@ -251,6 +304,7 @@ namespace CognitiveSupport
 				if (!e.Cancelled && _currentText is not null)
 				{
 					_currentPosition = _currentText.Length;
+					_navIndex = _sentenceStarts is { Count: > 0 } ? _sentenceStarts.Count - 1 : 0;
 				}
 			}
 		}
@@ -283,6 +337,7 @@ namespace CognitiveSupport
 				_currentText = null;
 				_lastInputText = null;
 				_sentenceStarts = null;
+				_currentPrompt = null;
 			}
 			oldCts?.Cancel();
 			oldCts?.Dispose();

--- a/Mutation.Tests/SettingsDefaultsParityTests.cs
+++ b/Mutation.Tests/SettingsDefaultsParityTests.cs
@@ -98,6 +98,7 @@ public class SettingsDefaultsParityTests : IDisposable
 		Assert.Equal(SettingsDefaults.Tts.Rate, tts.Rate);
 		Assert.Equal(SettingsDefaults.Tts.Volume, tts.Volume);
 		Assert.Equal(SettingsDefaults.Tts.EnableSpeechPreprocessing, tts.EnableSpeechPreprocessing);
+		Assert.Equal(SettingsDefaults.Tts.SkipSentenceGraceWindowMs, tts.SkipSentenceGraceWindowMs);
 	}
 
 	[Fact]

--- a/Mutation.Tests/TextToSpeechSkipNavigationTests.cs
+++ b/Mutation.Tests/TextToSpeechSkipNavigationTests.cs
@@ -1,0 +1,122 @@
+using CognitiveSupport;
+using Xunit;
+
+namespace Mutation.Tests;
+
+// Verifies the pure sentence-skip decision used by TextToSpeechService.SkipSentence.
+// These rules are timing-sensitive and hard to test by ear, so the decision is kept
+// side-effect free and exercised here with explicit clock values.
+public class TextToSpeechSkipNavigationTests
+{
+	private const int Grace = 1500;
+	private const int LastIndex = 9; // 10 sentences
+	// Matches TextToSpeechService.NoRecentSkipTick: a sentinel far enough in the past
+	// that the next press is never treated as part of a burst (without overflow).
+	private const long NoRecentSkip = long.MinValue / 2;
+
+	private static int Skip(
+		int direction, long now, long lastSkipTick, int pendingSkipIndex,
+		int navIndex, long sentenceEnteredAtTick) =>
+		TextToSpeechService.ComputeSkipTarget(
+			direction, now, lastSkipTick, pendingSkipIndex,
+			navIndex, sentenceEnteredAtTick, LastIndex, Grace);
+
+	[Fact]
+	public void FreshBackPress_Settled_RestartsCurrentSentence()
+	{
+		// Listened to sentence 5 for a while (entered long ago) → media-player restart.
+		int target = Skip(direction: -1, now: 100_000, lastSkipTick: NoRecentSkip,
+			pendingSkipIndex: 5, navIndex: 5, sentenceEnteredAtTick: 0);
+		Assert.Equal(5, target);
+	}
+
+	[Fact]
+	public void FreshBackPress_JustEntered_GoesToPreviousSentence()
+	{
+		// Only just entered sentence 5 (within grace) → step back to 4.
+		int target = Skip(direction: -1, now: 100_000, lastSkipTick: NoRecentSkip,
+			pendingSkipIndex: 5, navIndex: 5, sentenceEnteredAtTick: 100_000 - 200);
+		Assert.Equal(4, target);
+	}
+
+	[Fact]
+	public void BurstBack_MarchesBack_EvenWhilePlaybackAdvancesNavIndex()
+	{
+		// The regression: each tap ~1s apart must step back one more, regardless of
+		// playback rolling the navIndex forward into later sentences between taps.
+		long t1 = 100_000;
+		int pending = 5; // after the first press restarted/targeted sentence 5
+
+		// Tap 2, 1s later. Playback has rolled navIndex forward to 8 — must be ignored.
+		int t2target = Skip(direction: -1, now: t1 + 1000, lastSkipTick: t1,
+			pendingSkipIndex: pending, navIndex: 8, sentenceEnteredAtTick: t1 + 900);
+		Assert.Equal(4, t2target);
+		pending = t2target;
+
+		// Tap 3, another 1s later. navIndex rolled to 7 — still ignored.
+		int t3target = Skip(direction: -1, now: t1 + 2000, lastSkipTick: t1 + 1000,
+			pendingSkipIndex: pending, navIndex: 7, sentenceEnteredAtTick: t1 + 1900);
+		Assert.Equal(3, t3target);
+		pending = t3target;
+
+		// Tap 4.
+		int t4target = Skip(direction: -1, now: t1 + 3000, lastSkipTick: t1 + 2000,
+			pendingSkipIndex: pending, navIndex: 9, sentenceEnteredAtTick: t1 + 2900);
+		Assert.Equal(2, t4target);
+	}
+
+	[Fact]
+	public void BurstForward_MarchesForward()
+	{
+		long t1 = 100_000;
+		int pending = 2;
+
+		int t2 = Skip(direction: 1, now: t1 + 1000, lastSkipTick: t1,
+			pendingSkipIndex: pending, navIndex: 0, sentenceEnteredAtTick: t1 + 900);
+		Assert.Equal(3, t2);
+		pending = t2;
+
+		int t3 = Skip(direction: 1, now: t1 + 2000, lastSkipTick: t1 + 1000,
+			pendingSkipIndex: pending, navIndex: 0, sentenceEnteredAtTick: t1 + 1900);
+		Assert.Equal(4, t3);
+	}
+
+	[Fact]
+	public void GapLongerThanGrace_EndsBurst_FreshSemanticsApply()
+	{
+		long t1 = 100_000;
+		// Next press comes after the grace window → not a burst. Settled in current
+		// sentence (navIndex 6) → media-player restart of 6, not a step from pending.
+		int target = Skip(direction: -1, now: t1 + Grace + 1, lastSkipTick: t1,
+			pendingSkipIndex: 3, navIndex: 6, sentenceEnteredAtTick: 0);
+		Assert.Equal(6, target);
+	}
+
+	[Fact]
+	public void BurstBack_AtFirstSentence_SignalsBeginningOfText()
+	{
+		long t1 = 100_000;
+		int target = Skip(direction: -1, now: t1 + 500, lastSkipTick: t1,
+			pendingSkipIndex: 0, navIndex: 0, sentenceEnteredAtTick: t1 + 400);
+		Assert.Equal(-1, target); // caller announces "Beginning of text."
+	}
+
+	[Fact]
+	public void ForwardPastLastSentence_SignalsEndOfText()
+	{
+		int target = Skip(direction: 1, now: 100_000, lastSkipTick: NoRecentSkip,
+			pendingSkipIndex: LastIndex, navIndex: LastIndex, sentenceEnteredAtTick: 0);
+		Assert.Equal(LastIndex + 1, target); // caller announces "End of text."
+	}
+
+	[Fact]
+	public void FirstPress_AfterStart_IsNeverTreatedAsBurst()
+	{
+		// NoRecentSkip sentinel must not overflow into a false "burst" on the first tap.
+		// pending=7 is deliberately far from navIndex=4: a (wrong) burst would yield 6,
+		// while correct fresh just-entered semantics yield navIndex-1 = 3.
+		int target = Skip(direction: -1, now: 50, lastSkipTick: NoRecentSkip,
+			pendingSkipIndex: 7, navIndex: 4, sentenceEnteredAtTick: 0);
+		Assert.Equal(3, target);
+	}
+}

--- a/Mutation.Tests/TextToSpeechSkipNavigationTests.cs
+++ b/Mutation.Tests/TextToSpeechSkipNavigationTests.cs
@@ -6,6 +6,9 @@ namespace Mutation.Tests;
 // Verifies the pure sentence-skip decision used by TextToSpeechService.SkipSentence.
 // These rules are timing-sensitive and hard to test by ear, so the decision is kept
 // side-effect free and exercised here with explicit clock values.
+//
+// Returned index meaning: -1 => beginning-of-text, lastIndex+1 => end-of-text,
+// otherwise the sentence to play.
 public class TextToSpeechSkipNavigationTests
 {
 	private const int Grace = 1500;
@@ -21,10 +24,12 @@ public class TextToSpeechSkipNavigationTests
 			direction, now, lastSkipTick, pendingSkipIndex,
 			navIndex, sentenceEnteredAtTick, LastIndex, Grace);
 
+	// ---- Backward: fresh-press (media-player) semantics ----
+
 	[Fact]
 	public void FreshBackPress_Settled_RestartsCurrentSentence()
 	{
-		// Listened to sentence 5 for a while (entered long ago) → media-player restart.
+		// Listened to sentence 5 for a while (entered long ago) -> media-player restart.
 		int target = Skip(direction: -1, now: 100_000, lastSkipTick: NoRecentSkip,
 			pendingSkipIndex: 5, navIndex: 5, sentenceEnteredAtTick: 0);
 		Assert.Equal(5, target);
@@ -33,63 +38,45 @@ public class TextToSpeechSkipNavigationTests
 	[Fact]
 	public void FreshBackPress_JustEntered_GoesToPreviousSentence()
 	{
-		// Only just entered sentence 5 (within grace) → step back to 4.
+		// Only just entered sentence 5 (within grace) -> step back to 4.
 		int target = Skip(direction: -1, now: 100_000, lastSkipTick: NoRecentSkip,
 			pendingSkipIndex: 5, navIndex: 5, sentenceEnteredAtTick: 100_000 - 200);
 		Assert.Equal(4, target);
 	}
 
 	[Fact]
+	public void FreshBackPress_AtFirstSentence_SignalsBeginningOfText()
+	{
+		// Nothing before the first sentence: a back-press there announces beginning,
+		// even when settled (this is what makes "previous up to the start" reachable).
+		int target = Skip(direction: -1, now: 100_000, lastSkipTick: NoRecentSkip,
+			pendingSkipIndex: 0, navIndex: 0, sentenceEnteredAtTick: 0);
+		Assert.Equal(-1, target);
+	}
+
+	// ---- Backward: burst (rapid tapping) semantics ----
+
+	[Fact]
 	public void BurstBack_MarchesBack_EvenWhilePlaybackAdvancesNavIndex()
 	{
-		// The regression: each tap ~1s apart must step back one more, regardless of
-		// playback rolling the navIndex forward into later sentences between taps.
+		// The core requirement: each tap ~1s apart steps back one more, regardless of
+		// playback rolling navIndex forward into later sentences between taps.
 		long t1 = 100_000;
 		int pending = 5; // after the first press restarted/targeted sentence 5
 
-		// Tap 2, 1s later. Playback has rolled navIndex forward to 8 — must be ignored.
-		int t2target = Skip(direction: -1, now: t1 + 1000, lastSkipTick: t1,
+		int t2 = Skip(direction: -1, now: t1 + 1000, lastSkipTick: t1,
 			pendingSkipIndex: pending, navIndex: 8, sentenceEnteredAtTick: t1 + 900);
-		Assert.Equal(4, t2target);
-		pending = t2target;
-
-		// Tap 3, another 1s later. navIndex rolled to 7 — still ignored.
-		int t3target = Skip(direction: -1, now: t1 + 2000, lastSkipTick: t1 + 1000,
-			pendingSkipIndex: pending, navIndex: 7, sentenceEnteredAtTick: t1 + 1900);
-		Assert.Equal(3, t3target);
-		pending = t3target;
-
-		// Tap 4.
-		int t4target = Skip(direction: -1, now: t1 + 3000, lastSkipTick: t1 + 2000,
-			pendingSkipIndex: pending, navIndex: 9, sentenceEnteredAtTick: t1 + 2900);
-		Assert.Equal(2, t4target);
-	}
-
-	[Fact]
-	public void BurstForward_MarchesForward()
-	{
-		long t1 = 100_000;
-		int pending = 2;
-
-		int t2 = Skip(direction: 1, now: t1 + 1000, lastSkipTick: t1,
-			pendingSkipIndex: pending, navIndex: 0, sentenceEnteredAtTick: t1 + 900);
-		Assert.Equal(3, t2);
+		Assert.Equal(4, t2);
 		pending = t2;
 
-		int t3 = Skip(direction: 1, now: t1 + 2000, lastSkipTick: t1 + 1000,
-			pendingSkipIndex: pending, navIndex: 0, sentenceEnteredAtTick: t1 + 1900);
-		Assert.Equal(4, t3);
-	}
+		int t3 = Skip(direction: -1, now: t1 + 2000, lastSkipTick: t1 + 1000,
+			pendingSkipIndex: pending, navIndex: 7, sentenceEnteredAtTick: t1 + 1900);
+		Assert.Equal(3, t3);
+		pending = t3;
 
-	[Fact]
-	public void GapLongerThanGrace_EndsBurst_FreshSemanticsApply()
-	{
-		long t1 = 100_000;
-		// Next press comes after the grace window → not a burst. Settled in current
-		// sentence (navIndex 6) → media-player restart of 6, not a step from pending.
-		int target = Skip(direction: -1, now: t1 + Grace + 1, lastSkipTick: t1,
-			pendingSkipIndex: 3, navIndex: 6, sentenceEnteredAtTick: 0);
-		Assert.Equal(6, target);
+		int t4 = Skip(direction: -1, now: t1 + 3000, lastSkipTick: t1 + 2000,
+			pendingSkipIndex: pending, navIndex: 9, sentenceEnteredAtTick: t1 + 2900);
+		Assert.Equal(2, t4);
 	}
 
 	[Fact]
@@ -98,19 +85,22 @@ public class TextToSpeechSkipNavigationTests
 		long t1 = 100_000;
 		int target = Skip(direction: -1, now: t1 + 500, lastSkipTick: t1,
 			pendingSkipIndex: 0, navIndex: 0, sentenceEnteredAtTick: t1 + 400);
-		Assert.Equal(-1, target); // caller announces "Beginning of text."
+		Assert.Equal(-1, target);
 	}
 
 	[Fact]
-	public void ForwardPastLastSentence_SignalsEndOfText()
+	public void GapLongerThanGrace_EndsBurst_FreshSemanticsApply()
 	{
-		int target = Skip(direction: 1, now: 100_000, lastSkipTick: NoRecentSkip,
-			pendingSkipIndex: LastIndex, navIndex: LastIndex, sentenceEnteredAtTick: 0);
-		Assert.Equal(LastIndex + 1, target); // caller announces "End of text."
+		long t1 = 100_000;
+		// Next press comes after the grace window -> not a burst. Settled in current
+		// sentence (navIndex 6) -> media-player restart of 6, not a step from pending.
+		int target = Skip(direction: -1, now: t1 + Grace + 1, lastSkipTick: t1,
+			pendingSkipIndex: 3, navIndex: 6, sentenceEnteredAtTick: 0);
+		Assert.Equal(6, target);
 	}
 
 	[Fact]
-	public void FirstPress_AfterStart_IsNeverTreatedAsBurst()
+	public void FirstBackPress_AfterStart_IsNeverTreatedAsBurst()
 	{
 		// NoRecentSkip sentinel must not overflow into a false "burst" on the first tap.
 		// pending=7 is deliberately far from navIndex=4: a (wrong) burst would yield 6,
@@ -118,5 +108,47 @@ public class TextToSpeechSkipNavigationTests
 		int target = Skip(direction: -1, now: 50, lastSkipTick: NoRecentSkip,
 			pendingSkipIndex: 7, navIndex: 4, sentenceEnteredAtTick: 0);
 		Assert.Equal(3, target);
+	}
+
+	// ---- Forward: always steps from the live playback position ----
+
+	[Fact]
+	public void Forward_StepsFromLivePlayback()
+	{
+		int target = Skip(direction: 1, now: 100_000, lastSkipTick: NoRecentSkip,
+			pendingSkipIndex: 0, navIndex: 3, sentenceEnteredAtTick: 0);
+		Assert.Equal(4, target);
+	}
+
+	[Fact]
+	public void Forward_InBurst_IgnoresStaleAnchor_UsesLivePlayback()
+	{
+		// Even within a burst, forward advances from live navIndex, never the frozen
+		// anchor — a stale anchor must not drag forward steps backward.
+		long t1 = 100_000;
+		int target = Skip(direction: 1, now: t1 + 1000, lastSkipTick: t1,
+			pendingSkipIndex: 2, navIndex: 5, sentenceEnteredAtTick: t1 + 900);
+		Assert.Equal(6, target);
+	}
+
+	[Fact]
+	public void Forward_AfterListeningPastNavigation_ReachesEndOfText()
+	{
+		// Regression: navigated to the second-to-last sentence (anchor lags), then
+		// listened so playback rolled navIndex onto the last sentence. A forward tap
+		// within the grace window must announce end-of-text, NOT re-read the last
+		// sentence (the previously reported bug).
+		long t1 = 100_000;
+		int target = Skip(direction: 1, now: t1 + 1000, lastSkipTick: t1,
+			pendingSkipIndex: LastIndex - 1, navIndex: LastIndex, sentenceEnteredAtTick: t1 + 900);
+		Assert.Equal(LastIndex + 1, target);
+	}
+
+	[Fact]
+	public void Forward_OnLastSentence_SignalsEndOfText()
+	{
+		int target = Skip(direction: 1, now: 100_000, lastSkipTick: NoRecentSkip,
+			pendingSkipIndex: LastIndex, navIndex: LastIndex, sentenceEnteredAtTick: 0);
+		Assert.Equal(LastIndex + 1, target);
 	}
 }

--- a/Mutation.Ui/MainWindow.xaml.cs
+++ b/Mutation.Ui/MainWindow.xaml.cs
@@ -839,13 +839,13 @@ public sealed partial class MainWindow : Window, IDisposable
 	public void BtnSkipSentenceBack_Click(object? sender, RoutedEventArgs? e)
 	{
 		var tts = _settings.TextToSpeechSettings ?? new TextToSpeechSettings();
-		_textToSpeech.SkipSentence(-1, tts.Rate, tts.Volume, tts.VoiceName);
+		_textToSpeech.SkipSentence(-1, tts.Rate, tts.Volume, tts.VoiceName, tts.SkipSentenceGraceWindowMs);
 	}
 
 	public void BtnSkipSentenceForward_Click(object? sender, RoutedEventArgs? e)
 	{
 		var tts = _settings.TextToSpeechSettings ?? new TextToSpeechSettings();
-		_textToSpeech.SkipSentence(1, tts.Rate, tts.Volume, tts.VoiceName);
+		_textToSpeech.SkipSentence(1, tts.Rate, tts.Volume, tts.VoiceName, tts.SkipSentenceGraceWindowMs);
 	}
 
 	public async void SpeakActiveSelectionAsync()

--- a/Mutation.Ui/Resources/HelpText.xaml
+++ b/Mutation.Ui/Resources/HelpText.xaml
@@ -24,6 +24,7 @@
 
 	<!-- Text to Speech -->
 	<x:String x:Key="Help.Tts.Preprocessing">Clean up text, such as expanding abbreviations and symbols, before it is spoken aloud.</x:String>
+	<x:String x:Key="Help.Tts.SkipSentenceGrace">When skipping back, how long after a sentence starts that a back-press still steps to the previous sentence. After this window a back-press restarts the current sentence instead. A larger value makes stepping back easier; a smaller value favours re-reading the current sentence.</x:String>
 
 	<!-- Speech to Text -->
 	<x:String x:Key="Help.Speech.ActiveService">The transcription engine used when you record or transcribe speech.</x:String>

--- a/Mutation.Ui/Views/Settings/Pages/TtsSettingsPage.xaml
+++ b/Mutation.Ui/Views/Settings/Pages/TtsSettingsPage.xaml
@@ -28,6 +28,26 @@
 			</Button>
 		</StackPanel>
 
+		<StackPanel Spacing="4">
+			<StackPanel Orientation="Horizontal" Spacing="6">
+				<TextBlock Text="Skip-back grace window (milliseconds)" VerticalAlignment="Center" Style="{StaticResource BodyStrongTextBlockStyle}" />
+				<controls:InfoHint Text="{StaticResource Help.Tts.SkipSentenceGrace}" VerticalAlignment="Center" />
+			</StackPanel>
+			<StackPanel Orientation="Horizontal" Spacing="6">
+				<NumberBox x:Name="NbSkipGrace"
+						   AutomationProperties.Name="Skip-back grace window (milliseconds)"
+						   AutomationProperties.HelpText="{StaticResource Help.Tts.SkipSentenceGrace}"
+						   Minimum="250" Maximum="5000"
+						   SmallChange="250" LargeChange="500"
+						   SpinButtonPlacementMode="Inline"
+						   Width="220"
+						   ValueChanged="NbSkipGrace_ValueChanged" />
+				<Button Click="BtnResetSkipGrace_Click" ToolTipService.ToolTip="Reset to default" AutomationProperties.Name="Reset skip-back grace window">
+					<FontIcon Glyph="&#xE72C;" FontFamily="Segoe Fluent Icons" FontSize="12" AutomationProperties.AccessibilityView="Raw" />
+				</Button>
+			</StackPanel>
+		</StackPanel>
+
 		<TextBlock Text="TTS hotkeys appear in the Hotkeys tab."
 				   Style="{StaticResource CaptionTextBlockStyle}"
 				   Foreground="{ThemeResource TextFillColorTertiaryBrush}" />

--- a/Mutation.Ui/Views/Settings/Pages/TtsSettingsPage.xaml.cs
+++ b/Mutation.Ui/Views/Settings/Pages/TtsSettingsPage.xaml.cs
@@ -23,6 +23,7 @@ public sealed partial class TtsSettingsPage : UserControl
 		{
 			var tts = _settings.TextToSpeechSettings ??= new TextToSpeechSettings();
 			ToggleSpeechPreprocessing.IsOn = tts.EnableSpeechPreprocessing;
+			NbSkipGrace.Value = tts.SkipSentenceGraceWindowMs;
 		}
 		finally { _suppressEvents = false; }
 	}
@@ -36,5 +37,17 @@ public sealed partial class TtsSettingsPage : UserControl
 	private void BtnResetPreproc_Click(object sender, RoutedEventArgs e)
 	{
 		ToggleSpeechPreprocessing.IsOn = SettingsDefaults.Tts.EnableSpeechPreprocessing;
+	}
+
+	private void NbSkipGrace_ValueChanged(NumberBox sender, NumberBoxValueChangedEventArgs args)
+	{
+		if (_suppressEvents) return;
+		if (double.IsNaN(args.NewValue)) return;
+		(_settings.TextToSpeechSettings ??= new TextToSpeechSettings()).SkipSentenceGraceWindowMs = (int)args.NewValue;
+	}
+
+	private void BtnResetSkipGrace_Click(object sender, RoutedEventArgs e)
+	{
+		NbSkipGrace.Value = SettingsDefaults.Tts.SkipSentenceGraceWindowMs;
 	}
 }

--- a/Mutation.Ui/Views/Settings/SettingsDefaults.cs
+++ b/Mutation.Ui/Views/Settings/SettingsDefaults.cs
@@ -57,6 +57,9 @@ internal static class SettingsDefaults
 		public const int Rate = 8;
 		public const int Volume = 100;
 		public const bool EnableSpeechPreprocessing = true;
+		public const int SkipSentenceGraceWindowMs = 1500;
+		public const int MinSkipSentenceGraceWindowMs = 250;
+		public const int MaxSkipSentenceGraceWindowMs = 5000;
 	}
 
 	public static class Llm

--- a/Mutation.Ui/Views/Settings/SettingsWorkingCopy.cs
+++ b/Mutation.Ui/Views/Settings/SettingsWorkingCopy.cs
@@ -106,6 +106,7 @@ internal static class SettingsWorkingCopy
 			dst.Volume = src.Volume;
 			dst.EnableSpeechPreprocessing = src.EnableSpeechPreprocessing;
 			dst.VoiceName = src.VoiceName;
+			dst.SkipSentenceGraceWindowMs = src.SkipSentenceGraceWindowMs;
 		}
 
 		live.MainWindowUiSettings ??= new MainWindowUiSettings();


### PR DESCRIPTION
## Problem

Two issues with text-to-speech hotkey navigation:

1. **Boundary announcements never fired.** Pressing Previous on the first sentence re-read sentence 1 instead of saying "Beginning of text."; pressing Next on the last sentence re-read it instead of saying "End of text."
2. **The 1.5s skip-back grace period didn't work.** Pressing Previous on a sentence restarted it (correct), but a second Previous press within ~1s restarted the same sentence again instead of stepping back. It only stepped back if both presses landed milliseconds apart.

## Root cause

Navigation decisions were driven off the live, continuously-advancing spoken character position (`_currentPosition`) instead of a stable sentence cursor and a clock. The back-skip "am I at the sentence start?" test was positional, so as soon as the first `SpeakProgress` event advanced the cursor a few characters, a subsequent press read as "restart current" again. There was no timer, so the grace period didn't exist, and there was no branch to detect crossing past either edge, so the announcements were unreachable.

## Fix

- Introduce a stable `_navIndex` sentence cursor, driven explicitly by skips and only nudged by playback — rapid presses accumulate deterministically.
- Back-skip is now time-based (configurable grace window, default 1500ms). Rapid taps form a "burst" anchored to the last press (`_pendingSkipIndex`), which playback never moves — marching back one sentence per tap, no ping-pong.
- Forward always steps from the live playback position so it reliably reaches end-of-text.
- Announce "Beginning of text." / "End of text." at the edges.
- Generation guard (`_currentPrompt`) so stale progress/completed events from a cancelled utterance can't corrupt the cursor.
- Expose `SkipSentenceGraceWindowMs` (250–5000ms, default 1500) with a screen-reader-named NumberBox, reset button, and help text on the TTS settings page.

## Tests

Decision logic extracted into a pure static `ComputeSkipTarget`, covered by new `TextToSpeechSkipNavigationTests` (burst marching, playback-advance immunity, gap-ends-burst, both boundary cases). Build succeeds; the 17 skip-navigation + settings-parity tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)