### PR TITLE
Settings editors: Speech services, Transcript formatting, OCR knobs, TTS resume rewind

### DIFF
--- a/CognitiveSupport/CompositeLlmService.cs
+++ b/CognitiveSupport/CompositeLlmService.cs
@@ -31,14 +31,14 @@ public class CompositeLlmService : ILlmService
 				if (_anthropicService == null)
 					throw new InvalidOperationException(
 						$"Model '{llmModelName}' is an Anthropic model but no Anthropic API key is configured. " +
-						"Please set AnthropicApiKey in Mutation.json and restart.");
+						"Please set AnthropicApiKey in the ApiKeys section of Mutation.json and restart.");
 				return _anthropicService.CreateChatCompletion(messages, llmModelName);
 
 			case LlmProvider.OpenAI:
 				if (_openAiService == null)
 					throw new InvalidOperationException(
 						$"Model '{llmModelName}' is an OpenAI model but no OpenAI API key is configured. " +
-						"Please set ApiKey in Mutation.json and restart.");
+						"Please set OpenAiApiKey in the ApiKeys section of Mutation.json and restart.");
 				return _openAiService.CreateChatCompletion(messages, llmModelName);
 
 			default:

--- a/CognitiveSupport/ITextToSpeechService.cs
+++ b/CognitiveSupport/ITextToSpeechService.cs
@@ -5,7 +5,7 @@ public interface ITextToSpeechService : IDisposable
 	bool IsSpeaking { get; }
 	string? CurrentText { get; }
 	IReadOnlyList<string> GetVoiceNames();
-	void Speak(string text, int rate, int volume, string? voiceName, bool resumeIfSame, bool preprocess);
+	void Speak(string text, int rate, int volume, string? voiceName, bool resumeIfSame, bool preprocess, int resumeRewindWordCount = 0);
 	void SkipSentence(int direction, int rate, int volume, string? voiceName, int graceWindowMs);
 	void SpeakAnnouncement(string text, int rate, int volume, string? voiceName);
 	void Stop();

--- a/CognitiveSupport/Settings.cs
+++ b/CognitiveSupport/Settings.cs
@@ -7,6 +7,7 @@ public class Settings
 	public AudioSettings? AudioSettings { get; set; }
 	public AzureComputerVisionSettings? AzureComputerVisionSettings { get; set; }
         public SpeechToTextSettings? SpeechToTextSettings { get; set; }
+	public ApiKeys? ApiKeys { get; set; }
 	public LlmSettings? LlmSettings { get; set; }
 	public TextToSpeechSettings? TextToSpeechSettings { get; set; }
 
@@ -173,14 +174,26 @@ public class SpeechToTextServiceSettings
 	public int TimeoutSeconds { get; set; } = 10;
 }
 
+// Central store for provider API keys. These are the primary keys used across the
+// app (LLM, speech-to-text, etc.); they are not LLM-specific. A speech service's
+// per-service ApiKey acts as an optional override that takes precedence when set.
+public class ApiKeys
+{
+	public string? OpenAiApiKey { get; set; }
+	public string? AnthropicApiKey { get; set; }
+	public string? DeepgramApiKey { get; set; }
+
+	public ApiKeys()
+	{
+	}
+}
+
 public class LlmSettings
 {
 	public const string DefaultModel = "chat-latest";
 	public const string DefaultSecondaryModel = "gpt-4.1";
 	public const string DefaultAnthropicModel = "claude-sonnet-4-6";
 
-	public string? OpenAiApiKey { get; set; }
-	public string? AnthropicApiKey { get; set; }
 	public List<LlmModelConfig> Models { get; set; }
 	public List<LlmPrompt> Prompts { get; set; } = new List<LlmPrompt>();
 	public int TimeoutSeconds { get; set; } = 60;

--- a/CognitiveSupport/Settings.cs
+++ b/CognitiveSupport/Settings.cs
@@ -250,6 +250,11 @@ public class TextToSpeechSettings
 	// re-reading the current sentence.
 	public int SkipSentenceGraceWindowMs { get; set; } = 1500;
 
+	// When resuming playback (pressing the speak hotkey again after a pause), rewind
+	// this many words before where playback stopped so the listener regains context
+	// of where they are. 0 resumes exactly where it stopped (no rewind).
+	public int ResumeRewindWordCount { get; set; } = 5;
+
 	public TextToSpeechSettings()
 	{
 	}

--- a/CognitiveSupport/Settings.cs
+++ b/CognitiveSupport/Settings.cs
@@ -179,7 +179,6 @@ public class LlmSettings
 	public string? OpenAiApiKey { get; set; }
 	public string? AnthropicApiKey { get; set; }
 	public List<LlmModelConfig> Models { get; set; }
-	public string? ProcessWithLlmHotKey { get; set; }
 	public List<LlmPrompt> Prompts { get; set; } = new List<LlmPrompt>();
 	public int TimeoutSeconds { get; set; } = 60;
 	public int RetryCount { get; set; } = 3;

--- a/CognitiveSupport/Settings.cs
+++ b/CognitiveSupport/Settings.cs
@@ -120,7 +120,10 @@ public class AzureComputerVisionSettings
 	public int FreeTierPageLimit { get; set; } = 2;
 	public int MaxParallelDocuments { get; set; } = 2;
 	public int MaxParallelRequests { get; set; } = 4;
-	public long? MaxDocumentBytes { get; set; }
+
+	// Maximum size of a single file/page sent for OCR. Files larger than this are
+	// skipped before the upload. null or <= 0 means no limit. Default 10 MB.
+	public long? MaxDocumentBytes { get; set; } = 10L * 1024 * 1024;
 
 	public AzureComputerVisionSettings()
 	{

--- a/CognitiveSupport/TextToSpeechService.cs
+++ b/CognitiveSupport/TextToSpeechService.cs
@@ -175,9 +175,16 @@ namespace CognitiveSupport
 
 				if (desiredIndex < 0)
 				{
+					// Reached before the first sentence: announce the boundary, then keep
+					// reading from the start rather than stopping. The announcement is
+					// prepended to the text (like the length warning in RunSpeak) and the
+					// spoken->current delta offsets it so progress maps back onto sentence 0.
 					_pendingSkipIndex = 0;
-					_speakingAnnouncement = true;
-					_currentPrompt = _synth!.SpeakAsync(BeginningOfTextAnnouncement);
+					EnterSentence(0);
+					_currentPosition = 0;
+					string announcement = BeginningOfTextAnnouncement + " ";
+					_spokenToCurrentDelta = -announcement.Length;
+					_currentPrompt = _synth!.SpeakAsync(announcement + _currentText);
 				}
 				else if (desiredIndex > lastIndex)
 				{

--- a/CognitiveSupport/TextToSpeechService.cs
+++ b/CognitiveSupport/TextToSpeechService.cs
@@ -74,7 +74,7 @@ namespace CognitiveSupport
 			}
 		}
 
-		public void Speak(string text, int rate, int volume, string? voiceName, bool resumeIfSame, bool preprocess)
+		public void Speak(string text, int rate, int volume, string? voiceName, bool resumeIfSame, bool preprocess, int resumeRewindWordCount = 0)
 		{
 			if (string.IsNullOrEmpty(text)) return;
 
@@ -93,10 +93,10 @@ namespace CognitiveSupport
 			oldCts?.Dispose();
 
 			CancellationToken token = newCts.Token;
-			Task.Run(() => RunSpeak(text, rate, volume, voiceName, resumeIfSame, preprocess, token));
+			Task.Run(() => RunSpeak(text, rate, volume, voiceName, resumeIfSame, preprocess, resumeRewindWordCount, token));
 		}
 
-		private void RunSpeak(string text, int rate, int volume, string? voiceName, bool resumeIfSame, bool preprocess, CancellationToken token)
+		private void RunSpeak(string text, int rate, int volume, string? voiceName, bool resumeIfSame, bool preprocess, int resumeRewindWordCount, CancellationToken token)
 		{
 			if (token.IsCancellationRequested) return;
 
@@ -120,10 +120,14 @@ namespace CognitiveSupport
 				if (canResume)
 				{
 					_lastInputText = text;
-					_spokenToCurrentDelta = _currentPosition;
-					EnterSentence(FindSentenceIndex(_currentPosition));
+					// Rewind a few words before the stop point so the listener regains
+					// context of where they are, then resume from there.
+					int resumePos = RewindByWords(processed, _currentPosition, resumeRewindWordCount);
+					_currentPosition = resumePos;
+					_spokenToCurrentDelta = resumePos;
+					EnterSentence(FindSentenceIndex(resumePos));
 					ResetSkipBurst();
-					_currentPrompt = _synth.SpeakAsync(processed.Substring(_currentPosition));
+					_currentPrompt = _synth.SpeakAsync(processed.Substring(resumePos));
 				}
 				else
 				{
@@ -361,6 +365,22 @@ namespace CognitiveSupport
 					_navIndex = _sentenceStarts is { Count: > 0 } ? _sentenceStarts.Count - 1 : 0;
 				}
 			}
+		}
+
+		// Move `position` backward past `wordCount` whitespace-delimited words so a
+		// resumed read re-speaks a little prior context. Clamped to the start of the
+		// text. Kept side-effect free and static so it can be unit-tested. If `position`
+		// falls mid-word, that partial word counts as the first word stepped over.
+		internal static int RewindByWords(string text, int position, int wordCount)
+		{
+			if (wordCount <= 0) return position;
+			int i = Math.Clamp(position, 0, text.Length);
+			for (int w = 0; w < wordCount && i > 0; w++)
+			{
+				while (i > 0 && char.IsWhiteSpace(text[i - 1])) i--;
+				while (i > 0 && !char.IsWhiteSpace(text[i - 1])) i--;
+			}
+			return i;
 		}
 
 		private int FindSentenceIndex(int position)

--- a/Mutation.Tests/OcrManagerTests.cs
+++ b/Mutation.Tests/OcrManagerTests.cs
@@ -507,6 +507,49 @@ public class OcrManagerTests
 		Assert.Contains(BeepType.Success, manager.Beeps);
 	}
 
+	[Fact]
+	public async Task ExtractTextFromFilesAsync_SkipsFile_ExceedingMaxDocumentBytes()
+	{
+		var settings = CreateValidSettings();
+		settings.AzureComputerVisionSettings!.MaxDocumentBytes = 10; // 10-byte cap
+		var clipboard = new TestClipboard();
+		var service = new StubOcrService("should not run");
+		using var file = new TempFile(".png", new string('x', 50)); // 50 bytes > cap
+		var manager = new TestableOcrManager(settings, service, clipboard);
+
+		var result = await manager.ExtractTextFromFilesAsync(new[] { file.Path }, DefaultOrder, CancellationToken.None);
+
+		Assert.False(result.Success);
+		Assert.Equal(1, result.TotalCount);
+		Assert.Equal(0, result.SuccessCount);
+		Assert.Single(result.Failures);
+		Assert.Contains("maximum document size", result.Failures[0], StringComparison.OrdinalIgnoreCase);
+		Assert.Contains(Path.GetFileName(file.Path), result.Failures[0]);
+		Assert.Equal(0, service.CallCount); // OCR never invoked for the oversized file
+		Assert.Equal(0, clipboard.SetTextCalls);
+		WaitForBeep(manager, 1);
+		Assert.Contains(BeepType.Failure, manager.Beeps);
+	}
+
+	[Fact]
+	public async Task ExtractTextFromFilesAsync_ProcessesLargeFile_WhenMaxDocumentBytesIsZero()
+	{
+		var settings = CreateValidSettings();
+		settings.AzureComputerVisionSettings!.MaxDocumentBytes = 0; // 0 = no limit
+		var clipboard = new TestClipboard();
+		var service = new StubOcrService("recognized text");
+		using var file = new TempFile(".png", new string('x', 50));
+		var manager = new TestableOcrManager(settings, service, clipboard);
+
+		var result = await manager.ExtractTextFromFilesAsync(new[] { file.Path }, DefaultOrder, CancellationToken.None);
+
+		Assert.True(result.Success);
+		Assert.Equal(1, result.SuccessCount);
+		Assert.Equal(1, service.CallCount);
+		WaitForBeep(manager, 1);
+		Assert.Contains(BeepType.Success, manager.Beeps);
+	}
+
 	private static string ExtractSection(string text, string header)
 	{
 		int start = text.IndexOf(header, StringComparison.Ordinal);

--- a/Mutation.Tests/OcrManagerTests.cs
+++ b/Mutation.Tests/OcrManagerTests.cs
@@ -259,7 +259,8 @@ public class OcrManagerTests
 		}));
 		var manager = new TestableOcrManager(settings, service, clipboard);
 
-		await Assert.ThrowsAsync<OperationCanceledException>(() => manager.ExtractTextFromFilesAsync(new[] { first.Path, second.Path }, DefaultOrder, cts.Token));
+		// ThrowsAny: a cancelled gate surfaces TaskCanceledException, a subclass of OperationCanceledException.
+		await Assert.ThrowsAnyAsync<OperationCanceledException>(() => manager.ExtractTextFromFilesAsync(new[] { first.Path, second.Path }, DefaultOrder, cts.Token));
 
 		Assert.Equal(0, clipboard.SetTextCalls);
 		Assert.Equal(1, service.CallCount);
@@ -550,6 +551,177 @@ public class OcrManagerTests
 		Assert.Contains(BeepType.Success, manager.Beeps);
 	}
 
+	[Fact]
+	public async Task ExtractTextFromFilesAsync_HonoursMaxParallelRequests()
+	{
+		var settings = CreateValidSettings();
+		// Document gate wide open so the request gate is the only binding constraint.
+		settings.AzureComputerVisionSettings!.MaxParallelDocuments = 100;
+		settings.AzureComputerVisionSettings!.MaxParallelRequests = 2;
+		var clipboard = new TestClipboard();
+		var service = new ConcurrencyTrackingOcrService(delayMs: 50);
+		var files = Enumerable.Range(0, 8).Select(_ => new TempFile(".png")).ToList();
+		try
+		{
+			var manager = new TestableOcrManager(settings, service, clipboard);
+
+			var result = await manager.ExtractTextFromFilesAsync(files.Select(f => f.Path), DefaultOrder, CancellationToken.None);
+
+			Assert.True(result.Success);
+			Assert.Equal(8, service.CallCount);
+			Assert.True(service.MaxConcurrency <= 2, $"Observed {service.MaxConcurrency} concurrent OCR calls; expected at most 2.");
+			Assert.True(service.MaxConcurrency >= 2, $"Expected the throttle to allow up to 2 concurrent calls; observed {service.MaxConcurrency}.");
+		}
+		finally
+		{
+			foreach (var file in files)
+				file.Dispose();
+		}
+	}
+
+	[Fact]
+	public async Task ExtractTextFromFilesAsync_HonoursMaxParallelDocuments()
+	{
+		var settings = CreateValidSettings();
+		settings.AzureComputerVisionSettings!.MaxParallelDocuments = 2;
+		// Request gate wide open so the document gate is the only binding constraint.
+		settings.AzureComputerVisionSettings!.MaxParallelRequests = 100;
+		var clipboard = new TestClipboard();
+		var service = new ConcurrencyTrackingOcrService(delayMs: 50);
+		var files = Enumerable.Range(0, 8).Select(_ => new TempFile(".png")).ToList();
+		try
+		{
+			var manager = new TestableOcrManager(settings, service, clipboard);
+
+			var result = await manager.ExtractTextFromFilesAsync(files.Select(f => f.Path), DefaultOrder, CancellationToken.None);
+
+			Assert.True(result.Success);
+			Assert.Equal(8, service.CallCount);
+			// Each single-page file makes exactly one OCR call while holding the document gate,
+			// so concurrent OCR calls equal concurrent documents here.
+			Assert.True(service.MaxConcurrency <= 2, $"Observed {service.MaxConcurrency} concurrent documents; expected at most 2.");
+			Assert.True(service.MaxConcurrency >= 2, $"Expected up to 2 concurrent documents; observed {service.MaxConcurrency}.");
+		}
+		finally
+		{
+			foreach (var file in files)
+				file.Dispose();
+		}
+	}
+
+	[Fact]
+	public async Task ExtractTextFromFilesAsync_FreeTier_ProcessesEveryPageInOrder()
+	{
+		var settings = CreateValidSettings();
+		settings.AzureComputerVisionSettings!.UseFreeTier = true;
+		settings.AzureComputerVisionSettings!.FreeTierPageLimit = 2;
+		var clipboard = new TestClipboard();
+		var service = new StubOcrService(Enumerable.Range(1, 9).Select(i => (object)$"page {i}").ToArray());
+		using var pdf = new TempPdf(9);
+		var manager = new TestableOcrManager(settings, service, clipboard);
+
+		var result = await manager.ExtractTextFromFilesAsync(new[] { pdf.Path }, DefaultOrder, CancellationToken.None);
+
+		Assert.True(result.Success);
+		// Recommended per-page model: 9 pages produce exactly 9 OCR requests, nothing truncated.
+		Assert.Equal(9, service.CallCount);
+
+		string section = ExtractSection(result.Text, $"[{Path.GetFileName(pdf.Path)}]");
+		int previousIndex = -1;
+		for (int page = 1; page <= 9; page++)
+		{
+			string label = $"(Page {page})";
+			int index = section.IndexOf(label, StringComparison.Ordinal);
+			Assert.True(index >= 0, $"Page {page} is missing from the output.");
+			Assert.True(index > previousIndex, $"Page {page} is out of order.");
+			previousIndex = index;
+		}
+
+		Assert.DoesNotContain("Only first", result.Text, StringComparison.OrdinalIgnoreCase);
+		Assert.DoesNotContain("truncat", result.Text, StringComparison.OrdinalIgnoreCase);
+	}
+
+	[Fact]
+	public async Task ExtractTextFromFilesAsync_FreeTierDisabled_ProcessesEveryPage()
+	{
+		var settings = CreateValidSettings();
+		settings.AzureComputerVisionSettings!.UseFreeTier = false;
+		var clipboard = new TestClipboard();
+		var service = new StubOcrService(Enumerable.Range(1, 9).Select(i => (object)$"page {i}").ToArray());
+		using var pdf = new TempPdf(9);
+		var manager = new TestableOcrManager(settings, service, clipboard);
+
+		var result = await manager.ExtractTextFromFilesAsync(new[] { pdf.Path }, DefaultOrder, CancellationToken.None);
+
+		Assert.True(result.Success);
+		Assert.Equal(9, service.CallCount);
+
+		string section = ExtractSection(result.Text, $"[{Path.GetFileName(pdf.Path)}]");
+		for (int page = 1; page <= 9; page++)
+			Assert.Contains($"(Page {page})", section, StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public async Task ExtractTextFromFilesAsync_RequestGate_HoldsAcrossManyWorkItems()
+	{
+		var settings = CreateValidSettings();
+		settings.AzureComputerVisionSettings!.MaxParallelDocuments = 8;
+		settings.AzureComputerVisionSettings!.MaxParallelRequests = 2;
+		var clipboard = new TestClipboard();
+		var service = new ConcurrencyTrackingOcrService(delayMs: 30);
+		var pdfs = new[] { new TempPdf(4), new TempPdf(4), new TempPdf(4) };
+		try
+		{
+			var manager = new TestableOcrManager(settings, service, clipboard);
+
+			var result = await manager.ExtractTextFromFilesAsync(pdfs.Select(p => p.Path), DefaultOrder, CancellationToken.None);
+
+			Assert.True(result.Success);
+			Assert.Equal(12, service.CallCount);
+			// The global request gate must hold even when many pages across documents are queued.
+			Assert.True(service.MaxConcurrency <= 2, $"Observed {service.MaxConcurrency} concurrent OCR calls; expected at most 2.");
+		}
+		finally
+		{
+			foreach (var pdf in pdfs)
+				pdf.Dispose();
+		}
+	}
+
+	[Fact]
+	public async Task ExtractTextFromFilesAsync_ParallelRun_ProducesDeterministicOrderedOutput()
+	{
+		var settings = CreateValidSettings();
+		settings.AzureComputerVisionSettings!.MaxParallelDocuments = 4;
+		settings.AzureComputerVisionSettings!.MaxParallelRequests = 4;
+
+		using var pdf = new TempPdf(3);
+		using var png = new TempFile(".png");
+		using var jpeg = new TempFile(".jpeg");
+		using var bmp = new TempFile(".bmp");
+		var paths = new[] { pdf.Path, png.Path, jpeg.Path, bmp.Path };
+
+		string? expected = null;
+		for (int run = 0; run < 5; run++)
+		{
+			var clipboard = new TestClipboard();
+			var service = new ConcurrencyTrackingOcrService(delayMs: 10);
+			var manager = new TestableOcrManager(settings, service, clipboard);
+
+			var result = await manager.ExtractTextFromFilesAsync(paths, DefaultOrder, CancellationToken.None);
+
+			Assert.True(result.Success);
+			expected ??= result.Text;
+			Assert.Equal(expected, result.Text);
+
+			int pdfIndex = result.Text.IndexOf($"[{Path.GetFileName(pdf.Path)}]", StringComparison.Ordinal);
+			int pngIndex = result.Text.IndexOf($"[{Path.GetFileName(png.Path)}]", StringComparison.Ordinal);
+			int jpegIndex = result.Text.IndexOf($"[{Path.GetFileName(jpeg.Path)}]", StringComparison.Ordinal);
+			int bmpIndex = result.Text.IndexOf($"[{Path.GetFileName(bmp.Path)}]", StringComparison.Ordinal);
+			Assert.True(pdfIndex < pngIndex && pngIndex < jpegIndex && jpegIndex < bmpIndex, "Files are not in original selection order.");
+		}
+	}
+
 	private static string ExtractSection(string text, string header)
 	{
 		int start = text.IndexOf(header, StringComparison.Ordinal);
@@ -660,6 +832,48 @@ public class OcrManagerTests
 			Exception ex => (_, _) => Task.FromException<string>(ex),
 			_ => throw new ArgumentException("Unsupported behavior type.", nameof(behavior))
 		};
+	}
+
+	// Records the peak number of overlapping ExtractText calls so concurrency throttles are
+	// observable. The delay keeps each call in flight long enough for overlap to occur.
+	private sealed class ConcurrencyTrackingOcrService : IOcrService
+	{
+		private readonly int _delayMs;
+		private int _current;
+		private int _maxConcurrency;
+		private int _callCount;
+
+		public ConcurrencyTrackingOcrService(int delayMs = 50)
+		{
+			_delayMs = delayMs;
+		}
+
+		public int CallCount => Volatile.Read(ref _callCount);
+		public int MaxConcurrency => Volatile.Read(ref _maxConcurrency);
+
+		public async Task<string> ExtractText(OcrReadingOrder ocrReadingOrder, Stream imageStream, CancellationToken overallCancellationToken)
+		{
+			Interlocked.Increment(ref _callCount);
+			int now = Interlocked.Increment(ref _current);
+			int observed;
+			do
+			{
+				observed = Volatile.Read(ref _maxConcurrency);
+				if (now <= observed)
+					break;
+			}
+			while (Interlocked.CompareExchange(ref _maxConcurrency, now, observed) != observed);
+
+			try
+			{
+				await Task.Delay(_delayMs, overallCancellationToken);
+				return "ocr text";
+			}
+			finally
+			{
+				Interlocked.Decrement(ref _current);
+			}
+		}
 	}
 
 		private sealed class TempFile : IDisposable

--- a/Mutation.Tests/SettingsDefaultsParityTests.cs
+++ b/Mutation.Tests/SettingsDefaultsParityTests.cs
@@ -99,6 +99,7 @@ public class SettingsDefaultsParityTests : IDisposable
 		Assert.Equal(SettingsDefaults.Tts.Volume, tts.Volume);
 		Assert.Equal(SettingsDefaults.Tts.EnableSpeechPreprocessing, tts.EnableSpeechPreprocessing);
 		Assert.Equal(SettingsDefaults.Tts.SkipSentenceGraceWindowMs, tts.SkipSentenceGraceWindowMs);
+		Assert.Equal(SettingsDefaults.Tts.ResumeRewindWordCount, tts.ResumeRewindWordCount);
 	}
 
 	[Fact]

--- a/Mutation.Tests/SettingsDefaultsParityTests.cs
+++ b/Mutation.Tests/SettingsDefaultsParityTests.cs
@@ -59,6 +59,7 @@ public class SettingsDefaultsParityTests : IDisposable
 		Assert.Equal(SettingsDefaults.Ocr.FreeTierPageLimit, ocr.FreeTierPageLimit);
 		Assert.Equal(SettingsDefaults.Ocr.MaxParallelDocuments, ocr.MaxParallelDocuments);
 		Assert.Equal(SettingsDefaults.Ocr.MaxParallelRequests, ocr.MaxParallelRequests);
+		Assert.Equal(SettingsDefaults.Ocr.MaxDocumentBytes, ocr.MaxDocumentBytes!.Value);
 	}
 
 	[Fact]

--- a/Mutation.Tests/SettingsManagerMigrationTests.cs
+++ b/Mutation.Tests/SettingsManagerMigrationTests.cs
@@ -149,8 +149,10 @@ public class SettingsManagerMigrationTests : IDisposable
 	}
 
 	[Fact]
-	public void UpgradeSettings_RenamesLlmApiKeyToOpenAiApiKey()
+	public void UpgradeSettings_RenamesLegacyLlmApiKeyAndMovesToRootApiKeys()
 	{
+		// Legacy LlmSettings.ApiKey is renamed to OpenAiApiKey, then both provider keys
+		// are moved out of LlmSettings into the central root ApiKeys section.
 		string json = """
 			{
 				"LlmSettings": {
@@ -165,8 +167,39 @@ public class SettingsManagerMigrationTests : IDisposable
 		var llm = (JObject)result["LlmSettings"]!;
 
 		Assert.Null(llm["ApiKey"]);
-		Assert.Equal("sk-openai-xxx", llm["OpenAiApiKey"]?.ToString());
-		Assert.Equal("ant-yyy", llm["AnthropicApiKey"]?.ToString());
+		Assert.Null(llm["OpenAiApiKey"]);
+		Assert.Null(llm["AnthropicApiKey"]);
+
+		var apiKeys = (JObject)result["ApiKeys"]!;
+		Assert.Equal("sk-openai-xxx", apiKeys["OpenAiApiKey"]?.ToString());
+		Assert.Equal("ant-yyy", apiKeys["AnthropicApiKey"]?.ToString());
+	}
+
+	[Fact]
+	public void UpgradeSettings_DoesNotOverwriteExistingRootApiKeys()
+	{
+		// A key already present under root ApiKeys wins; the stale LlmSettings copy is
+		// dropped rather than clobbering the central one.
+		string json = """
+			{
+				"ApiKeys": { "OpenAiApiKey": "root-key" },
+				"LlmSettings": {
+					"OpenAiApiKey": "stale-llm-key",
+					"AnthropicApiKey": "ant-yyy",
+					"Prompts": []
+				}
+			}
+			""";
+
+		JObject result = UpgradeAndReload(json);
+		var llm = (JObject)result["LlmSettings"]!;
+
+		Assert.Null(llm["OpenAiApiKey"]);
+		Assert.Null(llm["AnthropicApiKey"]);
+
+		var apiKeys = (JObject)result["ApiKeys"]!;
+		Assert.Equal("root-key", apiKeys["OpenAiApiKey"]?.ToString());
+		Assert.Equal("ant-yyy", apiKeys["AnthropicApiKey"]?.ToString());
 	}
 
 	[Fact]
@@ -175,9 +208,11 @@ public class SettingsManagerMigrationTests : IDisposable
 		string json = """
 			{
 				"TextToSpeechSettings": { "SpeakClipboard": "CTRL+SHIFT+ALT+Q" },
-				"LlmSettings": {
+				"ApiKeys": {
 					"OpenAiApiKey": "sk-openai-xxx",
-					"AnthropicApiKey": "ant-yyy",
+					"AnthropicApiKey": "ant-yyy"
+				},
+				"LlmSettings": {
 					"Prompts": [
 						{ "Id": 1, "Name": "P1", "Content": "x", "ModelName": "chat-latest" }
 					]
@@ -448,7 +483,8 @@ public class SettingsManagerMigrationTests : IDisposable
 		Assert.Equal("azure-key", result["AzureComputerVisionSettings"]?["ApiKey"]?.ToString());
 		Assert.Equal("stt-key", result["SpeechToTextSettings"]?["Services"]?[0]?["ApiKey"]?.ToString());
 		Assert.Null(result["LlmSettings"]?["ApiKey"]);
-		Assert.Equal("llm-key", result["LlmSettings"]?["OpenAiApiKey"]?.ToString());
+		Assert.Null(result["LlmSettings"]?["OpenAiApiKey"]);
+		Assert.Equal("llm-key", result["ApiKeys"]?["OpenAiApiKey"]?.ToString());
 	}
 
 	// Chain test: a JSON containing every legacy key still recognised by UpgradeSettings.
@@ -532,12 +568,13 @@ public class SettingsManagerMigrationTests : IDisposable
 		Assert.Null(vision["SendKotKeyAfterOcrOperation"]);
 		Assert.Equal("CTRL+ALT+C", vision["SendHotkeyAfterOcrOperation"]?.ToString());
 
-		// LlmSettings: SelectedLlmModel dropped, ApiKey -> OpenAiApiKey,
+		// LlmSettings: SelectedLlmModel dropped, ApiKey -> OpenAiApiKey -> moved to root ApiKeys,
 		// FormatWithLlmHotKey -> ProcessWithLlmHotKey -> dropped as obsolete.
 		var llm = (JObject)result["LlmSettings"]!;
 		Assert.Null(llm["SelectedLlmModel"]);
 		Assert.Null(llm["ApiKey"]);
-		Assert.Equal("openai-key", llm["OpenAiApiKey"]?.ToString());
+		Assert.Null(llm["OpenAiApiKey"]);
+		Assert.Equal("openai-key", result["ApiKeys"]?["OpenAiApiKey"]?.ToString());
 		Assert.Null(llm["FormatWithLlmHotKey"]);
 		Assert.Null(llm["ProcessWithLlmHotKey"]);
 

--- a/Mutation.Tests/SettingsManagerMigrationTests.cs
+++ b/Mutation.Tests/SettingsManagerMigrationTests.cs
@@ -217,9 +217,10 @@ public class SettingsManagerMigrationTests : IDisposable
 		Assert.Equal("Clean up this transcript.", prompts[0]?["Content"]?.ToString());
 		Assert.Equal("ALT+SHIFT+P", prompts[0]?["Hotkey"]?.ToString());
 		Assert.Equal(LlmSettings.DefaultModel, prompts[0]?["ModelName"]?.ToString());
-		// Legacy FormatWithLlmHotKey is renamed to ProcessWithLlmHotKey by the rename migration.
+		// Legacy FormatWithLlmHotKey is renamed to ProcessWithLlmHotKey, used to seed the
+		// prompt's Hotkey above, then dropped as obsolete. Both keys end up removed.
 		Assert.Null(llm["FormatWithLlmHotKey"]);
-		Assert.Equal("ALT+SHIFT+P", llm["ProcessWithLlmHotKey"]?.ToString());
+		Assert.Null(llm["ProcessWithLlmHotKey"]);
 	}
 
 	[Fact]
@@ -316,8 +317,10 @@ public class SettingsManagerMigrationTests : IDisposable
 	}
 
 	[Fact]
-	public void UpgradeSettings_RenamesFormatWithLlmHotKey()
+	public void UpgradeSettings_DropsLegacyFormatAndProcessWithLlmHotKeys()
 	{
+		// FormatWithLlmHotKey is renamed to ProcessWithLlmHotKey, which is now itself
+		// obsolete (per-prompt hotkeys replaced it) and removed in the same pass.
 		string json = """
 			{
 				"LlmSettings": {
@@ -331,7 +334,33 @@ public class SettingsManagerMigrationTests : IDisposable
 		var llm = (JObject)result["LlmSettings"]!;
 
 		Assert.Null(llm["FormatWithLlmHotKey"]);
-		Assert.Equal("ALT+SHIFT+P", llm["ProcessWithLlmHotKey"]?.ToString());
+		Assert.Null(llm["ProcessWithLlmHotKey"]);
+	}
+
+	[Fact]
+	public void UpgradeSettings_DropsProcessWithLlmHotKey_PreservesExistingPrompts()
+	{
+		// An already-migrated file: ProcessWithLlmHotKey lingers but per-prompt hotkeys
+		// drive everything. The leftover key is removed; the prompt is left untouched.
+		string json = """
+			{
+				"LlmSettings": {
+					"ProcessWithLlmHotKey": "CTRL+SHIFT+F",
+					"Prompts": [
+						{ "Id": 1, "Name": "Mine", "Content": "do it", "Hotkey": "CTRL+ALT+G", "ModelName": "chat-latest" }
+					]
+				}
+			}
+			""";
+
+		JObject result = UpgradeAndReload(json);
+		var llm = (JObject)result["LlmSettings"]!;
+
+		Assert.Null(llm["ProcessWithLlmHotKey"]);
+		var prompts = (JArray)llm["Prompts"]!;
+		Assert.Single(prompts);
+		Assert.Equal("Mine", prompts[0]?["Name"]?.ToString());
+		Assert.Equal("CTRL+ALT+G", prompts[0]?["Hotkey"]?.ToString());
 	}
 
 	[Fact]
@@ -504,13 +533,13 @@ public class SettingsManagerMigrationTests : IDisposable
 		Assert.Equal("CTRL+ALT+C", vision["SendHotkeyAfterOcrOperation"]?.ToString());
 
 		// LlmSettings: SelectedLlmModel dropped, ApiKey -> OpenAiApiKey,
-		// FormatWithLlmHotKey -> ProcessWithLlmHotKey.
+		// FormatWithLlmHotKey -> ProcessWithLlmHotKey -> dropped as obsolete.
 		var llm = (JObject)result["LlmSettings"]!;
 		Assert.Null(llm["SelectedLlmModel"]);
 		Assert.Null(llm["ApiKey"]);
 		Assert.Equal("openai-key", llm["OpenAiApiKey"]?.ToString());
 		Assert.Null(llm["FormatWithLlmHotKey"]);
-		Assert.Equal("ALT+SHIFT+P", llm["ProcessWithLlmHotKey"]?.ToString());
+		Assert.Null(llm["ProcessWithLlmHotKey"]);
 
 		// Models: List<string> -> List<LlmModelConfig>, provider inferred from name.
 		var models = (JArray)llm["Models"]!;

--- a/Mutation.Tests/TextToSpeechRewindTests.cs
+++ b/Mutation.Tests/TextToSpeechRewindTests.cs
@@ -1,0 +1,77 @@
+using CognitiveSupport;
+using Xunit;
+
+namespace Mutation.Tests;
+
+// Verifies the pure word-rewind used by TextToSpeechService when resuming playback.
+// Resuming rewinds a configurable number of words before the stop point so the
+// listener regains context of where they are.
+public class TextToSpeechRewindTests
+{
+	private const string Text = "The quick brown fox jumps over the lazy dog";
+	//                           0123456789...
+	// Word starts: The=0 quick=4 brown=10 fox=16 jumps=20 over=26 the=31 lazy=35 dog=40
+
+	[Fact]
+	public void ZeroWords_ReturnsSamePosition()
+	{
+		Assert.Equal(20, TextToSpeechService.RewindByWords(Text, 20, 0));
+	}
+
+	[Fact]
+	public void NegativeWords_ReturnsSamePosition()
+	{
+		Assert.Equal(20, TextToSpeechService.RewindByWords(Text, 20, -3));
+	}
+
+	[Fact]
+	public void RewindsThreeWordsFromWordBoundary()
+	{
+		// Stopped at the start of "over" (26). Back 3 words (jumps, fox, brown) ->
+		// start of "brown" (10).
+		Assert.Equal(10, TextToSpeechService.RewindByWords(Text, 26, 3));
+	}
+
+	[Fact]
+	public void RewindOneWord_LandsOnPreviousWordStart()
+	{
+		// Start of "over" (26) back 1 word -> start of "jumps" (20).
+		Assert.Equal(20, TextToSpeechService.RewindByWords(Text, 26, 1));
+	}
+
+	[Fact]
+	public void MidWord_CountsPartialWordAsFirstStep()
+	{
+		// Position 23 is inside "jumps" (20-24). Back 1 word steps over the partial
+		// word to its start (20).
+		Assert.Equal(20, TextToSpeechService.RewindByWords(Text, 23, 1));
+	}
+
+	[Fact]
+	public void MoreWordsThanAvailable_ClampsToStart()
+	{
+		Assert.Equal(0, TextToSpeechService.RewindByWords(Text, 26, 99));
+	}
+
+	[Fact]
+	public void PositionAtStart_StaysAtStart()
+	{
+		Assert.Equal(0, TextToSpeechService.RewindByWords(Text, 0, 3));
+	}
+
+	[Fact]
+	public void PositionPastEnd_IsClampedThenRewinds()
+	{
+		// Position beyond the text clamps to length, then steps back 1 word -> "dog" (40).
+		Assert.Equal(40, TextToSpeechService.RewindByWords(Text, Text.Length + 10, 1));
+	}
+
+	[Fact]
+	public void HandlesMultipleSpacesBetweenWords()
+	{
+		const string spaced = "alpha   beta   gamma";
+		// alpha=0  beta=8  gamma=15
+		// Back 2 words from end (20) -> start of "beta" (8).
+		Assert.Equal(8, TextToSpeechService.RewindByWords(spaced, spaced.Length, 2));
+	}
+}

--- a/Mutation.Tests/TranscriptFormatRuleEntryTests.cs
+++ b/Mutation.Tests/TranscriptFormatRuleEntryTests.cs
@@ -1,0 +1,102 @@
+using CognitiveSupport;
+using Microsoft.UI.Xaml;
+using Mutation.Ui;
+using static CognitiveSupport.TranscriptFormatRule;
+
+namespace Mutation.Tests;
+
+public class TranscriptFormatRuleEntryTests
+{
+	[Fact]
+	public void Ctor_NullRule_Throws()
+	{
+		Assert.Throws<ArgumentNullException>(() => new TranscriptFormatRuleEntry(null!));
+	}
+
+	[Fact]
+	public void Properties_WriteThroughToBackingRule()
+	{
+		var rule = new TranscriptFormatRule();
+		var entry = new TranscriptFormatRuleEntry(rule)
+		{
+			Find = "foo",
+			ReplaceWith = "bar",
+			CaseSensitive = true,
+			MatchType = MatchTypeEnum.Smart,
+		};
+
+		Assert.Equal("foo", rule.Find);
+		Assert.Equal("bar", rule.ReplaceWith);
+		Assert.True(rule.CaseSensitive);
+		Assert.Equal(MatchTypeEnum.Smart, rule.MatchType);
+	}
+
+	[Fact]
+	public void NullBackingValues_SurfaceAsEmptyStrings()
+	{
+		var entry = new TranscriptFormatRuleEntry(new TranscriptFormatRule());
+
+		Assert.Equal(string.Empty, entry.Find);
+		Assert.Equal(string.Empty, entry.ReplaceWith);
+	}
+
+	[Fact]
+	public void MatchTypeOptions_ContainsAllThree()
+	{
+		var entry = new TranscriptFormatRuleEntry(new TranscriptFormatRule());
+
+		Assert.Equal(
+			new[] { MatchTypeEnum.Plain, MatchTypeEnum.RegEx, MatchTypeEnum.Smart },
+			entry.MatchTypeOptions);
+	}
+
+	[Fact]
+	public void Regex_ValidPattern_HasNoError()
+	{
+		var rule = new TranscriptFormatRule("\\d+", "#", false, MatchTypeEnum.RegEx);
+		var entry = new TranscriptFormatRuleEntry(rule);
+
+		Assert.False(entry.HasRegexError);
+		Assert.Null(entry.RegexError);
+		Assert.Equal(Visibility.Collapsed, entry.RegexErrorVisibility);
+	}
+
+	[Fact]
+	public void Regex_InvalidPattern_SurfacesError()
+	{
+		var rule = new TranscriptFormatRule("(unterminated", "x", false, MatchTypeEnum.RegEx);
+		var entry = new TranscriptFormatRuleEntry(rule);
+
+		Assert.True(entry.HasRegexError);
+		Assert.False(string.IsNullOrEmpty(entry.RegexError));
+		Assert.Equal(Visibility.Visible, entry.RegexErrorVisibility);
+	}
+
+	[Fact]
+	public void InvalidPattern_OnlyValidatedWhenMatchTypeIsRegEx()
+	{
+		// A malformed regex is harmless for Plain matching, so no error should show.
+		var entry = new TranscriptFormatRuleEntry(
+			new TranscriptFormatRule("(unterminated", "x", false, MatchTypeEnum.Plain));
+		Assert.False(entry.HasRegexError);
+
+		// Switching the same bad pattern to RegEx must surface the error.
+		entry.MatchType = MatchTypeEnum.RegEx;
+		Assert.True(entry.HasRegexError);
+
+		// Switching back clears it.
+		entry.MatchType = MatchTypeEnum.Plain;
+		Assert.False(entry.HasRegexError);
+	}
+
+	[Fact]
+	public void EditingFind_RevalidatesRegex()
+	{
+		var entry = new TranscriptFormatRuleEntry(
+			new TranscriptFormatRule("(unterminated", "x", false, MatchTypeEnum.RegEx));
+		Assert.True(entry.HasRegexError);
+
+		entry.Find = "valid";
+		Assert.False(entry.HasRegexError);
+	}
+}

--- a/Mutation.Ui/App.xaml.cs
+++ b/Mutation.Ui/App.xaml.cs
@@ -153,8 +153,8 @@ public partial class App : Application
 	// keys (Anthropic alone, Azure OCR) are not required to clear this.
 	private static bool NeedsFirstRunSetup(Settings settings)
 	{
-		var llm = settings.LlmSettings;
-		return !IsKeyConfigured(llm?.OpenAiApiKey) && !IsKeyConfigured(llm?.AnthropicApiKey);
+		var keys = settings.ApiKeys;
+		return !IsKeyConfigured(keys?.OpenAiApiKey) && !IsKeyConfigured(keys?.AnthropicApiKey);
 	}
 
 	private static bool IsKeyConfigured(string? value)
@@ -205,8 +205,8 @@ public partial class App : Application
 			builder.Services.AddSingleton<ILlmService>(sp =>
 			{
 				var llmSettings = settings.LlmSettings;
-				string openAiKey = llmSettings?.OpenAiApiKey ?? string.Empty;
-				string anthropicKey = llmSettings?.AnthropicApiKey ?? string.Empty;
+				string openAiKey = settings.ApiKeys?.OpenAiApiKey ?? string.Empty;
+				string anthropicKey = settings.ApiKeys?.AnthropicApiKey ?? string.Empty;
 				int timeoutSeconds = llmSettings?.TimeoutSeconds > 0 ? llmSettings.TimeoutSeconds : 60;
 				int retryCount = llmSettings?.RetryCount ?? SettingsDefaults.Llm.RetryCount;
 				if (retryCount < 0) retryCount = SettingsDefaults.Llm.RetryCount;
@@ -466,10 +466,12 @@ public partial class App : Application
 				switch (serviceSettings.Provider)
 				{
 					case SpeechToTextProviders.OpenAi:
-						services.Add(CreateWhisperSpeechToTextService(builder, serviceSettings, sp));
+						services.Add(CreateWhisperSpeechToTextService(
+							builder, serviceSettings, ResolveServiceApiKey(settings.ApiKeys?.OpenAiApiKey, serviceSettings.ApiKey), sp));
 						break;
 					case SpeechToTextProviders.Deepgram:
-						services.Add(CreateDeepgramSpeechToTextService(builder, serviceSettings));
+						services.Add(CreateDeepgramSpeechToTextService(
+							builder, serviceSettings, ResolveServiceApiKey(settings.ApiKeys?.DeepgramApiKey, serviceSettings.ApiKey)));
 						break;
 					default:
 						throw new NotSupportedException($"The SpeechToText service '{serviceSettings.Provider}' is not supported.");
@@ -479,10 +481,22 @@ public partial class App : Application
 		});
 	}
 
-	private static ISpeechToTextService CreateWhisperSpeechToTextService(HostApplicationBuilder builder, SpeechToTextServiceSettings serviceSettings, IServiceProvider sp)
+	// Resolve the API key for a speech service: the per-service key is an optional
+	// override that wins when set; otherwise the central root-level key is used.
+	// A placeholder value counts as "not set" so it never shadows a real root key.
+	private static string ResolveServiceApiKey(string? rootKey, string? overrideKey)
+	{
+		string ov = overrideKey?.Trim() ?? string.Empty;
+		if (ov.Length > 0 && ov != SettingsDefaults.PlaceholderValue)
+			return ov;
+
+		string root = rootKey?.Trim() ?? string.Empty;
+		return root == SettingsDefaults.PlaceholderValue ? string.Empty : root;
+	}
+
+	private static ISpeechToTextService CreateWhisperSpeechToTextService(HostApplicationBuilder builder, SpeechToTextServiceSettings serviceSettings, string apiKey, IServiceProvider sp)
 	{
 		string baseDomain = serviceSettings.BaseDomain?.Trim() ?? string.Empty;
-		string apiKey = serviceSettings.ApiKey ?? string.Empty;
 		string modelId = serviceSettings.ModelId ?? string.Empty;
 
 		AudioClient audioClient;
@@ -507,9 +521,9 @@ public partial class App : Application
 				  serviceSettings.TimeoutSeconds > 0 ? serviceSettings.TimeoutSeconds : 10);
 	}
 
-	private static ISpeechToTextService CreateDeepgramSpeechToTextService(HostApplicationBuilder builder, SpeechToTextServiceSettings serviceSettings)
+	private static ISpeechToTextService CreateDeepgramSpeechToTextService(HostApplicationBuilder builder, SpeechToTextServiceSettings serviceSettings, string apiKey)
 	{
-		Deepgram.Clients.Interfaces.v1.IListenRESTClient deepgramClient = ClientFactory.CreateListenRESTClient(serviceSettings.ApiKey ?? string.Empty);
+		Deepgram.Clients.Interfaces.v1.IListenRESTClient deepgramClient = ClientFactory.CreateListenRESTClient(apiKey);
 
 		return new DeepgramSpeechToTextService(
 				  serviceSettings.Name ?? string.Empty,

--- a/Mutation.Ui/MainWindow.xaml.cs
+++ b/Mutation.Ui/MainWindow.xaml.cs
@@ -823,7 +823,8 @@ public sealed partial class MainWindow : Window, IDisposable
 		if (kind == ClipboardKind.Text && trimmed.Length > 0)
 		{
 			_textToSpeech.Speak(trimmed, tts.Rate, tts.Volume, tts.VoiceName,
-				resumeIfSame: true, preprocess: tts.EnableSpeechPreprocessing);
+				resumeIfSame: true, preprocess: tts.EnableSpeechPreprocessing,
+				resumeRewindWordCount: tts.ResumeRewindWordCount);
 			ShowStatus("Text to Speech", "Speaking…", InfoBarSeverity.Informational);
 			return;
 		}

--- a/Mutation.Ui/Resources/HelpText.xaml
+++ b/Mutation.Ui/Resources/HelpText.xaml
@@ -25,6 +25,7 @@
 	<!-- Text to Speech -->
 	<x:String x:Key="Help.Tts.Preprocessing">Clean up text, such as expanding abbreviations and symbols, before it is spoken aloud.</x:String>
 	<x:String x:Key="Help.Tts.SkipSentenceGrace">When skipping back, how long after a sentence starts that a back-press still steps to the previous sentence. After this window a back-press restarts the current sentence instead. A larger value makes stepping back easier; a smaller value favours re-reading the current sentence.</x:String>
+	<x:String x:Key="Help.Tts.ResumeRewindWords">When you resume reading after pausing, rewind this many words before where it stopped so you regain context of where you are. Set to 0 for no rewind: reading resumes from exactly where it stopped.</x:String>
 
 	<!-- Speech to Text -->
 	<x:String x:Key="Help.Speech.ActiveService">The transcription engine used when you record or transcribe speech.</x:String>

--- a/Mutation.Ui/Resources/HelpText.xaml
+++ b/Mutation.Ui/Resources/HelpText.xaml
@@ -37,6 +37,14 @@
 	<x:String x:Key="Help.Speech.SilenceThreshold">Loudness floor in dBFS. Audio at or below this level counts as silence. Lower (more negative) values are stricter, treating only quieter sounds as silence. Default -40.</x:String>
 	<x:String x:Key="Help.Speech.MinSilence">Shortest silence to keep, in seconds. Pauses shorter than this are left untouched; longer pauses are trimmed down to this length. Default 1.0.</x:String>
 	<x:String x:Key="Help.Speech.SilenceGuard">Audio kept on each side of speech, in milliseconds, so soft word starts, breaths, and word endings are not clipped. Default 200.</x:String>
+	<x:String x:Key="Help.Speech.Services">Define the transcription services you can choose from. Adding, removing, or editing a service definition takes effect after you restart the app; the per-service prompt and the active-service selection apply immediately.</x:String>
+	<x:String x:Key="Help.Speech.Service.Name">A label for this service, shown in the active-service list. Must be unique.</x:String>
+	<x:String x:Key="Help.Speech.Service.Provider">Which transcription backend this service talks to: OpenAI (Whisper) or Deepgram.</x:String>
+	<x:String x:Key="Help.Speech.Service.ApiKey">The secret API key used to authenticate with the provider.</x:String>
+	<x:String x:Key="Help.Speech.Service.BaseDomain">The provider's API base URL, for example https://api.openai.com/. Change only to target a proxy or self-hosted endpoint.</x:String>
+	<x:String x:Key="Help.Speech.Service.ModelId">The provider's model identifier, for example whisper-1.</x:String>
+	<x:String x:Key="Help.Speech.Service.Prompt">Optional priming text sent with each transcription to bias spelling of names and punctuation. Applies immediately for the active service.</x:String>
+	<x:String x:Key="Help.Speech.Service.Timeout">Per-attempt timeout in seconds for a transcription request to this service before it is retried or aborted.</x:String>
 
 	<!-- Audio -->
 	<x:String x:Key="Help.Audio.MicVisualization">Show a live waveform of the microphone input while recording.</x:String>

--- a/Mutation.Ui/Resources/HelpText.xaml
+++ b/Mutation.Ui/Resources/HelpText.xaml
@@ -39,7 +39,7 @@
 	<x:String x:Key="Help.Speech.Services">Define the transcription services you can choose from. Adding, removing, or editing a service definition takes effect after you restart the app; the per-service prompt and the active-service selection apply immediately.</x:String>
 	<x:String x:Key="Help.Speech.Service.Name">A label for this service, shown in the active-service list. Must be unique.</x:String>
 	<x:String x:Key="Help.Speech.Service.Provider">Which transcription backend this service talks to: OpenAI (Whisper) or Deepgram.</x:String>
-	<x:String x:Key="Help.Speech.Service.ApiKey">The secret API key used to authenticate with the provider.</x:String>
+	<x:String x:Key="Help.Speech.Service.ApiKey">Optional override of the central API key for this provider (set under API keys). Leave blank to use the central key; fill it in only to use a different key for this service.</x:String>
 	<x:String x:Key="Help.Speech.Service.BaseDomain">The provider's API base URL, for example https://api.openai.com/. Change only to target a proxy or self-hosted endpoint.</x:String>
 	<x:String x:Key="Help.Speech.Service.ModelId">The provider's model identifier, for example whisper-1.</x:String>
 	<x:String x:Key="Help.Speech.Service.Prompt">Optional priming text sent with each transcription to bias spelling of names and punctuation. Applies immediately for the active service.</x:String>
@@ -49,9 +49,12 @@
 	<x:String x:Key="Help.Audio.MicVisualization">Show a live waveform of the microphone input while recording.</x:String>
 	<x:String x:Key="Help.Audio.UseCustomBeeps">Play your own sound files instead of the built-in beeps for status cues.</x:String>
 
+	<!-- API keys -->
+	<x:String x:Key="Help.ApiKeys.OpenAi">API key used to authenticate requests to OpenAI, for both LLM models and OpenAI/Whisper speech-to-text. A speech service can override this with its own key.</x:String>
+	<x:String x:Key="Help.ApiKeys.Anthropic">API key used to authenticate requests to Anthropic (Claude) models.</x:String>
+	<x:String x:Key="Help.ApiKeys.Deepgram">API key used to authenticate requests to Deepgram speech-to-text. A speech service can override this with its own key.</x:String>
+
 	<!-- LLM / AI assistance -->
-	<x:String x:Key="Help.Llm.OpenAiKey">API key used to authenticate requests to OpenAI models.</x:String>
-	<x:String x:Key="Help.Llm.AnthropicKey">API key used to authenticate requests to Anthropic (Claude) models.</x:String>
 	<x:String x:Key="Help.Llm.RequestTimeout">How long to wait for the language model to respond before giving up.</x:String>
 	<x:String x:Key="Help.Llm.RetryCount">How many times to retry a failed language-model request before giving up. Retries help the first request after a reboot succeed while the network warms up. Default 3.</x:String>
 	<x:String x:Key="Help.Llm.Temperature">Controls how random responses are; leave empty to use the provider default.</x:String>

--- a/Mutation.Ui/Resources/HelpText.xaml
+++ b/Mutation.Ui/Resources/HelpText.xaml
@@ -49,6 +49,10 @@
 	<x:String x:Key="Help.Llm.RetryCount">How many times to retry a failed language-model request before giving up. Retries help the first request after a reboot succeed while the network warms up. Default 3.</x:String>
 	<x:String x:Key="Help.Llm.Temperature">Controls how random responses are; leave empty to use the provider default.</x:String>
 
+	<!-- Transcript formatting -->
+	<x:String x:Key="Help.Transcript.MatchType">How the Find text is interpreted. Plain replaces the literal text wherever it appears. RegEx treats Find as a regular-expression pattern (and Replace with as its substitution). Smart matches the word with surrounding spaces and punctuation tidied up, useful for replacing a spoken word or phrase cleanly.</x:String>
+	<x:String x:Key="Help.Transcript.CaseSensitive">When on, upper- and lower-case must match exactly. When off, case is ignored.</x:String>
+
 	<!-- Hotkeys -->
 	<x:String x:Key="Help.Hotkeys.Router">Map one shortcut to another so a single key press can trigger a more complex shortcut. Changes apply when you save settings.</x:String>
 

--- a/Mutation.Ui/Resources/HelpText.xaml
+++ b/Mutation.Ui/Resources/HelpText.xaml
@@ -16,6 +16,7 @@
 	<x:String x:Key="Help.Ocr.MaxParallelRequests">How many OCR requests are sent to the service at the same time.</x:String>
 	<x:String x:Key="Help.Ocr.UseFreeTier">Use the free OCR tier, which limits how many pages each document can contain.</x:String>
 	<x:String x:Key="Help.Ocr.InvertScreenshot">Invert image colors before OCR to improve accuracy on light text over a dark background.</x:String>
+	<x:String x:Key="Help.Ocr.MaxDocumentSize">Maximum size of a file or page sent for OCR. Larger files are skipped before upload to avoid unexpectedly large uploads. Set to 0 for no limit.</x:String>
 	<x:String x:Key="Help.Ocr.SendHotkeyAfter">Optional keystrokes sent to the active app after OCR text is delivered, for example CTRL+V to paste.</x:String>
 
 	<!-- Interface -->

--- a/Mutation.Ui/Resources/HelpText.xaml
+++ b/Mutation.Ui/Resources/HelpText.xaml
@@ -29,7 +29,6 @@
 	<x:String x:Key="Help.Tts.ResumeRewindWords">When you resume reading after pausing, rewind this many words before where it stopped so you regain context of where you are. Set to 0 for no rewind: reading resumes from exactly where it stopped.</x:String>
 
 	<!-- Speech to Text -->
-	<x:String x:Key="Help.Speech.ActiveService">The transcription engine used when you record or transcribe speech.</x:String>
 	<x:String x:Key="Help.Speech.FileTimeout">How long to wait for a file transcription to finish before giving up.</x:String>
 	<x:String x:Key="Help.Speech.TempDir">Folder where temporary audio files are written during recording and transcription.</x:String>
 	<x:String x:Key="Help.Speech.SendHotkeyAfter">Optional keystrokes sent to the active app after a transcript is delivered, for example CTRL+V to paste.</x:String>

--- a/Mutation.Ui/Services/OcrManager.cs
+++ b/Mutation.Ui/Services/OcrManager.cs
@@ -184,6 +184,15 @@ public class OcrManager
 					}
 
 					using var stream = await item.OpenStreamAsync();
+
+					long maxDocumentBytes = GetMaxDocumentBytes();
+					if (maxDocumentBytes > 0 && stream.CanSeek && stream.Length > maxDocumentBytes)
+					{
+						fileHasFailure = true;
+						failures.Add($"{batch.FileName} (Page {item.PageNumber}): {FormatMegabytes(stream.Length)} exceeds the {FormatMegabytes(maxDocumentBytes)} maximum document size.");
+						continue;
+					}
+
 					string text = await _ocrService.ExtractText(order, stream, cancellationToken);
 					string sanitizedText = string.IsNullOrWhiteSpace(text) ? string.Empty : text.TrimEnd();
 					pageResults.Add((item.PageNumber, sanitizedText));
@@ -272,6 +281,16 @@ public class OcrManager
             return new(false, ex.Message);
         }
     }
+
+    // Configured maximum bytes for a single OCR upload, or 0 when no limit applies
+    // (null or a non-positive stored value).
+    private long GetMaxDocumentBytes()
+    {
+        long? configured = _settings.AzureComputerVisionSettings?.MaxDocumentBytes;
+        return configured is > 0 ? configured.Value : 0;
+    }
+
+    private static string FormatMegabytes(long bytes) => $"{bytes / (1024.0 * 1024.0):0.#} MB";
 
     private bool IsOcrConfigured(out string message)
     {

--- a/Mutation.Ui/Services/OcrManager.cs
+++ b/Mutation.Ui/Services/OcrManager.cs
@@ -21,6 +21,7 @@ using System.Drawing.Imaging;
 using System.Windows.Forms;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.WindowsRuntime;
+using System.Runtime.CompilerServices;
 
 namespace Mutation.Ui.Services;
 
@@ -156,99 +157,64 @@ public class OcrManager
             return new(false, string.Empty, paths.Count, 0, Array.Empty<string>());
         }
 
+        int maxParallelDocuments = GetMaxParallelDocuments();
+        int maxParallelRequests = GetMaxParallelRequests();
+        (bool useFreeTier, int freeTierPageLimit) = GetFreeTierGrouping();
+
+        // Two shared throttles for the whole run: documentGate caps files in flight,
+        // requestGate is the global ceiling on concurrent OCR service calls across all files.
+        using var documentGate = new SemaphoreSlim(maxParallelDocuments, maxParallelDocuments);
+        using var requestGate = new SemaphoreSlim(maxParallelRequests, maxParallelRequests);
+
+        var processedSegments = new StrongBox<int>(0);
+
+        // Map: fan out one self-contained task per file. Each returns a FileOcrOutcome
+        // and never mutates shared run-level state.
+        var tasks = new List<Task<FileOcrOutcome>>(batches.Count);
+        for (int index = 0; index < batches.Count; index++)
+        {
+            tasks.Add(ProcessBatchAsync(
+                batches[index],
+                index,
+                order,
+                documentGate,
+                requestGate,
+                useFreeTier,
+                freeTierPageLimit,
+                totalSegments,
+                processedSegments,
+                progress,
+                cancellationToken));
+        }
+
+        // Throttle is enforced inside the tasks via the two gates. Task.WhenAll propagates
+        // OperationCanceledException so fail-fast cancellation behaviour is preserved.
+        FileOcrOutcome[] outcomes = await Task.WhenAll(tasks);
+
+        // Reduce: combine results on a single thread, in original selection order, so today's
+        // output format and ordering are protected against the concurrent execution above.
         var combinedText = new StringBuilder();
         var failures = new List<string>();
         int successCount = 0;
-        int processedSegments = 0;
 
-		foreach (var batch in batches)
-		{
-			cancellationToken.ThrowIfCancellationRequested();
+        foreach (var outcome in outcomes.OrderBy(outcome => outcome.Order))
+        {
+            if (!string.IsNullOrEmpty(outcome.Section))
+            {
+                if (combinedText.Length > 0)
+                    combinedText.AppendLine().AppendLine();
 
-			bool fileHasSuccess = false;
-			bool fileHasFailure = false;
-			int totalPagesForFile = Math.Max(1, batch.Items.Select(item => Math.Max(item.TotalPages, item.PageNumber)).DefaultIfEmpty(1).Max());
-			var pageResults = new List<(int PageNumber, string Text)>();
+                combinedText.Append(outcome.Section);
+            }
 
-			foreach (var item in batch.Items)
-			{
-				cancellationToken.ThrowIfCancellationRequested();
+            if (outcome.Failures.Count > 0)
+                failures.AddRange(outcome.Failures);
 
-				try
-				{
-					if (item.InitializationError is not null)
-					{
-						fileHasFailure = true;
-						failures.Add($"{batch.FileName}: {item.InitializationError.Message}");
-						continue;
-					}
+            if (outcome.Succeeded)
+                ++successCount;
+        }
 
-					using var stream = await item.OpenStreamAsync();
-
-					long maxDocumentBytes = GetMaxDocumentBytes();
-					if (maxDocumentBytes > 0 && stream.CanSeek && stream.Length > maxDocumentBytes)
-					{
-						fileHasFailure = true;
-						failures.Add($"{batch.FileName} (Page {item.PageNumber}): {FormatMegabytes(stream.Length)} exceeds the {FormatMegabytes(maxDocumentBytes)} maximum document size.");
-						continue;
-					}
-
-					string text = await _ocrService.ExtractText(order, stream, cancellationToken);
-					string sanitizedText = string.IsNullOrWhiteSpace(text) ? string.Empty : text.TrimEnd();
-					pageResults.Add((item.PageNumber, sanitizedText));
-					fileHasSuccess = true;
-				}
-				catch (OperationCanceledException)
-				{
-					throw;
-				}
-				catch (Exception ex)
-				{
-					fileHasFailure = true;
-					failures.Add($"{batch.FileName} (Page {item.PageNumber}): {ex.Message}");
-				}
-				finally
-				{
-					processedSegments++;
-					progress?.Report(new OcrProcessingProgress(processedSegments, totalSegments, batch.FileName, item.PageNumber, totalPagesForFile));
-				}
-			}
-
-			if (fileHasSuccess)
-			{
-				if (combinedText.Length > 0)
-					combinedText.AppendLine().AppendLine();
-
-				combinedText.AppendLine($"[{batch.FileName}]");
-
-				pageResults.Sort((left, right) => left.PageNumber.CompareTo(right.PageNumber));
-				var fileTextBuilder = new StringBuilder();
-
-				for (int index = 0; index < pageResults.Count; index++)
-				{
-					var segment = pageResults[index];
-
-					if (totalPagesForFile > 1)
-						fileTextBuilder.AppendLine($"(Page {segment.PageNumber})");
-
-					if (!string.IsNullOrWhiteSpace(segment.Text))
-						fileTextBuilder.AppendLine(segment.Text);
-
-					bool hasAdditionalSegments = index < pageResults.Count - 1;
-					if (hasAdditionalSegments && totalPagesForFile > 1)
-						fileTextBuilder.AppendLine();
-				}
-
-				string fileText = fileTextBuilder.ToString().TrimEnd();
-				if (!string.IsNullOrWhiteSpace(fileText))
-					combinedText.AppendLine(fileText);
-			}
-
-			if (fileHasSuccess && !fileHasFailure)
-				++successCount;
-		}
-
-		string resultText = combinedText.ToString();
+        string resultText = combinedText.ToString();
         if (successCount > 0 && !string.IsNullOrWhiteSpace(resultText))
             await SetClipboardTextAsync(resultText);
 
@@ -256,6 +222,163 @@ public class OcrManager
         await PlayBeepSafeAsync(success ? BeepType.Success : BeepType.Failure);
 
         return new(success, resultText, paths.Count, successCount, failures.AsReadOnly());
+    }
+
+    // Self-contained processing for a single file. Returns a FileOcrOutcome and never mutates
+    // shared run-level state, so many of these can run concurrently under the shared gates.
+    private async Task<FileOcrOutcome> ProcessBatchAsync(
+        FileOcrBatch batch,
+        int order,
+        OcrReadingOrder readingOrder,
+        SemaphoreSlim documentGate,
+        SemaphoreSlim requestGate,
+        bool useFreeTier,
+        int freeTierPageLimit,
+        int totalSegments,
+        StrongBox<int> processedSegments,
+        IProgress<OcrProcessingProgress>? progress,
+        CancellationToken cancellationToken)
+    {
+        await documentGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            bool fileHasSuccess = false;
+            bool fileHasFailure = false;
+            int totalPagesForFile = Math.Max(1, batch.Items.Select(item => Math.Max(item.TotalPages, item.PageNumber)).DefaultIfEmpty(1).Max());
+            var pageResults = new List<(int PageNumber, string Text)>();
+            var failures = new List<string>();
+
+            // Free-tier grouping only defines the logical submission chunk size. Each page is
+            // still processed as its own OCR request, so every page is processed and nothing is
+            // truncated regardless of FreeTierPageLimit.
+            foreach (var submission in GroupIntoSubmissions(batch.Items, useFreeTier, freeTierPageLimit))
+            {
+                foreach (var item in submission)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    try
+                    {
+                        if (item.InitializationError is not null)
+                        {
+                            fileHasFailure = true;
+                            failures.Add($"{batch.FileName}: {item.InitializationError.Message}");
+                            continue;
+                        }
+
+                        using var stream = await item.OpenStreamAsync().ConfigureAwait(false);
+
+                        long maxDocumentBytes = GetMaxDocumentBytes();
+                        if (maxDocumentBytes > 0 && stream.CanSeek && stream.Length > maxDocumentBytes)
+                        {
+                            fileHasFailure = true;
+                            failures.Add($"{batch.FileName} (Page {item.PageNumber}): {FormatMegabytes(stream.Length)} exceeds the {FormatMegabytes(maxDocumentBytes)} maximum document size.");
+                            continue;
+                        }
+
+                        string text = await ExtractTextThrottledAsync(readingOrder, stream, requestGate, cancellationToken).ConfigureAwait(false);
+                        string sanitizedText = string.IsNullOrWhiteSpace(text) ? string.Empty : text.TrimEnd();
+                        pageResults.Add((item.PageNumber, sanitizedText));
+                        fileHasSuccess = true;
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        throw;
+                    }
+                    catch (Exception ex)
+                    {
+                        fileHasFailure = true;
+                        failures.Add($"{batch.FileName} (Page {item.PageNumber}): {ex.Message}");
+                    }
+                    finally
+                    {
+                        int processed = Interlocked.Increment(ref processedSegments.Value);
+                        progress?.Report(new OcrProcessingProgress(processed, totalSegments, batch.FileName, item.PageNumber, totalPagesForFile));
+                    }
+                }
+            }
+
+            string section = BuildFileSection(batch.FileName, fileHasSuccess, totalPagesForFile, pageResults);
+            bool succeeded = fileHasSuccess && !fileHasFailure;
+            return new FileOcrOutcome(order, section, failures, succeeded);
+        }
+        finally
+        {
+            documentGate.Release();
+        }
+    }
+
+    // Wraps a single OCR service call with the global request gate so MaxParallelRequests is a
+    // true ceiling across all files and all generated work items.
+    private async Task<string> ExtractTextThrottledAsync(OcrReadingOrder order, Stream stream, SemaphoreSlim requestGate, CancellationToken cancellationToken)
+    {
+        await requestGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            return await _ocrService.ExtractText(order, stream, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            requestGate.Release();
+        }
+    }
+
+    // Builds a file's combined-text section exactly as the sequential implementation did, so the
+    // ordered reduce can simply append sections separated by a blank line.
+    private static string BuildFileSection(string fileName, bool fileHasSuccess, int totalPagesForFile, List<(int PageNumber, string Text)> pageResults)
+    {
+        if (!fileHasSuccess)
+            return string.Empty;
+
+        var builder = new StringBuilder();
+        builder.AppendLine($"[{fileName}]");
+
+        pageResults.Sort((left, right) => left.PageNumber.CompareTo(right.PageNumber));
+        var fileTextBuilder = new StringBuilder();
+
+        for (int index = 0; index < pageResults.Count; index++)
+        {
+            var segment = pageResults[index];
+
+            if (totalPagesForFile > 1)
+                fileTextBuilder.AppendLine($"(Page {segment.PageNumber})");
+
+            if (!string.IsNullOrWhiteSpace(segment.Text))
+                fileTextBuilder.AppendLine(segment.Text);
+
+            bool hasAdditionalSegments = index < pageResults.Count - 1;
+            if (hasAdditionalSegments && totalPagesForFile > 1)
+                fileTextBuilder.AppendLine();
+        }
+
+        string fileText = fileTextBuilder.ToString().TrimEnd();
+        if (!string.IsNullOrWhiteSpace(fileText))
+            builder.AppendLine(fileText);
+
+        return builder.ToString();
+    }
+
+    // Groups a file's per-page work items into logical free-tier submissions. We keep one page
+    // per OCR request, so this only documents the intended chunk size; the same FreeTierPageLimit
+    // can drive multi-page submissions later without changing the call sites.
+    private static IReadOnlyList<IReadOnlyList<OcrWorkItem>> GroupIntoSubmissions(IReadOnlyList<OcrWorkItem> items, bool useFreeTier, int freeTierPageLimit)
+    {
+        if (!useFreeTier || freeTierPageLimit <= 1 || items.Count <= freeTierPageLimit)
+            return new[] { items };
+
+        var groups = new List<IReadOnlyList<OcrWorkItem>>();
+        for (int start = 0; start < items.Count; start += freeTierPageLimit)
+        {
+            int count = Math.Min(freeTierPageLimit, items.Count - start);
+            var chunk = new List<OcrWorkItem>(count);
+            for (int offset = 0; offset < count; offset++)
+                chunk.Add(items[start + offset]);
+            groups.Add(chunk);
+        }
+
+        return groups;
     }
 
     private async Task<OcrResult> ExtractTextViaOcrAsync(OcrReadingOrder order, SoftwareBitmap bitmap)
@@ -288,6 +411,21 @@ public class OcrManager
     {
         long? configured = _settings.AzureComputerVisionSettings?.MaxDocumentBytes;
         return configured is > 0 ? configured.Value : 0;
+    }
+
+    // Concurrency knobs are clamped to at least 1, mirroring the GetMaxDocumentBytes pattern.
+    private int GetMaxParallelDocuments() =>
+        Math.Max(1, _settings.AzureComputerVisionSettings?.MaxParallelDocuments ?? 1);
+
+    private int GetMaxParallelRequests() =>
+        Math.Max(1, _settings.AzureComputerVisionSettings?.MaxParallelRequests ?? 1);
+
+    private (bool UseFreeTier, int FreeTierPageLimit) GetFreeTierGrouping()
+    {
+        var settings = _settings.AzureComputerVisionSettings;
+        bool useFreeTier = settings?.UseFreeTier ?? false;
+        int pageLimit = Math.Max(1, settings?.FreeTierPageLimit ?? 1);
+        return (useFreeTier, pageLimit);
     }
 
     private static string FormatMegabytes(long bytes) => $"{bytes / (1024.0 * 1024.0):0.#} MB";
@@ -451,6 +589,10 @@ public class OcrManager
         await page.RenderToStreamAsync(stream);
         return stream.AsStreamForRead();
     }
+
+    // Self-contained result for a single file, carried back from ProcessBatchAsync to the
+    // ordered reduce. Order preserves the file's original position in the selection.
+    private sealed record FileOcrOutcome(int Order, string Section, IReadOnlyList<string> Failures, bool Succeeded);
 
     private sealed class FileOcrBatch
     {

--- a/Mutation.Ui/Services/SettingsManager.cs
+++ b/Mutation.Ui/Services/SettingsManager.cs
@@ -447,15 +447,11 @@ Collaboration among various healthcare professionals ensures that the informatio
 End of summary.
 ";
 
-             string? legacyHotkey = llmSettings.ProcessWithLlmHotKey;
-             if (string.IsNullOrWhiteSpace(legacyHotkey))
-                 legacyHotkey = "ALT+SHIFT+P";
-
              llmSettings.Prompts.Add(new LlmSettings.LlmPrompt {
                 Id = 1,
                 Name = "Default",
                 Content = defaultPrompt,
-                Hotkey = legacyHotkey,
+                Hotkey = "ALT+SHIFT+P",
                 AutoRun = false,
                 ModelName = LlmSettings.DefaultModel
              });
@@ -859,6 +855,16 @@ End of summary.
 					};
 				}
 				llmSettingsJObj.Remove("FormatTranscriptPrompt");
+				saveRequired = true;
+			}
+
+			// Drop the obsolete single-hotkey LlmSettings.ProcessWithLlmHotKey. Per-prompt
+			// hotkeys (Prompts[].Hotkey) now drive every LLM action. This runs AFTER the
+			// FormatTranscriptPrompt seed above, which still reads ProcessWithLlmHotKey to
+			// carry a legacy single hotkey forward into the seeded Prompts[0].
+			if (llmSettingsJObj["ProcessWithLlmHotKey"] is not null)
+			{
+				llmSettingsJObj.Remove("ProcessWithLlmHotKey");
 				saveRequired = true;
 			}
 

--- a/Mutation.Ui/Services/SettingsManager.cs
+++ b/Mutation.Ui/Services/SettingsManager.cs
@@ -150,6 +150,14 @@ internal class SettingsManager : ISettingsManager
                         somethingWasMissing = true;
                 }
 
+                // null = never configured -> apply the 10 MB default. A stored 0 (or
+                // negative) is left as-is and means "no limit".
+                if (azureComputerVisionSettings.MaxDocumentBytes is null)
+                {
+                        azureComputerVisionSettings.MaxDocumentBytes = 10L * 1024 * 1024;
+                        somethingWasMissing = true;
+                }
+
 
 		if (settings.AudioSettings is null)
 		{

--- a/Mutation.Ui/Services/SettingsManager.cs
+++ b/Mutation.Ui/Services/SettingsManager.cs
@@ -318,11 +318,9 @@ internal class SettingsManager : ISettingsManager
 		{
 			if (s.Provider == SpeechToTextProviders.None)
 				s.Provider = SpeechToTextProviders.OpenAi;
-			if (string.IsNullOrWhiteSpace(s.ApiKey))
-			{
-				s.ApiKey = PlaceholderValue;
-				somethingWasMissing = true;
-			}
+			// A service's ApiKey is an optional override of the root-level ApiKeys.
+			// Leave it blank by default so the central key is used unless the user
+			// explicitly supplies a per-service key here.
 			if (string.IsNullOrWhiteSpace(s.SpeechToTextPrompt))
 			{
 				s.SpeechToTextPrompt = "Hello, let's use punctuation. Names: Kobus, Piro.";
@@ -386,22 +384,34 @@ internal class SettingsManager : ISettingsManager
 		}
 
 
+		if (settings.ApiKeys is null)
+		{
+			settings.ApiKeys = new ApiKeys();
+			somethingWasMissing = true;
+		}
+		var apiKeys = settings.ApiKeys;
+		if (string.IsNullOrWhiteSpace(apiKeys.OpenAiApiKey))
+		{
+			apiKeys.OpenAiApiKey = PlaceholderValue;
+			somethingWasMissing = true;
+		}
+		if (string.IsNullOrWhiteSpace(apiKeys.AnthropicApiKey))
+		{
+			apiKeys.AnthropicApiKey = PlaceholderValue;
+			somethingWasMissing = true;
+		}
+		if (string.IsNullOrWhiteSpace(apiKeys.DeepgramApiKey))
+		{
+			apiKeys.DeepgramApiKey = PlaceholderValue;
+			somethingWasMissing = true;
+		}
+
 		if (settings.LlmSettings is null)
 		{
 			settings.LlmSettings = new LlmSettings();
 			somethingWasMissing = true;
 		}
 		var llmSettings = settings.LlmSettings;
-		if (string.IsNullOrWhiteSpace(llmSettings.OpenAiApiKey))
-		{
-			llmSettings.OpenAiApiKey = PlaceholderValue;
-			somethingWasMissing = true;
-		}
-		if (string.IsNullOrWhiteSpace(llmSettings.AnthropicApiKey))
-		{
-			llmSettings.AnthropicApiKey = PlaceholderValue;
-			somethingWasMissing = true;
-		}
 
 		// Correct hand-edited invalid retry counts. A fresh LlmSettings already has
 		// RetryCount = 3 via field init, so a clean object is unchanged (parity holds).
@@ -814,6 +824,31 @@ End of summary.
 				}
 				llmSettingsJObj.Remove("ApiKey");
 				saveRequired = true;
+			}
+
+			// Move LlmSettings.OpenAiApiKey / AnthropicApiKey -> root ApiKeys section.
+			// These keys are no longer LLM-specific (e.g. the OpenAI key is also used
+			// for OpenAI/Whisper speech-to-text), so they live in a central ApiKeys
+			// object. Runs AFTER the ApiKey -> OpenAiApiKey rename above so a legacy
+			// LlmSettings.ApiKey is carried all the way to ApiKeys.OpenAiApiKey in one pass.
+			{
+				JObject apiKeys = jObj["ApiKeys"] as JObject ?? new JObject();
+				bool movedAnyKey = false;
+				foreach (string keyName in new[] { "OpenAiApiKey", "AnthropicApiKey" })
+				{
+					if (llmSettingsJObj[keyName] is JToken movedKey)
+					{
+						if (apiKeys[keyName] is null)
+							apiKeys[keyName] = movedKey;
+						llmSettingsJObj.Remove(keyName);
+						movedAnyKey = true;
+					}
+				}
+				if (movedAnyKey)
+				{
+					jObj["ApiKeys"] = apiKeys;
+					saveRequired = true;
+				}
 			}
 
 			// Move LlmSettings.TranscriptFormatRules -> root TranscriptFormatRules (rules aren't LLM-specific).

--- a/Mutation.Ui/SpeechServiceEntry.cs
+++ b/Mutation.Ui/SpeechServiceEntry.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Collections.Generic;
+using CognitiveSupport;
+
+namespace Mutation.Ui;
+
+// INotifyPropertyChanged row wrapper around a single SpeechToTextServiceSettings,
+// bound by the Speech settings page's per-service expander list. Field setters
+// mutate the wrapped model in place, so the array the page hands back to settings
+// stays current without rebuilding on every keystroke (only add/delete rebuild it).
+public sealed class SpeechServiceEntry : System.ComponentModel.INotifyPropertyChanged
+{
+	private static readonly IReadOnlyList<SpeechToTextProviders> _providerOptions =
+		new[] { SpeechToTextProviders.None, SpeechToTextProviders.OpenAi, SpeechToTextProviders.Deepgram };
+
+	private readonly SpeechToTextServiceSettings _model;
+
+	public SpeechServiceEntry(SpeechToTextServiceSettings model)
+	{
+		_model = model ?? throw new ArgumentNullException(nameof(model));
+	}
+
+	internal SpeechToTextServiceSettings Model => _model;
+
+	public IReadOnlyList<SpeechToTextProviders> ProviderOptions => _providerOptions;
+
+	public event System.ComponentModel.PropertyChangedEventHandler? PropertyChanged;
+
+	// Shown in the expander header; falls back to a placeholder when unnamed so the
+	// header never collapses to an empty, unfocusable strip for screen-reader users.
+	public string HeaderText =>
+		string.IsNullOrWhiteSpace(_model.Name) ? "(unnamed service)" : _model.Name!;
+
+	public string Name
+	{
+		get => _model.Name ?? string.Empty;
+		set
+		{
+			string v = value ?? string.Empty;
+			if (string.Equals(_model.Name, v, StringComparison.Ordinal)) return;
+			_model.Name = v;
+			OnPropertyChanged(nameof(Name));
+			OnPropertyChanged(nameof(HeaderText));
+		}
+	}
+
+	public SpeechToTextProviders Provider
+	{
+		get => _model.Provider;
+		set
+		{
+			if (_model.Provider == value) return;
+			_model.Provider = value;
+			OnPropertyChanged(nameof(Provider));
+		}
+	}
+
+	public string ApiKey
+	{
+		get => _model.ApiKey ?? string.Empty;
+		set
+		{
+			string v = value ?? string.Empty;
+			if (string.Equals(_model.ApiKey, v, StringComparison.Ordinal)) return;
+			_model.ApiKey = v;
+			OnPropertyChanged(nameof(ApiKey));
+		}
+	}
+
+	public string BaseDomain
+	{
+		get => _model.BaseDomain ?? string.Empty;
+		set
+		{
+			string v = value ?? string.Empty;
+			if (string.Equals(_model.BaseDomain, v, StringComparison.Ordinal)) return;
+			_model.BaseDomain = v;
+			OnPropertyChanged(nameof(BaseDomain));
+		}
+	}
+
+	public string ModelId
+	{
+		get => _model.ModelId ?? string.Empty;
+		set
+		{
+			string v = value ?? string.Empty;
+			if (string.Equals(_model.ModelId, v, StringComparison.Ordinal)) return;
+			_model.ModelId = v;
+			OnPropertyChanged(nameof(ModelId));
+		}
+	}
+
+	public string SpeechToTextPrompt
+	{
+		get => _model.SpeechToTextPrompt ?? string.Empty;
+		set
+		{
+			string v = value ?? string.Empty;
+			if (string.Equals(_model.SpeechToTextPrompt, v, StringComparison.Ordinal)) return;
+			_model.SpeechToTextPrompt = v;
+			OnPropertyChanged(nameof(SpeechToTextPrompt));
+		}
+	}
+
+	// NumberBox.Value is a double; the model stores an int.
+	public double TimeoutSeconds
+	{
+		get => _model.TimeoutSeconds;
+		set
+		{
+			if (double.IsNaN(value)) return;
+			int v = (int)value;
+			if (_model.TimeoutSeconds == v) return;
+			_model.TimeoutSeconds = v;
+			OnPropertyChanged(nameof(TimeoutSeconds));
+		}
+	}
+
+	private void OnPropertyChanged(string propertyName) =>
+		PropertyChanged?.Invoke(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
+}

--- a/Mutation.Ui/TranscriptFormatRuleEntry.cs
+++ b/Mutation.Ui/TranscriptFormatRuleEntry.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text.RegularExpressions;
+using CognitiveSupport;
+using Microsoft.UI.Xaml;
+using static CognitiveSupport.TranscriptFormatRule;
+
+namespace Mutation.Ui;
+
+// Row wrapper for a single TranscriptFormatRule, mirroring LlmModelEntry.
+// Wraps the live rule so two-way edits flow straight into the working-copy list.
+public sealed class TranscriptFormatRuleEntry : INotifyPropertyChanged
+{
+	private static readonly IReadOnlyList<MatchTypeEnum> _matchTypeOptions =
+		new[] { MatchTypeEnum.Plain, MatchTypeEnum.RegEx, MatchTypeEnum.Smart };
+
+	private readonly TranscriptFormatRule _rule;
+	private string? _regexError;
+
+	public TranscriptFormatRuleEntry(TranscriptFormatRule rule)
+	{
+		_rule = rule ?? throw new ArgumentNullException(nameof(rule));
+		ValidateRegex();
+	}
+
+	internal TranscriptFormatRule Rule => _rule;
+
+	public IReadOnlyList<MatchTypeEnum> MatchTypeOptions => _matchTypeOptions;
+
+	public event PropertyChangedEventHandler? PropertyChanged;
+
+	public string Find
+	{
+		get => _rule.Find ?? string.Empty;
+		set
+		{
+			string v = value ?? string.Empty;
+			if (string.Equals(_rule.Find, v, StringComparison.Ordinal)) return;
+			_rule.Find = v;
+			OnPropertyChanged(nameof(Find));
+			ValidateRegex();
+		}
+	}
+
+	public string ReplaceWith
+	{
+		get => _rule.ReplaceWith ?? string.Empty;
+		set
+		{
+			string v = value ?? string.Empty;
+			if (string.Equals(_rule.ReplaceWith, v, StringComparison.Ordinal)) return;
+			_rule.ReplaceWith = v;
+			OnPropertyChanged(nameof(ReplaceWith));
+		}
+	}
+
+	public bool CaseSensitive
+	{
+		get => _rule.CaseSensitive;
+		set
+		{
+			if (_rule.CaseSensitive == value) return;
+			_rule.CaseSensitive = value;
+			OnPropertyChanged(nameof(CaseSensitive));
+		}
+	}
+
+	public MatchTypeEnum MatchType
+	{
+		get => _rule.MatchType;
+		set
+		{
+			if (_rule.MatchType == value) return;
+			_rule.MatchType = value;
+			OnPropertyChanged(nameof(MatchType));
+			ValidateRegex();
+		}
+	}
+
+	// Inline validation: only RegEx (and the regex-backed Smart) patterns can be malformed.
+	public string? RegexError => _regexError;
+
+	public bool HasRegexError => !string.IsNullOrEmpty(_regexError);
+
+	public Visibility RegexErrorVisibility => HasRegexError ? Visibility.Visible : Visibility.Collapsed;
+
+	private void ValidateRegex()
+	{
+		string? error = null;
+		if (_rule.MatchType == MatchTypeEnum.RegEx && !string.IsNullOrEmpty(_rule.Find))
+		{
+			try
+			{
+				_ = new Regex(_rule.Find);
+			}
+			catch (ArgumentException ex)
+			{
+				error = ex.Message;
+			}
+		}
+
+		if (string.Equals(_regexError, error, StringComparison.Ordinal)) return;
+		_regexError = error;
+		OnPropertyChanged(nameof(RegexError));
+		OnPropertyChanged(nameof(HasRegexError));
+		OnPropertyChanged(nameof(RegexErrorVisibility));
+	}
+
+	private void OnPropertyChanged(string propertyName) =>
+		PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+}

--- a/Mutation.Ui/Views/Settings/Pages/ApiKeysSettingsPage.xaml
+++ b/Mutation.Ui/Views/Settings/Pages/ApiKeysSettingsPage.xaml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<UserControl
+	x:Class="Mutation.Ui.Views.SettingsUi.Pages.ApiKeysSettingsPage"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:controls="using:Mutation.Ui.Views.SettingsUi.Controls"
+	xmlns:local="using:Mutation.Ui"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d">
+
+	<StackPanel Spacing="14">
+		<TextBlock Text="API keys" Style="{StaticResource SubtitleTextBlockStyle}" />
+
+		<TextBlock Text="Central provider API keys used across the app. A speech service can override its key from the Speech to Text section; otherwise the key here is used."
+				   Style="{StaticResource CaptionTextBlockStyle}"
+				   TextWrapping="Wrap"
+				   Foreground="{ThemeResource TextFillColorTertiaryBrush}" />
+
+		<controls:SecretBox x:Name="TxtOpenAiKey" Header="OpenAI API key" HelpText="{StaticResource Help.ApiKeys.OpenAi}" />
+		<controls:SecretBox x:Name="TxtAnthropicKey" Header="Anthropic API key" HelpText="{StaticResource Help.ApiKeys.Anthropic}" />
+		<controls:SecretBox x:Name="TxtDeepgramKey" Header="Deepgram API key" HelpText="{StaticResource Help.ApiKeys.Deepgram}" />
+	</StackPanel>
+</UserControl>

--- a/Mutation.Ui/Views/Settings/Pages/ApiKeysSettingsPage.xaml.cs
+++ b/Mutation.Ui/Views/Settings/Pages/ApiKeysSettingsPage.xaml.cs
@@ -1,0 +1,48 @@
+using CognitiveSupport;
+using Microsoft.UI.Xaml.Controls;
+
+namespace Mutation.Ui.Views.SettingsUi.Pages;
+
+public sealed partial class ApiKeysSettingsPage : UserControl
+{
+	private readonly Settings _settings;
+	private bool _suppressEvents;
+
+	public ApiKeysSettingsPage(Settings settings)
+	{
+		_settings = settings;
+		InitializeComponent();
+		LoadValues();
+
+		TxtOpenAiKey.RegisterPropertyChangedCallback(Controls.SecretBox.SecretProperty, (_, _) =>
+		{
+			if (_suppressEvents) return;
+			(_settings.ApiKeys ??= new ApiKeys()).OpenAiApiKey = TxtOpenAiKey.Secret;
+		});
+
+		TxtAnthropicKey.RegisterPropertyChangedCallback(Controls.SecretBox.SecretProperty, (_, _) =>
+		{
+			if (_suppressEvents) return;
+			(_settings.ApiKeys ??= new ApiKeys()).AnthropicApiKey = TxtAnthropicKey.Secret;
+		});
+
+		TxtDeepgramKey.RegisterPropertyChangedCallback(Controls.SecretBox.SecretProperty, (_, _) =>
+		{
+			if (_suppressEvents) return;
+			(_settings.ApiKeys ??= new ApiKeys()).DeepgramApiKey = TxtDeepgramKey.Secret;
+		});
+	}
+
+	private void LoadValues()
+	{
+		_suppressEvents = true;
+		try
+		{
+			var keys = _settings.ApiKeys ??= new ApiKeys();
+			TxtOpenAiKey.Secret = keys.OpenAiApiKey ?? string.Empty;
+			TxtAnthropicKey.Secret = keys.AnthropicApiKey ?? string.Empty;
+			TxtDeepgramKey.Secret = keys.DeepgramApiKey ?? string.Empty;
+		}
+		finally { _suppressEvents = false; }
+	}
+}

--- a/Mutation.Ui/Views/Settings/Pages/HotkeysSettingsPage.xaml.cs
+++ b/Mutation.Ui/Views/Settings/Pages/HotkeysSettingsPage.xaml.cs
@@ -96,11 +96,6 @@ public sealed partial class HotkeysSettingsPage : UserControl
 			(s, v) => (s.SpeechToTextSettings ??= new SpeechToTextSettings()).SendHotkeyAfterTranscriptionOperation = v,
 			true, null),
 
-		new HotkeySpec("Process with LLM",
-			s => s.LlmSettings?.ProcessWithLlmHotKey,
-			(s, v) => (s.LlmSettings ??= new LlmSettings()).ProcessWithLlmHotKey = v,
-			true, SettingsDefaults.Llm.ProcessPromptHotKey),
-
 		new HotkeySpec("Speak clipboard",
 			s => s.TextToSpeechSettings?.SpeakClipboard,
 			(s, v) => (s.TextToSpeechSettings ??= new TextToSpeechSettings()).SpeakClipboard = v,

--- a/Mutation.Ui/Views/Settings/Pages/LlmSettingsPage.xaml
+++ b/Mutation.Ui/Views/Settings/Pages/LlmSettingsPage.xaml
@@ -12,8 +12,10 @@
 	<StackPanel Spacing="14">
 		<TextBlock Text="AI assistance" Style="{StaticResource SubtitleTextBlockStyle}" />
 
-		<controls:SecretBox x:Name="TxtOpenAiKey" Header="OpenAI API key" HelpText="{StaticResource Help.Llm.OpenAiKey}" />
-		<controls:SecretBox x:Name="TxtAnthropicKey" Header="Anthropic API key" HelpText="{StaticResource Help.Llm.AnthropicKey}" />
+		<TextBlock Text="OpenAI and Anthropic API keys now live under the API keys section."
+				   Style="{StaticResource CaptionTextBlockStyle}"
+				   TextWrapping="Wrap"
+				   Foreground="{ThemeResource TextFillColorTertiaryBrush}" />
 
 		<StackPanel Spacing="4">
 			<StackPanel Orientation="Horizontal" Spacing="6">

--- a/Mutation.Ui/Views/Settings/Pages/LlmSettingsPage.xaml.cs
+++ b/Mutation.Ui/Views/Settings/Pages/LlmSettingsPage.xaml.cs
@@ -17,18 +17,6 @@ public sealed partial class LlmSettingsPage : UserControl
 		_settings = settings;
 		InitializeComponent();
 		LoadValues();
-
-		TxtOpenAiKey.RegisterPropertyChangedCallback(Controls.SecretBox.SecretProperty, (_, _) =>
-		{
-			if (_suppressEvents) return;
-			(_settings.LlmSettings ??= new LlmSettings()).OpenAiApiKey = TxtOpenAiKey.Secret;
-		});
-
-		TxtAnthropicKey.RegisterPropertyChangedCallback(Controls.SecretBox.SecretProperty, (_, _) =>
-		{
-			if (_suppressEvents) return;
-			(_settings.LlmSettings ??= new LlmSettings()).AnthropicApiKey = TxtAnthropicKey.Secret;
-		});
 	}
 
 	private void LoadValues()
@@ -37,8 +25,6 @@ public sealed partial class LlmSettingsPage : UserControl
 		try
 		{
 			var llm = _settings.LlmSettings ??= new LlmSettings();
-			TxtOpenAiKey.Secret = llm.OpenAiApiKey ?? string.Empty;
-			TxtAnthropicKey.Secret = llm.AnthropicApiKey ?? string.Empty;
 			NbTimeout.Value = llm.TimeoutSeconds > 0 ? llm.TimeoutSeconds : SettingsDefaults.Llm.TimeoutSeconds;
 			NbRetryCount.Value = llm.RetryCount >= 0 ? llm.RetryCount : SettingsDefaults.Llm.RetryCount;
 

--- a/Mutation.Ui/Views/Settings/Pages/OcrSettingsPage.xaml
+++ b/Mutation.Ui/Views/Settings/Pages/OcrSettingsPage.xaml
@@ -70,6 +70,18 @@
 					</Button>
 				</StackPanel>
 			</StackPanel>
+			<StackPanel>
+				<StackPanel Orientation="Horizontal" Spacing="6">
+					<TextBlock Text="Max document size (MB)" VerticalAlignment="Center" Style="{StaticResource BodyStrongTextBlockStyle}" />
+					<controls:InfoHint Text="{StaticResource Help.Ocr.MaxDocumentSize}" VerticalAlignment="Center" />
+				</StackPanel>
+				<StackPanel Orientation="Horizontal" Spacing="6">
+					<NumberBox x:Name="NbMaxDocumentSizeMb" AutomationProperties.Name="Max document size (MB)" AutomationProperties.HelpText="{StaticResource Help.Ocr.MaxDocumentSize}" Minimum="0" Maximum="500" SmallChange="1" LargeChange="10" Width="180" SpinButtonPlacementMode="Inline" ValueChanged="NbMaxDocumentSizeMb_ValueChanged" />
+					<Button Click="BtnResetMaxDocSize_Click" ToolTipService.ToolTip="Reset to default" AutomationProperties.Name="Reset max document size">
+						<FontIcon Glyph="&#xE72C;" FontFamily="Segoe Fluent Icons" FontSize="12" AutomationProperties.AccessibilityView="Raw" />
+					</Button>
+				</StackPanel>
+			</StackPanel>
 		</StackPanel>
 
 		<StackPanel Orientation="Horizontal" Spacing="6">

--- a/Mutation.Ui/Views/Settings/Pages/OcrSettingsPage.xaml.cs
+++ b/Mutation.Ui/Views/Settings/Pages/OcrSettingsPage.xaml.cs
@@ -6,6 +6,8 @@ namespace Mutation.Ui.Views.SettingsUi.Pages;
 
 public sealed partial class OcrSettingsPage : UserControl
 {
+	private const double BytesPerMb = 1024.0 * 1024.0;
+
 	private readonly Settings _settings;
 	private bool _suppressEvents;
 
@@ -40,6 +42,9 @@ public sealed partial class OcrSettingsPage : UserControl
 			NbFreeTierPageLimit.Value = ocr.FreeTierPageLimit > 0 ? ocr.FreeTierPageLimit : SettingsDefaults.Ocr.FreeTierPageLimit;
 			NbMaxParallelDocuments.Value = ocr.MaxParallelDocuments > 0 ? ocr.MaxParallelDocuments : SettingsDefaults.Ocr.MaxParallelDocuments;
 			NbMaxParallelRequests.Value = ocr.MaxParallelRequests > 0 ? ocr.MaxParallelRequests : SettingsDefaults.Ocr.MaxParallelRequests;
+			NbMaxDocumentSizeMb.Value = ocr.MaxDocumentBytes is > 0
+				? System.Math.Round(ocr.MaxDocumentBytes.Value / BytesPerMb, 1)
+				: 0;
 			ToggleUseFreeTier.IsOn = ocr.UseFreeTier;
 			ToggleInvert.IsOn = ocr.InvertScreenshot;
 			HkSendAfterOcr.Hotkey = ocr.SendHotkeyAfterOcrOperation ?? string.Empty;
@@ -64,6 +69,15 @@ public sealed partial class OcrSettingsPage : UserControl
 
 	private void NbMaxParallelRequests_ValueChanged(NumberBox sender, NumberBoxValueChangedEventArgs args) =>
 		WriteInt(args.NewValue, v => (_settings.AzureComputerVisionSettings ??= new AzureComputerVisionSettings()).MaxParallelRequests = v);
+
+	private void NbMaxDocumentSizeMb_ValueChanged(NumberBox sender, NumberBoxValueChangedEventArgs args)
+	{
+		if (_suppressEvents) return;
+		if (double.IsNaN(args.NewValue)) return;
+		// 0 (or less) stores 0 = "no limit"; otherwise convert MB -> bytes.
+		long bytes = args.NewValue <= 0 ? 0 : (long)System.Math.Round(args.NewValue * BytesPerMb);
+		(_settings.AzureComputerVisionSettings ??= new AzureComputerVisionSettings()).MaxDocumentBytes = bytes;
+	}
 
 	private void ToggleUseFreeTier_Toggled(object sender, RoutedEventArgs e)
 	{
@@ -92,4 +106,6 @@ public sealed partial class OcrSettingsPage : UserControl
 		NbMaxParallelDocuments.Value = SettingsDefaults.Ocr.MaxParallelDocuments;
 	private void BtnResetMaxReqs_Click(object sender, RoutedEventArgs e) =>
 		NbMaxParallelRequests.Value = SettingsDefaults.Ocr.MaxParallelRequests;
+	private void BtnResetMaxDocSize_Click(object sender, RoutedEventArgs e) =>
+		NbMaxDocumentSizeMb.Value = SettingsDefaults.Ocr.MaxDocumentBytes / BytesPerMb;
 }

--- a/Mutation.Ui/Views/Settings/Pages/SpeechSettingsPage.xaml
+++ b/Mutation.Ui/Views/Settings/Pages/SpeechSettingsPage.xaml
@@ -4,6 +4,7 @@
 	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 	xmlns:controls="using:Mutation.Ui.Views.SettingsUi.Controls"
+	xmlns:local="using:Mutation.Ui"
 	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	mc:Ignorable="d">
@@ -22,9 +23,124 @@
 					  Width="280"
 					  HorizontalAlignment="Left"
 					  SelectionChanged="CmbActiveService_SelectionChanged" />
-			<TextBlock Text="(Edit individual service definitions on the main window or in Mutation.json.)"
+		</StackPanel>
+
+		<StackPanel Spacing="8">
+			<StackPanel Orientation="Horizontal" Spacing="6">
+				<TextBlock Text="Service definitions" VerticalAlignment="Center" Style="{StaticResource BodyStrongTextBlockStyle}" />
+				<controls:InfoHint Text="{StaticResource Help.Speech.Services}" VerticalAlignment="Center" />
+			</StackPanel>
+			<TextBlock Text="Changes to a service definition take effect after you restart the app. The per-service prompt and the active-service selection apply immediately."
 					   Style="{StaticResource CaptionTextBlockStyle}"
+					   TextWrapping="Wrap"
 					   Foreground="{ThemeResource TextFillColorTertiaryBrush}" />
+
+			<ItemsControl x:Name="ServicesList"
+						  AutomationProperties.Name="Speech to text service definitions"
+						  ItemsSource="{x:Bind ServiceEntries, Mode=OneWay}">
+				<ItemsControl.ItemsPanel>
+					<ItemsPanelTemplate>
+						<StackPanel Spacing="8" />
+					</ItemsPanelTemplate>
+				</ItemsControl.ItemsPanel>
+				<ItemsControl.ItemTemplate>
+					<DataTemplate x:DataType="local:SpeechServiceEntry">
+						<Expander HorizontalAlignment="Stretch"
+								  HorizontalContentAlignment="Stretch"
+								  Header="{x:Bind HeaderText, Mode=OneWay}"
+								  AutomationProperties.Name="{x:Bind HeaderText, Mode=OneWay}">
+							<StackPanel Spacing="10" Margin="0,4,0,4">
+								<StackPanel Spacing="4">
+									<StackPanel Orientation="Horizontal" Spacing="6">
+										<TextBlock Text="Name" VerticalAlignment="Center" Style="{StaticResource BodyStrongTextBlockStyle}" />
+										<controls:InfoHint Text="{StaticResource Help.Speech.Service.Name}" VerticalAlignment="Center" />
+									</StackPanel>
+									<TextBox Text="{x:Bind Name, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+											 AutomationProperties.Name="Service name"
+											 AutomationProperties.HelpText="{StaticResource Help.Speech.Service.Name}" />
+								</StackPanel>
+
+								<StackPanel Spacing="4">
+									<StackPanel Orientation="Horizontal" Spacing="6">
+										<TextBlock Text="Provider" VerticalAlignment="Center" Style="{StaticResource BodyStrongTextBlockStyle}" />
+										<controls:InfoHint Text="{StaticResource Help.Speech.Service.Provider}" VerticalAlignment="Center" />
+									</StackPanel>
+									<ComboBox ItemsSource="{x:Bind ProviderOptions}"
+											  SelectedItem="{x:Bind Provider, Mode=TwoWay}"
+											  Width="280"
+											  HorizontalAlignment="Left"
+											  AutomationProperties.Name="Provider"
+											  AutomationProperties.HelpText="{StaticResource Help.Speech.Service.Provider}" />
+								</StackPanel>
+
+								<controls:SecretBox Header="API key"
+													HelpText="{StaticResource Help.Speech.Service.ApiKey}"
+													Secret="{x:Bind ApiKey, Mode=TwoWay}" />
+
+								<StackPanel Spacing="4">
+									<StackPanel Orientation="Horizontal" Spacing="6">
+										<TextBlock Text="Base domain" VerticalAlignment="Center" Style="{StaticResource BodyStrongTextBlockStyle}" />
+										<controls:InfoHint Text="{StaticResource Help.Speech.Service.BaseDomain}" VerticalAlignment="Center" />
+									</StackPanel>
+									<TextBox Text="{x:Bind BaseDomain, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+											 AutomationProperties.Name="Base domain"
+											 AutomationProperties.HelpText="{StaticResource Help.Speech.Service.BaseDomain}" />
+								</StackPanel>
+
+								<StackPanel Spacing="4">
+									<StackPanel Orientation="Horizontal" Spacing="6">
+										<TextBlock Text="Model id" VerticalAlignment="Center" Style="{StaticResource BodyStrongTextBlockStyle}" />
+										<controls:InfoHint Text="{StaticResource Help.Speech.Service.ModelId}" VerticalAlignment="Center" />
+									</StackPanel>
+									<TextBox Text="{x:Bind ModelId, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+											 AutomationProperties.Name="Model id"
+											 AutomationProperties.HelpText="{StaticResource Help.Speech.Service.ModelId}" />
+								</StackPanel>
+
+								<StackPanel Spacing="4">
+									<StackPanel Orientation="Horizontal" Spacing="6">
+										<TextBlock Text="Prompt" VerticalAlignment="Center" Style="{StaticResource BodyStrongTextBlockStyle}" />
+										<controls:InfoHint Text="{StaticResource Help.Speech.Service.Prompt}" VerticalAlignment="Center" />
+									</StackPanel>
+									<TextBox Text="{x:Bind SpeechToTextPrompt, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+											 AcceptsReturn="True"
+											 TextWrapping="Wrap"
+											 MinHeight="60"
+											 AutomationProperties.Name="Per-service prompt"
+											 AutomationProperties.HelpText="{StaticResource Help.Speech.Service.Prompt}" />
+								</StackPanel>
+
+								<StackPanel Spacing="4">
+									<StackPanel Orientation="Horizontal" Spacing="6">
+										<TextBlock Text="Timeout (seconds)" VerticalAlignment="Center" Style="{StaticResource BodyStrongTextBlockStyle}" />
+										<controls:InfoHint Text="{StaticResource Help.Speech.Service.Timeout}" VerticalAlignment="Center" />
+									</StackPanel>
+									<NumberBox Value="{x:Bind TimeoutSeconds, Mode=TwoWay}"
+											   Minimum="1" Maximum="600"
+											   SmallChange="1" LargeChange="10"
+											   SpinButtonPlacementMode="Inline"
+											   Width="180"
+											   HorizontalAlignment="Left"
+											   AutomationProperties.Name="Service timeout (seconds)"
+											   AutomationProperties.HelpText="{StaticResource Help.Speech.Service.Timeout}" />
+								</StackPanel>
+
+								<Button Style="{StaticResource SubtleButtonStyle}"
+										Content="Delete service"
+										AutomationProperties.Name="Delete service"
+										Click="ServiceDelete_Click"
+										Tag="{x:Bind}" />
+							</StackPanel>
+						</Expander>
+					</DataTemplate>
+				</ItemsControl.ItemTemplate>
+			</ItemsControl>
+
+			<Button x:Name="BtnAddService"
+					Style="{StaticResource AccentButtonStyle}"
+					HorizontalAlignment="Left"
+					Click="BtnAddService_Click"
+					Content="Add service" />
 		</StackPanel>
 
 		<StackPanel Orientation="Horizontal" Spacing="16">

--- a/Mutation.Ui/Views/Settings/Pages/SpeechSettingsPage.xaml
+++ b/Mutation.Ui/Views/Settings/Pages/SpeechSettingsPage.xaml
@@ -12,25 +12,12 @@
 	<StackPanel Spacing="14">
 		<TextBlock Text="Speech to Text" Style="{StaticResource SubtitleTextBlockStyle}" />
 
-		<StackPanel Spacing="4">
-			<StackPanel Orientation="Horizontal" Spacing="6">
-				<TextBlock Text="Active service" VerticalAlignment="Center" Style="{StaticResource BodyStrongTextBlockStyle}" />
-				<controls:InfoHint Text="{StaticResource Help.Speech.ActiveService}" VerticalAlignment="Center" />
-			</StackPanel>
-			<ComboBox x:Name="CmbActiveService"
-					  AutomationProperties.Name="Active service"
-					  AutomationProperties.HelpText="{StaticResource Help.Speech.ActiveService}"
-					  Width="280"
-					  HorizontalAlignment="Left"
-					  SelectionChanged="CmbActiveService_SelectionChanged" />
-		</StackPanel>
-
 		<StackPanel Spacing="8">
 			<StackPanel Orientation="Horizontal" Spacing="6">
 				<TextBlock Text="Service definitions" VerticalAlignment="Center" Style="{StaticResource BodyStrongTextBlockStyle}" />
 				<controls:InfoHint Text="{StaticResource Help.Speech.Services}" VerticalAlignment="Center" />
 			</StackPanel>
-			<TextBlock Text="Changes to a service definition take effect after you restart the app. The per-service prompt and the active-service selection apply immediately."
+			<TextBlock Text="Changes to a service definition take effect after you restart the app; the per-service prompt applies immediately. Choose which service is active from the main window."
 					   Style="{StaticResource CaptionTextBlockStyle}"
 					   TextWrapping="Wrap"
 					   Foreground="{ThemeResource TextFillColorTertiaryBrush}" />

--- a/Mutation.Ui/Views/Settings/Pages/SpeechSettingsPage.xaml
+++ b/Mutation.Ui/Views/Settings/Pages/SpeechSettingsPage.xaml
@@ -60,7 +60,7 @@
 											  AutomationProperties.HelpText="{StaticResource Help.Speech.Service.Provider}" />
 								</StackPanel>
 
-								<controls:SecretBox Header="API key"
+								<controls:SecretBox Header="API key override (optional)"
 													HelpText="{StaticResource Help.Speech.Service.ApiKey}"
 													Secret="{x:Bind ApiKey, Mode=TwoWay}" />
 

--- a/Mutation.Ui/Views/Settings/Pages/SpeechSettingsPage.xaml.cs
+++ b/Mutation.Ui/Views/Settings/Pages/SpeechSettingsPage.xaml.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Linq;
@@ -54,7 +53,6 @@ public sealed partial class SpeechSettingsPage : UserControl
 			}
 			_activeEntry = ServiceEntries.FirstOrDefault(e =>
 				string.Equals(e.Name, stt.ActiveSpeechToTextService, StringComparison.Ordinal));
-			RefreshActiveServiceCombo();
 
 			NbFileTimeout.Value = stt.FileTranscriptionTimeoutSeconds > 0
 				? stt.FileTranscriptionTimeoutSeconds
@@ -70,55 +68,17 @@ public sealed partial class SpeechSettingsPage : UserControl
 		finally { _suppressEvents = false; }
 	}
 
-	private void CmbActiveService_SelectionChanged(object sender, SelectionChangedEventArgs e)
-	{
-		if (_suppressEvents) return;
-		string? name = CmbActiveService.SelectedItem as string;
-		(_settings.SpeechToTextSettings ??= new SpeechToTextSettings()).ActiveSpeechToTextService = name;
-		_activeEntry = name is null
-			? null
-			: ServiceEntries.FirstOrDefault(x => string.Equals(x.Name, name, StringComparison.Ordinal));
-	}
-
-	// Rebuilds the active-service dropdown from the current entries, skipping blank
-	// or duplicate names (only uniquely named services can be the active one), and
-	// restores the selection from the stored active-service name.
-	private void RefreshActiveServiceCombo()
-	{
-		bool previous = _suppressEvents;
-		_suppressEvents = true;
-		try
-		{
-			string? desired = _settings.SpeechToTextSettings?.ActiveSpeechToTextService;
-			CmbActiveService.Items.Clear();
-			var seen = new HashSet<string>(StringComparer.Ordinal);
-			foreach (var entry in ServiceEntries)
-			{
-				string name = entry.Name;
-				if (string.IsNullOrWhiteSpace(name)) continue;
-				if (!seen.Add(name)) continue;
-				CmbActiveService.Items.Add(name);
-			}
-			CmbActiveService.SelectedItem =
-				!string.IsNullOrWhiteSpace(desired) && CmbActiveService.Items.Contains(desired)
-					? desired
-					: null;
-		}
-		finally { _suppressEvents = previous; }
-	}
-
+	// The active service is chosen from the main window, not here. When the user
+	// renames the service that happens to be active, follow the rename so the stored
+	// reference does not dangle (PropertyChanged does not carry the previous name).
 	private void ServiceEntry_PropertyChanged(object? sender, PropertyChangedEventArgs e)
 	{
 		if (e.PropertyName != nameof(SpeechServiceEntry.Name)) return;
 		if (sender is not SpeechServiceEntry entry) return;
+		if (!ReferenceEquals(entry, _activeEntry)) return;
 
-		// Keep the active-service reference pointed at the (possibly renamed) service.
-		if (ReferenceEquals(entry, _activeEntry))
-		{
-			(_settings.SpeechToTextSettings ??= new SpeechToTextSettings()).ActiveSpeechToTextService =
-				string.IsNullOrWhiteSpace(entry.Name) ? null : entry.Name;
-		}
-		RefreshActiveServiceCombo();
+		(_settings.SpeechToTextSettings ??= new SpeechToTextSettings()).ActiveSpeechToTextService =
+			string.IsNullOrWhiteSpace(entry.Name) ? null : entry.Name;
 	}
 
 	private void BtnAddService_Click(object sender, RoutedEventArgs e)
@@ -136,7 +96,6 @@ public sealed partial class SpeechSettingsPage : UserControl
 		entry.PropertyChanged += ServiceEntry_PropertyChanged;
 		ServiceEntries.Add(entry);
 		SyncServicesArray();
-		RefreshActiveServiceCombo();
 	}
 
 	private void ServiceDelete_Click(object sender, RoutedEventArgs e)
@@ -158,7 +117,6 @@ public sealed partial class SpeechSettingsPage : UserControl
 		}
 
 		SyncServicesArray();
-		RefreshActiveServiceCombo();
 	}
 
 	// Writes the entry-backed models back as the Services array. Field edits mutate

--- a/Mutation.Ui/Views/Settings/Pages/SpeechSettingsPage.xaml.cs
+++ b/Mutation.Ui/Views/Settings/Pages/SpeechSettingsPage.xaml.cs
@@ -1,4 +1,7 @@
 using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.Linq;
 using CognitiveSupport;
 using Microsoft.UI.Xaml;
@@ -12,6 +15,13 @@ public sealed partial class SpeechSettingsPage : UserControl
 {
 	private readonly Settings _settings;
 	private bool _suppressEvents;
+
+	// The entry whose name currently equals ActiveSpeechToTextService, tracked by
+	// reference so a rename of the active service can follow it (PropertyChanged
+	// does not carry the previous name).
+	private SpeechServiceEntry? _activeEntry;
+
+	public ObservableCollection<SpeechServiceEntry> ServiceEntries { get; } = new();
 
 	public SpeechSettingsPage(Settings settings)
 	{
@@ -33,14 +43,18 @@ public sealed partial class SpeechSettingsPage : UserControl
 		{
 			var stt = _settings.SpeechToTextSettings ??= new SpeechToTextSettings();
 
-			CmbActiveService.Items.Clear();
+			foreach (var existing in ServiceEntries)
+				existing.PropertyChanged -= ServiceEntry_PropertyChanged;
+			ServiceEntries.Clear();
 			foreach (var s in stt.Services ?? Array.Empty<SpeechToTextServiceSettings>())
 			{
-				if (!string.IsNullOrWhiteSpace(s.Name))
-					CmbActiveService.Items.Add(s.Name);
+				var entry = new SpeechServiceEntry(s);
+				entry.PropertyChanged += ServiceEntry_PropertyChanged;
+				ServiceEntries.Add(entry);
 			}
-			if (!string.IsNullOrWhiteSpace(stt.ActiveSpeechToTextService))
-				CmbActiveService.SelectedItem = stt.ActiveSpeechToTextService;
+			_activeEntry = ServiceEntries.FirstOrDefault(e =>
+				string.Equals(e.Name, stt.ActiveSpeechToTextService, StringComparison.Ordinal));
+			RefreshActiveServiceCombo();
 
 			NbFileTimeout.Value = stt.FileTranscriptionTimeoutSeconds > 0
 				? stt.FileTranscriptionTimeoutSeconds
@@ -59,8 +73,99 @@ public sealed partial class SpeechSettingsPage : UserControl
 	private void CmbActiveService_SelectionChanged(object sender, SelectionChangedEventArgs e)
 	{
 		if (_suppressEvents) return;
-		(_settings.SpeechToTextSettings ??= new SpeechToTextSettings()).ActiveSpeechToTextService = CmbActiveService.SelectedItem as string;
+		string? name = CmbActiveService.SelectedItem as string;
+		(_settings.SpeechToTextSettings ??= new SpeechToTextSettings()).ActiveSpeechToTextService = name;
+		_activeEntry = name is null
+			? null
+			: ServiceEntries.FirstOrDefault(x => string.Equals(x.Name, name, StringComparison.Ordinal));
 	}
+
+	// Rebuilds the active-service dropdown from the current entries, skipping blank
+	// or duplicate names (only uniquely named services can be the active one), and
+	// restores the selection from the stored active-service name.
+	private void RefreshActiveServiceCombo()
+	{
+		bool previous = _suppressEvents;
+		_suppressEvents = true;
+		try
+		{
+			string? desired = _settings.SpeechToTextSettings?.ActiveSpeechToTextService;
+			CmbActiveService.Items.Clear();
+			var seen = new HashSet<string>(StringComparer.Ordinal);
+			foreach (var entry in ServiceEntries)
+			{
+				string name = entry.Name;
+				if (string.IsNullOrWhiteSpace(name)) continue;
+				if (!seen.Add(name)) continue;
+				CmbActiveService.Items.Add(name);
+			}
+			CmbActiveService.SelectedItem =
+				!string.IsNullOrWhiteSpace(desired) && CmbActiveService.Items.Contains(desired)
+					? desired
+					: null;
+		}
+		finally { _suppressEvents = previous; }
+	}
+
+	private void ServiceEntry_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+	{
+		if (e.PropertyName != nameof(SpeechServiceEntry.Name)) return;
+		if (sender is not SpeechServiceEntry entry) return;
+
+		// Keep the active-service reference pointed at the (possibly renamed) service.
+		if (ReferenceEquals(entry, _activeEntry))
+		{
+			(_settings.SpeechToTextSettings ??= new SpeechToTextSettings()).ActiveSpeechToTextService =
+				string.IsNullOrWhiteSpace(entry.Name) ? null : entry.Name;
+		}
+		RefreshActiveServiceCombo();
+	}
+
+	private void BtnAddService_Click(object sender, RoutedEventArgs e)
+	{
+		var model = new SpeechToTextServiceSettings
+		{
+			Name = SettingsDefaults.Speech.DefaultServiceName,
+			Provider = SpeechToTextProviders.OpenAi,
+			ModelId = SettingsDefaults.Speech.DefaultServiceModelId,
+			BaseDomain = SettingsDefaults.Speech.DefaultServiceBaseDomain,
+			SpeechToTextPrompt = SettingsDefaults.Speech.DefaultServicePrompt,
+			TimeoutSeconds = SettingsDefaults.Speech.ServiceTimeoutSeconds,
+		};
+		var entry = new SpeechServiceEntry(model);
+		entry.PropertyChanged += ServiceEntry_PropertyChanged;
+		ServiceEntries.Add(entry);
+		SyncServicesArray();
+		RefreshActiveServiceCombo();
+	}
+
+	private void ServiceDelete_Click(object sender, RoutedEventArgs e)
+	{
+		if (sender is not Button { Tag: SpeechServiceEntry entry }) return;
+		entry.PropertyChanged -= ServiceEntry_PropertyChanged;
+		ServiceEntries.Remove(entry);
+
+		if (ReferenceEquals(entry, _activeEntry))
+		{
+			// Repoint the active service to the first remaining named service, or clear it.
+			string? next = ServiceEntries
+				.Select(x => x.Name)
+				.FirstOrDefault(n => !string.IsNullOrWhiteSpace(n));
+			(_settings.SpeechToTextSettings ??= new SpeechToTextSettings()).ActiveSpeechToTextService = next;
+			_activeEntry = next is null
+				? null
+				: ServiceEntries.FirstOrDefault(x => string.Equals(x.Name, next, StringComparison.Ordinal));
+		}
+
+		SyncServicesArray();
+		RefreshActiveServiceCombo();
+	}
+
+	// Writes the entry-backed models back as the Services array. Field edits mutate
+	// the wrapped models in place, so only add/delete need to rebuild the array.
+	private void SyncServicesArray() =>
+		(_settings.SpeechToTextSettings ??= new SpeechToTextSettings()).Services =
+			ServiceEntries.Select(x => x.Model).ToArray();
 
 	private void NbFileTimeout_ValueChanged(NumberBox sender, NumberBoxValueChangedEventArgs args)
 	{

--- a/Mutation.Ui/Views/Settings/Pages/TranscriptFormattingSettingsPage.xaml
+++ b/Mutation.Ui/Views/Settings/Pages/TranscriptFormattingSettingsPage.xaml
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="utf-8"?>
+<UserControl
+	x:Class="Mutation.Ui.Views.SettingsUi.Pages.TranscriptFormattingSettingsPage"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:controls="using:Mutation.Ui.Views.SettingsUi.Controls"
+	xmlns:local="using:Mutation.Ui"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d">
+
+	<StackPanel Spacing="14">
+		<TextBlock Text="Transcript formatting" Style="{StaticResource SubtitleTextBlockStyle}" />
+		<TextBlock Text="Find-and-replace rules applied to a transcript by the Format button. Rules run from top to bottom, so order matters."
+				   TextWrapping="Wrap"
+				   Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+
+		<StackPanel Spacing="8">
+			<Grid ColumnSpacing="12">
+				<Grid.ColumnDefinitions>
+					<ColumnDefinition Width="2*" />
+					<ColumnDefinition Width="2*" />
+					<ColumnDefinition Width="*" />
+					<ColumnDefinition Width="Auto" />
+					<ColumnDefinition Width="Auto" />
+				</Grid.ColumnDefinitions>
+				<TextBlock Grid.Column="0" Text="Find" FontWeight="SemiBold" />
+				<TextBlock Grid.Column="1" Text="Replace with" FontWeight="SemiBold" />
+				<StackPanel Grid.Column="2" Orientation="Horizontal" Spacing="6">
+					<TextBlock Text="Match type" VerticalAlignment="Center" FontWeight="SemiBold" />
+					<controls:InfoHint Text="{StaticResource Help.Transcript.MatchType}" VerticalAlignment="Center" />
+				</StackPanel>
+				<StackPanel Grid.Column="3" Orientation="Horizontal" Spacing="6">
+					<TextBlock Text="Case sensitive" VerticalAlignment="Center" FontWeight="SemiBold" />
+					<controls:InfoHint Text="{StaticResource Help.Transcript.CaseSensitive}" VerticalAlignment="Center" />
+				</StackPanel>
+				<TextBlock Grid.Column="4" Text="Actions" FontWeight="SemiBold" />
+			</Grid>
+
+			<ListView
+				x:Name="RulesList"
+				AutomationProperties.Name="Transcript format rules"
+				ItemsSource="{x:Bind RuleEntries, Mode=OneWay}"
+				SelectionMode="None"
+				IsItemClickEnabled="False"
+				Background="Transparent"
+				BorderThickness="0"
+				IsTabStop="False">
+				<ListView.ItemTemplate>
+					<DataTemplate x:DataType="local:TranscriptFormatRuleEntry">
+						<StackPanel Spacing="2" Padding="0,4">
+							<Grid ColumnSpacing="12">
+								<Grid.ColumnDefinitions>
+									<ColumnDefinition Width="2*" />
+									<ColumnDefinition Width="2*" />
+									<ColumnDefinition Width="*" />
+									<ColumnDefinition Width="Auto" />
+									<ColumnDefinition Width="Auto" />
+								</Grid.ColumnDefinitions>
+
+								<TextBox
+									Grid.Column="0"
+									Text="{x:Bind Find, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+									PlaceholderText="text or pattern"
+									HorizontalAlignment="Stretch"
+									AutomationProperties.Name="Find"
+									ToolTipService.ToolTip="Text or pattern to find" />
+
+								<TextBox
+									Grid.Column="1"
+									Text="{x:Bind ReplaceWith, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+									PlaceholderText="replacement"
+									HorizontalAlignment="Stretch"
+									AutomationProperties.Name="Replace with"
+									ToolTipService.ToolTip="Text to replace each match with" />
+
+								<ComboBox
+									Grid.Column="2"
+									ItemsSource="{x:Bind MatchTypeOptions}"
+									SelectedItem="{x:Bind MatchType, Mode=TwoWay}"
+									HorizontalAlignment="Stretch"
+									AutomationProperties.Name="Match type"
+									AutomationProperties.HelpText="{StaticResource Help.Transcript.MatchType}"
+									ToolTipService.ToolTip="How Find is interpreted" />
+
+								<CheckBox
+									Grid.Column="3"
+									IsChecked="{x:Bind CaseSensitive, Mode=TwoWay}"
+									HorizontalAlignment="Center"
+									AutomationProperties.Name="Case sensitive"
+									AutomationProperties.HelpText="{StaticResource Help.Transcript.CaseSensitive}"
+									ToolTipService.ToolTip="Match upper- and lower-case exactly" />
+
+								<StackPanel Grid.Column="4" Orientation="Horizontal" Spacing="4">
+									<Button
+										Style="{StaticResource SubtleButtonStyle}"
+										AutomationProperties.Name="Move rule up"
+										ToolTipService.ToolTip="Move up"
+										Click="RuleMoveUp_Click"
+										Tag="{x:Bind}">
+										<FontIcon Glyph="&#xE70E;" FontFamily="Segoe Fluent Icons" FontSize="12"
+												  AutomationProperties.AccessibilityView="Raw" />
+									</Button>
+									<Button
+										Style="{StaticResource SubtleButtonStyle}"
+										AutomationProperties.Name="Move rule down"
+										ToolTipService.ToolTip="Move down"
+										Click="RuleMoveDown_Click"
+										Tag="{x:Bind}">
+										<FontIcon Glyph="&#xE70D;" FontFamily="Segoe Fluent Icons" FontSize="12"
+												  AutomationProperties.AccessibilityView="Raw" />
+									</Button>
+									<Button
+										Style="{StaticResource SubtleButtonStyle}"
+										Content="Delete"
+										AutomationProperties.Name="Delete rule"
+										Click="RuleDelete_Click"
+										Tag="{x:Bind}" />
+								</StackPanel>
+							</Grid>
+
+							<TextBlock
+								Text="{x:Bind RegexError, Mode=OneWay}"
+								Visibility="{x:Bind RegexErrorVisibility, Mode=OneWay}"
+								Foreground="{ThemeResource SystemFillColorCriticalBrush}"
+								TextWrapping="Wrap"
+								Style="{StaticResource CaptionTextBlockStyle}"
+								AutomationProperties.Name="Invalid regular expression" />
+						</StackPanel>
+					</DataTemplate>
+				</ListView.ItemTemplate>
+			</ListView>
+
+			<Button
+				x:Name="BtnAddRule"
+				Style="{StaticResource AccentButtonStyle}"
+				HorizontalAlignment="Left"
+				Click="BtnAddRule_Click"
+				Content="Add rule" />
+		</StackPanel>
+	</StackPanel>
+</UserControl>

--- a/Mutation.Ui/Views/Settings/Pages/TranscriptFormattingSettingsPage.xaml.cs
+++ b/Mutation.Ui/Views/Settings/Pages/TranscriptFormattingSettingsPage.xaml.cs
@@ -1,0 +1,72 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using CognitiveSupport;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace Mutation.Ui.Views.SettingsUi.Pages;
+
+public sealed partial class TranscriptFormattingSettingsPage : UserControl
+{
+	private readonly Settings _settings;
+
+	public ObservableCollection<TranscriptFormatRuleEntry> RuleEntries { get; } = new();
+
+	public TranscriptFormattingSettingsPage(Settings settings)
+	{
+		_settings = settings;
+		InitializeComponent();
+		LoadValues();
+	}
+
+	private List<TranscriptFormatRule> Rules =>
+		_settings.TranscriptFormatRules ??= new List<TranscriptFormatRule>();
+
+	private void LoadValues()
+	{
+		RuleEntries.Clear();
+		foreach (var rule in Rules)
+			RuleEntries.Add(new TranscriptFormatRuleEntry(rule));
+	}
+
+	private void BtnAddRule_Click(object sender, RoutedEventArgs e)
+	{
+		var rule = new TranscriptFormatRule();
+		Rules.Add(rule);
+		RuleEntries.Add(new TranscriptFormatRuleEntry(rule));
+	}
+
+	private void RuleDelete_Click(object sender, RoutedEventArgs e)
+	{
+		if (sender is not Button { Tag: TranscriptFormatRuleEntry entry }) return;
+		Rules.Remove(entry.Rule);
+		RuleEntries.Remove(entry);
+	}
+
+	private void RuleMoveUp_Click(object sender, RoutedEventArgs e)
+	{
+		if (sender is not Button { Tag: TranscriptFormatRuleEntry entry }) return;
+		int index = RuleEntries.IndexOf(entry);
+		if (index <= 0) return;
+		MoveRule(index, index - 1);
+	}
+
+	private void RuleMoveDown_Click(object sender, RoutedEventArgs e)
+	{
+		if (sender is not Button { Tag: TranscriptFormatRuleEntry entry }) return;
+		int index = RuleEntries.IndexOf(entry);
+		if (index < 0 || index >= RuleEntries.Count - 1) return;
+		MoveRule(index, index + 1);
+	}
+
+	// Keep the backing list and the displayed collection in lockstep so the saved
+	// order matches what the user sees; TranscriptFormatter applies rules in list order.
+	private void MoveRule(int fromIndex, int toIndex)
+	{
+		var rules = Rules;
+		var rule = rules[fromIndex];
+		rules.RemoveAt(fromIndex);
+		rules.Insert(toIndex, rule);
+		RuleEntries.Move(fromIndex, toIndex);
+	}
+}

--- a/Mutation.Ui/Views/Settings/Pages/TtsSettingsPage.xaml
+++ b/Mutation.Ui/Views/Settings/Pages/TtsSettingsPage.xaml
@@ -48,6 +48,26 @@
 			</StackPanel>
 		</StackPanel>
 
+		<StackPanel Spacing="4">
+			<StackPanel Orientation="Horizontal" Spacing="6">
+				<TextBlock Text="Rewind on resume (words)" VerticalAlignment="Center" Style="{StaticResource BodyStrongTextBlockStyle}" />
+				<controls:InfoHint Text="{StaticResource Help.Tts.ResumeRewindWords}" VerticalAlignment="Center" />
+			</StackPanel>
+			<StackPanel Orientation="Horizontal" Spacing="6">
+				<NumberBox x:Name="NbResumeRewindWords"
+						   AutomationProperties.Name="Rewind on resume (words)"
+						   AutomationProperties.HelpText="{StaticResource Help.Tts.ResumeRewindWords}"
+						   Minimum="0" Maximum="20"
+						   SmallChange="1" LargeChange="5"
+						   SpinButtonPlacementMode="Inline"
+						   Width="220"
+						   ValueChanged="NbResumeRewindWords_ValueChanged" />
+				<Button Click="BtnResetResumeRewind_Click" ToolTipService.ToolTip="Reset to default" AutomationProperties.Name="Reset rewind on resume">
+					<FontIcon Glyph="&#xE72C;" FontFamily="Segoe Fluent Icons" FontSize="12" AutomationProperties.AccessibilityView="Raw" />
+				</Button>
+			</StackPanel>
+		</StackPanel>
+
 		<TextBlock Text="TTS hotkeys appear in the Hotkeys tab."
 				   Style="{StaticResource CaptionTextBlockStyle}"
 				   Foreground="{ThemeResource TextFillColorTertiaryBrush}" />

--- a/Mutation.Ui/Views/Settings/Pages/TtsSettingsPage.xaml.cs
+++ b/Mutation.Ui/Views/Settings/Pages/TtsSettingsPage.xaml.cs
@@ -24,6 +24,7 @@ public sealed partial class TtsSettingsPage : UserControl
 			var tts = _settings.TextToSpeechSettings ??= new TextToSpeechSettings();
 			ToggleSpeechPreprocessing.IsOn = tts.EnableSpeechPreprocessing;
 			NbSkipGrace.Value = tts.SkipSentenceGraceWindowMs;
+			NbResumeRewindWords.Value = tts.ResumeRewindWordCount;
 		}
 		finally { _suppressEvents = false; }
 	}
@@ -49,5 +50,17 @@ public sealed partial class TtsSettingsPage : UserControl
 	private void BtnResetSkipGrace_Click(object sender, RoutedEventArgs e)
 	{
 		NbSkipGrace.Value = SettingsDefaults.Tts.SkipSentenceGraceWindowMs;
+	}
+
+	private void NbResumeRewindWords_ValueChanged(NumberBox sender, NumberBoxValueChangedEventArgs args)
+	{
+		if (_suppressEvents) return;
+		if (double.IsNaN(args.NewValue)) return;
+		(_settings.TextToSpeechSettings ??= new TextToSpeechSettings()).ResumeRewindWordCount = (int)args.NewValue;
+	}
+
+	private void BtnResetResumeRewind_Click(object sender, RoutedEventArgs e)
+	{
+		NbResumeRewindWords.Value = SettingsDefaults.Tts.ResumeRewindWordCount;
 	}
 }

--- a/Mutation.Ui/Views/Settings/SettingsDefaults.cs
+++ b/Mutation.Ui/Views/Settings/SettingsDefaults.cs
@@ -60,6 +60,9 @@ internal static class SettingsDefaults
 		public const int SkipSentenceGraceWindowMs = 1500;
 		public const int MinSkipSentenceGraceWindowMs = 250;
 		public const int MaxSkipSentenceGraceWindowMs = 5000;
+		public const int ResumeRewindWordCount = 5;
+		public const int MinResumeRewindWordCount = 0;
+		public const int MaxResumeRewindWordCount = 20;
 	}
 
 	public static class Llm

--- a/Mutation.Ui/Views/Settings/SettingsDefaults.cs
+++ b/Mutation.Ui/Views/Settings/SettingsDefaults.cs
@@ -69,7 +69,6 @@ internal static class SettingsDefaults
 	{
 		public const int TimeoutSeconds = 60;
 		public const int RetryCount = 3;
-		public const string ProcessPromptHotKey = "ALT+SHIFT+P";
 	}
 
 	public static class MainWindowUi

--- a/Mutation.Ui/Views/Settings/SettingsDefaults.cs
+++ b/Mutation.Ui/Views/Settings/SettingsDefaults.cs
@@ -28,6 +28,8 @@ internal static class SettingsDefaults
 		public const int MaxParallelRequests = 4;
 		public const int MaxFreeTierPageLimit = 20;
 		public const int MaxParallelRequestsLimit = 20;
+		public const long MaxDocumentBytes = 10L * 1024 * 1024;
+		public const int MaxDocumentSizeMbUiMax = 500;
 	}
 
 	public static class Speech

--- a/Mutation.Ui/Views/Settings/SettingsWorkingCopy.cs
+++ b/Mutation.Ui/Views/Settings/SettingsWorkingCopy.cs
@@ -107,6 +107,7 @@ internal static class SettingsWorkingCopy
 			dst.EnableSpeechPreprocessing = src.EnableSpeechPreprocessing;
 			dst.VoiceName = src.VoiceName;
 			dst.SkipSentenceGraceWindowMs = src.SkipSentenceGraceWindowMs;
+			dst.ResumeRewindWordCount = src.ResumeRewindWordCount;
 		}
 
 		live.MainWindowUiSettings ??= new MainWindowUiSettings();

--- a/Mutation.Ui/Views/Settings/SettingsWorkingCopy.cs
+++ b/Mutation.Ui/Views/Settings/SettingsWorkingCopy.cs
@@ -76,13 +76,21 @@ internal static class SettingsWorkingCopy
 			dst.SilenceGuardMilliseconds = src.SilenceGuardMilliseconds;
 		}
 
+		live.ApiKeys ??= new ApiKeys();
+		if (workingCopy.ApiKeys is not null)
+		{
+			var src = workingCopy.ApiKeys;
+			var dst = live.ApiKeys;
+			dst.OpenAiApiKey = src.OpenAiApiKey;
+			dst.AnthropicApiKey = src.AnthropicApiKey;
+			dst.DeepgramApiKey = src.DeepgramApiKey;
+		}
+
 		live.LlmSettings ??= new LlmSettings();
 		if (workingCopy.LlmSettings is not null)
 		{
 			var src = workingCopy.LlmSettings;
 			var dst = live.LlmSettings;
-			dst.OpenAiApiKey = src.OpenAiApiKey;
-			dst.AnthropicApiKey = src.AnthropicApiKey;
 			dst.Models = src.Models;
 			dst.Prompts = src.Prompts;
 			dst.TimeoutSeconds = src.TimeoutSeconds;

--- a/Mutation.Ui/Views/Settings/SettingsWorkingCopy.cs
+++ b/Mutation.Ui/Views/Settings/SettingsWorkingCopy.cs
@@ -84,7 +84,6 @@ internal static class SettingsWorkingCopy
 			dst.OpenAiApiKey = src.OpenAiApiKey;
 			dst.AnthropicApiKey = src.AnthropicApiKey;
 			dst.Models = src.Models;
-			dst.ProcessWithLlmHotKey = src.ProcessWithLlmHotKey;
 			dst.Prompts = src.Prompts;
 			dst.TimeoutSeconds = src.TimeoutSeconds;
 			dst.RetryCount = src.RetryCount;

--- a/Mutation.Ui/Views/SettingsDialog.xaml.cs
+++ b/Mutation.Ui/Views/SettingsDialog.xaml.cs
@@ -92,6 +92,8 @@ public sealed partial class SettingsDialog : ContentDialog
 			new[] { "llm", "openai", "anthropic", "claude", "api key", "prompts", "models" }));
 		_allCategories.Add(new SettingsCategoryItem("tts", "Text to Speech", "Voice playback and narration.", "",
 			new[] { "tts", "text to speech", "voice", "rate", "volume", "preprocessing" }));
+		_allCategories.Add(new SettingsCategoryItem("transcript", "Transcript formatting", "Find-and-replace rules applied by the Format button.", "",
+			new[] { "transcript", "format", "find", "replace", "regex", "rule", "rules", "smart" }));
 		_allCategories.Add(new SettingsCategoryItem("ui", "Interface", "Window layout and dictation insert behavior.", "",
 			new[] { "ui", "interface", "max line", "dictation", "paste", "type" }));
 		_allCategories.Add(new SettingsCategoryItem("hotkeys", "Hotkeys", "All keyboard shortcuts in one place.", "",
@@ -138,6 +140,7 @@ public sealed partial class SettingsDialog : ContentDialog
 			"speech" => new SpeechSettingsPage(_workingCopy),
 			"llm" => new LlmSettingsPage(_workingCopy),
 			"tts" => new TtsSettingsPage(_workingCopy),
+			"transcript" => new TranscriptFormattingSettingsPage(_workingCopy),
 			"ui" => new InterfaceSettingsPage(_workingCopy),
 			"hotkeys" => new HotkeysSettingsPage(_workingCopy),
 			_ => null,

--- a/Mutation.Ui/Views/SettingsDialog.xaml.cs
+++ b/Mutation.Ui/Views/SettingsDialog.xaml.cs
@@ -88,8 +88,10 @@ public sealed partial class SettingsDialog : ContentDialog
 			new[] { "ocr", "azure", "screenshot", "vision", "endpoint", "free tier" }));
 		_allCategories.Add(new SettingsCategoryItem("speech", "Speech to Text", "Transcription providers and recording behavior.", "",
 			new[] { "speech", "stt", "whisper", "deepgram", "transcription", "temp directory", "timeout" }));
-		_allCategories.Add(new SettingsCategoryItem("llm", "AI assistance", "LLM providers, API keys, prompts.", "",
-			new[] { "llm", "openai", "anthropic", "claude", "api key", "prompts", "models" }));
+		_allCategories.Add(new SettingsCategoryItem("apikeys", "API keys", "Central provider keys: OpenAI, Anthropic, Deepgram.", "",
+			new[] { "api key", "api keys", "openai", "anthropic", "claude", "deepgram", "key", "credentials" }));
+		_allCategories.Add(new SettingsCategoryItem("llm", "AI assistance", "LLM providers, models, prompts.", "",
+			new[] { "llm", "openai", "anthropic", "claude", "prompts", "models" }));
 		_allCategories.Add(new SettingsCategoryItem("tts", "Text to Speech", "Voice playback and narration.", "",
 			new[] { "tts", "text to speech", "voice", "rate", "volume", "preprocessing" }));
 		_allCategories.Add(new SettingsCategoryItem("transcript", "Transcript formatting", "Find-and-replace rules applied by the Format button.", "",
@@ -138,6 +140,7 @@ public sealed partial class SettingsDialog : ContentDialog
 			"audio" => new AudioSettingsPage(_workingCopy),
 			"ocr" => new OcrSettingsPage(_workingCopy),
 			"speech" => new SpeechSettingsPage(_workingCopy),
+			"apikeys" => new ApiKeysSettingsPage(_workingCopy),
 			"llm" => new LlmSettingsPage(_workingCopy),
 			"tts" => new TtsSettingsPage(_workingCopy),
 			"transcript" => new TranscriptFormattingSettingsPage(_workingCopy),

--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ Process text through OpenAI, Anthropic, or any OpenAI-compatible endpoint. Defin
 
 | Hotkey | Description |
 |--------|-------------|
-| `ProcessWithLlmHotKey` | Apply the auto-run prompt to clipboard text. |
 | Per-prompt `Hotkey` | Trigger a specific prompt directly. |
 
 **Prompt Configuration:**
@@ -192,7 +191,6 @@ All hotkeys are global and fully customisable. Below is an example covering ever
       { "Name": "gpt-4.1",           "Provider": "OpenAI",    "CustomTemperature": null },
       { "Name": "claude-sonnet-4-6", "Provider": "Anthropic", "CustomTemperature": null }
     ],
-    "ProcessWithLlmHotKey": "Ctrl+Shift+F",
     "Prompts": [
       {
         "Id": 1,

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Process text through OpenAI, Anthropic, or any OpenAI-compatible endpoint. Defin
 - Set `ModelName` on a prompt to override the default model on a per-prompt basis (must match a `Name` from `LlmSettings.Models`)
 
 **Model Configuration:**
-Each entry in `LlmSettings.Models` is an object with `Name`, `Provider` (`OpenAI` or `Anthropic`), and an optional `CustomTemperature` (leave `null` for models that only accept the API default — the request will then omit the temperature parameter). OpenAI keys go in `OpenAiApiKey`; Anthropic keys go in `AnthropicApiKey`.
+Each entry in `LlmSettings.Models` is an object with `Name`, `Provider` (`OpenAI` or `Anthropic`), and an optional `CustomTemperature` (leave `null` for models that only accept the API default — the request will then omit the temperature parameter). Provider API keys live in the top-level `ApiKeys` section: `OpenAiApiKey`, `AnthropicApiKey`, and `DeepgramApiKey`.
 
 ### 5. Transcript Formatting Rules  
 Apply find-and-replace rules to transcripts before or instead of LLM processing:
@@ -153,6 +153,12 @@ All hotkeys are global and fully customisable. Below is an example covering ever
     }
   },
 
+  "ApiKeys": {
+    "OpenAiApiKey": "<your OpenAI key>",
+    "AnthropicApiKey": "<your Anthropic key>",
+    "DeepgramApiKey": "<your Deepgram key>"
+  },
+
   "AzureComputerVisionSettings": {
     "ApiKey": "<your Azure key>",
     "Endpoint": "https://<region>.api.cognitive.microsoft.com/",
@@ -181,7 +187,6 @@ All hotkeys are global and fully customisable. Below is an example covering ever
       {
         "Name": "OpenAI gpt-4o-transcribe",
         "Provider": "OpenAi",
-        "ApiKey": "<your OpenAI key>",
         "BaseDomain": "https://api.openai.com/",
         "ModelId": "gpt-4o-transcribe",
         "SpeechToTextPrompt": "Optional per-service prompt to bias transcription (e.g. domain vocabulary)."
@@ -196,7 +201,6 @@ All hotkeys are global and fully customisable. Below is an example covering ever
       {
         "Name": "Deepgram Nova3",
         "Provider": "Deepgram",
-        "ApiKey": "<your Deepgram key>",
         "BaseDomain": null,
         "ModelId": "nova-3"
       }
@@ -204,8 +208,6 @@ All hotkeys are global and fully customisable. Below is an example covering ever
   },
 
   "LlmSettings": {
-    "OpenAiApiKey": "<your OpenAI key>",
-    "AnthropicApiKey": "<your Anthropic key>",
     "Models": [
       { "Name": "gpt-4.1",           "Provider": "OpenAI",    "CustomTemperature": null },
       { "Name": "claude-sonnet-4-6", "Provider": "Anthropic", "CustomTemperature": null }
@@ -255,7 +257,8 @@ All hotkeys are global and fully customisable. Below is an example covering ever
 ### Provisioning Speech-to-Text Providers
 
 * Follow each provider's portal to create an account and API key.
-* Paste the credentials into the relevant object under `SpeechToTextSettings → Services`.
+* Paste OpenAI/Whisper and Deepgram keys into the top-level `ApiKeys` section (`OpenAiApiKey`, `DeepgramApiKey`); they are shared with the rest of the app.
+* A service's own `ApiKey` under `SpeechToTextSettings → Services` is an optional override — set it only when that service needs a different key (for example a Groq endpoint that reuses the OpenAI provider).
 
 ## Contribute
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Mutation supports two OCR reading orders via Azure **Computer Vision**:
 - `UseFreeTier` – respects Azure free tier limits by default
 - `FreeTierPageLimit` – limits pages per PDF on free tier (default: 2)
 - `MaxParallelDocuments` / `MaxParallelRequests` – concurrency controls for paid tiers
-- `MaxDocumentBytes` – caps upload size to avoid unexpectedly large files
+- `MaxDocumentBytes` – caps the size of a file/page sent for OCR; larger files are skipped before upload (default: 10 MB; 0 = no limit)
 
 ### 3. Speech to Text Conversion  
 Press one hotkey to start recording, press it again to stop and send the audio for transcription. Supported providers:
@@ -104,13 +104,32 @@ Replace the default system beeps with custom audio files for different actions:
 - `BeepMuteFile` / `BeepUnmuteFile` – for microphone state changes
 
 ### 8. Text-to-Speech
-Press a hotkey to speak the current clipboard text aloud through your default audio output.
+Mutation can read text aloud — either whatever is on your clipboard or text you've selected in another app — through your default audio output. All hotkeys are global, so they work no matter which app is in front; you don't need to switch back to Mutation first. Once you know the handful of shortcuts below you can drive it like a media player: play, pause, skip ahead, jump back.
 
-**Hotkey:**
+**Starting to read:**
 
-| Hotkey | Description |
-|--------|-------------|
-| `SpeakClipboard` | Speak the clipboard text aloud. |
+| Hotkey | Default | Description |
+|--------|---------|-------------|
+| `SpeakClipboard` | `Ctrl+Shift+Alt+Q` | Copy text anywhere, then press this to read your clipboard aloud. |
+| `SpeakSelectionHotKey` | `Ctrl+Shift+Q` | Highlight text in any app and press this — Mutation reads the selection without you having to copy first. |
+
+If your clipboard is empty or holds something that can't be read (such as an image), Mutation announces that out loud rather than staying silent. For very long text (over ~5,000 characters) it first announces roughly how many minutes the reading will take.
+
+**Pause and resume:** The `SpeakClipboard` hotkey doubles as pause/resume. Press it while reading to **pause**; press it again to **resume**, backing up a few words first for context (5 words by default, configurable). If you copied new text while paused, pressing it reads the new clipboard instead of resuming.
+
+**Moving around the text** (sentence by sentence, like a media player's skip buttons):
+
+| Hotkey | Default | Description |
+|--------|---------|-------------|
+| `SkipSentenceForwardHotKey` | `Ctrl+Shift+K` | Skip forward one sentence. Past the last sentence, announces "End of text." |
+| `SkipSentenceBackwardHotKey` | `Ctrl+Shift+J` | Skip back one sentence. Just landed on a sentence? Back jumps to the previous one; settled in for a moment? Back restarts the current sentence. Before the first sentence, announces "Beginning of text." |
+| `RestartFromBeginningHotKey` | `Ctrl+Shift+B` | Restart from the very beginning of the text. |
+
+**Voice, rate, and volume:** The main window's **Voice & Speech** card lets you pick any voice installed on Windows (a short sample plays when you choose one), set the reading **Rate** from `-10` (slow) to `+10` (fast, default `8`), and set the **Volume** from 0–100%. To add more voices, install them through Windows' own speech settings and they'll appear in the dropdown.
+
+**Tidier reading:** By default Mutation cleans text up before speaking so it sounds natural — skipping markdown clutter (`#`, `**bold**`, backticks, bullets), turning long links into "link to [site]," and expanding shorthand ("e.g." → "for example," "i.e." → "that is," "etc." → "et cetera," "vs." → "versus"). You can turn this off to hear text exactly as written.
+
+**Customising it all:** Open **Settings** with `Ctrl+,`. The **Hotkeys** tab lets you rebind every shortcut above. The **Text to Speech** tab lets you toggle speech preprocessing, set how many words to rewind on resume (`0`–`20`, default `5`), and adjust the skip-back grace window (`250`–`5000` ms, default `1500`) that decides whether a back-press goes to the previous sentence or restarts the current one. Voice, rate, and volume live on the main window and are saved automatically.
 
 ## Getting Started
 Install the .NET 10 runtime (or newer) and run **Mutation.exe**. On first launch, the app creates *Mutation.json* with sensible defaults, then shows a welcome message and automatically opens the in-app **Settings** dialog so you can add your API keys (OpenAI for dictation + LLM; Anthropic and Azure Computer Vision are optional). You can reopen Settings anytime with `Ctrl+,`.
@@ -148,7 +167,7 @@ All hotkeys are global and fully customisable. Below is an example covering ever
     "FreeTierPageLimit": 2,
     "MaxParallelDocuments": 2,
     "MaxParallelRequests": 4,
-    "MaxDocumentBytes": null
+    "MaxDocumentBytes": 10485760
   },
 
   "SpeechToTextSettings": {


### PR DESCRIPTION
## Summary

This branch bundles several settings/UX improvements that had accumulated on `feature/tts-beginning-continues-reading`. Highlights:

- **Speech-to-Text service definitions editor** — the Speech settings page now has an inline expander-per-service editor (Name, Provider, API key, Base domain, Model id, Prompt, Timeout) with Add/Delete, replacing the old "edit in Mutation.json" caption. Service definition edits apply after restart (live services cache their client at construction); the per-service prompt applies immediately. The duplicate "Active service" selector was removed from the Settings dialog — the active service is chosen only on the main window — while the editor still repoints/clears `ActiveSpeechToTextService` when the active service is renamed or deleted so the stored reference never dangles.
- **Transcript Formatting settings editor** — find-and-replace rules editable from the Settings dialog.
- **OCR throughput knobs** — parallel-processing controls wired up, plus a `MaxDocumentBytes` upload cap (default 10 MB).
- **TTS resume rewind** — playback rewinds a few words when resuming, and continues reading after the beginning-of-text announcement.
- Removed the obsolete `ProcessWithLlmHotKey` setting.

## Accessibility

All new controls carry `AutomationProperties.Name`/`HelpText` and `InfoHint` help, consistent with the existing settings pages (screen-reader navigability is a core requirement).

## Testing

- `dotnet build Mutation.Ui` — clean (0 warnings, 0 errors)
- `dotnet test Mutation.Tests` — 355 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)