### PR TITLE
Graceful warnings for missing API keys (Deepgram/STT + Azure OCR)

### DIFF
--- a/Mutation.Ui/App.xaml.cs
+++ b/Mutation.Ui/App.xaml.cs
@@ -366,9 +366,23 @@ public partial class App : Application
 			// dialog so the user can add their API keys. Runs last so the window is
 			// fully live first — hotkeys are registered and the Closed/shutdown
 			// handler is wired before the user is parked in modal dialogs.
-			if (_window is MainWindow onboardingWindow && NeedsFirstRunSetup(settings))
+			if (_window is MainWindow onboardingWindow)
 			{
-				await onboardingWindow.ShowFirstRunOnboardingAsync();
+				if (NeedsFirstRunSetup(settings))
+				{
+					// No LLM provider key at all: full first-run onboarding already opens
+					// Settings (on the API keys tab path), so don't also raise the per-service
+					// speech warning here — it would double up the dialogs.
+					await onboardingWindow.ShowFirstRunOnboardingAsync();
+				}
+				else
+				{
+					// LLM is configured, but a speech-to-text service (e.g. Deepgram) may still
+					// be missing its key. Warn and open the API keys tab instead of crashing.
+					var missingSpeechKeys = GetSpeechServicesMissingApiKey(settings);
+					if (missingSpeechKeys.Count > 0)
+						await onboardingWindow.ShowMissingSpeechServiceKeysWarningAsync(missingSpeechKeys);
+				}
 			}
 		}
 		catch (Exception ex)
@@ -466,19 +480,66 @@ public partial class App : Application
 				switch (serviceSettings.Provider)
 				{
 					case SpeechToTextProviders.OpenAi:
-						services.Add(CreateWhisperSpeechToTextService(
-							builder, serviceSettings, ResolveServiceApiKey(settings.ApiKeys?.OpenAiApiKey, serviceSettings.ApiKey), sp));
+					{
+						// A missing key would make the OpenAI client constructor throw and crash
+						// startup. Skip the service instead; the user is warned and steered to the
+						// API keys tab (see GetSpeechServicesMissingApiKey / OnLaunched).
+						string apiKey = ResolveServiceApiKey(settings.ApiKeys?.OpenAiApiKey, serviceSettings.ApiKey);
+						if (string.IsNullOrEmpty(apiKey))
+							break;
+						services.Add(CreateWhisperSpeechToTextService(builder, serviceSettings, apiKey, sp));
 						break;
+					}
 					case SpeechToTextProviders.Deepgram:
-						services.Add(CreateDeepgramSpeechToTextService(
-							builder, serviceSettings, ResolveServiceApiKey(settings.ApiKeys?.DeepgramApiKey, serviceSettings.ApiKey)));
+					{
+						// Same rationale as OpenAI above: ClientFactory.CreateListenRESTClient throws
+						// on an empty key, which previously surfaced as a fatal startup error dialog.
+						string apiKey = ResolveServiceApiKey(settings.ApiKeys?.DeepgramApiKey, serviceSettings.ApiKey);
+						if (string.IsNullOrEmpty(apiKey))
+							break;
+						services.Add(CreateDeepgramSpeechToTextService(builder, serviceSettings, apiKey));
 						break;
+					}
 					default:
 						throw new NotSupportedException($"The SpeechToText service '{serviceSettings.Provider}' is not supported.");
 				}
 			}
 			return services.ToArray();
 		});
+	}
+
+	// Names of configured speech-to-text services that have no resolvable API key.
+	// These are skipped during service creation (so startup no longer crashes), and
+	// the names are surfaced in the missing-key warning that opens the API keys tab.
+	private static List<string> GetSpeechServicesMissingApiKey(Settings settings)
+	{
+		var missing = new List<string>();
+		var sttSettings = settings.SpeechToTextSettings?.Services ?? Array.Empty<SpeechToTextServiceSettings>();
+		foreach (var serviceSettings in sttSettings)
+		{
+			string? rootKey = serviceSettings.Provider switch
+			{
+				SpeechToTextProviders.OpenAi => settings.ApiKeys?.OpenAiApiKey,
+				SpeechToTextProviders.Deepgram => settings.ApiKeys?.DeepgramApiKey,
+				_ => null,
+			};
+
+			// Only providers that require a key participate; unknown/None providers are ignored.
+			if (serviceSettings.Provider != SpeechToTextProviders.OpenAi
+				&& serviceSettings.Provider != SpeechToTextProviders.Deepgram)
+				continue;
+
+			string apiKey = ResolveServiceApiKey(rootKey, serviceSettings.ApiKey);
+			if (string.IsNullOrEmpty(apiKey))
+			{
+				string name = string.IsNullOrWhiteSpace(serviceSettings.Name)
+					? serviceSettings.Provider.ToString()
+					: serviceSettings.Name!;
+				missing.Add(name);
+			}
+		}
+
+		return missing;
 	}
 
 	// Resolve the API key for a speech service: the per-service key is an optional

--- a/Mutation.Ui/MainWindow.Onboarding.cs
+++ b/Mutation.Ui/MainWindow.Onboarding.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Automation;
@@ -62,8 +64,9 @@ public sealed partial class MainWindow
 	}
 
 	// Opens the Settings dialog. Reused by the Settings menu item, the Ctrl+,
-	// shortcut, and first-run onboarding in App.OnLaunched.
-	internal async Task ShowSettingsDialogAsync()
+	// shortcut, and first-run onboarding in App.OnLaunched. An optional category key
+	// (e.g. "apikeys") opens the dialog directly on that tab.
+	internal async Task ShowSettingsDialogAsync(string? initialCategoryKey = null)
 	{
 		if (Content is not FrameworkElement rootElement)
 		{
@@ -74,13 +77,59 @@ public sealed partial class MainWindow
 			_settings,
 			_settingsManager,
 			_settingsManager.SettingsFilePath,
-			ApplyLiveSettings)
+			ApplyLiveSettings,
+			initialCategoryKey)
 		{
 			XamlRoot = rootElement.XamlRoot,
 			RequestedTheme = rootElement.ActualTheme
 		};
 
 		await ShowDialogAsync(settingsDialog);
+	}
+
+	// Shown at startup when one or more configured speech-to-text services have no
+	// API key. Mirrors the OpenAI/Anthropic onboarding flow: a friendly,
+	// screen-reader-accessible warning, then the Settings dialog opened on the API
+	// keys tab so the user can add the missing key — instead of the old behaviour of
+	// crashing with a "see the log" error dialog that closed the app on OK.
+	internal async Task ShowMissingSpeechServiceKeysWarningAsync(IReadOnlyList<string> serviceNames)
+	{
+		const string title = "Speech-to-Text API Key Missing";
+		string list = string.Join("\n", serviceNames.Select(n => $"• {n}"));
+		string message =
+			"One or more speech-to-text services are missing their API key and were disabled:\n\n" +
+			list +
+			"\n\nThe Settings window will now open on the API keys tab so you can add the missing key. " +
+			"Restart Mutation after saving for the service to become available.";
+
+		if (Content is FrameworkElement rootElement && rootElement.XamlRoot is not null)
+		{
+			var dialog = new ContentDialog
+			{
+				Title = title,
+				Content = new TextBlock { Text = message, TextWrapping = Microsoft.UI.Xaml.TextWrapping.Wrap },
+				CloseButtonText = "Continue",
+				XamlRoot = rootElement.XamlRoot,
+				RequestedTheme = rootElement.ActualTheme
+			};
+			AutomationProperties.SetName(dialog, title);
+			AutomationProperties.SetHelpText(dialog, message);
+
+			await ShowDialogAsync(dialog);
+		}
+		else
+		{
+			System.Windows.Forms.MessageBox.Show(
+				message,
+				title,
+				System.Windows.Forms.MessageBoxButtons.OK,
+				System.Windows.Forms.MessageBoxIcon.Warning);
+		}
+
+		// Yield a dispatcher turn so the warning dialog fully closes before the
+		// Settings dialog opens (WinUI allows only one ContentDialog at a time).
+		await YieldToDispatcherAsync();
+		await ShowSettingsDialogAsync("apikeys");
 	}
 
 	// Completes on a fresh dispatcher turn, breaking out of the current

--- a/Mutation.Ui/MainWindow.xaml.cs
+++ b/Mutation.Ui/MainWindow.xaml.cs
@@ -271,6 +271,7 @@ public sealed partial class MainWindow : Window, IDisposable
 			{
 				try
 				{
+					if (!await EnsureOcrConfiguredAsync()) return;
 					var result = await _ocrManager.TakeScreenshotAndExtractTextAsync(OcrReadingOrder.TopToBottomColumnAware);
 					SetOcrText(result.Message);
 					HotkeyManager.SendHotkeyAfterDelay(_settings.AzureComputerVisionSettings?.SendHotkeyAfterOcrOperation, result.Success ? Constants.SendHotkeyDelay : Constants.FailureSendHotkeyDelay);
@@ -283,6 +284,7 @@ public sealed partial class MainWindow : Window, IDisposable
 			{
 				try
 				{
+					if (!await EnsureOcrConfiguredAsync()) return;
 					var result = await _ocrManager.TakeScreenshotAndExtractTextAsync(OcrReadingOrder.LeftToRightTopToBottom);
 					SetOcrText(result.Message);
 					HotkeyManager.SendHotkeyAfterDelay(_settings.AzureComputerVisionSettings?.SendHotkeyAfterOcrOperation, result.Success ? Constants.SendHotkeyDelay : Constants.FailureSendHotkeyDelay);
@@ -295,6 +297,7 @@ public sealed partial class MainWindow : Window, IDisposable
 			{
 				try
 				{
+					if (!await EnsureOcrConfiguredAsync()) return;
 					var result = await _ocrManager.ExtractTextFromClipboardImageAsync(OcrReadingOrder.TopToBottomColumnAware);
 					SetOcrText(result.Message);
 					HotkeyManager.SendHotkeyAfterDelay(_settings.AzureComputerVisionSettings?.SendHotkeyAfterOcrOperation, result.Success ? Constants.SendHotkeyDelay : Constants.FailureSendHotkeyDelay);
@@ -307,6 +310,7 @@ public sealed partial class MainWindow : Window, IDisposable
 			{
 				try
 				{
+					if (!await EnsureOcrConfiguredAsync()) return;
 					var result = await _ocrManager.ExtractTextFromClipboardImageAsync(OcrReadingOrder.LeftToRightTopToBottom);
 					SetOcrText(result.Message);
 					HotkeyManager.SendHotkeyAfterDelay(_settings.AzureComputerVisionSettings?.SendHotkeyAfterOcrOperation, result.Success ? Constants.SendHotkeyDelay : Constants.FailureSendHotkeyDelay);
@@ -483,6 +487,7 @@ public sealed partial class MainWindow : Window, IDisposable
 	{
 		try
 		{
+			if (!await EnsureOcrConfiguredAsync()) return;
 			var result = await _ocrManager.TakeScreenshotAndExtractTextAsync(OcrReadingOrder.TopToBottomColumnAware);
 			SetOcrText(result.Message);
 			HotkeyManager.SendHotkeyAfterDelay(_settings.AzureComputerVisionSettings?.SendHotkeyAfterOcrOperation, result.Success ? Constants.SendHotkeyDelay : Constants.FailureSendHotkeyDelay);
@@ -502,6 +507,7 @@ public sealed partial class MainWindow : Window, IDisposable
 	{
 		try
 		{
+			if (!await EnsureOcrConfiguredAsync()) return;
 			var result = await _ocrManager.TakeScreenshotAndExtractTextAsync(OcrReadingOrder.LeftToRightTopToBottom);
 			SetOcrText(result.Message);
 			HotkeyManager.SendHotkeyAfterDelay(_settings.AzureComputerVisionSettings?.SendHotkeyAfterOcrOperation, result.Success ? Constants.SendHotkeyDelay : Constants.FailureSendHotkeyDelay);
@@ -521,6 +527,7 @@ public sealed partial class MainWindow : Window, IDisposable
 	{
 		try
 		{
+			if (!await EnsureOcrConfiguredAsync()) return;
 			var result = await _ocrManager.ExtractTextFromClipboardImageAsync(OcrReadingOrder.TopToBottomColumnAware);
 			SetOcrText(result.Message);
 			HotkeyManager.SendHotkeyAfterDelay(_settings.AzureComputerVisionSettings?.SendHotkeyAfterOcrOperation ?? string.Empty, result.Success ? Constants.SendHotkeyDelay : Constants.FailureSendHotkeyDelay);
@@ -540,6 +547,7 @@ public sealed partial class MainWindow : Window, IDisposable
 	{
 		try
 		{
+			if (!await EnsureOcrConfiguredAsync()) return;
 			var picker = new FileOpenPicker
 			{
 				SuggestedStartLocation = PickerLocationId.DocumentsLibrary,
@@ -732,6 +740,7 @@ public sealed partial class MainWindow : Window, IDisposable
 	{
 		try
 		{
+			if (!await EnsureOcrConfiguredAsync()) return;
 			var result = await _ocrManager.ExtractTextFromClipboardImageAsync(OcrReadingOrder.LeftToRightTopToBottom);
 			SetOcrText(result.Message);
 			HotkeyManager.SendHotkeyAfterDelay(_settings.AzureComputerVisionSettings?.SendHotkeyAfterOcrOperation ?? string.Empty, result.Success ? Constants.SendHotkeyDelay : Constants.FailureSendHotkeyDelay);
@@ -1596,6 +1605,57 @@ public sealed partial class MainWindow : Window, IDisposable
 		{
 			BtnDownloadOcrResults.IsEnabled = !string.IsNullOrWhiteSpace(safeMessage);
 		}
+	}
+
+	// Guards an OCR action: returns true when Azure OCR is configured, otherwise warns
+	// the user and opens Settings on the OCR tab, returning false so the caller skips
+	// the attempt. Mirrors the speech-to-text missing-key flow, but routes to the OCR
+	// tab because the Azure key and endpoint live there, not on the API keys tab.
+	private async Task<bool> EnsureOcrConfiguredAsync()
+	{
+		if (_ocrManager.IsOcrConfigured(out string message))
+			return true;
+
+		await ShowOcrNotConfiguredWarningAsync(message);
+		return false;
+	}
+
+	private async Task ShowOcrNotConfiguredWarningAsync(string detail)
+	{
+		const string title = "OCR Not Configured";
+		string message =
+			(string.IsNullOrWhiteSpace(detail) ? "Azure Computer Vision is not configured." : detail) +
+			"\n\nThe Settings window will now open on the Screen capture & OCR tab so you can add the " +
+			"Azure Computer Vision API key and endpoint.";
+
+		if (Content is FrameworkElement rootElement && rootElement.XamlRoot is not null)
+		{
+			var dialog = new ContentDialog
+			{
+				Title = title,
+				Content = new TextBlock { Text = message, TextWrapping = TextWrapping.Wrap },
+				CloseButtonText = "Continue",
+				XamlRoot = rootElement.XamlRoot,
+				RequestedTheme = rootElement.ActualTheme
+			};
+			AutomationProperties.SetName(dialog, title);
+			AutomationProperties.SetHelpText(dialog, message);
+
+			await ShowDialogAsync(dialog);
+		}
+		else
+		{
+			System.Windows.Forms.MessageBox.Show(
+				message,
+				title,
+				System.Windows.Forms.MessageBoxButtons.OK,
+				System.Windows.Forms.MessageBoxIcon.Warning);
+		}
+
+		// Yield a dispatcher turn so the warning dialog finishes closing before the
+		// Settings dialog opens (WinUI allows only one ContentDialog at a time).
+		await YieldToDispatcherAsync();
+		await ShowSettingsDialogAsync("ocr");
 	}
 
 	private void RootContent_KeyDown(object sender, KeyRoutedEventArgs e)

--- a/Mutation.Ui/Services/OcrManager.cs
+++ b/Mutation.Ui/Services/OcrManager.cs
@@ -430,7 +430,10 @@ public class OcrManager
 
     private static string FormatMegabytes(long bytes) => $"{bytes / (1024.0 * 1024.0):0.#} MB";
 
-    private bool IsOcrConfigured(out string message)
+    // True when Azure Computer Vision has a real key and endpoint (neither is the
+    // placeholder default). Exposed so the UI can warn and steer the user to the OCR
+    // settings tab before attempting an operation that would otherwise just fail.
+    public bool IsOcrConfigured(out string message)
     {
         var settings = _settings.AzureComputerVisionSettings;
         if (settings is null)

--- a/Mutation.Ui/Views/SettingsDialog.xaml.cs
+++ b/Mutation.Ui/Views/SettingsDialog.xaml.cs
@@ -38,7 +38,8 @@ public sealed partial class SettingsDialog : ContentDialog
 		Settings settings,
 		ISettingsManager? settingsManager,
 		string? settingsFilePath,
-		Action? onLiveApply)
+		Action? onLiveApply,
+		string? initialCategoryKey = null)
 	{
 		_live = settings ?? throw new ArgumentNullException(nameof(settings));
 		_workingCopy = SettingsWorkingCopy.Clone(_live);
@@ -52,7 +53,7 @@ public sealed partial class SettingsDialog : ContentDialog
 
 		if (FilteredCategories.Count > 0)
 		{
-			CategoryList.SelectedIndex = 0;
+			CategoryList.SelectedIndex = IndexOfCategory(initialCategoryKey);
 		}
 		else
 		{
@@ -102,6 +103,24 @@ public sealed partial class SettingsDialog : ContentDialog
 			new[] { "hotkey", "shortcut", "keys", "binding", "router" }));
 
 		ApplySearchFilter(string.Empty);
+	}
+
+	// Resolve the list index of the category to open initially. Falls back to the
+	// first category (index 0) when no key is supplied or it does not match, so the
+	// dialog always opens on a real page. Used to deep-link callers (e.g. the
+	// missing speech-to-text key warning) straight to the API keys tab.
+	private int IndexOfCategory(string? categoryKey)
+	{
+		if (!string.IsNullOrWhiteSpace(categoryKey))
+		{
+			for (int i = 0; i < FilteredCategories.Count; i++)
+			{
+				if (string.Equals(FilteredCategories[i].Key, categoryKey, StringComparison.OrdinalIgnoreCase))
+					return i;
+			}
+		}
+
+		return 0;
 	}
 
 	private void ApplySearchFilter(string query)


### PR DESCRIPTION
## Problem

When the **Deepgram** API key was unset, the app crashed at startup: creating the Deepgram client (`ClientFactory.CreateListenRESTClient("")`) threw while the DI container built `MainWindow`, surfacing as a generic **"Startup Error"** dialog that pointed at the log file — and clicking OK **closed the app**. OpenAI speech-to-text had the same latent crash (`ApiKeyCredential` rejects an empty key).

The goal: behave like the OpenAI/Anthropic onboarding flow — show a *warning* and open Settings on the right tab — instead of crashing.

## Changes

### Speech-to-Text (Deepgram + OpenAI Whisper)
- Skip creating any STT service whose key resolves to empty/placeholder (matching how the LLM services are left null), so startup no longer crashes.
- Detect the missing key(s) and, after the window is live, show an accessible warning and open Settings on the **API keys** tab.
- Skipped when full first-run onboarding already runs (no LLM key at all), to avoid double dialogs.

### Azure OCR
OCR didn't crash (its placeholder defaults parse), but failed silently-ish at use time with just a beep. Now, before any OCR action, it checks `IsOcrConfigured` (key **and** endpoint) and — when unconfigured — warns and opens Settings on the **Screen capture & OCR** tab. It routes there rather than the API keys tab because Azure needs both the key and a region-specific endpoint, and those live on the OCR tab, not in the central keys section.

### Supporting
- `SettingsDialog` gained an optional `initialCategoryKey` so callers can deep-link a specific tab.
- `MainWindow.ShowSettingsDialogAsync` takes an optional tab key.

All new dialogs set `AutomationProperties` name/help text for screen-reader accessibility.

## Testing
- `dotnet build Mutation.Ui` — clean (0 warnings, 0 errors).
- Not yet exercised interactively in the running WinUI app; logic mirrors the existing, working onboarding path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)