### PR TITLE
Add "Speak to file" action to export TTS audio as WAV

### DIFF
--- a/CognitiveSupport/IWavFileSpeechExporter.cs
+++ b/CognitiveSupport/IWavFileSpeechExporter.cs
@@ -1,0 +1,13 @@
+namespace CognitiveSupport;
+
+// Exports synthesized speech to a WAV file using a dedicated, throwaway
+// synthesizer. Kept separate from ITextToSpeechService so a file export can
+// never touch the live reader's playback, position, or navigation state.
+public interface IWavFileSpeechExporter
+{
+	// Synthesize <paramref name="text"/> to a .wav file at <paramref name="filePath"/>
+	// using the given voice/rate/volume and optional speech preprocessing. Runs
+	// synchronously (the caller should invoke it off the UI thread); throws on empty
+	// input or synthesis/IO failure so the caller can surface an accessible error.
+	void ExportToWavFile(string text, string filePath, int rate, int volume, string? voiceName, bool preprocess);
+}

--- a/CognitiveSupport/Settings.cs
+++ b/CognitiveSupport/Settings.cs
@@ -253,6 +253,7 @@ public class TextToSpeechSettings
 	public string? RestartFromBeginningHotKey { get; set; }
 	public string? SkipSentenceBackwardHotKey { get; set; }
 	public string? SkipSentenceForwardHotKey { get; set; }
+	public string? SpeakToFileHotKey { get; set; }
 	public int Rate { get; set; } = 8;
 	public int Volume { get; set; } = 100;
 	public bool EnableSpeechPreprocessing { get; set; } = true;

--- a/CognitiveSupport/TtsFileExport.cs
+++ b/CognitiveSupport/TtsFileExport.cs
@@ -1,0 +1,45 @@
+namespace CognitiveSupport;
+
+// Pure, voice-free helpers for the "Speak to file" (WAV export) action. Kept
+// separate from the synthesizer so the naming, extension, and input-resolution
+// rules can be unit-tested without a system voice.
+public static class TtsFileExport
+{
+	private const string WavExtension = ".wav";
+
+	// Suggested file name (no extension — the file picker appends .wav from its
+	// FileTypeChoices, mirroring the OCR-results export). Example: tts-20260623-153012.
+	public static string BuildSuggestedFileName(DateTime now) =>
+		$"tts-{now:yyyyMMdd-HHmmss}";
+
+	// Guarantee the destination path ends with .wav (case-insensitive). The picker
+	// already enforces the extension, but the exporter validates defensively so a
+	// hotkey-driven or programmatic path can never write a mis-named file.
+	public static string EnsureWavExtension(string path)
+	{
+		if (string.IsNullOrWhiteSpace(path))
+			throw new ArgumentException("Path must not be empty.", nameof(path));
+
+		return path.EndsWith(WavExtension, StringComparison.OrdinalIgnoreCase)
+			? path
+			: path + WavExtension;
+	}
+
+	// Resolve the raw input (clipboard/selection text) into the text to synthesize.
+	// Trims surrounding whitespace; empty or whitespace-only input is rejected with a
+	// clear message and writes no file.
+	public static bool TryResolveExportText(string? rawText, out string resolved, out string error)
+	{
+		string trimmed = (rawText ?? string.Empty).Trim();
+		if (trimmed.Length == 0)
+		{
+			resolved = string.Empty;
+			error = "Nothing to speak — the clipboard has no text to save.";
+			return false;
+		}
+
+		resolved = trimmed;
+		error = string.Empty;
+		return true;
+	}
+}

--- a/CognitiveSupport/WavFileSpeechExporter.cs
+++ b/CognitiveSupport/WavFileSpeechExporter.cs
@@ -1,0 +1,40 @@
+using System.Speech.Synthesis;
+
+namespace CognitiveSupport;
+
+// Synthesizes text to a WAV file with a dedicated, single-use SpeechSynthesizer.
+// It deliberately shares no state with TextToSpeechService: a file export runs on
+// its own synthesizer that writes to the file sink instead of the audio device, so
+// exporting never disturbs an in-progress live read.
+public class WavFileSpeechExporter : IWavFileSpeechExporter
+{
+	public void ExportToWavFile(string text, string filePath, int rate, int volume, string? voiceName, bool preprocess)
+	{
+		if (!TtsFileExport.TryResolveExportText(text, out string resolved, out string error))
+			throw new ArgumentException(error, nameof(text));
+
+		string wavPath = TtsFileExport.EnsureWavExtension(filePath);
+		string spoken = preprocess ? TextToSpeechService.PreprocessForSpeech(resolved) : resolved;
+		if (string.IsNullOrWhiteSpace(spoken))
+			throw new ArgumentException("Nothing to speak after preprocessing.", nameof(text));
+
+		using var synth = new SpeechSynthesizer();
+		ApplyVoiceParams(synth, rate, volume, voiceName);
+		synth.SetOutputToWaveFile(wavPath);
+		synth.Speak(spoken);
+		// Detach the file sink before disposal so the WAV is finalized and released.
+		synth.SetOutputToNull();
+	}
+
+	private static void ApplyVoiceParams(SpeechSynthesizer synth, int rate, int volume, string? voiceName)
+	{
+		synth.Rate = Math.Clamp(rate, -10, 10);
+		synth.Volume = Math.Clamp(volume, 0, 100);
+
+		if (!string.IsNullOrWhiteSpace(voiceName))
+		{
+			try { synth.SelectVoice(voiceName); }
+			catch { /* fall back to the default voice */ }
+		}
+	}
+}

--- a/Mutation.Tests/TtsFileExportTests.cs
+++ b/Mutation.Tests/TtsFileExportTests.cs
@@ -1,0 +1,74 @@
+using CognitiveSupport;
+using Xunit;
+
+namespace Mutation.Tests;
+
+// Verifies the pure, voice-free logic behind the "Speak to file" (WAV export)
+// action: suggested-filename generation, extension handling, and input
+// resolution. The actual System.Speech WAV write depends on a system voice and
+// is verified manually/integration.
+public class TtsFileExportTests
+{
+	[Fact]
+	public void BuildSuggestedFileName_UsesTimestampWithoutExtension()
+	{
+		var when = new DateTime(2026, 6, 23, 15, 30, 12);
+		Assert.Equal("tts-20260623-153012", TtsFileExport.BuildSuggestedFileName(when));
+	}
+
+	[Fact]
+	public void EnsureWavExtension_AppendsWhenMissing()
+	{
+		Assert.Equal(@"C:\audio\reading.wav", TtsFileExport.EnsureWavExtension(@"C:\audio\reading"));
+	}
+
+	[Fact]
+	public void EnsureWavExtension_KeepsExistingExtension()
+	{
+		Assert.Equal(@"C:\audio\reading.wav", TtsFileExport.EnsureWavExtension(@"C:\audio\reading.wav"));
+	}
+
+	[Fact]
+	public void EnsureWavExtension_IsCaseInsensitive()
+	{
+		Assert.Equal(@"C:\audio\reading.WAV", TtsFileExport.EnsureWavExtension(@"C:\audio\reading.WAV"));
+	}
+
+	[Theory]
+	[InlineData(null)]
+	[InlineData("")]
+	[InlineData("   ")]
+	[InlineData("\t\r\n ")]
+	public void TryResolveExportText_RejectsEmptyOrWhitespace(string? raw)
+	{
+		bool ok = TtsFileExport.TryResolveExportText(raw, out string resolved, out string error);
+
+		Assert.False(ok);
+		Assert.Equal(string.Empty, resolved);
+		Assert.False(string.IsNullOrWhiteSpace(error));
+	}
+
+	[Fact]
+	public void TryResolveExportText_TrimsAndAcceptsRealText()
+	{
+		bool ok = TtsFileExport.TryResolveExportText("  hello world  ", out string resolved, out string error);
+
+		Assert.True(ok);
+		Assert.Equal("hello world", resolved);
+		Assert.Equal(string.Empty, error);
+	}
+
+	// The exporter must reject empty input before opening a synthesizer or writing a
+	// file — this guard is voice-free and so unit-testable.
+	[Fact]
+	public void Exporter_RejectsEmptyInput_WithoutWritingFile()
+	{
+		var exporter = new WavFileSpeechExporter();
+		string path = Path.Combine(Path.GetTempPath(), $"tts-export-test-{Guid.NewGuid():N}.wav");
+
+		Assert.Throws<ArgumentException>(() =>
+			exporter.ExportToWavFile("   ", path, rate: 0, volume: 100, voiceName: null, preprocess: true));
+
+		Assert.False(File.Exists(path));
+	}
+}

--- a/Mutation.Ui/App.xaml.cs
+++ b/Mutation.Ui/App.xaml.cs
@@ -239,6 +239,7 @@ public partial class App : Application
 			builder.Services.AddSingleton<SpeechToTextManager>();
 			builder.Services.AddSingleton<Mutation.Ui.Core.AudioSessionManager>();
                         builder.Services.AddSingleton<ITextToSpeechService, TextToSpeechService>();
+                        builder.Services.AddSingleton<IWavFileSpeechExporter, WavFileSpeechExporter>();
 			builder.Services.AddHttpClient(OpenAiHttpClientName);
 			builder.Services.AddHttpClient(AnthropicHttpClientName);
 			AddSpeechToTextServices(builder, settings);

--- a/Mutation.Ui/MainWindow.xaml
+++ b/Mutation.Ui/MainWindow.xaml
@@ -849,6 +849,18 @@
                                             ToolTipService.ToolTip="Jump to the next sentence">
                                             <FontIcon Glyph="&#xE893;" FontFamily="Segoe Fluent Icons" />
                                         </Button>
+
+                                        <Button
+                                            x:Name="BtnSpeakToFile"
+                                            Style="{StaticResource OutlinedButtonStyle}"
+                                            Click="BtnSpeakToFile_Click"
+                                            AutomationProperties.Name="Speak to file"
+                                            ToolTipService.ToolTip="Save the clipboard text as a spoken WAV audio file">
+                                            <StackPanel Orientation="Horizontal" Spacing="8" HorizontalAlignment="Center">
+                                                <FontIcon Glyph="&#xE105;" FontFamily="Segoe Fluent Icons" />
+                                                <TextBlock Text="Speak to file" />
+                                            </StackPanel>
+                                        </Button>
                                     </StackPanel>
                                 </StackPanel>
                             </StackPanel>

--- a/Mutation.Ui/MainWindow.xaml.cs
+++ b/Mutation.Ui/MainWindow.xaml.cs
@@ -40,6 +40,7 @@ public sealed partial class MainWindow : Window, IDisposable
 	private readonly Mutation.Ui.Core.AudioSessionManager _audioSessionManager;
 	private readonly TranscriptFormatter _transcriptFormatter;
 	private readonly ITextToSpeechService _textToSpeech;
+	private readonly IWavFileSpeechExporter _wavFileSpeechExporter;
 	private readonly Settings _settings;
 	private HotkeyManager? _hotkeyManager;
 	private MicrophoneVisualizationController? _microphoneVisualization;
@@ -98,6 +99,7 @@ public sealed partial class MainWindow : Window, IDisposable
 		OcrManager ocrManager,
 		ISpeechToTextService[] speechServices,
 		ITextToSpeechService textToSpeech,
+		IWavFileSpeechExporter wavFileSpeechExporter,
 		TranscriptFormatter transcriptFormatter,
 
 		ISettingsManager settingsManager,
@@ -111,6 +113,7 @@ public sealed partial class MainWindow : Window, IDisposable
 		_ocrManager = ocrManager;
 		_speechServices = speechServices;
 		_textToSpeech = textToSpeech;
+		_wavFileSpeechExporter = wavFileSpeechExporter;
 		_transcriptFormatter = transcriptFormatter;
 		_settings = settings;
 
@@ -349,6 +352,10 @@ public sealed partial class MainWindow : Window, IDisposable
 		if (!string.IsNullOrWhiteSpace(tts?.SkipSentenceForwardHotKey))
 			TryRegister(hk, tts.SkipSentenceForwardHotKey!, () =>
 				DispatcherQueue.TryEnqueue(() => BtnSkipSentenceForward_Click(null!, null!)));
+
+		if (!string.IsNullOrWhiteSpace(tts?.SpeakToFileHotKey))
+			TryRegister(hk, tts.SpeakToFileHotKey!, () =>
+				DispatcherQueue.TryEnqueue(() => BtnSpeakToFile_Click(null!, null!)));
 	}
 
 	private static void TryRegister(HotkeyManager hk, string hotkey, Action callback)
@@ -424,6 +431,7 @@ public sealed partial class MainWindow : Window, IDisposable
 		ConfigureButtonHotkey(BtnSkipSentenceBack, null, _settings.TextToSpeechSettings?.SkipSentenceBackwardHotKey, "Jump to the previous sentence");
 		ConfigureButtonHotkey(BtnSkipSentenceForward, null, _settings.TextToSpeechSettings?.SkipSentenceForwardHotKey, "Jump to the next sentence");
 		ConfigureButtonHotkey(BtnSpeakSelection, null, _settings.TextToSpeechSettings?.SpeakSelectionHotKey, "Copy the current selection from the active app and read it aloud");
+		ConfigureButtonHotkey(BtnSpeakToFile, null, _settings.TextToSpeechSettings?.SpeakToFileHotKey, "Save the clipboard text as a spoken WAV audio file");
 		ConfigureButtonHotkey(BtnProcessLlm, null, null, "Send transcript through the configured language model");
 	}
 
@@ -856,6 +864,69 @@ public sealed partial class MainWindow : Window, IDisposable
 	{
 		var tts = _settings.TextToSpeechSettings ?? new TextToSpeechSettings();
 		_textToSpeech.SkipSentence(1, tts.Rate, tts.Volume, tts.VoiceName, tts.SkipSentenceGraceWindowMs);
+	}
+
+	public async void BtnSpeakToFile_Click(object? sender, RoutedEventArgs? e)
+	{
+		var tts = _settings.TextToSpeechSettings ?? new TextToSpeechSettings();
+
+		var (kind, clipboardText) = await _clipboard.InspectAsync();
+		if (kind != ClipboardKind.Text)
+		{
+			AnnounceUnreadableClipboard(kind, tts);
+			return;
+		}
+
+		if (!TtsFileExport.TryResolveExportText(clipboardText, out string text, out string resolveError))
+		{
+			_textToSpeech.SpeakAnnouncement(resolveError, tts.Rate, tts.Volume, tts.VoiceName);
+			BeepPlayer.Play(BeepType.Failure);
+			ShowStatus("Speak to file", resolveError, InfoBarSeverity.Warning);
+			return;
+		}
+
+		StorageFile? file;
+		try
+		{
+			var picker = new FileSavePicker
+			{
+				SuggestedStartLocation = PickerLocationId.MusicLibrary,
+				SuggestedFileName = TtsFileExport.BuildSuggestedFileName(DateTime.Now)
+			};
+			picker.FileTypeChoices.Add("Audio (WAV)", new List<string> { ".wav" });
+
+			InitializeWithWindow.Initialize(picker, WindowNative.GetWindowHandle(this));
+			file = await picker.PickSaveFileAsync();
+		}
+		catch (Exception ex)
+		{
+			ShowStatus("Speak to file", ex.Message, InfoBarSeverity.Error);
+			await ShowErrorDialog("Speak to File Error", ex);
+			return;
+		}
+
+		if (file is null)
+			return; // user cancelled the picker
+
+		BtnSpeakToFile.IsEnabled = false;
+		ShowStatus("Speak to file", $"Saving audio to {file.Name}…", InfoBarSeverity.Informational);
+		try
+		{
+			// Synthesize off the UI thread so a long article does not freeze the window.
+			// A dedicated exporter writes to the file, leaving any live read untouched.
+			await Task.Run(() => _wavFileSpeechExporter.ExportToWavFile(
+				text, file.Path, tts.Rate, tts.Volume, tts.VoiceName, tts.EnableSpeechPreprocessing));
+			ShowStatus("Speak to file", $"Saved audio to {file.Name}.", InfoBarSeverity.Success);
+		}
+		catch (Exception ex)
+		{
+			ShowStatus("Speak to file", ex.Message, InfoBarSeverity.Error);
+			await ShowErrorDialog("Speak to File Error", ex);
+		}
+		finally
+		{
+			BtnSpeakToFile.IsEnabled = true;
+		}
 	}
 
 	public async void SpeakActiveSelectionAsync()


### PR DESCRIPTION
## Summary

Adds an accessible **"Speak to file"** action that synthesizes the current
clipboard text to a user-chosen `.wav` file, using the same voice, rate,
volume, and speech preprocessing as the live text-to-speech reader. This lets
a user capture an article as an audio file to replay later on a phone or during
a walk.

The export runs on a dedicated, single-use `SpeechSynthesizer` in a separate
`WavFileSpeechExporter` class that shares no state with the live reader. Because
it is a distinct object writing to a file sink instead of the audio device,
exporting can never disturb an in-progress live read's playback, position, or
sentence navigation. Synthesis runs off the UI thread so a long article does
not freeze the window.

## What changed

- **`TtsFileExport`** (new) — pure, voice-free helpers: suggested filename
  (`tts-yyyyMMdd-HHmmss`), `.wav` extension normalization, and empty-input
  resolution. Fully unit-tested.
- **`IWavFileSpeechExporter` / `WavFileSpeechExporter`** (new) — export to WAV
  via a throwaway synthesizer (`SetOutputToWaveFile`), applying the same
  voice/rate/volume and optional preprocessing as the live reader.
- **`MainWindow`** — a labelled "Speak to file" button in the Voice & Speech
  card (with `AutomationProperties.Name` and tooltip), a `FileSavePicker`
  ("Audio (WAV)" → `.wav`, suggested name, Music library default), accessible
  status InfoBar (in-progress / success / failure), button disabled during
  export, and an optional configurable hotkey.
- **`Settings`** — `SpeakToFileHotKey` (user-configured, suggested
  `CTRL+SHIFT+ALT+F`).
- **DI** — registered `IWavFileSpeechExporter`.

## Acceptance criteria

- ✅ "Speak to file" lets the user pick a `.wav` destination and saves the
  spoken audio of the current clipboard text, using the current
  voice/rate/volume/preprocessing.
- ✅ Running it does not disturb an in-progress live read — the export uses a
  separate exporter/synthesizer and never touches the reader's state.
- ✅ Success and failure are surfaced accessibly (InfoBar + spoken announcement
  + failure beep); empty/whitespace input is handled gracefully with no file
  written; picker cancellation is a no-op.
- ✅ New pure logic is unit-tested; `dotnet test --configuration Release` is
  green (366 passing).

## Test plan

- `dotnet test --configuration Release` — all 366 tests pass, including 9 new
  `TtsFileExportTests` covering filename generation, extension handling,
  empty-input rejection, and the exporter's empty-input guard.
- **Manual** (requires a system voice): copy text, click "Speak to file", pick
  a destination, confirm the WAV is written and plays back correctly on another
  device; start a live read, then export, and confirm the live read's position
  and playback are unchanged.

## Notes

- WAV only — `System.Speech` writes WAV natively. MP3/OGG would require an
  encoder and is out of scope here.

Closes #132
