### PR TITLE
Add speak-position hotkey and configurable progress announcements (#131)

### DIFF
--- a/CognitiveSupport/ITextToSpeechService.cs
+++ b/CognitiveSupport/ITextToSpeechService.cs
@@ -8,5 +8,19 @@ public interface ITextToSpeechService : IDisposable
 	void Speak(string text, int rate, int volume, string? voiceName, bool resumeIfSame, bool preprocess, int resumeRewindWordCount = 0);
 	void SkipSentence(int direction, int rate, int volume, string? voiceName, int graceWindowMs);
 	void SpeakAnnouncement(string text, int rate, int volume, string? voiceName);
+
+	// A snapshot of where the current read is, for the speak-position hotkey. Returns
+	// ReadingPosition.NotReading when nothing is being read.
+	ReadingPosition GetReadingPosition();
+
+	// Push the configurable reading-time and periodic-progress announcement settings
+	// into the service. Safe to call at any time; takes effect on the next read.
+	void SetAnnouncementOptions(
+		bool announceReadingTimeAtStart,
+		int readingTimeMinimumMinutes,
+		bool announceProgressEnabled,
+		int announceProgressEveryPercent,
+		int announceProgressMinimumMinutes);
+
 	void Stop();
 }

--- a/CognitiveSupport/ReadingAnnouncements.cs
+++ b/CognitiveSupport/ReadingAnnouncements.cs
@@ -1,0 +1,36 @@
+namespace CognitiveSupport;
+
+// Builds the spoken wording for reading-position and progress announcements. Pure and
+// static so the phrasing (singular/plural minutes, the "not reading" and "less than a
+// minute" edge cases) is unit-testable and lives in one place.
+public static class ReadingAnnouncements
+{
+	public const string NotReading = "Not currently reading.";
+
+	// "Sentence 4 of 22, about 40% through, about 2 minutes left."
+	public static string Position(ReadingPosition position)
+	{
+		if (!position.IsReading)
+			return NotReading;
+
+		return $"Sentence {position.SentenceNumber} of {position.SentenceCount}, " +
+			$"about {position.PercentComplete}% through, {MinutesLeftPhrase(position.MinutesRemaining)}.";
+	}
+
+	// "50%, about 3 minutes left."
+	public static string Progress(int percentComplete, int minutesRemaining)
+		=> $"{percentComplete}%, {MinutesLeftPhrase(minutesRemaining)}.";
+
+	// "Reading approximately 3 minutes of text. " — trailing space because the caller
+	// prepends it to the text being read.
+	public static string StartupReadingTime(int minutes)
+	{
+		if (minutes < 1) minutes = 1;
+		return $"Reading approximately {minutes} {MinuteUnit(minutes)} of text. ";
+	}
+
+	private static string MinutesLeftPhrase(int minutes)
+		=> minutes <= 0 ? "less than a minute left" : $"about {minutes} {MinuteUnit(minutes)} left";
+
+	private static string MinuteUnit(int minutes) => minutes == 1 ? "minute" : "minutes";
+}

--- a/CognitiveSupport/ReadingEstimate.cs
+++ b/CognitiveSupport/ReadingEstimate.cs
@@ -1,0 +1,45 @@
+namespace CognitiveSupport;
+
+// Single source of truth for the characters -> reading-time estimate shared by the
+// startup reading-time announcement, the speak-position hotkey, and the periodic
+// progress announcements. Keeping the constants and arithmetic in one pure, static
+// place stops the three callers from drifting apart.
+public static class ReadingEstimate
+{
+	// Rough average word length (including the trailing space) and an adult reading
+	// pace. These mirror the values the original BuildLengthAnnouncement used so the
+	// startup announcement keeps producing the same minute estimate.
+	public const int CharsPerWord = 5;
+	public const int WordsPerMinute = 180;
+
+	// Estimated reading time, in minutes, as a raw (unrounded) value. Used for the
+	// threshold comparisons ("only announce when the read is longer than N minutes")
+	// where rounding to a whole minute first would distort the cutoff.
+	public static double EstimateMinutes(int charCount)
+	{
+		if (charCount <= 0) return 0d;
+		double words = (double)charCount / CharsPerWord;
+		return words / WordsPerMinute;
+	}
+
+	// Whole-minute estimate for phrases that always name at least one minute, e.g.
+	// the startup "Reading approximately N minutes of text" announcement.
+	public static int SpokenWholeMinutes(int charCount)
+	{
+		int minutes = (int)Math.Round(EstimateMinutes(charCount));
+		return minutes < 1 ? 1 : minutes;
+	}
+
+	// Whole-minute estimate of how much reading remains. Allowed to be 0 so callers
+	// can say "less than a minute left" near the end of a read.
+	public static int RemainingWholeMinutes(int remainingChars)
+	{
+		int minutes = (int)Math.Round(EstimateMinutes(remainingChars));
+		return minutes < 0 ? 0 : minutes;
+	}
+
+	// Shared gate for the "only announce when the read is longer than N minutes"
+	// thresholds used by both the startup and periodic announcements.
+	public static bool ExceedsMinutes(int charCount, int minimumMinutes)
+		=> EstimateMinutes(charCount) > minimumMinutes;
+}

--- a/CognitiveSupport/ReadingPosition.cs
+++ b/CognitiveSupport/ReadingPosition.cs
@@ -1,0 +1,46 @@
+namespace CognitiveSupport;
+
+// A pure, presentation-ready snapshot of where a read currently is. Computed from
+// the raw character position and sentence segmentation so the speak-position hotkey
+// can describe the location without the UI reaching into the synthesizer's state.
+public readonly record struct ReadingPosition
+{
+	// False when nothing is being (or has been) read; the other fields are then 0.
+	public bool IsReading { get; init; }
+
+	// 1-based sentence number, natural to speak ("Sentence 4 of 22").
+	public int SentenceNumber { get; init; }
+	public int SentenceCount { get; init; }
+
+	// Percentage through the text, already rounded to the nearest 5% — honest about
+	// the estimate's precision and natural to say aloud.
+	public int PercentComplete { get; init; }
+
+	// Whole minutes of reading left; 0 means less than a minute remains.
+	public int MinutesRemaining { get; init; }
+
+	public static readonly ReadingPosition NotReading = new() { IsReading = false };
+
+	public static ReadingPosition Create(int currentPosition, int textLength, int sentenceIndex, int sentenceCount)
+	{
+		if (textLength <= 0 || sentenceCount <= 0)
+			return NotReading;
+
+		int position = Math.Clamp(currentPosition, 0, textLength);
+		double fraction = (double)position / textLength;
+		int percent = (int)(Math.Round(fraction * 100d / 5d) * 5);
+		percent = Math.Clamp(percent, 0, 100);
+
+		int sentenceNumber = Math.Clamp(sentenceIndex + 1, 1, sentenceCount);
+		int minutesRemaining = ReadingEstimate.RemainingWholeMinutes(textLength - position);
+
+		return new ReadingPosition
+		{
+			IsReading = true,
+			SentenceNumber = sentenceNumber,
+			SentenceCount = sentenceCount,
+			PercentComplete = percent,
+			MinutesRemaining = minutesRemaining,
+		};
+	}
+}

--- a/CognitiveSupport/ReadingProgress.cs
+++ b/CognitiveSupport/ReadingProgress.cs
@@ -1,0 +1,31 @@
+namespace CognitiveSupport;
+
+// Pure decision for the periodic progress announcements. Kept side-effect free and
+// static so the threshold-crossing rules can be unit-tested without a synthesizer.
+public static class ReadingProgress
+{
+	// Returns the highest progress threshold (a multiple of stepPercent, strictly
+	// below 100) that the read has just crossed and has not yet announced, or 0 when
+	// there is nothing new to announce.
+	//
+	// When a single jump crosses several thresholds at once (e.g. a skip-forward that
+	// leaps 25% -> 75%), only the highest is returned; the caller stores it as the new
+	// "last announced" value, which silently marks the skipped lower thresholds as
+	// passed so they never stack up as queued utterances. 100% is deliberately never a
+	// threshold — end-of-text has its own announcement.
+	public static int HighestThresholdCrossed(int lastAnnouncedPercent, int currentPercent, int stepPercent)
+	{
+		if (stepPercent <= 0) return 0;
+		if (currentPercent <= lastAnnouncedPercent) return 0;
+
+		// Largest step multiple that is still strictly below 100 (e.g. 75 for a step of
+		// 25, 90 for a step of 30) so we never announce completion as progress.
+		int maxThreshold = ((100 - 1) / stepPercent) * stepPercent;
+
+		// Highest step multiple at or below the current percentage.
+		int reached = (currentPercent / stepPercent) * stepPercent;
+
+		int highest = Math.Min(reached, maxThreshold);
+		return highest > lastAnnouncedPercent && highest > 0 ? highest : 0;
+	}
+}

--- a/CognitiveSupport/Settings.cs
+++ b/CognitiveSupport/Settings.cs
@@ -254,6 +254,7 @@ public class TextToSpeechSettings
 	public string? SkipSentenceBackwardHotKey { get; set; }
 	public string? SkipSentenceForwardHotKey { get; set; }
 	public string? SpeakToFileHotKey { get; set; }
+	public string? SpeakPositionHotKey { get; set; }
 	public int Rate { get; set; } = 8;
 	public int Volume { get; set; } = 100;
 	public bool EnableSpeechPreprocessing { get; set; } = true;
@@ -270,6 +271,24 @@ public class TextToSpeechSettings
 	// this many words before where playback stopped so the listener regains context
 	// of where they are. 0 resumes exactly where it stopped (no rewind).
 	public int ResumeRewindWordCount { get; set; } = 5;
+
+	// Master on/off for the startup "Reading approximately N minutes" announcement.
+	// Default true to preserve the previous behaviour.
+	public bool AnnounceReadingTimeAtStart { get; set; } = true;
+
+	// The startup announcement plays only when the estimated read time exceeds this
+	// many minutes. Replaces the old hardcoded 5000-character cutoff.
+	public int AnnounceReadingTimeMinimumMinutes { get; set; } = 1;
+
+	// Master on/off for the periodic progress announcements spoken while reading.
+	public bool AnnounceProgressEnabled { get; set; } = true;
+
+	// Announce progress at each multiple of this percentage (e.g. 25 -> 25/50/75%).
+	public int AnnounceProgressEveryPercent { get; set; } = 25;
+
+	// Periodic progress is announced only when the estimated total read time exceeds
+	// this many minutes; shorter reads stay silent.
+	public int AnnounceProgressMinimumMinutes { get; set; } = 2;
 
 	public TextToSpeechSettings()
 	{

--- a/CognitiveSupport/TextToSpeechService.cs
+++ b/CognitiveSupport/TextToSpeechService.cs
@@ -6,7 +6,6 @@ namespace CognitiveSupport
 {
 	public class TextToSpeechService : ITextToSpeechService
 	{
-		private const int LengthWarningThresholdChars = 5000;
 		private const string EndOfTextAnnouncement = "End of text.";
 		private const string BeginningOfTextAnnouncement = "Beginning of text.";
 
@@ -42,6 +41,31 @@ namespace CognitiveSupport
 		private bool _speakingAnnouncement;
 		private bool _disposed;
 		private CancellationTokenSource? _opCts;
+
+		// Configurable announcement behaviour, pushed in from settings. Defaults mirror
+		// the settings defaults so the service behaves sensibly before it is configured.
+		private bool _announceReadingTimeAtStart = true;
+		private int _announceReadingTimeMinimumMinutes = 1;
+		private bool _announceProgressEnabled = true;
+		private int _announceProgressEveryPercent = 25;
+		private int _announceProgressMinimumMinutes = 2;
+
+		// The voice parameters of the live read, captured so a periodic progress
+		// announcement can re-speak the remainder in the same voice without the caller
+		// having to thread them back in.
+		private int _liveRate;
+		private int _liveVolume;
+		private string? _liveVoice;
+
+		// Highest progress threshold already announced for the current read (0 = none).
+		private int _lastAnnouncedProgressPercent;
+		// Set while a progress announcement is being scheduled/spoken so the flood of
+		// SpeakProgress events does not stack up duplicate announcements.
+		private bool _progressInterjectionInFlight;
+		// Bumped whenever a new top-level operation begins (read, stop, skip, spoken
+		// announcement). A deferred progress interjection captures the value at schedule
+		// time and bails if it changed, so a Stop/Skip during the gap always wins.
+		private long _playbackEpoch;
 
 		public bool IsSpeaking
 		{
@@ -112,6 +136,11 @@ namespace CognitiveSupport
 				if (_synth is null) return;
 
 				ApplyVoiceParams(rate, volume, voiceName);
+				_liveRate = rate;
+				_liveVolume = volume;
+				_liveVoice = voiceName;
+				_playbackEpoch++;
+				_progressInterjectionInFlight = false;
 
 				bool sameContent = string.Equals(processed, _currentText, StringComparison.Ordinal);
 				bool canResume = resumeIfSame && sameContent
@@ -127,6 +156,9 @@ namespace CognitiveSupport
 					_spokenToCurrentDelta = resumePos;
 					EnterSentence(FindSentenceIndex(resumePos));
 					ResetSkipBurst();
+					// Keep already-passed progress thresholds marked so resuming mid-read
+					// does not re-announce them.
+					_lastAnnouncedProgressPercent = ProgressPercentAt(resumePos, processed.Length);
 					_currentPrompt = _synth.SpeakAsync(processed.Substring(resumePos));
 				}
 				else
@@ -137,6 +169,7 @@ namespace CognitiveSupport
 					_sentenceStarts = FindSentenceStarts(processed);
 					EnterSentence(0);
 					ResetSkipBurst();
+					_lastAnnouncedProgressPercent = 0;
 
 					string warning = ShouldAnnounceLength(processed)
 						? BuildLengthAnnouncement(processed)
@@ -168,6 +201,11 @@ namespace CognitiveSupport
 				_opCts = newCts;
 
 				ApplyVoiceParams(rate, volume, voiceName);
+				_liveRate = rate;
+				_liveVolume = volume;
+				_liveVoice = voiceName;
+				_playbackEpoch++;
+				_progressInterjectionInFlight = false;
 
 				int lastIndex = _sentenceStarts.Count - 1;
 				long now = Environment.TickCount64;
@@ -186,6 +224,7 @@ namespace CognitiveSupport
 					_pendingSkipIndex = 0;
 					EnterSentence(0);
 					_currentPosition = 0;
+					_lastAnnouncedProgressPercent = 0;
 					string announcement = BeginningOfTextAnnouncement + " ";
 					_spokenToCurrentDelta = -announcement.Length;
 					_currentPrompt = _synth!.SpeakAsync(announcement + _currentText);
@@ -279,10 +318,43 @@ namespace CognitiveSupport
 
 				ApplyVoiceParams(rate, volume, voiceName);
 				_speakingAnnouncement = true;
+				_playbackEpoch++;
+				_progressInterjectionInFlight = false;
 				_currentPrompt = _synth!.SpeakAsync(text);
 			}
 			oldCts?.Cancel();
 			oldCts?.Dispose();
+		}
+
+		public ReadingPosition GetReadingPosition()
+		{
+			lock (_gate)
+			{
+				if (_currentText is null || _currentText.Length == 0
+					|| _sentenceStarts is null || _sentenceStarts.Count == 0)
+					return ReadingPosition.NotReading;
+
+				int sentenceIndex = FindSentenceIndex(_currentPosition);
+				return ReadingPosition.Create(
+					_currentPosition, _currentText.Length, sentenceIndex, _sentenceStarts.Count);
+			}
+		}
+
+		public void SetAnnouncementOptions(
+			bool announceReadingTimeAtStart,
+			int readingTimeMinimumMinutes,
+			bool announceProgressEnabled,
+			int announceProgressEveryPercent,
+			int announceProgressMinimumMinutes)
+		{
+			lock (_gate)
+			{
+				_announceReadingTimeAtStart = announceReadingTimeAtStart;
+				_announceReadingTimeMinimumMinutes = readingTimeMinimumMinutes;
+				_announceProgressEnabled = announceProgressEnabled;
+				_announceProgressEveryPercent = announceProgressEveryPercent > 0 ? announceProgressEveryPercent : 25;
+				_announceProgressMinimumMinutes = announceProgressMinimumMinutes;
+			}
 		}
 
 		public void Stop()
@@ -292,6 +364,8 @@ namespace CognitiveSupport
 			{
 				oldCts = _opCts;
 				_opCts = null;
+				_playbackEpoch++;
+				_progressInterjectionInFlight = false;
 				if (_synth is null) return;
 				try { _synth.SpeakAsyncCancelAll(); } catch { }
 				_speakingAnnouncement = false;
@@ -346,7 +420,84 @@ namespace CognitiveSupport
 				int sentenceIndex = FindSentenceIndex(mapped);
 				if (sentenceIndex != _navIndex)
 					EnterSentence(sentenceIndex);
+
+				MaybeAnnounceProgress();
 			}
+		}
+
+		// Decide, on each progress tick, whether the read has crossed a new percentage
+		// threshold worth announcing. Cheap by design: a couple of integer comparisons in
+		// the common case. The actual speak is deferred off the synth's event thread.
+		private void MaybeAnnounceProgress()
+		{
+			if (!_announceProgressEnabled || _speakingAnnouncement || _progressInterjectionInFlight)
+				return;
+			if (_currentText is null || _currentText.Length == 0)
+				return;
+			if (!ReadingEstimate.ExceedsMinutes(_currentText.Length, _announceProgressMinimumMinutes))
+				return;
+
+			int percent = ProgressPercentAt(_currentPosition, _currentText.Length);
+			int crossed = ReadingProgress.HighestThresholdCrossed(
+				_lastAnnouncedProgressPercent, percent, _announceProgressEveryPercent);
+			if (crossed <= 0)
+				return;
+
+			// Mark every threshold up to the highest crossed as announced so a single big
+			// jump never queues a burst of lower announcements.
+			_lastAnnouncedProgressPercent = crossed;
+			_progressInterjectionInFlight = true;
+
+			int minutesRemaining = ReadingEstimate.RemainingWholeMinutes(_currentText.Length - _currentPosition);
+			string text = ReadingAnnouncements.Progress(crossed, minutesRemaining);
+			long epoch = _playbackEpoch;
+			Task.Run(() => SpeakProgressInterjection(text, epoch));
+		}
+
+		// Speak a progress update, then carry on reading from where playback was. We
+		// cannot interleave audio into the single in-flight utterance, so we cancel it and
+		// re-issue "<progress>. <remaining text>" as one new utterance — the same prefix +
+		// offset idiom the length warning and beginning-of-text announcement already use,
+		// which keeps progress character positions mapping back onto the real text.
+		private void SpeakProgressInterjection(string progressText, long epoch)
+		{
+			CancellationTokenSource? oldCts;
+			CancellationTokenSource newCts = new();
+			lock (_gate)
+			{
+				// A Stop/Skip/new read between scheduling and running bumps the epoch; in
+				// that case the read we meant to resume no longer exists, so do nothing.
+				if (_disposed || _currentText is null || _playbackEpoch != epoch)
+				{
+					newCts.Dispose();
+					_progressInterjectionInFlight = false;
+					return;
+				}
+
+				EnsureSynth();
+				try { _synth!.SpeakAsyncCancelAll(); } catch { }
+				oldCts = _opCts;
+				_opCts = newCts;
+
+				ApplyVoiceParams(_liveRate, _liveVolume, _liveVoice);
+
+				int position = Math.Clamp(_currentPosition, 0, _currentText.Length);
+				string prefix = progressText + " ";
+				string remainder = _currentText.Substring(position);
+				_spokenToCurrentDelta = position - prefix.Length;
+				_speakingAnnouncement = false;
+				_currentPrompt = _synth!.SpeakAsync(prefix + remainder);
+				_progressInterjectionInFlight = false;
+			}
+			oldCts?.Cancel();
+			oldCts?.Dispose();
+		}
+
+		private static int ProgressPercentAt(int position, int length)
+		{
+			if (length <= 0) return 0;
+			int pos = Math.Clamp(position, 0, length);
+			return (int)((double)pos * 100d / length);
 		}
 
 		private void OnSpeakCompleted(object? sender, SpeakCompletedEventArgs e)
@@ -433,17 +584,15 @@ namespace CognitiveSupport
 			return starts;
 		}
 
-		private static bool ShouldAnnounceLength(string text) => text.Length > LengthWarningThresholdChars;
+		// The startup reading-time announcement plays when it is enabled AND the estimated
+		// read is longer than the configured minimum minutes. This replaces the old fixed
+		// 5000-character cutoff with a minutes-based threshold from the shared estimate.
+		private bool ShouldAnnounceLength(string text)
+			=> _announceReadingTimeAtStart
+				&& ReadingEstimate.ExceedsMinutes(text.Length, _announceReadingTimeMinimumMinutes);
 
 		private static string BuildLengthAnnouncement(string text)
-		{
-			int wordsApprox = Math.Max(1, text.Length / 5);
-			int wpm = 180;
-			int minutes = (int)Math.Round((double)wordsApprox / wpm);
-			if (minutes < 1) minutes = 1;
-			string unit = minutes == 1 ? "minute" : "minutes";
-			return $"Reading approximately {minutes} {unit} of text. ";
-		}
+			=> ReadingAnnouncements.StartupReadingTime(ReadingEstimate.SpokenWholeMinutes(text.Length));
 
 		private static readonly Regex CodeFenceRegex = new(@"```[\s\S]*?```", RegexOptions.Compiled);
 		private static readonly Regex InlineCodeRegex = new(@"`([^`\n]+)`", RegexOptions.Compiled);

--- a/Mutation.Tests/ReadingPositionAndProgressTests.cs
+++ b/Mutation.Tests/ReadingPositionAndProgressTests.cs
@@ -1,0 +1,195 @@
+using CognitiveSupport;
+using Xunit;
+
+namespace Mutation.Tests;
+
+// Pure-logic tests for the speak-position hotkey and periodic progress announcements:
+// the characters->minutes estimate, the reading-position snapshot, the threshold-
+// crossing decision, and the spoken phrasing. None of these need a synthesizer.
+public class ReadingPositionAndProgressTests
+{
+	// ---- ReadingEstimate: chars -> minutes (one shared source of truth) ----
+
+	[Theory]
+	[InlineData(0, 0d)]
+	[InlineData(900, 1d)]     // 900 chars / 5 per word = 180 words / 180 wpm = 1 min
+	[InlineData(5400, 6d)]    // 5400 / 5 / 180 = 6 min
+	public void EstimateMinutes_MatchesSharedFormula(int chars, double expected)
+	{
+		Assert.Equal(expected, ReadingEstimate.EstimateMinutes(chars), 3);
+	}
+
+	[Theory]
+	[InlineData(0, 1)]        // always at least one minute when spoken
+	[InlineData(900, 1)]
+	[InlineData(5400, 6)]
+	public void SpokenWholeMinutes_NeverBelowOne(int chars, int expected)
+	{
+		Assert.Equal(expected, ReadingEstimate.SpokenWholeMinutes(chars));
+	}
+
+	[Theory]
+	[InlineData(0, 0)]        // remaining may be zero -> "less than a minute"
+	[InlineData(900, 1)]
+	public void RemainingWholeMinutes_AllowsZero(int chars, int expected)
+	{
+		Assert.Equal(expected, ReadingEstimate.RemainingWholeMinutes(chars));
+	}
+
+	[Theory]
+	[InlineData(900, 1, false)]    // ~1.0 min is not strictly greater than 1
+	[InlineData(1100, 1, true)]    // ~1.2 min exceeds 1
+	[InlineData(1000, 2, false)]   // short read stays silent under a 2-minute floor
+	[InlineData(5400, 2, true)]    // 6 min exceeds 2
+	public void ExceedsMinutes_GatesAnnouncements(int chars, int minimumMinutes, bool expected)
+	{
+		Assert.Equal(expected, ReadingEstimate.ExceedsMinutes(chars, minimumMinutes));
+	}
+
+	// ---- ReadingPosition.Create: percentage / sentence / minutes ----
+
+	[Fact]
+	public void Create_EmptyText_IsNotReading()
+	{
+		var p = ReadingPosition.Create(currentPosition: 0, textLength: 0, sentenceIndex: 0, sentenceCount: 0);
+		Assert.False(p.IsReading);
+		Assert.Equal(ReadingPosition.NotReading, p);
+	}
+
+	[Fact]
+	public void Create_NoSentences_IsNotReading()
+	{
+		var p = ReadingPosition.Create(currentPosition: 10, textLength: 100, sentenceIndex: 0, sentenceCount: 0);
+		Assert.False(p.IsReading);
+	}
+
+	[Fact]
+	public void Create_RoundsPercentToNearestFive()
+	{
+		// 380 / 1000 = 38% -> nearest 5% = 40%.
+		var p = ReadingPosition.Create(currentPosition: 380, textLength: 1000, sentenceIndex: 3, sentenceCount: 22);
+		Assert.True(p.IsReading);
+		Assert.Equal(40, p.PercentComplete);
+		Assert.Equal(4, p.SentenceNumber); // 1-based
+		Assert.Equal(22, p.SentenceCount);
+	}
+
+	[Fact]
+	public void Create_SingleSentence_ReportsOneOfOne()
+	{
+		var p = ReadingPosition.Create(currentPosition: 0, textLength: 200, sentenceIndex: 0, sentenceCount: 1);
+		Assert.Equal(1, p.SentenceNumber);
+		Assert.Equal(1, p.SentenceCount);
+		Assert.Equal(0, p.PercentComplete);
+	}
+
+	[Fact]
+	public void Create_EndOfText_IsHundredPercentWithNoMinutesLeft()
+	{
+		var p = ReadingPosition.Create(currentPosition: 1000, textLength: 1000, sentenceIndex: 21, sentenceCount: 22);
+		Assert.Equal(100, p.PercentComplete);
+		Assert.Equal(22, p.SentenceNumber);
+		Assert.Equal(0, p.MinutesRemaining);
+	}
+
+	[Fact]
+	public void Create_ClampsSentenceIndexAndPosition()
+	{
+		// Position past the end and sentence index past the count both clamp.
+		var p = ReadingPosition.Create(currentPosition: 5000, textLength: 1000, sentenceIndex: 99, sentenceCount: 10);
+		Assert.Equal(100, p.PercentComplete);
+		Assert.Equal(10, p.SentenceNumber);
+	}
+
+	// ---- ReadingProgress: threshold crossing ----
+
+	[Theory]
+	[InlineData(0, 25, 25, 25)]
+	[InlineData(0, 50, 25, 50)]
+	[InlineData(0, 24, 25, 0)]   // not reached yet
+	[InlineData(50, 50, 25, 0)]  // already announced exactly this point
+	[InlineData(75, 80, 25, 0)]  // nothing new below 100
+	public void HighestThresholdCrossed_BasicSteps(int last, int current, int step, int expected)
+	{
+		Assert.Equal(expected, ReadingProgress.HighestThresholdCrossed(last, current, step));
+	}
+
+	[Fact]
+	public void HighestThresholdCrossed_SingleBigJump_AnnouncesOnlyHighest()
+	{
+		// A 25% -> 75% jump announces once at 75 and marks 50 passed silently.
+		int crossed = ReadingProgress.HighestThresholdCrossed(lastAnnouncedPercent: 25, currentPercent: 75, stepPercent: 25);
+		Assert.Equal(75, crossed);
+
+		// After recording 75, the skipped 50 never re-announces.
+		Assert.Equal(0, ReadingProgress.HighestThresholdCrossed(75, 76, 25));
+	}
+
+	[Theory]
+	[InlineData(0, 100, 25, 75)]  // 100% is never a progress threshold
+	[InlineData(75, 100, 25, 0)]
+	[InlineData(0, 100, 30, 90)]  // largest multiple of 30 below 100
+	public void HighestThresholdCrossed_NeverAnnouncesHundred(int last, int current, int step, int expected)
+	{
+		Assert.Equal(expected, ReadingProgress.HighestThresholdCrossed(last, current, step));
+	}
+
+	[Fact]
+	public void HighestThresholdCrossed_ZeroStep_IsSafe()
+	{
+		Assert.Equal(0, ReadingProgress.HighestThresholdCrossed(0, 50, 0));
+	}
+
+	// ---- ReadingAnnouncements: spoken phrasing ----
+
+	[Fact]
+	public void Position_NotReading_SpeaksClearMessage()
+	{
+		Assert.Equal("Not currently reading.", ReadingAnnouncements.Position(ReadingPosition.NotReading));
+	}
+
+	[Fact]
+	public void Position_SpeaksSentencePercentAndMinutes()
+	{
+		var p = new ReadingPosition
+		{
+			IsReading = true,
+			SentenceNumber = 4,
+			SentenceCount = 22,
+			PercentComplete = 40,
+			MinutesRemaining = 2,
+		};
+		Assert.Equal("Sentence 4 of 22, about 40% through, about 2 minutes left.", ReadingAnnouncements.Position(p));
+	}
+
+	[Fact]
+	public void Position_SingularMinute()
+	{
+		var p = new ReadingPosition { IsReading = true, SentenceNumber = 1, SentenceCount = 3, PercentComplete = 10, MinutesRemaining = 1 };
+		Assert.Equal("Sentence 1 of 3, about 10% through, about 1 minute left.", ReadingAnnouncements.Position(p));
+	}
+
+	[Fact]
+	public void Position_ZeroMinutes_SaysLessThanAMinute()
+	{
+		var p = new ReadingPosition { IsReading = true, SentenceNumber = 22, SentenceCount = 22, PercentComplete = 100, MinutesRemaining = 0 };
+		Assert.Equal("Sentence 22 of 22, about 100% through, less than a minute left.", ReadingAnnouncements.Position(p));
+	}
+
+	[Theory]
+	[InlineData(50, 3, "50%, about 3 minutes left.")]
+	[InlineData(25, 1, "25%, about 1 minute left.")]
+	[InlineData(75, 0, "75%, less than a minute left.")]
+	public void Progress_Phrasing(int percent, int minutes, string expected)
+	{
+		Assert.Equal(expected, ReadingAnnouncements.Progress(percent, minutes));
+	}
+
+	[Theory]
+	[InlineData(1, "Reading approximately 1 minute of text. ")]
+	[InlineData(5, "Reading approximately 5 minutes of text. ")]
+	public void StartupReadingTime_Phrasing(int minutes, string expected)
+	{
+		Assert.Equal(expected, ReadingAnnouncements.StartupReadingTime(minutes));
+	}
+}

--- a/Mutation.Tests/SettingsDefaultsParityTests.cs
+++ b/Mutation.Tests/SettingsDefaultsParityTests.cs
@@ -96,11 +96,17 @@ public class SettingsDefaultsParityTests : IDisposable
 		Assert.Equal(SettingsDefaults.Tts.RestartFromBeginningHotKey, tts.RestartFromBeginningHotKey);
 		Assert.Equal(SettingsDefaults.Tts.SkipSentenceBackwardHotKey, tts.SkipSentenceBackwardHotKey);
 		Assert.Equal(SettingsDefaults.Tts.SkipSentenceForwardHotKey, tts.SkipSentenceForwardHotKey);
+		Assert.Equal(SettingsDefaults.Tts.SpeakPositionHotKey, tts.SpeakPositionHotKey);
 		Assert.Equal(SettingsDefaults.Tts.Rate, tts.Rate);
 		Assert.Equal(SettingsDefaults.Tts.Volume, tts.Volume);
 		Assert.Equal(SettingsDefaults.Tts.EnableSpeechPreprocessing, tts.EnableSpeechPreprocessing);
 		Assert.Equal(SettingsDefaults.Tts.SkipSentenceGraceWindowMs, tts.SkipSentenceGraceWindowMs);
 		Assert.Equal(SettingsDefaults.Tts.ResumeRewindWordCount, tts.ResumeRewindWordCount);
+		Assert.Equal(SettingsDefaults.Tts.AnnounceReadingTimeAtStart, tts.AnnounceReadingTimeAtStart);
+		Assert.Equal(SettingsDefaults.Tts.AnnounceReadingTimeMinimumMinutes, tts.AnnounceReadingTimeMinimumMinutes);
+		Assert.Equal(SettingsDefaults.Tts.AnnounceProgressEnabled, tts.AnnounceProgressEnabled);
+		Assert.Equal(SettingsDefaults.Tts.AnnounceProgressEveryPercent, tts.AnnounceProgressEveryPercent);
+		Assert.Equal(SettingsDefaults.Tts.AnnounceProgressMinimumMinutes, tts.AnnounceProgressMinimumMinutes);
 	}
 
 	[Fact]

--- a/Mutation.Ui/MainWindow.xaml
+++ b/Mutation.Ui/MainWindow.xaml
@@ -791,6 +791,25 @@
                                         ToolTipService.ToolTip="Adjust speech volume independent of system volume" />
                                 </StackPanel>
 
+                                <StackPanel Spacing="8">
+                                    <ToggleSwitch
+                                        x:Name="ToggleAnnounceReadingTime"
+                                        Header="Announce reading time at start"
+                                        OffContent="Off"
+                                        OnContent="On"
+                                        AutomationProperties.Name="Announce reading time at start"
+                                        ToolTipService.ToolTip="Speak an estimate of how long the text will take to read before reading begins"
+                                        Toggled="ToggleAnnounceReadingTime_Toggled" />
+                                    <ToggleSwitch
+                                        x:Name="ToggleAnnounceProgress"
+                                        Header="Announce progress while reading"
+                                        OffContent="Off"
+                                        OnContent="On"
+                                        AutomationProperties.Name="Announce progress while reading"
+                                        ToolTipService.ToolTip="Speak your progress at regular points while reading a long text"
+                                        Toggled="ToggleAnnounceProgress_Toggled" />
+                                </StackPanel>
+
                                 <StackPanel x:Name="ClipboardActionsPanel" Orientation="Vertical" Spacing="8">
                                     <StackPanel x:Name="ClipboardPrimaryActions" Orientation="Horizontal" Spacing="12">
                                         <Button
@@ -848,6 +867,18 @@
                                             AutomationProperties.Name="Skip sentence forward"
                                             ToolTipService.ToolTip="Jump to the next sentence">
                                             <FontIcon Glyph="&#xE893;" FontFamily="Segoe Fluent Icons" />
+                                        </Button>
+
+                                        <Button
+                                            x:Name="BtnSpeakPosition"
+                                            Style="{StaticResource OutlinedButtonStyle}"
+                                            Click="BtnSpeakPosition_Click"
+                                            AutomationProperties.Name="Speak reading position"
+                                            ToolTipService.ToolTip="Speak the current reading position: sentence, percentage, and time remaining">
+                                            <StackPanel Orientation="Horizontal" Spacing="8" HorizontalAlignment="Center">
+                                                <FontIcon Glyph="&#xE8B9;" FontFamily="Segoe Fluent Icons" />
+                                                <TextBlock Text="Position" />
+                                            </StackPanel>
                                         </Button>
 
                                         <Button

--- a/Mutation.Ui/MainWindow.xaml.cs
+++ b/Mutation.Ui/MainWindow.xaml.cs
@@ -356,6 +356,10 @@ public sealed partial class MainWindow : Window, IDisposable
 		if (!string.IsNullOrWhiteSpace(tts?.SpeakToFileHotKey))
 			TryRegister(hk, tts.SpeakToFileHotKey!, () =>
 				DispatcherQueue.TryEnqueue(() => BtnSpeakToFile_Click(null!, null!)));
+
+		if (!string.IsNullOrWhiteSpace(tts?.SpeakPositionHotKey))
+			TryRegister(hk, tts.SpeakPositionHotKey!, () =>
+				DispatcherQueue.TryEnqueue(() => BtnSpeakPosition_Click(null!, null!)));
 	}
 
 	private static void TryRegister(HotkeyManager hk, string hotkey, Action callback)
@@ -432,6 +436,7 @@ public sealed partial class MainWindow : Window, IDisposable
 		ConfigureButtonHotkey(BtnSkipSentenceForward, null, _settings.TextToSpeechSettings?.SkipSentenceForwardHotKey, "Jump to the next sentence");
 		ConfigureButtonHotkey(BtnSpeakSelection, null, _settings.TextToSpeechSettings?.SpeakSelectionHotKey, "Copy the current selection from the active app and read it aloud");
 		ConfigureButtonHotkey(BtnSpeakToFile, null, _settings.TextToSpeechSettings?.SpeakToFileHotKey, "Save the clipboard text as a spoken WAV audio file");
+		ConfigureButtonHotkey(BtnSpeakPosition, null, _settings.TextToSpeechSettings?.SpeakPositionHotKey, "Speak the current reading position: sentence, percentage, and time remaining");
 		ConfigureButtonHotkey(BtnProcessLlm, null, null, "Send transcript through the configured language model");
 	}
 
@@ -866,6 +871,15 @@ public sealed partial class MainWindow : Window, IDisposable
 		_textToSpeech.SkipSentence(1, tts.Rate, tts.Volume, tts.VoiceName, tts.SkipSentenceGraceWindowMs);
 	}
 
+	public void BtnSpeakPosition_Click(object? sender, RoutedEventArgs? e)
+	{
+		var tts = _settings.TextToSpeechSettings ?? new TextToSpeechSettings();
+		ReadingPosition position = _textToSpeech.GetReadingPosition();
+		string announcement = ReadingAnnouncements.Position(position);
+		_textToSpeech.SpeakAnnouncement(announcement, tts.Rate, tts.Volume, tts.VoiceName);
+		ShowStatus("Text to Speech", announcement, InfoBarSeverity.Informational);
+	}
+
 	public async void BtnSpeakToFile_Click(object? sender, RoutedEventArgs? e)
 	{
 		var tts = _settings.TextToSpeechSettings ?? new TextToSpeechSettings();
@@ -1031,7 +1045,57 @@ public sealed partial class MainWindow : Window, IDisposable
 		else if (volume > 100) volume = 100;
 		SldTtsVolume.Value = volume;
 
+		ToggleAnnounceReadingTime.IsOn = settings.AnnounceReadingTimeAtStart;
+		ToggleAnnounceProgress.IsOn = settings.AnnounceProgressEnabled;
+
 		_ttsControlsReady = true;
+		PushTtsAnnouncementOptions();
+	}
+
+	// Mirror the on-screen toggle states from the current settings. Called after the
+	// settings dialog closes so a change made there shows on the main window too.
+	private void RefreshTtsAnnouncementToggles()
+	{
+		var settings = _settings.TextToSpeechSettings ?? new TextToSpeechSettings();
+		bool wasReady = _ttsControlsReady;
+		_ttsControlsReady = false;
+		try
+		{
+			ToggleAnnounceReadingTime.IsOn = settings.AnnounceReadingTimeAtStart;
+			ToggleAnnounceProgress.IsOn = settings.AnnounceProgressEnabled;
+		}
+		finally { _ttsControlsReady = wasReady; }
+	}
+
+	// Push the configurable announcement settings into the speech service so the next
+	// read picks them up.
+	private void PushTtsAnnouncementOptions()
+	{
+		var settings = _settings.TextToSpeechSettings ?? new TextToSpeechSettings();
+		_textToSpeech.SetAnnouncementOptions(
+			settings.AnnounceReadingTimeAtStart,
+			settings.AnnounceReadingTimeMinimumMinutes,
+			settings.AnnounceProgressEnabled,
+			settings.AnnounceProgressEveryPercent,
+			settings.AnnounceProgressMinimumMinutes);
+	}
+
+	private void ToggleAnnounceReadingTime_Toggled(object sender, RoutedEventArgs e)
+	{
+		if (!_ttsControlsReady) return;
+		_settings.TextToSpeechSettings ??= new TextToSpeechSettings();
+		_settings.TextToSpeechSettings.AnnounceReadingTimeAtStart = ToggleAnnounceReadingTime.IsOn;
+		_settingsManager.SaveSettingsToFile(_settings);
+		PushTtsAnnouncementOptions();
+	}
+
+	private void ToggleAnnounceProgress_Toggled(object sender, RoutedEventArgs e)
+	{
+		if (!_ttsControlsReady) return;
+		_settings.TextToSpeechSettings ??= new TextToSpeechSettings();
+		_settings.TextToSpeechSettings.AnnounceProgressEnabled = ToggleAnnounceProgress.IsOn;
+		_settingsManager.SaveSettingsToFile(_settings);
+		PushTtsAnnouncementOptions();
 	}
 
 	private void CmbTtsVoice_SelectionChanged(object sender, SelectionChangedEventArgs e)
@@ -1769,6 +1833,17 @@ public sealed partial class MainWindow : Window, IDisposable
 		catch (Exception ex)
 		{
 			System.Diagnostics.Debug.WriteLine($"ApplyLiveSettings (beeps) failed: {ex.Message}");
+		}
+
+		try
+		{
+			RefreshTtsAnnouncementToggles();
+			PushTtsAnnouncementOptions();
+			InitializeHotkeyVisuals();
+		}
+		catch (Exception ex)
+		{
+			System.Diagnostics.Debug.WriteLine($"ApplyLiveSettings (tts) failed: {ex.Message}");
 		}
 
 		IReadOnlyList<HotkeyManager.HotkeyRegistrationResult>? routerResults = null;

--- a/Mutation.Ui/Resources/HelpText.xaml
+++ b/Mutation.Ui/Resources/HelpText.xaml
@@ -27,6 +27,11 @@
 	<x:String x:Key="Help.Tts.Preprocessing">Clean up text, such as expanding abbreviations and symbols, before it is spoken aloud.</x:String>
 	<x:String x:Key="Help.Tts.SkipSentenceGrace">When skipping back, how long after a sentence starts that a back-press still steps to the previous sentence. After this window a back-press restarts the current sentence instead. A larger value makes stepping back easier; a smaller value favours re-reading the current sentence.</x:String>
 	<x:String x:Key="Help.Tts.ResumeRewindWords">When you resume reading after pausing, rewind this many words before where it stopped so you regain context of where you are. Set to 0 for no rewind: reading resumes from exactly where it stopped.</x:String>
+	<x:String x:Key="Help.Tts.AnnounceReadingTimeAtStart">When on, a short spoken estimate of how long the text will take to read is announced before reading begins.</x:String>
+	<x:String x:Key="Help.Tts.AnnounceReadingTimeMinimumMinutes">Only announce the reading-time estimate when the text is estimated to take longer than this many minutes. Set to 0 to announce for any length.</x:String>
+	<x:String x:Key="Help.Tts.AnnounceProgress">When on, your progress is spoken aloud at regular points while reading a long text, for example "50%, about 3 minutes left".</x:String>
+	<x:String x:Key="Help.Tts.AnnounceProgressEveryPercent">How often progress is announced, as a percentage step. For example 25 announces at 25%, 50%, and 75%.</x:String>
+	<x:String x:Key="Help.Tts.AnnounceProgressMinimumMinutes">Only announce progress when the whole text is estimated to take longer than this many minutes; shorter reads stay silent.</x:String>
 
 	<!-- Speech to Text -->
 	<x:String x:Key="Help.Speech.FileTimeout">How long to wait for a file transcription to finish before giving up.</x:String>

--- a/Mutation.Ui/Services/SettingsManager.cs
+++ b/Mutation.Ui/Services/SettingsManager.cs
@@ -649,6 +649,11 @@ End of summary.
 			textToSpeechSettings.SkipSentenceForwardHotKey = "CTRL+SHIFT+K";
 			somethingWasMissing = true;
 		}
+		if (string.IsNullOrWhiteSpace(textToSpeechSettings.SpeakPositionHotKey))
+		{
+			textToSpeechSettings.SpeakPositionHotKey = "CTRL+SHIFT+P";
+			somethingWasMissing = true;
+		}
 
 		// Only inject a sample router mapping on FIRST creation of the settings file.
 		// Previously we also injected when the list was empty, which could overwrite ("wipe")

--- a/Mutation.Ui/Views/Settings/Pages/HotkeysSettingsPage.xaml.cs
+++ b/Mutation.Ui/Views/Settings/Pages/HotkeysSettingsPage.xaml.cs
@@ -116,6 +116,10 @@ public sealed partial class HotkeysSettingsPage : UserControl
 			s => s.TextToSpeechSettings?.SkipSentenceForwardHotKey,
 			(s, v) => (s.TextToSpeechSettings ??= new TextToSpeechSettings()).SkipSentenceForwardHotKey = v,
 			false, SettingsDefaults.Tts.SkipSentenceForwardHotKey),
+		new HotkeySpec("Speak reading position",
+			s => s.TextToSpeechSettings?.SpeakPositionHotKey,
+			(s, v) => (s.TextToSpeechSettings ??= new TextToSpeechSettings()).SpeakPositionHotKey = v,
+			false, SettingsDefaults.Tts.SpeakPositionHotKey),
 	};
 
 	private void BuildRows()

--- a/Mutation.Ui/Views/Settings/Pages/TtsSettingsPage.xaml
+++ b/Mutation.Ui/Views/Settings/Pages/TtsSettingsPage.xaml
@@ -68,6 +68,72 @@
 			</StackPanel>
 		</StackPanel>
 
+		<StackPanel Spacing="4">
+			<StackPanel Orientation="Horizontal" Spacing="6">
+				<TextBlock Text="Announce reading time only above (minutes)" VerticalAlignment="Center" Style="{StaticResource BodyStrongTextBlockStyle}" />
+				<controls:InfoHint Text="{StaticResource Help.Tts.AnnounceReadingTimeMinimumMinutes}" VerticalAlignment="Center" />
+			</StackPanel>
+			<StackPanel Orientation="Horizontal" Spacing="6">
+				<NumberBox x:Name="NbAnnounceReadingTimeMin"
+						   AutomationProperties.Name="Announce reading time only above (minutes)"
+						   AutomationProperties.HelpText="{StaticResource Help.Tts.AnnounceReadingTimeMinimumMinutes}"
+						   Minimum="0" Maximum="120"
+						   SmallChange="1" LargeChange="5"
+						   SpinButtonPlacementMode="Inline"
+						   Width="220"
+						   ValueChanged="NbAnnounceReadingTimeMin_ValueChanged" />
+				<Button Click="BtnResetAnnounceReadingTimeMin_Click" ToolTipService.ToolTip="Reset to default" AutomationProperties.Name="Reset announce reading time minimum">
+					<FontIcon Glyph="&#xE72C;" FontFamily="Segoe Fluent Icons" FontSize="12" AutomationProperties.AccessibilityView="Raw" />
+				</Button>
+			</StackPanel>
+			<TextBlock Text="The reading-time announcement is turned on or off on the main window."
+					   Style="{StaticResource CaptionTextBlockStyle}"
+					   Foreground="{ThemeResource TextFillColorTertiaryBrush}" />
+		</StackPanel>
+
+		<StackPanel Spacing="4">
+			<StackPanel Orientation="Horizontal" Spacing="6">
+				<TextBlock Text="Announce progress every (percent)" VerticalAlignment="Center" Style="{StaticResource BodyStrongTextBlockStyle}" />
+				<controls:InfoHint Text="{StaticResource Help.Tts.AnnounceProgressEveryPercent}" VerticalAlignment="Center" />
+			</StackPanel>
+			<StackPanel Orientation="Horizontal" Spacing="6">
+				<NumberBox x:Name="NbAnnounceProgressPercent"
+						   AutomationProperties.Name="Announce progress every (percent)"
+						   AutomationProperties.HelpText="{StaticResource Help.Tts.AnnounceProgressEveryPercent}"
+						   Minimum="5" Maximum="50"
+						   SmallChange="5" LargeChange="10"
+						   SpinButtonPlacementMode="Inline"
+						   Width="220"
+						   ValueChanged="NbAnnounceProgressPercent_ValueChanged" />
+				<Button Click="BtnResetAnnounceProgressPercent_Click" ToolTipService.ToolTip="Reset to default" AutomationProperties.Name="Reset announce progress percent">
+					<FontIcon Glyph="&#xE72C;" FontFamily="Segoe Fluent Icons" FontSize="12" AutomationProperties.AccessibilityView="Raw" />
+				</Button>
+			</StackPanel>
+		</StackPanel>
+
+		<StackPanel Spacing="4">
+			<StackPanel Orientation="Horizontal" Spacing="6">
+				<TextBlock Text="Announce progress only above (minutes)" VerticalAlignment="Center" Style="{StaticResource BodyStrongTextBlockStyle}" />
+				<controls:InfoHint Text="{StaticResource Help.Tts.AnnounceProgressMinimumMinutes}" VerticalAlignment="Center" />
+			</StackPanel>
+			<StackPanel Orientation="Horizontal" Spacing="6">
+				<NumberBox x:Name="NbAnnounceProgressMin"
+						   AutomationProperties.Name="Announce progress only above (minutes)"
+						   AutomationProperties.HelpText="{StaticResource Help.Tts.AnnounceProgressMinimumMinutes}"
+						   Minimum="0" Maximum="120"
+						   SmallChange="1" LargeChange="5"
+						   SpinButtonPlacementMode="Inline"
+						   Width="220"
+						   ValueChanged="NbAnnounceProgressMin_ValueChanged" />
+				<Button Click="BtnResetAnnounceProgressMin_Click" ToolTipService.ToolTip="Reset to default" AutomationProperties.Name="Reset announce progress minimum">
+					<FontIcon Glyph="&#xE72C;" FontFamily="Segoe Fluent Icons" FontSize="12" AutomationProperties.AccessibilityView="Raw" />
+				</Button>
+			</StackPanel>
+			<TextBlock Text="Progress announcements are turned on or off on the main window."
+					   Style="{StaticResource CaptionTextBlockStyle}"
+					   Foreground="{ThemeResource TextFillColorTertiaryBrush}" />
+		</StackPanel>
+
 		<TextBlock Text="TTS hotkeys appear in the Hotkeys tab."
 				   Style="{StaticResource CaptionTextBlockStyle}"
 				   Foreground="{ThemeResource TextFillColorTertiaryBrush}" />

--- a/Mutation.Ui/Views/Settings/Pages/TtsSettingsPage.xaml.cs
+++ b/Mutation.Ui/Views/Settings/Pages/TtsSettingsPage.xaml.cs
@@ -25,6 +25,9 @@ public sealed partial class TtsSettingsPage : UserControl
 			ToggleSpeechPreprocessing.IsOn = tts.EnableSpeechPreprocessing;
 			NbSkipGrace.Value = tts.SkipSentenceGraceWindowMs;
 			NbResumeRewindWords.Value = tts.ResumeRewindWordCount;
+			NbAnnounceReadingTimeMin.Value = tts.AnnounceReadingTimeMinimumMinutes;
+			NbAnnounceProgressPercent.Value = tts.AnnounceProgressEveryPercent;
+			NbAnnounceProgressMin.Value = tts.AnnounceProgressMinimumMinutes;
 		}
 		finally { _suppressEvents = false; }
 	}
@@ -62,5 +65,41 @@ public sealed partial class TtsSettingsPage : UserControl
 	private void BtnResetResumeRewind_Click(object sender, RoutedEventArgs e)
 	{
 		NbResumeRewindWords.Value = SettingsDefaults.Tts.ResumeRewindWordCount;
+	}
+
+	private void NbAnnounceReadingTimeMin_ValueChanged(NumberBox sender, NumberBoxValueChangedEventArgs args)
+	{
+		if (_suppressEvents) return;
+		if (double.IsNaN(args.NewValue)) return;
+		(_settings.TextToSpeechSettings ??= new TextToSpeechSettings()).AnnounceReadingTimeMinimumMinutes = (int)args.NewValue;
+	}
+
+	private void BtnResetAnnounceReadingTimeMin_Click(object sender, RoutedEventArgs e)
+	{
+		NbAnnounceReadingTimeMin.Value = SettingsDefaults.Tts.AnnounceReadingTimeMinimumMinutes;
+	}
+
+	private void NbAnnounceProgressPercent_ValueChanged(NumberBox sender, NumberBoxValueChangedEventArgs args)
+	{
+		if (_suppressEvents) return;
+		if (double.IsNaN(args.NewValue)) return;
+		(_settings.TextToSpeechSettings ??= new TextToSpeechSettings()).AnnounceProgressEveryPercent = (int)args.NewValue;
+	}
+
+	private void BtnResetAnnounceProgressPercent_Click(object sender, RoutedEventArgs e)
+	{
+		NbAnnounceProgressPercent.Value = SettingsDefaults.Tts.AnnounceProgressEveryPercent;
+	}
+
+	private void NbAnnounceProgressMin_ValueChanged(NumberBox sender, NumberBoxValueChangedEventArgs args)
+	{
+		if (_suppressEvents) return;
+		if (double.IsNaN(args.NewValue)) return;
+		(_settings.TextToSpeechSettings ??= new TextToSpeechSettings()).AnnounceProgressMinimumMinutes = (int)args.NewValue;
+	}
+
+	private void BtnResetAnnounceProgressMin_Click(object sender, RoutedEventArgs e)
+	{
+		NbAnnounceProgressMin.Value = SettingsDefaults.Tts.AnnounceProgressMinimumMinutes;
 	}
 }

--- a/Mutation.Ui/Views/Settings/SettingsDefaults.cs
+++ b/Mutation.Ui/Views/Settings/SettingsDefaults.cs
@@ -56,6 +56,7 @@ internal static class SettingsDefaults
 		public const string RestartFromBeginningHotKey = "CTRL+SHIFT+B";
 		public const string SkipSentenceBackwardHotKey = "CTRL+SHIFT+J";
 		public const string SkipSentenceForwardHotKey = "CTRL+SHIFT+K";
+		public const string SpeakPositionHotKey = "CTRL+SHIFT+P";
 		public const int Rate = 8;
 		public const int Volume = 100;
 		public const bool EnableSpeechPreprocessing = true;
@@ -65,6 +66,19 @@ internal static class SettingsDefaults
 		public const int ResumeRewindWordCount = 5;
 		public const int MinResumeRewindWordCount = 0;
 		public const int MaxResumeRewindWordCount = 20;
+
+		public const bool AnnounceReadingTimeAtStart = true;
+		public const int AnnounceReadingTimeMinimumMinutes = 1;
+		public const int MinAnnounceReadingTimeMinimumMinutes = 0;
+		public const int MaxAnnounceReadingTimeMinimumMinutes = 120;
+
+		public const bool AnnounceProgressEnabled = true;
+		public const int AnnounceProgressEveryPercent = 25;
+		public const int MinAnnounceProgressEveryPercent = 5;
+		public const int MaxAnnounceProgressEveryPercent = 50;
+		public const int AnnounceProgressMinimumMinutes = 2;
+		public const int MinAnnounceProgressMinimumMinutes = 0;
+		public const int MaxAnnounceProgressMinimumMinutes = 120;
 	}
 
 	public static class Llm

--- a/Mutation.Ui/Views/Settings/SettingsWorkingCopy.cs
+++ b/Mutation.Ui/Views/Settings/SettingsWorkingCopy.cs
@@ -109,12 +109,18 @@ internal static class SettingsWorkingCopy
 			dst.RestartFromBeginningHotKey = src.RestartFromBeginningHotKey;
 			dst.SkipSentenceBackwardHotKey = src.SkipSentenceBackwardHotKey;
 			dst.SkipSentenceForwardHotKey = src.SkipSentenceForwardHotKey;
+			dst.SpeakPositionHotKey = src.SpeakPositionHotKey;
 			dst.Rate = src.Rate;
 			dst.Volume = src.Volume;
 			dst.EnableSpeechPreprocessing = src.EnableSpeechPreprocessing;
 			dst.VoiceName = src.VoiceName;
 			dst.SkipSentenceGraceWindowMs = src.SkipSentenceGraceWindowMs;
 			dst.ResumeRewindWordCount = src.ResumeRewindWordCount;
+			dst.AnnounceReadingTimeAtStart = src.AnnounceReadingTimeAtStart;
+			dst.AnnounceReadingTimeMinimumMinutes = src.AnnounceReadingTimeMinimumMinutes;
+			dst.AnnounceProgressEnabled = src.AnnounceProgressEnabled;
+			dst.AnnounceProgressEveryPercent = src.AnnounceProgressEveryPercent;
+			dst.AnnounceProgressMinimumMinutes = src.AnnounceProgressMinimumMinutes;
 		}
 
 		live.MainWindowUiSettings ??= new MainWindowUiSettings();


### PR DESCRIPTION
## Summary

Adds three accessibility-focused text-to-speech narration features so a blind user can orient themselves while listening to a long read. The character-count → reading-time estimate is refactored into one shared helper so all three features stay consistent.

### 1. Speak reading position hotkey
- New `Ctrl+Shift+P` hotkey (rebindable on the Hotkeys settings page) speaks the current location, e.g. *"Sentence 4 of 22, about 40% through, about 2 minutes left."*
- Spoken percentage is rounded to the nearest 5%; minutes use singular/plural and say *"less than a minute left"* near the end.
- Uses the announcement channel, so it does not move the reading position — playback resumes where it was.
- Edge cases handled: nothing being read ("Not currently reading."), empty / single-sentence / end-of-text.

### 2. Startup reading-time announcement — toggle + threshold
- New main-window toggle **"Announce reading time at start"** (default on).
- New TTS-settings value **"Announce reading time only above (minutes)"** (default 1) replaces the old hardcoded 5000-character cutoff with a minutes-based threshold.

### 3. Periodic progress announcements
- New main-window toggle **"Announce progress while reading"** (default on).
- TTS-settings values for the percentage step (default 25%) and the minimum read length (default 2 min). Short reads stay silent.
- A single jump across several thresholds (e.g. a skip-forward 25% → 75%) announces only the highest once and marks the skipped ones passed silently.

## Technical notes
- New pure, unit-tested domain types in `CognitiveSupport`: `ReadingEstimate` (shared chars→minutes), `ReadingPosition`, `ReadingProgress` (threshold crossing), `ReadingAnnouncements` (phrasing). Domain stays UI-free.
- Periodic announcements re-issue *"<progress>. <remaining text>"* as one utterance (the existing prefix + offset idiom), deferred off the synthesizer's event thread, with an epoch guard so a Stop/Skip during the gap wins.
- Settings plumbed through `SettingsManager.EnsureSettings`, `SettingsWorkingCopy`, `SettingsDefaults`, and the defaults parity test.

## Acceptance criteria
- [x] `Ctrl+Shift+P` mid-read speaks sentence X of Y, approximate percentage, and minutes remaining without altering playback position.
- [x] Hotkey is rebindable on the Hotkeys page and defaults to `CTRL+SHIFT+P`.
- [x] Main-UI toggle controls the startup reading-time announcement (default on); configurable minimum-minutes threshold (default 1) suppresses it for short reads; both persisted; old 5000-char cutoff gone.
- [x] Periodic progress announced at each configured step with percentage + minutes remaining; reads shorter than the minimum produce none.
- [x] N% step and minimum-minutes thresholds configurable and persisted.
- [x] New logic unit-tested; Release test run green.

## Test plan
- `dotnet test --configuration Release` — 403 passed, 0 failed (includes new `ReadingPositionAndProgressTests`).
- Manual (WinUI, requires desktop): press `Ctrl+Shift+P` mid-read; toggle the two main-window switches; adjust the three TTS-settings numbers and confirm they persist across restart.

Closes #131
