### PR TITLE
Speak periodic progress announcements at sentence boundaries (#136)

### DIFF
--- a/CognitiveSupport/ProgressDeferral.cs
+++ b/CognitiveSupport/ProgressDeferral.cs
@@ -1,0 +1,59 @@
+namespace CognitiveSupport;
+
+// State machine for deferring periodic progress announcements to a sentence boundary.
+// When the read crosses a percentage threshold mid-sentence the announcement is held
+// "pending" rather than interjected immediately, so it can be spoken cleanly between
+// sentences instead of cutting the current one off mid-way. Kept synthesizer-free and
+// self-contained so the timing rules can be unit-tested in isolation.
+public struct ProgressDeferral
+{
+	// Highest threshold already crossed and accounted for (0 = none). Crossed thresholds
+	// are recorded here even before they are spoken, so a burst of thresholds before the
+	// next boundary collapses to a single announcement of the highest.
+	public int LastAnnouncedPercent;
+
+	// Highest threshold waiting to be spoken at the next sentence boundary (0 = nothing
+	// pending).
+	public int PendingPercent;
+
+	// Record a progress tick. If the read has crossed a new threshold, mark every
+	// threshold up to the highest as passed and hold the highest as pending. Returns true
+	// when a new threshold became pending. Multiple ticks before a boundary keep only the
+	// highest pending, because LastAnnouncedPercent advances with each crossing.
+	public bool Observe(int currentPercent, int stepPercent)
+	{
+		int crossed = ReadingProgress.HighestThresholdCrossed(LastAnnouncedPercent, currentPercent, stepPercent);
+		if (crossed <= 0) return false;
+
+		LastAnnouncedPercent = crossed;
+		PendingPercent = crossed;
+		return true;
+	}
+
+	// Take the pending announcement at a sentence boundary, clearing it. Returns 0 when
+	// nothing is pending.
+	public int TakeAtBoundary()
+	{
+		int pending = PendingPercent;
+		PendingPercent = 0;
+		return pending;
+	}
+
+	// Take the pending announcement when the read completes on its final sentence. The
+	// read has reached the end (100%), which is never announced as progress, so a pending
+	// threshold is dropped. The `< 100%` guard is defensive: a non-terminal completion
+	// would still flush. Clears the pending state either way.
+	public int TakeOnCompletion(int finalPercent)
+	{
+		int pending = PendingPercent;
+		PendingPercent = 0;
+		return finalPercent < 100 ? pending : 0;
+	}
+
+	// Forget all threshold tracking — a fresh read or restart-from-beginning starts over.
+	public void Reset()
+	{
+		LastAnnouncedPercent = 0;
+		PendingPercent = 0;
+	}
+}

--- a/CognitiveSupport/TextToSpeechService.cs
+++ b/CognitiveSupport/TextToSpeechService.cs
@@ -57,8 +57,9 @@ namespace CognitiveSupport
 		private int _liveVolume;
 		private string? _liveVoice;
 
-		// Highest progress threshold already announced for the current read (0 = none).
-		private int _lastAnnouncedProgressPercent;
+		// Deferral state for periodic progress announcements: which thresholds have been
+		// passed and which (if any) is waiting to be spoken at the next sentence boundary.
+		private ProgressDeferral _progress;
 		// Set while a progress announcement is being scheduled/spoken so the flood of
 		// SpeakProgress events does not stack up duplicate announcements.
 		private bool _progressInterjectionInFlight;
@@ -157,8 +158,9 @@ namespace CognitiveSupport
 					EnterSentence(FindSentenceIndex(resumePos));
 					ResetSkipBurst();
 					// Keep already-passed progress thresholds marked so resuming mid-read
-					// does not re-announce them.
-					_lastAnnouncedProgressPercent = ProgressPercentAt(resumePos, processed.Length);
+					// does not re-announce them, and clear any pending announcement.
+					_progress.Reset();
+					_progress.LastAnnouncedPercent = ProgressPercentAt(resumePos, processed.Length);
 					_currentPrompt = _synth.SpeakAsync(processed.Substring(resumePos));
 				}
 				else
@@ -169,7 +171,7 @@ namespace CognitiveSupport
 					_sentenceStarts = FindSentenceStarts(processed);
 					EnterSentence(0);
 					ResetSkipBurst();
-					_lastAnnouncedProgressPercent = 0;
+					_progress.Reset();
 
 					string warning = ShouldAnnounceLength(processed)
 						? BuildLengthAnnouncement(processed)
@@ -207,6 +209,10 @@ namespace CognitiveSupport
 				_playbackEpoch++;
 				_progressInterjectionInFlight = false;
 
+				// A skip is a fresh navigation: drop any announcement that was waiting for a
+				// boundary, since its percentage no longer matches the new position.
+				_progress.PendingPercent = 0;
+
 				int lastIndex = _sentenceStarts.Count - 1;
 				long now = Environment.TickCount64;
 				int desiredIndex = ComputeSkipTarget(
@@ -224,7 +230,7 @@ namespace CognitiveSupport
 					_pendingSkipIndex = 0;
 					EnterSentence(0);
 					_currentPosition = 0;
-					_lastAnnouncedProgressPercent = 0;
+					_progress.Reset();
 					string announcement = BeginningOfTextAnnouncement + " ";
 					_spokenToCurrentDelta = -announcement.Length;
 					_currentPrompt = _synth!.SpeakAsync(announcement + _currentText);
@@ -366,6 +372,7 @@ namespace CognitiveSupport
 				_opCts = null;
 				_playbackEpoch++;
 				_progressInterjectionInFlight = false;
+				_progress.PendingPercent = 0;
 				if (_synth is null) return;
 				try { _synth.SpeakAsyncCancelAll(); } catch { }
 				_speakingAnnouncement = false;
@@ -418,16 +425,25 @@ namespace CognitiveSupport
 				// after the reader has crossed into a new sentence acts from there.
 				// Re-entering a sentence also restarts the back-skip grace window.
 				int sentenceIndex = FindSentenceIndex(mapped);
-				if (sentenceIndex != _navIndex)
+				bool sentenceAdvanced = sentenceIndex != _navIndex;
+				if (sentenceAdvanced)
 					EnterSentence(sentenceIndex);
+
+				// A progress announcement crossed mid-sentence is held until the sentence
+				// finishes, so it lands cleanly between sentences instead of cutting the
+				// current one off. A new sentence has just begun — flush it now.
+				if (sentenceAdvanced)
+					FlushPendingProgressAtBoundary();
 
 				MaybeAnnounceProgress();
 			}
 		}
 
-		// Decide, on each progress tick, whether the read has crossed a new percentage
-		// threshold worth announcing. Cheap by design: a couple of integer comparisons in
-		// the common case. The actual speak is deferred off the synth's event thread.
+		// Record, on each progress tick, whether the read has crossed a new percentage
+		// threshold. Cheap by design: a couple of integer comparisons in the common case.
+		// Crossing a threshold only marks it pending; the announcement itself is spoken at
+		// the next sentence boundary (see FlushPendingProgressAtBoundary) so it never cuts
+		// the current sentence off mid-way.
 		private void MaybeAnnounceProgress()
 		{
 			if (!_announceProgressEnabled || _speakingAnnouncement || _progressInterjectionInFlight)
@@ -438,18 +454,39 @@ namespace CognitiveSupport
 				return;
 
 			int percent = ProgressPercentAt(_currentPosition, _currentText.Length);
-			int crossed = ReadingProgress.HighestThresholdCrossed(
-				_lastAnnouncedProgressPercent, percent, _announceProgressEveryPercent);
-			if (crossed <= 0)
+			// Hold the highest crossed threshold pending. Multiple thresholds crossed before
+			// the next boundary collapse to a single announcement of the highest.
+			_progress.Observe(percent, _announceProgressEveryPercent);
+		}
+
+		// Flush a pending progress announcement now that playback has reached a sentence
+		// boundary. Minutes-remaining is recomputed here so the spoken estimate reflects the
+		// boundary position rather than the earlier crossing point.
+		private void FlushPendingProgressAtBoundary()
+		{
+			if (!_announceProgressEnabled || _speakingAnnouncement || _progressInterjectionInFlight)
+				return;
+			if (_currentText is null)
 				return;
 
-			// Mark every threshold up to the highest crossed as announced so a single big
-			// jump never queues a burst of lower announcements.
-			_lastAnnouncedProgressPercent = crossed;
-			_progressInterjectionInFlight = true;
+			int percent = _progress.TakeAtBoundary();
+			if (percent <= 0)
+				return;
 
+			SchedulePendingAnnouncement(percent);
+		}
+
+		// Schedule the deferred speak off the synth's event thread. Reuses the cancel +
+		// re-speak interjection path; because it now runs at a sentence start, no sentence
+		// is cut mid-way.
+		private void SchedulePendingAnnouncement(int percent)
+		{
+			if (_currentText is null)
+				return;
+
+			_progressInterjectionInFlight = true;
 			int minutesRemaining = ReadingEstimate.RemainingWholeMinutes(_currentText.Length - _currentPosition);
-			string text = ReadingAnnouncements.Progress(crossed, minutesRemaining);
+			string text = ReadingAnnouncements.Progress(percent, minutesRemaining);
 			long epoch = _playbackEpoch;
 			Task.Run(() => SpeakProgressInterjection(text, epoch));
 		}
@@ -514,6 +551,16 @@ namespace CognitiveSupport
 				{
 					_currentPosition = _currentText.Length;
 					_navIndex = _sentenceStarts is { Count: > 0 } ? _sentenceStarts.Count - 1 : 0;
+
+					// A threshold crossed during the final sentence has no following boundary
+					// to flush at. The read has reached 100%, which is never announced as
+					// progress, so the pending announcement is dropped here (end of text
+					// speaks for itself). The guard keeps it correct if a completion ever
+					// lands below 100%.
+					int finalPercent = ProgressPercentAt(_currentPosition, _currentText.Length);
+					int pending = _progress.TakeOnCompletion(finalPercent);
+					if (pending > 0)
+						SchedulePendingAnnouncement(pending);
 				}
 			}
 		}

--- a/Mutation.Tests/ReadingPositionAndProgressTests.cs
+++ b/Mutation.Tests/ReadingPositionAndProgressTests.cs
@@ -140,6 +140,85 @@ public class ReadingPositionAndProgressTests
 		Assert.Equal(0, ReadingProgress.HighestThresholdCrossed(0, 50, 0));
 	}
 
+	// ---- ProgressDeferral: hold the announcement until a sentence boundary ----
+
+	[Fact]
+	public void Deferral_CrossingThreshold_HoldsItPendingNotImmediate()
+	{
+		var d = new ProgressDeferral();
+
+		// Crossing a threshold mid-sentence records it as pending; nothing is "taken" yet.
+		Assert.True(d.Observe(currentPercent: 25, stepPercent: 25));
+		Assert.Equal(25, d.PendingPercent);
+
+		// It is only released at the next sentence boundary.
+		Assert.Equal(25, d.TakeAtBoundary());
+		Assert.Equal(0, d.PendingPercent);
+	}
+
+	[Fact]
+	public void Deferral_NoThresholdReached_NothingPending()
+	{
+		var d = new ProgressDeferral();
+		Assert.False(d.Observe(currentPercent: 24, stepPercent: 25));
+		Assert.Equal(0, d.PendingPercent);
+		Assert.Equal(0, d.TakeAtBoundary());
+	}
+
+	[Fact]
+	public void Deferral_MultipleThresholdsBeforeBoundary_FlushesOnlyHighest()
+	{
+		var d = new ProgressDeferral();
+
+		// Several thresholds cross before the next boundary (25 -> 50 -> 75).
+		Assert.True(d.Observe(currentPercent: 25, stepPercent: 25));
+		Assert.True(d.Observe(currentPercent: 50, stepPercent: 25));
+		Assert.True(d.Observe(currentPercent: 75, stepPercent: 25));
+
+		// Only the highest is pending, so the boundary produces a single announcement.
+		Assert.Equal(75, d.TakeAtBoundary());
+
+		// The skipped lower thresholds never re-announce afterwards.
+		Assert.False(d.Observe(currentPercent: 76, stepPercent: 25));
+		Assert.Equal(0, d.TakeAtBoundary());
+	}
+
+	[Fact]
+	public void Deferral_FinalSentenceCompletesAtHundred_DropsPending()
+	{
+		var d = new ProgressDeferral();
+		d.Observe(currentPercent: 75, stepPercent: 25);
+
+		// Reaching the end (100%) is never announced as progress, so the pending 75 is dropped.
+		Assert.Equal(0, d.TakeOnCompletion(finalPercent: 100));
+		Assert.Equal(0, d.PendingPercent);
+	}
+
+	[Fact]
+	public void Deferral_CompletionBelowHundred_StillFlushesPending()
+	{
+		var d = new ProgressDeferral();
+		d.Observe(currentPercent: 50, stepPercent: 25);
+
+		// Defensive guard: a completion below 100% still speaks the held announcement.
+		Assert.Equal(50, d.TakeOnCompletion(finalPercent: 99));
+		Assert.Equal(0, d.PendingPercent);
+	}
+
+	[Fact]
+	public void Deferral_Reset_ClearsThresholdAndPending()
+	{
+		var d = new ProgressDeferral();
+		d.Observe(currentPercent: 50, stepPercent: 25);
+
+		d.Reset();
+
+		Assert.Equal(0, d.LastAnnouncedPercent);
+		Assert.Equal(0, d.PendingPercent);
+		// After a reset the same threshold can be crossed (and announced) again.
+		Assert.True(d.Observe(currentPercent: 25, stepPercent: 25));
+	}
+
 	// ---- ReadingAnnouncements: spoken phrasing ----
 
 	[Fact]


### PR DESCRIPTION
## Summary

Periodic progress announcements (for example *"50%, about 3 minutes left."*) used to interrupt the read the instant the spoken position crossed a percentage threshold. Because a threshold is almost always crossed partway through a sentence, the announcement cut the current sentence off mid-way, which is jarring to listen to.

This change holds the announcement until playback reaches the **next sentence boundary**, so it is spoken cleanly *between* sentences instead of in the middle of one. Only the *timing* of the announcement changes — the percentage, the minutes-remaining estimate, and the spoken phrasing are all unchanged.

## What changed

- **New `ProgressDeferral` value type** (`CognitiveSupport/ProgressDeferral.cs`) owns the small state machine for deferral: the highest threshold already passed and the one (if any) waiting to be spoken. It has no dependency on the speech synthesizer, so the timing rules are unit-testable on their own.
- **`TextToSpeechService`**: crossing a threshold now only *records* it as pending (`MaybeAnnounceProgress`). The pending announcement is flushed when the sentence index advances in `OnSpeakProgress`, recomputing minutes-remaining at flush time so the estimate matches the boundary position. Flushing reuses the existing cancel + re-speak path, but because it happens at a sentence start no sentence is cut off.
- **Multiple thresholds before a boundary** collapse to a single announcement of the highest; the skipped lower ones are marked passed silently.
- **Final-sentence edge case**: a threshold crossed during the last sentence has no following boundary. It is **dropped** when the read completes, because the read ends at 100%, which is never announced as progress (end of text speaks for itself). A defensive `< 100%` guard keeps it correct if a completion ever lands below 100%.
- Pending state is reset on a fresh read, resume, restart-from-beginning, skip, and stop. The existing epoch guard still lets a Stop/Skip/new read during the deferred window win.

## Test plan

- `dotnet test --configuration Release` — green (409 tests). New tests in `Mutation.Tests/ReadingPositionAndProgressTests.cs` cover:
  - defer-to-next-boundary (a crossed threshold is held pending, then released at the boundary),
  - multiple thresholds crossed before a boundary producing a single highest announcement,
  - the final-sentence completion drop (and the defensive below-100% flush),
  - reset clearing both threshold and pending state.
- Manual (recommended, on a machine with the WinUI app): start a long read with periodic announcements enabled and confirm a progress update is spoken only after the current sentence finishes — never cutting a sentence mid-way.

> Note: the full-solution `dotnet test` build copies the class library into the running app's output directory; if the app is open the copy step fails with a file-lock error unrelated to this change. Tests were run green via the test project, which builds the same library.

## Acceptance criteria

- [x] Progress is spoken only after the current sentence finishes; a sentence is never cut off mid-way.
- [x] Several thresholds crossed before the next boundary still produce a single announcement (the highest).
- [x] Existing periodic-progress behaviour preserved (enable / percent / minimum-minutes gating, reset on restart and skip, no 100% announcement).
- [x] New unit tests cover the defer-to-next-boundary and multiple-thresholds-before-boundary cases.
- [x] `dotnet test --configuration Release` is green.

Closes #136
