### PR TITLE
Make audio session retention count configurable (1–500) (#141)

### DIFF
--- a/CognitiveSupport/Settings.cs
+++ b/CognitiveSupport/Settings.cs
@@ -1,4 +1,5 @@
-﻿using System.Drawing;
+﻿using System;
+using System.Drawing;
 
 namespace CognitiveSupport;
 
@@ -144,6 +145,21 @@ public class SpeechToTextSettings
         public string? ActiveSpeechToTextService { get; set; }
 
         public int FileTranscriptionTimeoutSeconds { get; set; } = 300;
+
+        // Number of past speech-to-text recording sessions kept on disk. Once the count
+        // exceeds this, cleanup deletes the oldest first (never the active recording).
+        // Bounded to [MinRetainedSessions, MaxRetainedSessionsLimit]; a minimum of 1
+        // guarantees the most recent recording is never deleted.
+        public const int MinRetainedSessions = 1;
+        public const int MaxRetainedSessionsLimit = 500;
+        public const int DefaultMaxRetainedSessions = 10;
+
+        public int MaxRetainedSessions { get; set; } = DefaultMaxRetainedSessions;
+
+        // Clamp a retained-session count into the supported range. Applied on load and at
+        // cleanup time so a hand-edited JSON value outside the range cannot break cleanup.
+        public static int ClampRetainedSessions(int value) =>
+                Math.Clamp(value, MinRetainedSessions, MaxRetainedSessionsLimit);
 
         // Per-attempt timeout for the live record→transcribe path. Kept generous so the
         // first call after a reboot or app update can absorb cold-start latency (cold

--- a/Mutation.Tests/RetainedSessionsClampTests.cs
+++ b/Mutation.Tests/RetainedSessionsClampTests.cs
@@ -1,0 +1,70 @@
+using System.IO;
+using CognitiveSupport;
+using Mutation.Ui.Services;
+using Newtonsoft.Json;
+
+namespace Mutation.Tests;
+
+// Covers the retained-session count contract: a sensible default, clamping to the
+// supported [1, 500] range, and backward compatibility for settings files written
+// before the field existed.
+public class RetainedSessionsClampTests
+{
+	[Fact]
+	public void Default_Is_Ten()
+	{
+		Assert.Equal(10, new SpeechToTextSettings().MaxRetainedSessions);
+		Assert.Equal(10, SpeechToTextSettings.DefaultMaxRetainedSessions);
+	}
+
+	[Theory]
+	[InlineData(0, 1)]
+	[InlineData(-5, 1)]
+	[InlineData(1, 1)]
+	[InlineData(10, 10)]
+	[InlineData(500, 500)]
+	[InlineData(501, 500)]
+	[InlineData(100000, 500)]
+	public void Clamp_Bounds_To_1_Through_500(int input, int expected)
+	{
+		Assert.Equal(expected, SpeechToTextSettings.ClampRetainedSessions(input));
+	}
+
+	[Fact]
+	public void MissingField_DeserializesAs_Ten()
+	{
+		// A settings file written before this field existed has no MaxRetainedSessions key.
+		var stt = JsonConvert.DeserializeObject<SpeechToTextSettings>("{\"TempDirectory\":\"C:\\\\Temp\"}");
+		Assert.NotNull(stt);
+		Assert.Equal(10, stt!.MaxRetainedSessions);
+	}
+
+	[Fact]
+	public void EnsureSettings_ClampsOutOfRangeValueOnLoad()
+	{
+		Assert.Equal(1, ApplyEnsure(0).SpeechToTextSettings!.MaxRetainedSessions);
+		Assert.Equal(500, ApplyEnsure(9999).SpeechToTextSettings!.MaxRetainedSessions);
+		Assert.Equal(42, ApplyEnsure(42).SpeechToTextSettings!.MaxRetainedSessions);
+	}
+
+	private static Settings ApplyEnsure(int storedValue)
+	{
+		string tempPath = Path.Combine(Path.GetTempPath(), $"mutation-retain-{System.Guid.NewGuid():N}.json");
+		File.WriteAllText(tempPath, "{}");
+		try
+		{
+			var manager = new SettingsManager(tempPath);
+			var settings = new Settings
+			{
+				SpeechToTextSettings = new SpeechToTextSettings { MaxRetainedSessions = storedValue },
+			};
+			manager.EnsureSettings(settings, isNewFile: false);
+			return settings;
+		}
+		finally
+		{
+			if (File.Exists(tempPath))
+				File.Delete(tempPath);
+		}
+	}
+}

--- a/Mutation.Tests/SessionRetentionPlannerTests.cs
+++ b/Mutation.Tests/SessionRetentionPlannerTests.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Mutation.Ui;
+using Mutation.Ui.Core;
+
+namespace Mutation.Tests;
+
+// Verifies the pure retention-cleanup decision logic: which session files get deleted
+// for a chosen retention count, oldest first, never touching excluded (active) sessions.
+public class SessionRetentionPlannerTests
+{
+	private static List<SpeechSession> MakeSessions(int count)
+	{
+		// Ascending timestamps so index 0 is the oldest and index count-1 the newest.
+		var baseTime = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+		return Enumerable.Range(0, count)
+			.Select(i => new SpeechSession($@"C:\sessions\session_{i:000}.wav", baseTime.AddMinutes(i)))
+			.ToList();
+	}
+
+	private static HashSet<string> NoExclusions() => new(StringComparer.OrdinalIgnoreCase);
+
+	[Theory]
+	[InlineData(15, 5)]
+	[InlineData(11, 10)]
+	[InlineData(500, 1)]
+	public void RetainsExactlyN_DeletingOldestFirst(int total, int maxRetained)
+	{
+		var sessions = MakeSessions(total);
+
+		var toDelete = SessionRetentionPlanner.SelectSessionsToDelete(sessions, NoExclusions(), maxRetained);
+
+		// Exactly the surplus is deleted, and the survivors are the N most-recent.
+		Assert.Equal(total - maxRetained, toDelete.Count);
+		var deletedPaths = toDelete.Select(s => s.FilePath).ToHashSet();
+		var survivors = sessions.Where(s => !deletedPaths.Contains(s.FilePath)).ToList();
+		Assert.Equal(maxRetained, survivors.Count);
+		var expectedSurvivors = sessions.OrderByDescending(s => s.Timestamp).Take(maxRetained).Select(s => s.FilePath).ToHashSet();
+		Assert.True(survivors.All(s => expectedSurvivors.Contains(s.FilePath)));
+
+		// Deletions are ordered oldest first.
+		var orderedOldestFirst = toDelete.OrderBy(s => s.Timestamp).Select(s => s.FilePath).ToList();
+		Assert.Equal(orderedOldestFirst, toDelete.Select(s => s.FilePath).ToList());
+	}
+
+	[Fact]
+	public void UnderOrAtCap_DeletesNothing()
+	{
+		var sessions = MakeSessions(8);
+
+		Assert.Empty(SessionRetentionPlanner.SelectSessionsToDelete(sessions, NoExclusions(), 10));
+		Assert.Empty(SessionRetentionPlanner.SelectSessionsToDelete(sessions, NoExclusions(), 8));
+	}
+
+	[Fact]
+	public void ExcludedActiveSession_IsNeverDeleted_AndStillCountsTowardRetention()
+	{
+		var sessions = MakeSessions(15);
+		// Exclude the oldest, as if it were the active recording.
+		var active = sessions[0];
+		var exclusions = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { active.FilePath };
+
+		var toDelete = SessionRetentionPlanner.SelectSessionsToDelete(sessions, exclusions, 5);
+
+		Assert.DoesNotContain(active.FilePath, toDelete.Select(s => s.FilePath));
+		// 15 sessions, cap 5: ten of the non-excluded oldest are removed; the active one is kept.
+		Assert.Equal(10, toDelete.Count);
+		var survivors = sessions.Where(s => toDelete.All(d => d.FilePath != s.FilePath)).ToList();
+		Assert.Contains(active.FilePath, survivors.Select(s => s.FilePath));
+		Assert.Equal(5, survivors.Count);
+	}
+
+	[Fact]
+	public void EmptyInput_DeletesNothing()
+	{
+		Assert.Empty(SessionRetentionPlanner.SelectSessionsToDelete(new List<SpeechSession>(), NoExclusions(), 10));
+	}
+}

--- a/Mutation.Tests/SettingsDefaultsParityTests.cs
+++ b/Mutation.Tests/SettingsDefaultsParityTests.cs
@@ -71,6 +71,7 @@ public class SettingsDefaultsParityTests : IDisposable
 		Assert.Equal(SettingsDefaults.Speech.SpeechToTextWithLlmProcessingHotKey, stt.SpeechToTextWithLlmProcessingHotKey);
 		Assert.Equal(SettingsDefaults.Speech.TempDirectory, stt.TempDirectory);
 		Assert.Equal(SettingsDefaults.Speech.FileTranscriptionTimeoutSeconds, stt.FileTranscriptionTimeoutSeconds);
+		Assert.Equal(SettingsDefaults.Speech.MaxRetainedSessions, stt.MaxRetainedSessions);
 		Assert.Equal(SettingsDefaults.Speech.EnableSilenceStripping, stt.EnableSilenceStripping);
 		Assert.Equal(SettingsDefaults.Speech.SilenceThresholdDbFs, stt.SilenceThresholdDbFs);
 		Assert.Equal(SettingsDefaults.Speech.MinSilenceSeconds, stt.MinSilenceSeconds);

--- a/Mutation.Ui/Core/AppConstants.cs
+++ b/Mutation.Ui/Core/AppConstants.cs
@@ -5,14 +5,8 @@ namespace Mutation.Ui.Core;
 /// </summary>
 public static class AppConstants
 {
-    // ============================================================
-    // Session Management
-    // ============================================================
-
-    /// <summary>
-    /// Maximum number of speech sessions to retain before cleanup removes the oldest.
-    /// </summary>
-    public const int MaxSpeechSessions = 10;
+    // Speech session retention is now user-configurable; see
+    // SpeechToTextSettings.MaxRetainedSessions (default 10, range 1–500).
 
     // ============================================================
     // Rate Limiting

--- a/Mutation.Ui/Core/SessionRetentionPlanner.cs
+++ b/Mutation.Ui/Core/SessionRetentionPlanner.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Mutation.Ui.Core;
+
+/// <summary>
+/// Pure decision logic for session retention cleanup: given the current sessions,
+/// the set of paths that must never be deleted, and the retention cap, decide which
+/// session files to delete. Kept free of any filesystem access so it is unit-testable
+/// in isolation; <see cref="SpeechToTextManager"/> owns the actual deletion and its
+/// best-effort error handling.
+/// </summary>
+internal static class SessionRetentionPlanner
+{
+	/// <summary>
+	/// Returns the session file paths to delete, oldest first, to bring the retained
+	/// count down to <paramref name="maxRetained"/>. Excluded sessions (e.g. the active
+	/// recording) are never deleted and still count toward the retained total, so the
+	/// active recording is preserved without shrinking the kept window below the cap.
+	/// </summary>
+	public static IReadOnlyList<SpeechSession> SelectSessionsToDelete(
+		IReadOnlyCollection<SpeechSession> sessions,
+		ISet<string> exclusions,
+		int maxRetained)
+	{
+		ArgumentNullException.ThrowIfNull(sessions);
+		ArgumentNullException.ThrowIfNull(exclusions);
+
+		int currentCount = sessions.Count;
+		if (currentCount <= maxRetained)
+			return Array.Empty<SpeechSession>();
+
+		var toDelete = new List<SpeechSession>();
+		foreach (var session in sessions.OrderBy(s => s.Timestamp))
+		{
+			if (currentCount <= maxRetained)
+				break;
+
+			if (exclusions.Contains(session.FilePath))
+				continue;
+
+			toDelete.Add(session);
+			currentCount--;
+		}
+
+		return toDelete;
+	}
+}

--- a/Mutation.Ui/Core/SpeechToTextManager.cs
+++ b/Mutation.Ui/Core/SpeechToTextManager.cs
@@ -15,7 +15,6 @@ public class SpeechToTextManager : IDisposable
 {
 	private const string SessionFilePrefix = "session_";
 	private const string SessionTimestampFormat = "yyyy-MM-dd_HH-mm-ss";
-	private const int MaxSessions = AppConstants.MaxSpeechSessions;
 	private static readonly TimeSpan SessionRetryDelay = TimeSpan.FromSeconds(1);
 	private static readonly Regex SessionFilePattern = new(
 			  "^session_(\\d{4}-\\d{2}-\\d{2}_\\d{2}-\\d{2}-\\d{2})\\.[A-Za-z0-9]+$",
@@ -358,24 +357,18 @@ public class SpeechToTextManager : IDisposable
 					sessions.Add(session);
 			}
 
-			sessions.Sort((left, right) => right.Timestamp.CompareTo(left.Timestamp));
+			// Read the retention cap at cleanup time (clamped defensively) so a changed
+			// setting takes effect without an app restart, and a hand-edited out-of-range
+			// JSON value cannot break cleanup.
+			int maxRetained = SpeechToTextSettings.ClampRetainedSessions(
+				_settings.SpeechToTextSettings?.MaxRetainedSessions
+				?? SpeechToTextSettings.DefaultMaxRetainedSessions);
 
-			int currentCount = sessions.Count;
-			if (currentCount <= MaxSessions)
-				return;
-
-			foreach (var session in sessions.OrderBy(s => s.Timestamp))
+			foreach (var session in SessionRetentionPlanner.SelectSessionsToDelete(sessions, exclusions, maxRetained))
 			{
-				if (currentCount <= MaxSessions)
-					break;
-
-				if (exclusions.Contains(session.FilePath))
-					continue;
-
 				try
 				{
 					File.Delete(session.FilePath);
-					currentCount--;
 				}
 				catch (DirectoryNotFoundException)
 				{

--- a/Mutation.Ui/Resources/HelpText.xaml
+++ b/Mutation.Ui/Resources/HelpText.xaml
@@ -37,6 +37,7 @@
 	<!-- Speech to Text -->
 	<x:String x:Key="Help.Speech.FileTimeout">How long to wait for a file transcription to finish before giving up.</x:String>
 	<x:String x:Key="Help.Speech.TempDir">Folder where temporary audio files are written during recording and transcription.</x:String>
+	<x:String x:Key="Help.Speech.MaxRetainedSessions">How many past recording sessions to keep on disk. When you exceed this, the oldest are deleted first; the recording in progress is never deleted. Range 1 to 500. Default 10.</x:String>
 	<x:String x:Key="Help.Speech.SendHotkeyAfter">Optional keystrokes sent to the active app after a transcript is delivered, for example CTRL+V to paste.</x:String>
 	<x:String x:Key="Help.Speech.StripSilence">Remove long silent gaps from audio before transcription, so pauses while you think do not bloat the recording. Applies to live recordings and imported files.</x:String>
 	<x:String x:Key="Help.Speech.SilenceThreshold">Loudness floor in dBFS. Audio at or below this level counts as silence. Lower (more negative) values are stricter, treating only quieter sounds as silence. Default -40.</x:String>

--- a/Mutation.Ui/Services/SettingsManager.cs
+++ b/Mutation.Ui/Services/SettingsManager.cs
@@ -362,6 +362,16 @@ internal class SettingsManager : ISettingsManager
 			somethingWasMissing = true;
 		}
 
+		// A settings file missing this field keeps the property initializer default (10);
+		// an explicit out-of-range value is clamped to [1, 500] so cleanup cannot retain
+		// zero (which would delete every recording) or an unbounded count.
+		int clampedRetained = SpeechToTextSettings.ClampRetainedSessions(speechToTextSettings.MaxRetainedSessions);
+		if (clampedRetained != speechToTextSettings.MaxRetainedSessions)
+		{
+			speechToTextSettings.MaxRetainedSessions = clampedRetained;
+			somethingWasMissing = true;
+		}
+
 		var duplicateGroups = speechToTextSettings.Services
 			 .GroupBy(s => s.Name, StringComparer.OrdinalIgnoreCase)
 			 .Where(g => g.Count() > 1)

--- a/Mutation.Ui/Views/Settings/Pages/SpeechSettingsPage.xaml
+++ b/Mutation.Ui/Views/Settings/Pages/SpeechSettingsPage.xaml
@@ -154,6 +154,27 @@
 
 		<StackPanel Spacing="4">
 			<StackPanel Orientation="Horizontal" Spacing="6">
+				<TextBlock Text="Recording sessions to keep" VerticalAlignment="Center" Style="{StaticResource BodyStrongTextBlockStyle}" />
+				<controls:InfoHint Text="{StaticResource Help.Speech.MaxRetainedSessions}" VerticalAlignment="Center" />
+			</StackPanel>
+			<StackPanel Orientation="Horizontal" Spacing="6">
+				<NumberBox x:Name="NbMaxRetainedSessions"
+						   AutomationProperties.Name="Recording sessions to keep"
+						   AutomationProperties.HelpText="{StaticResource Help.Speech.MaxRetainedSessions}"
+						   ToolTipService.ToolTip="{StaticResource Help.Speech.MaxRetainedSessions}"
+						   Minimum="1" Maximum="500"
+						   SmallChange="1" LargeChange="10"
+						   SpinButtonPlacementMode="Inline"
+						   Width="220"
+						   ValueChanged="NbMaxRetainedSessions_ValueChanged" />
+				<Button Click="BtnResetMaxRetainedSessions_Click" ToolTipService.ToolTip="Reset to default" AutomationProperties.Name="Reset recording sessions to keep">
+					<FontIcon Glyph="&#xE72C;" FontFamily="Segoe Fluent Icons" FontSize="12" AutomationProperties.AccessibilityView="Raw" />
+				</Button>
+			</StackPanel>
+		</StackPanel>
+
+		<StackPanel Spacing="4">
+			<StackPanel Orientation="Horizontal" Spacing="6">
 				<TextBlock Text="Temp directory" VerticalAlignment="Center" Style="{StaticResource BodyStrongTextBlockStyle}" />
 				<controls:InfoHint Text="{StaticResource Help.Speech.TempDir}" VerticalAlignment="Center" />
 			</StackPanel>

--- a/Mutation.Ui/Views/Settings/Pages/SpeechSettingsPage.xaml.cs
+++ b/Mutation.Ui/Views/Settings/Pages/SpeechSettingsPage.xaml.cs
@@ -57,6 +57,7 @@ public sealed partial class SpeechSettingsPage : UserControl
 			NbFileTimeout.Value = stt.FileTranscriptionTimeoutSeconds > 0
 				? stt.FileTranscriptionTimeoutSeconds
 				: SettingsDefaults.Speech.FileTranscriptionTimeoutSeconds;
+			NbMaxRetainedSessions.Value = SpeechToTextSettings.ClampRetainedSessions(stt.MaxRetainedSessions);
 			TxtTempDir.Text = stt.TempDirectory ?? string.Empty;
 			HkSendAfterTranscription.Hotkey = stt.SendHotkeyAfterTranscriptionOperation ?? string.Empty;
 
@@ -140,6 +141,17 @@ public sealed partial class SpeechSettingsPage : UserControl
 
 	private void BtnResetFileTimeout_Click(object sender, RoutedEventArgs e) =>
 		NbFileTimeout.Value = SettingsDefaults.Speech.FileTranscriptionTimeoutSeconds;
+
+	private void NbMaxRetainedSessions_ValueChanged(NumberBox sender, NumberBoxValueChangedEventArgs args)
+	{
+		if (_suppressEvents) return;
+		if (double.IsNaN(args.NewValue)) return;
+		(_settings.SpeechToTextSettings ??= new SpeechToTextSettings()).MaxRetainedSessions =
+			SpeechToTextSettings.ClampRetainedSessions((int)args.NewValue);
+	}
+
+	private void BtnResetMaxRetainedSessions_Click(object sender, RoutedEventArgs e) =>
+		NbMaxRetainedSessions.Value = SettingsDefaults.Speech.MaxRetainedSessions;
 
 	private void ChkStripSilence_Changed(object sender, RoutedEventArgs e)
 	{

--- a/Mutation.Ui/Views/Settings/SettingsDefaults.cs
+++ b/Mutation.Ui/Views/Settings/SettingsDefaults.cs
@@ -1,3 +1,5 @@
+using CognitiveSupport;
+
 namespace Mutation.Ui.Views.SettingsUi;
 
 // Single source of truth for default values exposed by the Settings dialog and
@@ -38,6 +40,11 @@ internal static class SettingsDefaults
 		public const string SpeechToTextWithLlmProcessingHotKey = "SHIFT+ALT+I";
 		public const string TempDirectory = @"C:\Temp\Mutation";
 		public const int FileTranscriptionTimeoutSeconds = 300;
+		// Retained-session count: default and UI bounds mirror the domain so the dialog,
+		// the load-time clamp, and cleanup all agree on one source of truth.
+		public const int MaxRetainedSessions = SpeechToTextSettings.DefaultMaxRetainedSessions;
+		public const int MinRetainedSessions = SpeechToTextSettings.MinRetainedSessions;
+		public const int MaxRetainedSessionsLimit = SpeechToTextSettings.MaxRetainedSessionsLimit;
 		public const int ServiceTimeoutSeconds = 10;
 		public const string DefaultServiceName = "OpenAI Whisper 1";
 		public const string DefaultServiceModelId = "whisper-1";

--- a/Mutation.Ui/Views/Settings/SettingsWorkingCopy.cs
+++ b/Mutation.Ui/Views/Settings/SettingsWorkingCopy.cs
@@ -70,6 +70,7 @@ internal static class SettingsWorkingCopy
 			dst.Services = src.Services;
 			dst.ActiveSpeechToTextService = src.ActiveSpeechToTextService;
 			dst.FileTranscriptionTimeoutSeconds = src.FileTranscriptionTimeoutSeconds;
+			dst.MaxRetainedSessions = src.MaxRetainedSessions;
 			dst.EnableSilenceStripping = src.EnableSilenceStripping;
 			dst.SilenceThresholdDbFs = src.SilenceThresholdDbFs;
 			dst.MinSilenceSeconds = src.MinSilenceSeconds;


### PR DESCRIPTION
## Summary

The number of past speech-to-text recording sessions kept on disk was hardcoded to **10**. This makes it a user-configurable setting on the **Speech** settings page, so users can keep more history (to re-transcribe older recordings) or set a tighter cap to save disk. Default stays 10, so existing behavior is preserved.

## What changed

- **Setting (domain).** Added `SpeechToTextSettings.MaxRetainedSessions` (default 10) with bound constants and a `ClampRetainedSessions` helper as the single source of truth for the inclusive range **[1, 500]**. A minimum of 1 guarantees the most-recent recording is never deleted.
- **Backward compatibility + clamping.** A settings file missing the field loads as 10 (property initializer). `SettingsManager.EnsureSettings` clamps an explicit out-of-range value on load, so a hand-edited or pre-existing JSON value cannot break cleanup.
- **Wiring.** `SpeechToTextManager` now reads the cap at cleanup time (clamped defensively) instead of the constant, so a changed value takes effect without an app restart. The retention decision is extracted into a pure, unit-testable `SessionRetentionPlanner` (deletes oldest first, never the active/excluded session). The now-unused `AppConstants.MaxSpeechSessions` was removed.
- **Accessible UI.** A `NumberBox` (min 1, max 500, spin buttons) on the Speech page, with `AutomationProperties.Name`, `AutomationProperties.HelpText`, and a `ToolTipService.ToolTip`, plus a reset-to-default button — keyboard-operable and screen-reader/ZoomText friendly, matching the page's existing control pattern. The value is routed through the settings working-copy so **Apply/OK** persists it and **Cancel** discards it.

## Acceptance criteria

- [x] Speech page shows a "sessions to keep" numeric control, bounded 1–500, defaulting to 10.
- [x] Changing the value and Apply/OK persists it; Cancel discards (working-copy plumbing).
- [x] Control is keyboard-operable and announced by the screen reader / ZoomText (AutomationProperties + tooltip).
- [x] With the value set to N, only the N most-recent recordings remain; the active session is never deleted (covered by `SessionRetentionPlanner` tests).
- [x] A settings file missing the field loads as 10; out-of-range JSON values clamp to [1, 500].
- [x] `dotnet test --configuration Release` passes.

## Test plan

- `dotnet test --configuration Release` → **437 passed, 0 failed**.
- New tests:
  - `SessionRetentionPlannerTests` — retains exactly N most-recent, deletes oldest first, excluded/active session never deleted and still counts toward retention, empty/under-cap cases.
  - `RetainedSessionsClampTests` — default is 10, clamp bounds [1, 500], load-time clamp via `EnsureSettings`, missing-field deserializes as 10.
  - `SettingsDefaultsParityTests` — parity assertion for the new default.

## Manual verification (needs human, WinUI runtime)

- Open Settings → Speech, confirm the control reads/writes correctly and is announced by the screen reader; verify on-disk retention after recording more than N sessions.

Closes #141
