### PR TITLE
Pin microphone input level and auto-restore it (#140)

### DIFF
--- a/CognitiveSupport/Settings.cs
+++ b/CognitiveSupport/Settings.cs
@@ -30,6 +30,12 @@ public class AudioSettings
 	public string? MicrophoneToggleMuteHotKey { get; set; }
         // Allows users to disable microphone visualization to save CPU
         public bool EnableMicrophoneVisualization { get; set; } = true;
+
+        // User-pinned Windows capture level (0–100) for the active microphone. When set,
+        // Mutation re-asserts this level on record/dictate, mic selection, and app startup
+        // so it stays consistent regardless of what other apps do. null means pinning is
+        // disabled ("don't manage the level").
+        public int? PinnedCaptureLevel { get; set; }
 	public CustomBeepSettingsData? CustomBeepSettings { get => customBeepSettings; set => customBeepSettings = value; }
 
 	public AudioSettings() { }

--- a/Mutation.Tests/MicrophoneLevelPinServiceTests.cs
+++ b/Mutation.Tests/MicrophoneLevelPinServiceTests.cs
@@ -1,0 +1,181 @@
+using System;
+using Mutation.Ui.Core;
+using Xunit;
+
+namespace Mutation.Tests;
+
+public class MicrophoneLevelPinServiceTests
+{
+	// Records every interaction so tests can assert the pin logic's behavior
+	// without real audio hardware. Crucially, this fake has no way to change mute
+	// state, mirroring ICaptureLevelController — the pin service can never touch it.
+	private sealed class FakeCaptureLevelController : ICaptureLevelController
+	{
+		public bool Supported { get; set; } = true;
+		public float? Level { get; set; }
+		public int SetCount { get; private set; }
+		public float? LastSet { get; private set; }
+		// Stands in for the device's mute flag; the pin service must never alter it.
+		public bool Mute { get; set; }
+
+		public bool IsLevelControlSupported => Supported;
+
+		public float? GetLevelScalar() => Level;
+
+		public void SetLevelScalar(float scalar)
+		{
+			SetCount++;
+			LastSet = scalar;
+			Level = scalar; // reflect the write so later reads see it
+		}
+	}
+
+	private static MicrophoneLevelPinService NewService(FakeCaptureLevelController controller) =>
+		new(controller);
+
+	[Fact]
+	public void ReassertPinnedLevel_AppliesPin_WhenEnabledAndDifferent()
+	{
+		var controller = new FakeCaptureLevelController { Level = 0.20f };
+		var service = NewService(controller);
+
+		bool changed = service.ReassertPinnedLevel(80);
+
+		Assert.True(changed);
+		Assert.Equal(1, controller.SetCount);
+		Assert.NotNull(controller.LastSet);
+		Assert.Equal(0.80f, controller.LastSet!.Value, 3);
+	}
+
+	[Fact]
+	public void ReassertPinnedLevel_IsNoOp_WhenDisabled()
+	{
+		var controller = new FakeCaptureLevelController { Level = 0.20f };
+		var service = NewService(controller);
+
+		bool changed = service.ReassertPinnedLevel(null);
+
+		Assert.False(changed);
+		Assert.Equal(0, controller.SetCount);
+	}
+
+	[Fact]
+	public void ReassertPinnedLevel_SkipsWrite_WhenWithinEpsilon()
+	{
+		// Current 50, pin 51 — one unit apart, which is at the epsilon boundary.
+		var controller = new FakeCaptureLevelController { Level = 0.50f };
+		var service = NewService(controller);
+
+		bool changed = service.ReassertPinnedLevel(51);
+
+		Assert.False(changed);
+		Assert.Equal(0, controller.SetCount);
+	}
+
+	[Fact]
+	public void ReassertPinnedLevel_Writes_WhenBeyondEpsilon()
+	{
+		// Current 50, pin 52 — two units apart, beyond the 1-unit epsilon.
+		var controller = new FakeCaptureLevelController { Level = 0.50f };
+		var service = NewService(controller);
+
+		bool changed = service.ReassertPinnedLevel(52);
+
+		Assert.True(changed);
+		Assert.Equal(1, controller.SetCount);
+		Assert.Equal(0.52f, controller.LastSet!.Value, 3);
+	}
+
+	[Fact]
+	public void Pinning_NeverChangesMuteState()
+	{
+		var controller = new FakeCaptureLevelController { Level = 0.10f, Mute = true };
+		var service = NewService(controller);
+
+		service.ReassertPinnedLevel(90);
+		service.ApplyLevel(40);
+
+		Assert.True(controller.Mute); // mute left exactly as it was
+	}
+
+	[Fact]
+	public void ReassertPinnedLevel_IsNoOpAndDoesNotThrow_OnUnsupportedDevice()
+	{
+		var controller = new FakeCaptureLevelController { Supported = false, Level = 0.20f };
+		var service = NewService(controller);
+
+		bool changed = service.ReassertPinnedLevel(80);
+
+		Assert.False(changed);
+		Assert.Equal(0, controller.SetCount);
+		Assert.False(service.IsLevelControlSupported);
+	}
+
+	[Fact]
+	public void ApplyLevel_IsNoOp_OnUnsupportedDevice()
+	{
+		var controller = new FakeCaptureLevelController { Supported = false, Level = 0.20f };
+		var service = NewService(controller);
+
+		bool changed = service.ApplyLevel(30);
+
+		Assert.False(changed);
+		Assert.Equal(0, controller.SetCount);
+	}
+
+	[Fact]
+	public void ApplyLevel_WritesImmediately_ForLiveDrag()
+	{
+		var controller = new FakeCaptureLevelController { Level = 0.90f };
+		var service = NewService(controller);
+
+		bool changed = service.ApplyLevel(30);
+
+		Assert.True(changed);
+		Assert.Equal(1, controller.SetCount);
+		Assert.Equal(0.30f, controller.LastSet!.Value, 3);
+	}
+
+	[Fact]
+	public void WriteLevel_ClampsAboveMaximum()
+	{
+		var controller = new FakeCaptureLevelController { Level = 0.0f };
+		var service = NewService(controller);
+
+		bool changed = service.ApplyLevel(150);
+
+		Assert.True(changed);
+		Assert.Equal(1.0f, controller.LastSet!.Value, 3);
+	}
+
+	[Fact]
+	public void WriteLevel_ClampsBelowMinimum()
+	{
+		var controller = new FakeCaptureLevelController { Level = 1.0f };
+		var service = NewService(controller);
+
+		bool changed = service.ReassertPinnedLevel(-10);
+
+		Assert.True(changed);
+		Assert.Equal(0.0f, controller.LastSet!.Value, 3);
+	}
+
+	[Fact]
+	public void WriteLevel_WritesWhenCurrentLevelUnknown()
+	{
+		// A supported device whose current level can't be read still gets written.
+		var controller = new FakeCaptureLevelController { Supported = true, Level = null };
+		var service = NewService(controller);
+
+		bool changed = service.ReassertPinnedLevel(60);
+
+		Assert.True(changed);
+		Assert.Equal(0.60f, controller.LastSet!.Value, 3);
+	}
+
+	[Fact]
+	public void Constructor_RejectsNullController()
+	{
+		Assert.Throws<ArgumentNullException>(() => new MicrophoneLevelPinService(null!));
+	}
+}

--- a/Mutation.Ui/App.xaml.cs
+++ b/Mutation.Ui/App.xaml.cs
@@ -191,6 +191,10 @@ public partial class App : Application
 			builder.Services.AddSingleton<UiStateManager>();
 			builder.Services.AddSingleton<MMDeviceEnumerator>(_ => new MMDeviceEnumerator(Guid.NewGuid()));
 			builder.Services.AddSingleton<AudioDeviceManager>();
+			builder.Services.AddSingleton<Mutation.Ui.Core.ICaptureLevelController>(sp =>
+				new Mutation.Ui.Core.CoreAudioCaptureLevelController(
+					() => sp.GetRequiredService<AudioDeviceManager>().Microphone));
+			builder.Services.AddSingleton<Mutation.Ui.Core.MicrophoneLevelPinService>();
 			builder.Services.AddSingleton<IOcrService>(sp =>
 	 new OcrService(
 		  settings.AzureComputerVisionSettings?.ApiKey,

--- a/Mutation.Ui/Core/AudioSessionManager.cs
+++ b/Mutation.Ui/Core/AudioSessionManager.cs
@@ -24,6 +24,7 @@ public class AudioSessionManager : IDisposable
     private readonly AudioDeviceManager _audioDeviceManager;
     private readonly TranscriptFormatter _transcriptFormatter;
     private readonly Settings _settings;
+    private readonly MicrophoneLevelPinService _levelPinService;
     private readonly AudioPlayer _playbackPlayer;
     private SpeechSession? _playingSession;
     private SpeechSession? _selectedSession;
@@ -61,12 +62,14 @@ public class AudioSessionManager : IDisposable
         SpeechToTextManager speechManager,
         AudioDeviceManager audioDeviceManager,
         TranscriptFormatter transcriptFormatter,
-        Settings settings)
+        Settings settings,
+        MicrophoneLevelPinService levelPinService)
     {
         _speechManager = speechManager;
         _audioDeviceManager = audioDeviceManager;
         _transcriptFormatter = transcriptFormatter;
         _settings = settings;
+        _levelPinService = levelPinService;
 
         _playbackPlayer = new AudioPlayer();
         _playbackPlayer.PlaybackEnded += PlaybackPlayer_PlaybackEnded;
@@ -145,6 +148,10 @@ public class AudioSessionManager : IDisposable
             {
                 _currentRecordingUsesLlmProcessing = useLlmProcessing;
                 StopPlayback();
+
+                // Re-assert the pinned capture level right before recording so a level
+                // another app may have changed is corrected back to the user's choice.
+                _levelPinService.ReassertPinnedLevel(_settings.AudioSettings?.PinnedCaptureLevel);
 
                 StatusMessage?.Invoke(this, "Listening for audio...");
                 StateChanged?.Invoke(this, EventArgs.Empty); // Notify UI to update buttons (Stop)

--- a/Mutation.Ui/Core/CoreAudioCaptureLevelController.cs
+++ b/Mutation.Ui/Core/CoreAudioCaptureLevelController.cs
@@ -1,0 +1,59 @@
+using CoreAudio;
+using System;
+
+namespace Mutation.Ui.Core;
+
+/// <summary>
+/// CoreAudio-backed <see cref="ICaptureLevelController"/>. Resolves the active
+/// microphone lazily through a delegate (over
+/// <see cref="AudioDeviceManager.Microphone"/>) so it always targets the
+/// currently-selected device, and so this controller does not depend on the
+/// device manager directly (which would form a cycle through the pin service).
+/// </summary>
+public sealed class CoreAudioCaptureLevelController : ICaptureLevelController
+{
+	private readonly Func<MMDevice?> _activeDevice;
+
+	public CoreAudioCaptureLevelController(Func<MMDevice?> activeDevice)
+	{
+		_activeDevice = activeDevice ?? throw new ArgumentNullException(nameof(activeDevice));
+	}
+
+	public bool IsLevelControlSupported => GetLevelScalar() is not null;
+
+	public float? GetLevelScalar()
+	{
+		var volume = _activeDevice()?.AudioEndpointVolume;
+		if (volume is null)
+			return null;
+
+		try
+		{
+			return volume.MasterVolumeLevelScalar;
+		}
+		catch
+		{
+			// Hardware-fixed or transient failure — treat as unreadable, never throw.
+			return null;
+		}
+	}
+
+	public void SetLevelScalar(float scalar)
+	{
+		var volume = _activeDevice()?.AudioEndpointVolume;
+		if (volume is null)
+			return;
+
+		float clamped = scalar < 0f ? 0f : scalar > 1f ? 1f : scalar;
+		try
+		{
+			// Only the level scalar is written; Mute is deliberately left untouched.
+			volume.MasterVolumeLevelScalar = clamped;
+		}
+		catch
+		{
+			// Hardware-fixed or transient failure — skip silently per the story's
+			// graceful-degradation requirement.
+		}
+	}
+}

--- a/Mutation.Ui/Core/ICaptureLevelController.cs
+++ b/Mutation.Ui/Core/ICaptureLevelController.cs
@@ -1,0 +1,29 @@
+namespace Mutation.Ui.Core;
+
+/// <summary>
+/// Abstraction over the active capture device's endpoint level — the Windows
+/// 0–100 "Line" slider on the device's Levels tab, exposed by CoreAudio as a
+/// 0.0–1.0 scalar (<c>MasterVolumeLevelScalar</c>). Hiding the hardware behind
+/// this interface lets the pin logic in <see cref="MicrophoneLevelPinService"/>
+/// be unit-tested without audio hardware.
+/// </summary>
+public interface ICaptureLevelController
+{
+	/// <summary>
+	/// True when the active device exposes a controllable software level. False
+	/// for hardware-fixed devices (no endpoint volume object or unreadable level).
+	/// </summary>
+	bool IsLevelControlSupported { get; }
+
+	/// <summary>
+	/// The active device's current level as a 0.0–1.0 scalar, or <c>null</c> when
+	/// no device is selected or the level cannot be read.
+	/// </summary>
+	float? GetLevelScalar();
+
+	/// <summary>
+	/// Sets the active device's level (clamped to 0.0–1.0). Never alters mute
+	/// state. A no-op when no device is selected or the device is hardware-fixed.
+	/// </summary>
+	void SetLevelScalar(float scalar);
+}

--- a/Mutation.Ui/Core/MicrophoneLevelPinService.cs
+++ b/Mutation.Ui/Core/MicrophoneLevelPinService.cs
@@ -1,0 +1,74 @@
+using System;
+
+namespace Mutation.Ui.Core;
+
+/// <summary>
+/// Applies a user-pinned capture level to the active microphone and re-asserts
+/// it on record/dictate, mic selection, and app startup, so the Windows capture
+/// level stays consistent regardless of what other apps do. All hardware access
+/// goes through <see cref="ICaptureLevelController"/>, keeping the rules here
+/// unit-testable without audio hardware.
+/// </summary>
+public sealed class MicrophoneLevelPinService
+{
+	/// <summary>
+	/// Levels closer than this (on the 0–100 scale) count as already correct, so
+	/// no redundant write is issued. One unit of 100 equals a 0.01 scalar.
+	/// </summary>
+	public const int LevelEpsilon = 1;
+
+	public const int MinLevel = 0;
+	public const int MaxLevel = 100;
+
+	private readonly ICaptureLevelController _controller;
+
+	public MicrophoneLevelPinService(ICaptureLevelController controller)
+	{
+		_controller = controller ?? throw new ArgumentNullException(nameof(controller));
+	}
+
+	/// <summary>
+	/// True when the active device exposes a controllable software level. The UI
+	/// uses this to disable the control on hardware-fixed devices.
+	/// </summary>
+	public bool IsLevelControlSupported => _controller.IsLevelControlSupported;
+
+	/// <summary>
+	/// Re-asserts the pinned level. A <c>null</c> target means pinning is disabled,
+	/// which is a no-op. Returns true when the hardware level was actually changed.
+	/// </summary>
+	public bool ReassertPinnedLevel(int? pinnedLevel)
+	{
+		if (pinnedLevel is null)
+			return false;
+
+		return WriteLevel(pinnedLevel.Value);
+	}
+
+	/// <summary>
+	/// Applies a level the user is setting live (e.g. dragging the slider), giving
+	/// instant feedback even when not recording. Honors the same epsilon and
+	/// mute rules as <see cref="ReassertPinnedLevel"/>. Returns true when the
+	/// hardware level was changed.
+	/// </summary>
+	public bool ApplyLevel(int level) => WriteLevel(level);
+
+	private bool WriteLevel(int level)
+	{
+		if (!_controller.IsLevelControlSupported)
+			return false;
+
+		int target = Clamp(level);
+		float? current = _controller.GetLevelScalar();
+
+		// Skip redundant writes when the current level is already within epsilon.
+		if (current is float c && Math.Abs(c * 100f - target) <= LevelEpsilon)
+			return false;
+
+		_controller.SetLevelScalar(target / 100f);
+		return true;
+	}
+
+	private static int Clamp(int level) =>
+		level < MinLevel ? MinLevel : level > MaxLevel ? MaxLevel : level;
+}

--- a/Mutation.Ui/MainWindow.xaml
+++ b/Mutation.Ui/MainWindow.xaml
@@ -242,6 +242,31 @@
                                     </Grid>
                                 </StackPanel>
                             </Grid>
+
+                            <StackPanel x:Name="MicLevelPinPanel" Spacing="8" Margin="0,12,0,0">
+                                <ToggleSwitch
+                                    x:Name="TglPinMicLevel"
+                                    Header="Pin input level"
+                                    OffContent="Off"
+                                    OnContent="On"
+                                    Toggled="TglPinMicLevel_Toggled"
+                                    AutomationProperties.Name="Pin microphone input level"
+                                    ToolTipService.ToolTip="Keep the Windows capture level fixed at the chosen value, re-asserting it on each recording, mic change, and app start" />
+                                <StackPanel Spacing="4">
+                                    <TextBlock Text="Input level" />
+                                    <Slider
+                                        x:Name="SldMicLevel"
+                                        Minimum="0"
+                                        Maximum="100"
+                                        StepFrequency="1"
+                                        TickFrequency="10"
+                                        TickPlacement="Outside"
+                                        SnapsTo="StepValues"
+                                        ValueChanged="SldMicLevel_ValueChanged"
+                                        AutomationProperties.Name="Microphone input level"
+                                        ToolTipService.ToolTip="Set the Windows capture level (0 to 100); the change applies immediately, even when not recording" />
+                                </StackPanel>
+                            </StackPanel>
                             </StackPanel>
                         </Grid>
                     </Border>

--- a/Mutation.Ui/MainWindow.xaml.cs
+++ b/Mutation.Ui/MainWindow.xaml.cs
@@ -38,6 +38,8 @@ public sealed partial class MainWindow : Window, IDisposable
 	private readonly OcrManager _ocrManager;
 	private readonly ISpeechToTextService[] _speechServices;
 	private readonly Mutation.Ui.Core.AudioSessionManager _audioSessionManager;
+	private readonly Mutation.Ui.Core.MicrophoneLevelPinService _micLevelPinService;
+	private readonly Mutation.Ui.Core.ICaptureLevelController _captureLevelController;
 	private readonly TranscriptFormatter _transcriptFormatter;
 	private readonly ITextToSpeechService _textToSpeech;
 	private readonly IWavFileSpeechExporter _wavFileSpeechExporter;
@@ -57,6 +59,13 @@ public sealed partial class MainWindow : Window, IDisposable
 	private readonly DispatcherTimer _statusDismissTimer;
 	private bool _isDialogOpen;
 	private bool _ttsControlsReady;
+	private bool _micLevelControlsReady;
+	// True once the mic-level controls have been set up at least once, so the
+	// microphone-selection handler knows it is safe to re-sync them for a new device.
+	private bool _micLevelInitialized;
+	// Slider position used when pinning is toggled off and the device has no
+	// readable level to fall back to, so the control still shows a sensible value.
+	private const int DefaultMicLevel = 75;
 	private const string DefaultVoiceLabel = "(System default)";
 
 	private static readonly IReadOnlyDictionary<string, string> AudioMimeTypeMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
@@ -104,7 +113,9 @@ public sealed partial class MainWindow : Window, IDisposable
 
 		ISettingsManager settingsManager,
 		Settings settings,
-		Mutation.Ui.Core.AudioSessionManager audioSessionManager)
+		Mutation.Ui.Core.AudioSessionManager audioSessionManager,
+		Mutation.Ui.Core.MicrophoneLevelPinService micLevelPinService,
+		Mutation.Ui.Core.ICaptureLevelController captureLevelController)
 	{
 		_clipboard = clipboard;
 		_uiStateManager = uiStateManager;
@@ -118,6 +129,8 @@ public sealed partial class MainWindow : Window, IDisposable
 		_settings = settings;
 
         _audioSessionManager = audioSessionManager;
+        _micLevelPinService = micLevelPinService;
+        _captureLevelController = captureLevelController;
         _audioSessionManager.StateChanged += AudioSessionManager_StateChanged;
         _audioSessionManager.TranscriptReady += AudioSessionManager_TranscriptReady;
         _audioSessionManager.ErrorOccurred += AudioSessionManager_ErrorOccurred;
@@ -210,6 +223,7 @@ public sealed partial class MainWindow : Window, IDisposable
 			BeepPlayer.Play(_audioDeviceManager.IsMuted ? BeepType.Mute : BeepType.Unmute);
 
 		InitializeTextToSpeechControls();
+		InitializeMicrophoneLevelControls();
 		InitializeHotkeyVisuals();
 
 		this.Closed += MainWindow_Closed;
@@ -1081,6 +1095,96 @@ public sealed partial class MainWindow : Window, IDisposable
 		PushTtsAnnouncementOptions();
 	}
 
+	// Sets up the "Pin input level" toggle and the input-level slider on the main
+	// window. On a device that doesn't support software level control, both are
+	// disabled with an explanatory tooltip and nothing is written. Otherwise the
+	// slider shows the pinned value (or the current hardware level), the toggle
+	// reflects whether pinning is enabled, and any pinned level is re-asserted now
+	// (app startup).
+	private void InitializeMicrophoneLevelControls()
+	{
+		_micLevelControlsReady = false;
+
+		bool supported = _micLevelPinService.IsLevelControlSupported;
+		TglPinMicLevel.IsEnabled = supported;
+		SldMicLevel.IsEnabled = supported;
+
+		if (!supported)
+		{
+			TglPinMicLevel.IsOn = false;
+			const string unsupported = "This microphone does not support software level control.";
+			ToolTipService.SetToolTip(TglPinMicLevel, unsupported);
+			ToolTipService.SetToolTip(SldMicLevel, unsupported);
+			_micLevelInitialized = true;
+			return;
+		}
+
+		int? pinned = _settings.AudioSettings?.PinnedCaptureLevel;
+		TglPinMicLevel.IsOn = pinned.HasValue;
+		SldMicLevel.Value = pinned ?? ReadCurrentMicLevelOrDefault();
+
+		_micLevelControlsReady = true;
+		_micLevelInitialized = true;
+
+		// Re-assert now (app startup, or after a mic change): correct the level if
+		// another app changed it.
+		_micLevelPinService.ReassertPinnedLevel(pinned);
+	}
+
+	// Current Windows capture level as a 0–100 value, or a sensible default when it
+	// cannot be read. Used to position the slider when no pinned value exists.
+	private int ReadCurrentMicLevelOrDefault()
+	{
+		float? scalar = _captureLevelController.GetLevelScalar();
+		if (scalar is float s)
+			return (int)Math.Round(Math.Clamp(s, 0f, 1f) * 100f);
+		return DefaultMicLevel;
+	}
+
+	// Toggle pinning on/off. Turning it on captures the slider's current value as the
+	// pinned target and applies it immediately; turning it off stops re-asserting but
+	// leaves the live level where it is. Persists the change.
+	private void TglPinMicLevel_Toggled(object sender, RoutedEventArgs e)
+	{
+		if (!_micLevelControlsReady) return;
+
+		_settings.AudioSettings ??= new AudioSettings();
+
+		if (TglPinMicLevel.IsOn)
+		{
+			int level = (int)Math.Round(SldMicLevel.Value);
+			_settings.AudioSettings.PinnedCaptureLevel = level;
+			_micLevelPinService.ApplyLevel(level);
+		}
+		else
+		{
+			_settings.AudioSettings.PinnedCaptureLevel = null;
+		}
+
+		_settingsManager.SaveSettingsToFile(_settings);
+	}
+
+	// Dragging the slider sets the actual Windows capture level immediately (instant
+	// feedback, even when not recording). When pinning is enabled, the same value
+	// becomes the stored pinned target so it is re-asserted later.
+	private void SldMicLevel_ValueChanged(object sender, RangeBaseValueChangedEventArgs e)
+	{
+		if (!_micLevelControlsReady) return;
+
+		int level = (int)Math.Round(e.NewValue);
+		_micLevelPinService.ApplyLevel(level);
+
+		if (TglPinMicLevel.IsOn)
+		{
+			_settings.AudioSettings ??= new AudioSettings();
+			if (_settings.AudioSettings.PinnedCaptureLevel != level)
+			{
+				_settings.AudioSettings.PinnedCaptureLevel = level;
+				_settingsManager.SaveSettingsToFile(_settings);
+			}
+		}
+	}
+
 	// Mirror the on-screen toggle states from the current settings. Called after the
 	// settings dialog closes so a change made there shows on the main window too.
 	private void RefreshTtsAnnouncementToggles()
@@ -1601,6 +1705,11 @@ public sealed partial class MainWindow : Window, IDisposable
 				_settingsManager.SaveSettingsToFile(_settings);
 			}
 			_microphoneVisualization?.RestartCapture();
+
+			// Re-sync the level controls to the newly-selected device (support and
+			// current level may differ) and re-assert the pinned level on it.
+			if (_micLevelInitialized)
+				InitializeMicrophoneLevelControls();
 		}
 		else
 		{


### PR DESCRIPTION
## Summary

Lets the user **pin** the Windows capture level (the 0–100 "Line" slider on a
microphone's Levels tab) so Mutation re-asserts it automatically. Other apps and
Windows itself frequently drift this value; pinning keeps the input gain
consistent, which protects dictation and transcription quality.

The capture level is read and written through CoreAudio's
`MMDevice.AudioEndpointVolume.MasterVolumeLevelScalar` (0.0–1.0), the same
0–100 slider Windows shows.

## What changed

- **Setting** — `AudioSettings.PinnedCaptureLevel` (`int?`, 0–100). `null` means
  pinning is disabled ("don't manage the level"). Persisted via the existing
  settings-save path.
- **Main-window UI** — the Microphone card gains a "Pin input level" toggle and
  an input-level slider (it is **not** added to the Settings dialog). Dragging
  the slider sets the actual Windows capture level **immediately**, even when not
  recording, giving instant feedback; when pinning is on, that value also becomes
  the stored pinned target. Both controls carry `AutomationProperties.Name` and
  tooltips for ZoomText / screen-reader use, and follow the existing TTS-slider
  pattern.
- **Auto-restore** — the pinned level is re-asserted right before each
  record/dictate (`AudioSessionManager.StartStopRecordingAsync`), on microphone
  selection, and on app startup. Writes are gated by a 1-unit epsilon to avoid
  redundant calls, and **mute state is never touched** (only the level scalar is
  written).
- **Graceful degradation** — on a device with no controllable level, the toggle
  and slider are disabled with an explanatory tooltip, and auto-restore is
  skipped silently; nothing throws.
- **Testability** — level read/write sits behind `ICaptureLevelController`
  (CoreAudio implementation `CoreAudioCaptureLevelController`), with the pin rules
  in `MicrophoneLevelPinService`. The re-assert is wired at the orchestration
  layer (session manager + main window) rather than inside `AudioDeviceManager`
  to avoid a circular dependency; the observable behavior is the same.

## Test plan

- `dotnet test --configuration Release` — **433 passed, 0 failed** (12 new tests
  in `MicrophoneLevelPinServiceTests` covering: pin applied when enabled, no-op
  when disabled, epsilon tolerance at and beyond the boundary, mute left
  untouched, unsupported-device path, live-drag write, clamping above/below
  range, write when the current level is unreadable, and null-controller guard).

Manual (hardware-dependent, not automated):

- Enable pinning, set a 0–100 level on the main window → persists across restart.
- Drag the slider → the device's Levels tab moves immediately, with no recording.
- The control does not appear in the Settings dialog.
- With pinning on, press record/dictate after another app changed the level → it
  snaps back to the pinned value.
- Re-asserts on mic selection and on app startup; mute state unaffected.
- On a hardware-fixed device the control is disabled with a tooltip; nothing
  throws.

Closes #140
