### PR TITLE
Add pitch-preserving playback speed control to recorded-audio player

### DIFF
--- a/CognitiveSupport/AudioPlayer.cs
+++ b/CognitiveSupport/AudioPlayer.cs
@@ -1,22 +1,29 @@
 using Concentus.Oggfile;
 using Concentus.Structs;
 using NAudio.Wave;
+using NAudio.Wave.SampleProviders;
 
 namespace CognitiveSupport;
 
 /// <summary>
 /// Audio player that supports OGG/Opus files using NAudio and Concentus.
 /// This bypasses Windows Media Foundation which doesn't natively support OGG/Opus.
+///
+/// Every format flows through a single chain: the decoded/read audio becomes a
+/// common sample source, passes through a pitch-preserving time-stretch stage
+/// (<see cref="SoundTouchSampleProvider"/>), and is then sent to the output
+/// device. That lets <see cref="Speed"/> change how fast playback runs — live,
+/// without restarting — while the voice keeps its natural pitch.
 /// </summary>
 public class AudioPlayer : IDisposable
 {
     private WaveOutEvent? _waveOut;
     private OpusDecoder? _decoder;
     private MemoryStream? _pcmStream;
-    private RawSourceWaveStream? _waveStream;
-    private WaveStream? _readerStream;
-    private WaveStream? _conversionStream;
+    private WaveStream? _sourceStream;
+    private SoundTouchSampleProvider? _speedProvider;
     private readonly object _playLock = new();
+    private double _speed = PlaybackSpeedOptions.Default;
     private bool _disposed;
 
     // Opus parameters matching AudioRecorder
@@ -24,6 +31,27 @@ public class AudioPlayer : IDisposable
     private const int Channels = 1;
 
     public bool IsPlaying => _waveOut?.PlaybackState == PlaybackState.Playing;
+
+    /// <summary>
+    /// Playback speed multiplier (1.0 = normal). Any value is snapped to the
+    /// nearest supported speed. Setting it applies immediately to audio that is
+    /// already playing — without stopping, restarting, or losing position — and
+    /// is remembered for the next file played.
+    /// </summary>
+    public double Speed
+    {
+        get { lock (_playLock) { return _speed; } }
+        set
+        {
+            lock (_playLock)
+            {
+                double normalized = PlaybackSpeedOptions.Normalize(value);
+                _speed = normalized;
+                if (_speedProvider != null)
+                    _speedProvider.Tempo = normalized;
+            }
+        }
+    }
 
     public event EventHandler? PlaybackEnded;
     public event EventHandler<string>? PlaybackFailed;
@@ -98,12 +126,7 @@ public class AudioPlayer : IDisposable
 
         _pcmStream = new MemoryStream(pcmBytes);
         var waveFormat = new WaveFormat(SampleRate, 16, Channels);
-        _waveStream = new RawSourceWaveStream(_pcmStream, waveFormat);
-
-        _waveOut = new WaveOutEvent();
-        _waveOut.PlaybackStopped += OnPlaybackStopped;
-        _waveOut.Init(_waveStream);
-        _waveOut.Play();
+        StartPlayback(new RawSourceWaveStream(_pcmStream, waveFormat));
     }
 
     /// <summary>
@@ -117,23 +140,27 @@ public class AudioPlayer : IDisposable
             ".mp3" => new Mp3FileReader(filePath),
             _ => new AudioFileReader(filePath) // Generic reader for other formats
         };
-        _readerStream = reader;
+
+        StartPlayback(reader);
+    }
+
+    /// <summary>
+    /// Wraps a format-specific audio source in the pitch-preserving speed stage and
+    /// starts playback. Shared by every playback path so the speed control applies
+    /// uniformly to OGG/Opus, WAV, MP3, and any other supported format.
+    /// </summary>
+    private void StartPlayback(WaveStream source)
+    {
+        _sourceStream = source;
+
+        // ToSampleProvider normalises every format to float samples; SoundTouch then
+        // time-stretches them, and SampleToWaveProvider converts back for output.
+        _speedProvider = new SoundTouchSampleProvider(source.ToSampleProvider()) { Tempo = _speed };
+        IWaveProvider output = new SampleToWaveProvider(_speedProvider);
 
         _waveOut = new WaveOutEvent();
         _waveOut.PlaybackStopped += OnPlaybackStopped;
-
-        // If the format isn't PCM, we need to convert it
-        if (reader.WaveFormat.Encoding != WaveFormatEncoding.Pcm)
-        {
-            var pcmStream = WaveFormatConversionStream.CreatePcmStream(reader);
-            _conversionStream = pcmStream;
-            _waveOut.Init(pcmStream);
-        }
-        else
-        {
-            _waveOut.Init(reader);
-        }
-
+        _waveOut.Init(output);
         _waveOut.Play();
     }
 
@@ -163,14 +190,10 @@ public class AudioPlayer : IDisposable
                     _waveOut = null;
                 }
 
-                _waveStream?.Dispose();
-                _waveStream = null;
+                _speedProvider = null;
 
-                _conversionStream?.Dispose();
-                _conversionStream = null;
-
-                _readerStream?.Dispose();
-                _readerStream = null;
+                _sourceStream?.Dispose();
+                _sourceStream = null;
 
                 _pcmStream?.Dispose();
                 _pcmStream = null;

--- a/CognitiveSupport/CognitiveSupport.csproj
+++ b/CognitiveSupport/CognitiveSupport.csproj
@@ -17,6 +17,7 @@
 		<PackageReference Include="Polly" Version="7.2.4" />
 		<PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
 		<PackageReference Include="NAudio" Version="2.2.1" />
+		<PackageReference Include="SoundTouch.Net" Version="2.3.2" />
 		<PackageReference Include="System.Speech" Version="10.0.0" />
 	</ItemGroup>
 </Project>

--- a/CognitiveSupport/PlaybackSpeedOptions.cs
+++ b/CognitiveSupport/PlaybackSpeedOptions.cs
@@ -1,0 +1,45 @@
+namespace CognitiveSupport;
+
+/// <summary>
+/// The fixed set of playback-speed multipliers offered for the recorded-audio
+/// player, plus helpers to pick a valid value. A multiplier is a literal speed:
+/// 1.0 is normal speed, 2.0 is twice as fast, 0.5 is half speed. Pitch is
+/// preserved at every speed by the time-stretch stage in <see cref="AudioPlayer"/>.
+/// </summary>
+public static class PlaybackSpeedOptions
+{
+    /// <summary>Normal speed, used when no speed has been chosen.</summary>
+    public const double Default = 1.0;
+
+    /// <summary>
+    /// The exact multipliers the UI lists, from slowest to fastest. These are the
+    /// only values playback speed is ever set to.
+    /// </summary>
+    public static IReadOnlyList<double> Speeds { get; } = new[]
+    {
+        0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.0, 2.25, 2.5, 2.75, 3.0,
+    };
+
+    /// <summary>
+    /// Snaps an arbitrary speed (e.g. a hand-edited settings value) to the nearest
+    /// allowed multiplier. Values outside the supported range collapse to the
+    /// closest end (below 0.5 → 0.5, above 3.0 → 3.0), so callers always get a
+    /// value that exists in <see cref="Speeds"/>.
+    /// </summary>
+    public static double Normalize(double speed)
+    {
+        double nearest = Default;
+        double smallestDifference = double.MaxValue;
+        foreach (double candidate in Speeds)
+        {
+            double difference = Math.Abs(candidate - speed);
+            if (difference < smallestDifference)
+            {
+                smallestDifference = difference;
+                nearest = candidate;
+            }
+        }
+
+        return nearest;
+    }
+}

--- a/CognitiveSupport/Settings.cs
+++ b/CognitiveSupport/Settings.cs
@@ -37,6 +37,11 @@ public class AudioSettings
         // so it stays consistent regardless of what other apps do. null means pinning is
         // disabled ("don't manage the level").
         public int? PinnedCaptureLevel { get; set; }
+
+	// Playback speed multiplier for the recorded-audio file player (1.0 = normal).
+	// Restored on launch and snapped to the nearest supported speed on load. Pitch
+	// is preserved at every speed. See PlaybackSpeedOptions for the allowed values.
+	public double PlaybackSpeed { get; set; } = PlaybackSpeedOptions.Default;
 	public CustomBeepSettingsData? CustomBeepSettings { get => customBeepSettings; set => customBeepSettings = value; }
 
 	public AudioSettings() { }

--- a/CognitiveSupport/SoundTouchSampleProvider.cs
+++ b/CognitiveSupport/SoundTouchSampleProvider.cs
@@ -1,0 +1,87 @@
+using NAudio.Wave;
+using SoundTouch;
+
+namespace CognitiveSupport;
+
+/// <summary>
+/// An NAudio sample provider that changes playback tempo while preserving pitch,
+/// using the managed SoundTouch.Net time-stretch engine. It sits between a source
+/// of audio samples and the output device: samples are pushed into SoundTouch,
+/// stretched or compressed in time, and pulled back out at the requested rate.
+///
+/// The sample rate and channel count are unchanged, so a voice keeps its natural
+/// pitch — only how fast it plays changes. <see cref="Tempo"/> can be changed at
+/// any time, including mid-playback, and takes effect on the audio produced next.
+/// </summary>
+public sealed class SoundTouchSampleProvider : ISampleProvider
+{
+    private readonly ISampleProvider _source;
+    private readonly SoundTouchProcessor _processor;
+    private readonly float[] _sourceBuffer;
+    private readonly int _channels;
+    private readonly object _lock = new();
+    private bool _sourceExhausted;
+
+    public WaveFormat WaveFormat => _source.WaveFormat;
+
+    public SoundTouchSampleProvider(ISampleProvider source, int readFrames = 4096)
+    {
+        _source = source ?? throw new ArgumentNullException(nameof(source));
+        _channels = source.WaveFormat.Channels;
+        _processor = new SoundTouchProcessor
+        {
+            SampleRate = source.WaveFormat.SampleRate,
+            Channels = _channels,
+        };
+        _sourceBuffer = new float[readFrames * _channels];
+    }
+
+    /// <summary>
+    /// The tempo multiplier: 1.0 is normal speed, 2.0 is twice as fast, 0.5 is
+    /// half speed. Safe to set from another thread while audio is playing.
+    /// </summary>
+    public double Tempo
+    {
+        get { lock (_lock) { return _processor.Tempo; } }
+        set { lock (_lock) { _processor.Tempo = value; } }
+    }
+
+    public int Read(float[] buffer, int offset, int count)
+    {
+        lock (_lock)
+        {
+            int framesRequested = count / _channels;
+            int framesWritten = 0;
+
+            while (framesWritten < framesRequested)
+            {
+                int framesRemaining = framesRequested - framesWritten;
+                var output = new Span<float>(buffer, offset + (framesWritten * _channels), framesRemaining * _channels);
+                int received = _processor.ReceiveSamples(output, framesRemaining);
+                if (received > 0)
+                {
+                    framesWritten += received;
+                    continue;
+                }
+
+                if (_sourceExhausted)
+                    break;
+
+                int floatsRead = _source.Read(_sourceBuffer, 0, _sourceBuffer.Length);
+                if (floatsRead == 0)
+                {
+                    // No more input: flush SoundTouch so any audio still buffered
+                    // inside the time-stretch stage drains out on the next receive.
+                    _sourceExhausted = true;
+                    _processor.Flush();
+                }
+                else
+                {
+                    _processor.PutSamples(new ReadOnlySpan<float>(_sourceBuffer, 0, floatsRead), floatsRead / _channels);
+                }
+            }
+
+            return framesWritten * _channels;
+        }
+    }
+}

--- a/Mutation.Tests/PlaybackSpeedOptionsTests.cs
+++ b/Mutation.Tests/PlaybackSpeedOptionsTests.cs
@@ -1,0 +1,57 @@
+using CognitiveSupport;
+
+namespace Mutation.Tests;
+
+public class PlaybackSpeedOptionsTests
+{
+	[Fact]
+	public void Speeds_AreTheExpectedMultipliers()
+	{
+		Assert.Equal(
+			new[] { 0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.0, 2.25, 2.5, 2.75, 3.0 },
+			PlaybackSpeedOptions.Speeds);
+	}
+
+	[Fact]
+	public void Default_IsNormalSpeedAndIsAnOption()
+	{
+		Assert.Equal(1.0, PlaybackSpeedOptions.Default);
+		Assert.Contains(PlaybackSpeedOptions.Default, PlaybackSpeedOptions.Speeds);
+	}
+
+	[Theory]
+	[InlineData(0.5, 0.5)]
+	[InlineData(1.0, 1.0)]
+	[InlineData(3.0, 3.0)]
+	[InlineData(1.25, 1.25)]
+	public void Normalize_ReturnsExactValueWhenAlreadyAllowed(double input, double expected)
+	{
+		Assert.Equal(expected, PlaybackSpeedOptions.Normalize(input));
+	}
+
+	[Theory]
+	[InlineData(0.6, 0.5)]   // closer to 0.5 than 0.75
+	[InlineData(0.7, 0.75)]  // closer to 0.75
+	[InlineData(1.1, 1.0)]   // closer to 1.0 than 1.25
+	public void Normalize_SnapsToNearestAllowedValue(double input, double expected)
+	{
+		Assert.Equal(expected, PlaybackSpeedOptions.Normalize(input));
+	}
+
+	[Theory]
+	[InlineData(0.1)]
+	[InlineData(0.0)]
+	[InlineData(-5.0)]
+	public void Normalize_ClampsBelowRangeToSlowest(double input)
+	{
+		Assert.Equal(0.5, PlaybackSpeedOptions.Normalize(input));
+	}
+
+	[Theory]
+	[InlineData(3.5)]
+	[InlineData(10.0)]
+	public void Normalize_ClampsAboveRangeToFastest(double input)
+	{
+		Assert.Equal(3.0, PlaybackSpeedOptions.Normalize(input));
+	}
+}

--- a/Mutation.Tests/PlaybackSpeedSettingsTests.cs
+++ b/Mutation.Tests/PlaybackSpeedSettingsTests.cs
@@ -1,0 +1,61 @@
+using System;
+using System.IO;
+using CognitiveSupport;
+using Mutation.Ui.Services;
+
+namespace Mutation.Tests;
+
+// Verifies the playback-speed value is sound after loading: a fresh file keeps the
+// normal-speed default, and a hand-edited out-of-range value is snapped to a
+// supported speed by SettingsManager.EnsureSettings.
+public class PlaybackSpeedSettingsTests : IDisposable
+{
+	private readonly string _tempPath;
+
+	public PlaybackSpeedSettingsTests()
+	{
+		_tempPath = Path.Combine(Path.GetTempPath(), $"mutation-playbackspeed-{Guid.NewGuid():N}.json");
+		File.WriteAllText(_tempPath, "{}");
+	}
+
+	public void Dispose()
+	{
+		if (File.Exists(_tempPath))
+			File.Delete(_tempPath);
+	}
+
+	private Settings Ensure(Settings settings)
+	{
+		var manager = new SettingsManager(_tempPath);
+		manager.EnsureSettings(settings, isNewFile: false);
+		return settings;
+	}
+
+	[Fact]
+	public void Default_PlaybackSpeed_IsNormal()
+	{
+		var s = Ensure(new Settings());
+		Assert.Equal(PlaybackSpeedOptions.Default, s.AudioSettings!.PlaybackSpeed);
+	}
+
+	[Fact]
+	public void OutOfRange_PlaybackSpeed_IsSnappedToFastest()
+	{
+		var s = Ensure(new Settings { AudioSettings = new AudioSettings { PlaybackSpeed = 4.7 } });
+		Assert.Equal(3.0, s.AudioSettings!.PlaybackSpeed);
+	}
+
+	[Fact]
+	public void OffGrid_PlaybackSpeed_IsSnappedToNearestSupported()
+	{
+		var s = Ensure(new Settings { AudioSettings = new AudioSettings { PlaybackSpeed = 1.1 } });
+		Assert.Equal(1.0, s.AudioSettings!.PlaybackSpeed);
+	}
+
+	[Fact]
+	public void SupportedValue_PlaybackSpeed_IsPreserved()
+	{
+		var s = Ensure(new Settings { AudioSettings = new AudioSettings { PlaybackSpeed = 1.5 } });
+		Assert.Equal(1.5, s.AudioSettings!.PlaybackSpeed);
+	}
+}

--- a/Mutation.Tests/SoundTouchSampleProviderTests.cs
+++ b/Mutation.Tests/SoundTouchSampleProviderTests.cs
@@ -1,0 +1,119 @@
+using System;
+using CognitiveSupport;
+using NAudio.Wave;
+
+namespace Mutation.Tests;
+
+public class SoundTouchSampleProviderTests
+{
+	private const int SampleRate = 48000;
+
+	// A one-second 440 Hz mono tone as float samples, used as a deterministic source.
+	private static float[] BuildTone(int frames)
+	{
+		var data = new float[frames];
+		for (int i = 0; i < frames; i++)
+			data[i] = 0.5f * (float)Math.Sin(2.0 * Math.PI * 440.0 * i / SampleRate);
+		return data;
+	}
+
+	private static int DrainFrameCount(ISampleProvider provider, out float peak)
+	{
+		peak = 0f;
+		var buffer = new float[SampleRate]; // 1s chunks
+		int totalFrames = 0;
+		int read;
+		while ((read = provider.Read(buffer, 0, buffer.Length)) > 0)
+		{
+			totalFrames += read / provider.WaveFormat.Channels;
+			for (int i = 0; i < read; i++)
+				peak = Math.Max(peak, Math.Abs(buffer[i]));
+		}
+
+		return totalFrames;
+	}
+
+	[Fact]
+	public void WaveFormat_PreservesSampleRate_SoPitchIsUnchanged()
+	{
+		var format = WaveFormat.CreateIeeeFloatWaveFormat(SampleRate, 1);
+		var source = new BufferSampleProvider(BuildTone(SampleRate), format);
+
+		var provider = new SoundTouchSampleProvider(source) { Tempo = 2.0 };
+
+		Assert.Equal(SampleRate, provider.WaveFormat.SampleRate);
+		Assert.Equal(1, provider.WaveFormat.Channels);
+	}
+
+	[Fact]
+	public void Tempo_Normal_ProducesRoughlyTheSameLength()
+	{
+		int frames = SampleRate;
+		var format = WaveFormat.CreateIeeeFloatWaveFormat(SampleRate, 1);
+		var source = new BufferSampleProvider(BuildTone(frames), format);
+
+		var provider = new SoundTouchSampleProvider(source) { Tempo = 1.0 };
+		int outFrames = DrainFrameCount(provider, out float peak);
+
+		// Allow a small tolerance for the time-stretch engine's internal latency.
+		Assert.InRange(outFrames, frames - (frames / 10), frames + (frames / 10));
+		Assert.True(peak > 0.01f, "Output should not be silent.");
+	}
+
+	[Fact]
+	public void Tempo_Double_HalvesTheLength()
+	{
+		int frames = SampleRate;
+		var format = WaveFormat.CreateIeeeFloatWaveFormat(SampleRate, 1);
+		var source = new BufferSampleProvider(BuildTone(frames), format);
+
+		var provider = new SoundTouchSampleProvider(source) { Tempo = 2.0 };
+		int outFrames = DrainFrameCount(provider, out float peak);
+
+		int expected = frames / 2;
+		Assert.InRange(outFrames, expected - (frames / 10), expected + (frames / 10));
+		Assert.True(peak > 0.01f, "Output should not be silent.");
+	}
+
+	[Fact]
+	public void Tempo_Half_DoublesTheLength()
+	{
+		int frames = SampleRate;
+		var format = WaveFormat.CreateIeeeFloatWaveFormat(SampleRate, 1);
+		var source = new BufferSampleProvider(BuildTone(frames), format);
+
+		var provider = new SoundTouchSampleProvider(source) { Tempo = 0.5 };
+		int outFrames = DrainFrameCount(provider, out _);
+
+		int expected = frames * 2;
+		Assert.InRange(outFrames, expected - (frames / 5), expected + (frames / 5));
+	}
+
+	// Minimal in-memory ISampleProvider that emits a fixed buffer once, then signals
+	// end of stream. Stands in for a decoded audio file in these tests.
+	private sealed class BufferSampleProvider : ISampleProvider
+	{
+		private readonly float[] _data;
+		private int _position;
+
+		public BufferSampleProvider(float[] data, WaveFormat format)
+		{
+			_data = data;
+			WaveFormat = format;
+		}
+
+		public WaveFormat WaveFormat { get; }
+
+		public int Read(float[] buffer, int offset, int count)
+		{
+			int remaining = _data.Length - _position;
+			int toCopy = Math.Min(count, remaining);
+			if (toCopy <= 0)
+				return 0;
+
+			Array.Copy(_data, _position, buffer, offset, toCopy);
+			_position += toCopy;
+			return toCopy;
+		}
+	}
+}

--- a/Mutation.Ui/Core/AudioSessionManager.cs
+++ b/Mutation.Ui/Core/AudioSessionManager.cs
@@ -49,6 +49,17 @@ public class AudioSessionManager : IDisposable
     public bool IsRecording => _speechManager.Recording;
     public bool IsTranscribing => _speechManager.Transcribing;
 
+    /// <summary>
+    /// Playback speed for the recorded-audio player (1.0 = normal). Setting it
+    /// retunes audio that is already playing, without restarting. The value is
+    /// snapped to the nearest supported speed by the player.
+    /// </summary>
+    public double PlaybackSpeed
+    {
+        get => _playbackPlayer.Speed;
+        set => _playbackPlayer.Speed = value;
+    }
+
     public event EventHandler? SelectedSessionChanged;
     public event EventHandler? PlaybackStarted;
     public event EventHandler? PlaybackStopped;
@@ -321,6 +332,9 @@ public class AudioSessionManager : IDisposable
             }
 
             _playingSession = SelectedSession;
+            // Start each playback at the persisted speed so a saved preference is
+            // honoured on launch and after navigating between sessions.
+            _playbackPlayer.Speed = _settings.AudioSettings?.PlaybackSpeed ?? PlaybackSpeedOptions.Default;
             _playbackPlayer.Play(SelectedSession.FilePath);
             
             PlaybackStarted?.Invoke(this, EventArgs.Empty);

--- a/Mutation.Ui/MainWindow.xaml
+++ b/Mutation.Ui/MainWindow.xaml
@@ -376,6 +376,15 @@
                                         ToolTipService.ToolTip="Upload an audio file for transcription">
                                         <FontIcon Glyph="&#xE898;" FontFamily="Segoe Fluent Icons" />
                                     </Button>
+
+                                    <ComboBox
+                                        x:Name="CmbPlaybackSpeed"
+                                        Header="Speed"
+                                        MinWidth="96"
+                                        VerticalAlignment="Center"
+                                        SelectionChanged="CmbPlaybackSpeed_SelectionChanged"
+                                        AutomationProperties.Name="Playback speed"
+                                        ToolTipService.ToolTip="Change how fast recordings play back; pitch stays natural at every speed" />
                                 </StackPanel>
 
                                 <StackPanel Grid.Row="2" Grid.ColumnSpan="2" Spacing="6">

--- a/Mutation.Ui/MainWindow.xaml.cs
+++ b/Mutation.Ui/MainWindow.xaml.cs
@@ -60,6 +60,7 @@ public sealed partial class MainWindow : Window, IDisposable
 	private bool _isDialogOpen;
 	private bool _ttsControlsReady;
 	private bool _micLevelControlsReady;
+	private bool _playbackSpeedReady;
 	// True once the mic-level controls have been set up at least once, so the
 	// microphone-selection handler knows it is safe to re-sync them for a new device.
 	private bool _micLevelInitialized;
@@ -223,6 +224,7 @@ public sealed partial class MainWindow : Window, IDisposable
 			BeepPlayer.Play(_audioDeviceManager.IsMuted ? BeepType.Mute : BeepType.Unmute);
 
 		InitializeTextToSpeechControls();
+		InitializePlaybackSpeedControl();
 		InitializeMicrophoneLevelControls();
 		InitializeHotkeyVisuals();
 
@@ -1093,6 +1095,49 @@ public sealed partial class MainWindow : Window, IDisposable
 
 		_ttsControlsReady = true;
 		PushTtsAnnouncementOptions();
+	}
+
+	// Populates the playback-speed dropdown and selects the saved speed, applying
+	// it to the player so the first playback honours the persisted preference.
+	private void InitializePlaybackSpeedControl()
+	{
+		var speeds = PlaybackSpeedOptions.Speeds;
+		CmbPlaybackSpeed.ItemsSource = speeds.Select(FormatPlaybackSpeed).ToList();
+
+		double saved = _settings.AudioSettings?.PlaybackSpeed ?? PlaybackSpeedOptions.Default;
+		double normalized = PlaybackSpeedOptions.Normalize(saved);
+		int index = speeds.ToList().IndexOf(normalized);
+		if (index < 0)
+			index = speeds.ToList().IndexOf(PlaybackSpeedOptions.Default);
+		CmbPlaybackSpeed.SelectedIndex = index;
+
+		_audioSessionManager.PlaybackSpeed = normalized;
+		_playbackSpeedReady = true;
+	}
+
+	// Labels a speed value for the dropdown, e.g. "1.0 (Normal)", "1.5", "0.75".
+	private static string FormatPlaybackSpeed(double speed)
+	{
+		string number = speed.ToString("0.0#", System.Globalization.CultureInfo.InvariantCulture);
+		return speed == PlaybackSpeedOptions.Default ? $"{number} (Normal)" : number;
+	}
+
+	private void CmbPlaybackSpeed_SelectionChanged(object sender, SelectionChangedEventArgs e)
+	{
+		if (!_playbackSpeedReady) return;
+
+		int index = CmbPlaybackSpeed.SelectedIndex;
+		if (index < 0 || index >= PlaybackSpeedOptions.Speeds.Count) return;
+
+		double speed = PlaybackSpeedOptions.Speeds[index];
+		_settings.AudioSettings ??= new AudioSettings();
+		if (_settings.AudioSettings.PlaybackSpeed == speed) return;
+
+		_settings.AudioSettings.PlaybackSpeed = speed;
+		_settingsManager.SaveSettingsToFile(_settings);
+
+		// Apply live so a change while a recording is playing takes effect at once.
+		_audioSessionManager.PlaybackSpeed = speed;
 	}
 
 	// Sets up the "Pin input level" toggle and the input-level slider on the main

--- a/Mutation.Ui/Services/SettingsManager.cs
+++ b/Mutation.Ui/Services/SettingsManager.cs
@@ -175,6 +175,14 @@ internal class SettingsManager : ISettingsManager
 			audioSettings.CustomBeepSettings = new AudioSettings.CustomBeepSettingsData();
 			somethingWasMissing = true;
 		}
+		// Snap playback speed to the nearest supported value so a hand-edited or
+		// missing value can never set the player to an unsupported speed.
+		double normalizedSpeed = PlaybackSpeedOptions.Normalize(audioSettings.PlaybackSpeed);
+		if (normalizedSpeed != audioSettings.PlaybackSpeed)
+		{
+			audioSettings.PlaybackSpeed = normalizedSpeed;
+			somethingWasMissing = true;
+		}
 		if (audioSettings.CustomBeepSettings.UseCustomBeeps)
 		{
 			string[] allowedExtensions = new[] { ".wav" };


### PR DESCRIPTION
## Summary

Adds a **playback speed** control to the recorded-audio file player. The
user picks from a fixed set of speed multipliers and the change takes effect
immediately on whatever is currently playing — without restarting or losing
position. The voice keeps its natural pitch at every speed, so faster playback
does not sound like a chipmunk and slower playback does not drone.

This is the recorded-file player only; the text-to-speech story reader (which
has its own speed setting) is untouched.

## How it works

- **SoundTouch.Net** (a managed, LGPL-licensed time-stretch library — its use
  was explicitly approved) is added as a new dependency and inserted as a
  tempo stage in the playback chain. It changes tempo while preserving pitch.
- A new `SoundTouchSampleProvider` wraps any audio source and exposes a
  thread-safe `Tempo` that can change live, mid-playback.
- `AudioPlayer` is refactored so every format (OGG/Opus, WAV, MP3, and the
  generic reader) flows through one chain: source → speed stage → output. It
  gains a `Speed` property that retunes audio already playing and is reused on
  the next file.
- `PlaybackSpeedOptions` holds the canonical speed list and a `Normalize`
  helper that snaps any value to the nearest supported speed.
- The selected speed is stored in `AudioSettings.PlaybackSpeed`, snapped to a
  supported value on load, and restored on the next launch (default 1.0×).
- The UI adds an accessible speed dropdown to the player row with
  `AutomationProperties.Name` set (mirroring the existing voice combo box), so
  the screen reader announces it and its current value.

## Speeds

`0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.0, 2.25, 2.5, 2.75, 3.0` — `1.0` is the
default, shown as "1.0 (Normal)".

## Acceptance criteria addressed

- [x] Speed control lists all the required multipliers.
- [x] Recordings play at normal speed (1.0) with no change made.
- [x] Changing speed mid-playback applies immediately and keeps position.
- [x] Pitch is preserved at every speed (pitch-preserving time-stretch, not resampling).
- [x] Works for OGG/Opus, WAV, and MP3 (unified through one playback chain).
- [x] Control is screen-reader reachable and announces its value.
- [x] Chosen speed is remembered across app restarts.

## Test plan

- `dotnet test --configuration Release` — **471 passed, 0 failed**.
- New automated tests:
  - `SoundTouchSampleProviderTests` — tempo 2.0 halves output length, 0.5
    doubles it, 1.0 preserves it, output stays non-silent, sample rate
    (pitch) unchanged.
  - `PlaybackSpeedOptionsTests` — the speed list, the default, and snapping /
    clamping behaviour of `Normalize`.
  - `PlaybackSpeedSettingsTests` — default speed, and on-load snapping of an
    out-of-range or off-grid persisted value.
- Manual verification of live audio playback was not run here (the WinUI app
  needs an interactive desktop session); the time-stretch behaviour is covered
  by the unit tests above.

Closes #145
