### PR TITLE
Expose speech-preprocessing rules as individual TTS toggles (#147)

### DIFF
--- a/CognitiveSupport/ITextToSpeechService.cs
+++ b/CognitiveSupport/ITextToSpeechService.cs
@@ -10,7 +10,7 @@ public interface ITextToSpeechService : IDisposable
 
 	string? CurrentText { get; }
 	IReadOnlyList<string> GetVoiceNames();
-	void Speak(string text, int rate, int volume, string? voiceName, bool resumeIfSame, bool preprocess, int resumeRewindWordCount = 0);
+	void Speak(string text, int rate, int volume, string? voiceName, bool resumeIfSame, bool preprocess, int resumeRewindWordCount = 0, SpeechPreprocessingOptions? options = null);
 	void SkipSentence(int direction, int rate, int volume, string? voiceName, int graceWindowMs);
 	void SpeakAnnouncement(string text, int rate, int volume, string? voiceName);
 

--- a/CognitiveSupport/IWavFileSpeechExporter.cs
+++ b/CognitiveSupport/IWavFileSpeechExporter.cs
@@ -6,8 +6,10 @@ namespace CognitiveSupport;
 public interface IWavFileSpeechExporter
 {
 	// Synthesize <paramref name="text"/> to a .wav file at <paramref name="filePath"/>
-	// using the given voice/rate/volume and optional speech preprocessing. Runs
-	// synchronously (the caller should invoke it off the UI thread); throws on empty
-	// input or synthesis/IO failure so the caller can surface an accessible error.
-	void ExportToWavFile(string text, string filePath, int rate, int volume, string? voiceName, bool preprocess);
+	// using the given voice/rate/volume and optional speech preprocessing. When
+	// <paramref name="preprocess"/> is true, <paramref name="options"/> selects which
+	// cleanup rules run (null means every rule). Runs synchronously (the caller should
+	// invoke it off the UI thread); throws on empty input or synthesis/IO failure so the
+	// caller can surface an accessible error.
+	void ExportToWavFile(string text, string filePath, int rate, int volume, string? voiceName, bool preprocess, SpeechPreprocessingOptions? options = null);
 }

--- a/CognitiveSupport/Settings.cs
+++ b/CognitiveSupport/Settings.cs
@@ -285,6 +285,18 @@ public class TextToSpeechSettings
 	public int Rate { get; set; } = 8;
 	public int Volume { get; set; } = 100;
 	public bool EnableSpeechPreprocessing { get; set; } = true;
+
+	// Per-rule speech-preprocessing switches. Each gates one cleanup rule applied
+	// before text is spoken; all default true so existing behaviour is unchanged.
+	// The master EnableSpeechPreprocessing switch above gates all of them at once.
+	public bool PreprocessRemoveCodeBlocks { get; set; } = true;
+	public bool PreprocessStripBoldItalicCode { get; set; } = true;
+	public bool PreprocessStripHeadingMarks { get; set; } = true;
+	public bool PreprocessShortenWebLinks { get; set; } = true;
+	public bool PreprocessStripBulletMarkers { get; set; } = true;
+	public bool PreprocessExpandAbbreviations { get; set; } = true;
+	public bool PreprocessNormaliseWhitespace { get; set; } = true;
+
 	public string? VoiceName { get; set; }
 
 	// How long (milliseconds) after a sentence starts that a "skip backward" press

--- a/CognitiveSupport/SpeechPreprocessingOptions.cs
+++ b/CognitiveSupport/SpeechPreprocessingOptions.cs
@@ -1,0 +1,51 @@
+namespace CognitiveSupport;
+
+// Per-rule switches for speech preprocessing. Each property gates one cleanup
+// rule applied to text before it is spoken. Every rule defaults to on, so the
+// combined result matches the previous all-or-nothing cleanup unless a user
+// turns an individual rule off. The master EnableSpeechPreprocessing switch
+// gates whether any of these rules run at all.
+public sealed class SpeechPreprocessingOptions
+{
+	// Drop fenced ``` code blocks ``` entirely.
+	public bool RemoveCodeBlocks { get; init; } = true;
+
+	// Strip bold (**), italic (* or _), and inline-code (`) symbols, keeping the
+	// inner text.
+	public bool StripBoldItalicCode { get; init; } = true;
+
+	// Strip leading heading marks (#, ##, ...).
+	public bool StripHeadingMarks { get; init; } = true;
+
+	// Replace web links with a short "link to {host}" phrase.
+	public bool ShortenWebLinks { get; init; } = true;
+
+	// Strip leading bullet markers (-, *, +).
+	public bool StripBulletMarkers { get; init; } = true;
+
+	// Expand common abbreviations (e.g., i.e., etc., vs.).
+	public bool ExpandAbbreviations { get; init; } = true;
+
+	// Collapse paragraph breaks and runs of whitespace into single spaces.
+	public bool NormaliseWhitespace { get; init; } = true;
+
+	// Every rule enabled — the default cleanup behaviour, applied when no
+	// per-rule options are supplied.
+	public static SpeechPreprocessingOptions All { get; } = new();
+
+	// Map the persisted per-rule settings onto an options instance.
+	public static SpeechPreprocessingOptions FromSettings(TextToSpeechSettings settings)
+	{
+		ArgumentNullException.ThrowIfNull(settings);
+		return new SpeechPreprocessingOptions
+		{
+			RemoveCodeBlocks = settings.PreprocessRemoveCodeBlocks,
+			StripBoldItalicCode = settings.PreprocessStripBoldItalicCode,
+			StripHeadingMarks = settings.PreprocessStripHeadingMarks,
+			ShortenWebLinks = settings.PreprocessShortenWebLinks,
+			StripBulletMarkers = settings.PreprocessStripBulletMarkers,
+			ExpandAbbreviations = settings.PreprocessExpandAbbreviations,
+			NormaliseWhitespace = settings.PreprocessNormaliseWhitespace,
+		};
+	}
+}

--- a/CognitiveSupport/TextToSpeechService.cs
+++ b/CognitiveSupport/TextToSpeechService.cs
@@ -115,7 +115,7 @@ namespace CognitiveSupport
 			}
 		}
 
-		public void Speak(string text, int rate, int volume, string? voiceName, bool resumeIfSame, bool preprocess, int resumeRewindWordCount = 0)
+		public void Speak(string text, int rate, int volume, string? voiceName, bool resumeIfSame, bool preprocess, int resumeRewindWordCount = 0, SpeechPreprocessingOptions? options = null)
 		{
 			if (string.IsNullOrEmpty(text)) return;
 
@@ -134,15 +134,15 @@ namespace CognitiveSupport
 			oldCts?.Dispose();
 
 			CancellationToken token = newCts.Token;
-			Task.Run(() => RunSpeak(text, rate, volume, voiceName, resumeIfSame, preprocess, resumeRewindWordCount, token));
+			Task.Run(() => RunSpeak(text, rate, volume, voiceName, resumeIfSame, preprocess, resumeRewindWordCount, options, token));
 		}
 
-		private void RunSpeak(string text, int rate, int volume, string? voiceName, bool resumeIfSame, bool preprocess, int resumeRewindWordCount, CancellationToken token)
+		private void RunSpeak(string text, int rate, int volume, string? voiceName, bool resumeIfSame, bool preprocess, int resumeRewindWordCount, SpeechPreprocessingOptions? options, CancellationToken token)
 		{
 			if (token.IsCancellationRequested) return;
 
 			string processed;
-			try { processed = preprocess ? PreprocessForSpeech(text) : text; }
+			try { processed = preprocess ? PreprocessForSpeech(text, options ?? SpeechPreprocessingOptions.All) : text; }
 			catch { return; }
 
 			if (token.IsCancellationRequested || string.IsNullOrEmpty(processed)) return;
@@ -722,24 +722,48 @@ namespace CognitiveSupport
 		private static readonly Regex AbbrevEtcRegex = new(@"\betc\.", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 		private static readonly Regex AbbrevVsRegex = new(@"\bvs\.", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
+		// Apply every cleanup rule. Kept for callers that always want the full
+		// pass; delegates to the per-rule overload with all rules enabled.
 		public static string PreprocessForSpeech(string text)
+			=> PreprocessForSpeech(text, SpeechPreprocessingOptions.All);
+
+		// Apply each cleanup rule only when its toggle in <paramref name="options"/>
+		// is on. Steps run in the same order as the original all-on pass, so the
+		// result with every rule enabled is identical to the previous behaviour.
+		public static string PreprocessForSpeech(string text, SpeechPreprocessingOptions options)
 		{
 			if (string.IsNullOrEmpty(text)) return text;
+			options ??= SpeechPreprocessingOptions.All;
+
 			string s = text;
-			s = CodeFenceRegex.Replace(s, " ");
-			s = InlineCodeRegex.Replace(s, "$1");
-			s = HeadingRegex.Replace(s, string.Empty);
-			s = UrlRegex.Replace(s, ReplaceUrlWithHost);
-			s = BoldRegex.Replace(s, "$1");
-			s = ItalicStarRegex.Replace(s, "$1");
-			s = ItalicUnderscoreRegex.Replace(s, "$1");
-			s = BulletRegex.Replace(s, string.Empty);
-			s = AbbrevEgRegex.Replace(s, "for example");
-			s = AbbrevIeRegex.Replace(s, "that is");
-			s = AbbrevEtcRegex.Replace(s, "et cetera");
-			s = AbbrevVsRegex.Replace(s, "versus");
-			s = ParagraphBreakRegex.Replace(s, ". ");
-			s = WhitespaceRegex.Replace(s, " ");
+			if (options.RemoveCodeBlocks)
+				s = CodeFenceRegex.Replace(s, " ");
+			if (options.StripBoldItalicCode)
+				s = InlineCodeRegex.Replace(s, "$1");
+			if (options.StripHeadingMarks)
+				s = HeadingRegex.Replace(s, string.Empty);
+			if (options.ShortenWebLinks)
+				s = UrlRegex.Replace(s, ReplaceUrlWithHost);
+			if (options.StripBoldItalicCode)
+			{
+				s = BoldRegex.Replace(s, "$1");
+				s = ItalicStarRegex.Replace(s, "$1");
+				s = ItalicUnderscoreRegex.Replace(s, "$1");
+			}
+			if (options.StripBulletMarkers)
+				s = BulletRegex.Replace(s, string.Empty);
+			if (options.ExpandAbbreviations)
+			{
+				s = AbbrevEgRegex.Replace(s, "for example");
+				s = AbbrevIeRegex.Replace(s, "that is");
+				s = AbbrevEtcRegex.Replace(s, "et cetera");
+				s = AbbrevVsRegex.Replace(s, "versus");
+			}
+			if (options.NormaliseWhitespace)
+			{
+				s = ParagraphBreakRegex.Replace(s, ". ");
+				s = WhitespaceRegex.Replace(s, " ");
+			}
 			return s.Trim();
 		}
 	}

--- a/CognitiveSupport/WavFileSpeechExporter.cs
+++ b/CognitiveSupport/WavFileSpeechExporter.cs
@@ -8,13 +8,15 @@ namespace CognitiveSupport;
 // exporting never disturbs an in-progress live read.
 public class WavFileSpeechExporter : IWavFileSpeechExporter
 {
-	public void ExportToWavFile(string text, string filePath, int rate, int volume, string? voiceName, bool preprocess)
+	public void ExportToWavFile(string text, string filePath, int rate, int volume, string? voiceName, bool preprocess, SpeechPreprocessingOptions? options = null)
 	{
 		if (!TtsFileExport.TryResolveExportText(text, out string resolved, out string error))
 			throw new ArgumentException(error, nameof(text));
 
 		string wavPath = TtsFileExport.EnsureWavExtension(filePath);
-		string spoken = preprocess ? TextToSpeechService.PreprocessForSpeech(resolved) : resolved;
+		string spoken = preprocess
+			? TextToSpeechService.PreprocessForSpeech(resolved, options ?? SpeechPreprocessingOptions.All)
+			: resolved;
 		if (string.IsNullOrWhiteSpace(spoken))
 			throw new ArgumentException("Nothing to speak after preprocessing.", nameof(text));
 

--- a/Mutation.Tests/SpeechPreprocessingTests.cs
+++ b/Mutation.Tests/SpeechPreprocessingTests.cs
@@ -1,0 +1,159 @@
+using CognitiveSupport;
+using Xunit;
+
+namespace Mutation.Tests;
+
+// Verifies the per-rule speech preprocessing: each cleanup rule must apply only
+// when its toggle is on, the all-on result must match the original behaviour, and
+// the settings-to-options mapping must carry each flag faithfully.
+public class SpeechPreprocessingTests
+{
+	// Build options with every rule off except the ones named, so each test
+	// exercises a single rule in isolation.
+	private static SpeechPreprocessingOptions With(
+		bool code = false, bool emph = false, bool head = false, bool link = false,
+		bool bullet = false, bool abbr = false, bool ws = false)
+		=> new()
+		{
+			RemoveCodeBlocks = code,
+			StripBoldItalicCode = emph,
+			StripHeadingMarks = head,
+			ShortenWebLinks = link,
+			StripBulletMarkers = bullet,
+			ExpandAbbreviations = abbr,
+			NormaliseWhitespace = ws,
+		};
+
+	[Fact]
+	public void Empty_ReturnsInput()
+	{
+		Assert.Equal(string.Empty, TextToSpeechService.PreprocessForSpeech(string.Empty, SpeechPreprocessingOptions.All));
+	}
+
+	[Fact]
+	public void NullOptions_TreatedAsAllRules()
+	{
+		const string input = "# Heading\n\n**bold** see https://example.com now e.g. here";
+		Assert.Equal(
+			TextToSpeechService.PreprocessForSpeech(input, SpeechPreprocessingOptions.All),
+			TextToSpeechService.PreprocessForSpeech(input, null!));
+	}
+
+	[Fact]
+	public void DefaultOverload_MatchesAllRulesOn()
+	{
+		const string input = "# Title\n\n- a bullet with **bold**, `code`, e.g. an example, https://example.com/x ```block```";
+		Assert.Equal(
+			TextToSpeechService.PreprocessForSpeech(input),
+			TextToSpeechService.PreprocessForSpeech(input, SpeechPreprocessingOptions.All));
+	}
+
+	[Fact]
+	public void AllOff_LeavesTextUnchangedApartFromTrim()
+	{
+		const string input = "# Title with **bold** and `code`";
+		Assert.Equal(input, TextToSpeechService.PreprocessForSpeech(input, With()));
+	}
+
+	[Fact]
+	public void RemoveCodeBlocks_Toggle()
+	{
+		const string input = "before ```secret code``` after";
+		Assert.DoesNotContain("secret code", TextToSpeechService.PreprocessForSpeech(input, With(code: true)));
+		Assert.Contains("secret code", TextToSpeechService.PreprocessForSpeech(input, With(code: false)));
+	}
+
+	[Fact]
+	public void StripBoldItalicCode_Toggle()
+	{
+		const string input = "x **bold** _ital_ `code` y";
+		string on = TextToSpeechService.PreprocessForSpeech(input, With(emph: true));
+		Assert.DoesNotContain("**", on);
+		Assert.DoesNotContain("`", on);
+		Assert.Contains("bold", on);
+		Assert.Contains("**", TextToSpeechService.PreprocessForSpeech(input, With(emph: false)));
+	}
+
+	[Fact]
+	public void StripHeadingMarks_Toggle()
+	{
+		const string input = "## Heading text";
+		Assert.Equal("Heading text", TextToSpeechService.PreprocessForSpeech(input, With(head: true)));
+		Assert.Contains("##", TextToSpeechService.PreprocessForSpeech(input, With(head: false)));
+	}
+
+	[Fact]
+	public void ShortenWebLinks_Toggle()
+	{
+		const string input = "see https://example.com/page now";
+		Assert.Contains("link to example.com", TextToSpeechService.PreprocessForSpeech(input, With(link: true)));
+		Assert.Contains("https://example.com", TextToSpeechService.PreprocessForSpeech(input, With(link: false)));
+	}
+
+	[Fact]
+	public void StripBulletMarkers_Toggle()
+	{
+		const string input = "- item one";
+		Assert.Equal("item one", TextToSpeechService.PreprocessForSpeech(input, With(bullet: true)));
+		Assert.Contains("- item one", TextToSpeechService.PreprocessForSpeech(input, With(bullet: false)));
+	}
+
+	[Fact]
+	public void ExpandAbbreviations_Toggle()
+	{
+		const string input = "e.g. this, i.e. that, etc. vs. them";
+		string on = TextToSpeechService.PreprocessForSpeech(input, With(abbr: true));
+		Assert.Contains("for example", on);
+		Assert.Contains("that is", on);
+		Assert.Contains("et cetera", on);
+		Assert.Contains("versus", on);
+		Assert.Contains("e.g.", TextToSpeechService.PreprocessForSpeech(input, With(abbr: false)));
+	}
+
+	[Fact]
+	public void NormaliseWhitespace_Toggle()
+	{
+		const string input = "a\n\nb   c";
+		Assert.Equal("a. b c", TextToSpeechService.PreprocessForSpeech(input, With(ws: true)));
+		Assert.Contains("\n", TextToSpeechService.PreprocessForSpeech(input, With(ws: false)));
+	}
+
+	[Fact]
+	public void FromSettings_MapsEachFlag()
+	{
+		var settings = new TextToSpeechSettings
+		{
+			PreprocessRemoveCodeBlocks = false,
+			PreprocessStripBoldItalicCode = true,
+			PreprocessStripHeadingMarks = false,
+			PreprocessShortenWebLinks = true,
+			PreprocessStripBulletMarkers = false,
+			PreprocessExpandAbbreviations = true,
+			PreprocessNormaliseWhitespace = false,
+		};
+
+		var options = SpeechPreprocessingOptions.FromSettings(settings);
+
+		Assert.False(options.RemoveCodeBlocks);
+		Assert.True(options.StripBoldItalicCode);
+		Assert.False(options.StripHeadingMarks);
+		Assert.True(options.ShortenWebLinks);
+		Assert.False(options.StripBulletMarkers);
+		Assert.True(options.ExpandAbbreviations);
+		Assert.False(options.NormaliseWhitespace);
+	}
+
+	[Fact]
+	public void FromSettings_DefaultsAreAllOn()
+	{
+		var options = SpeechPreprocessingOptions.FromSettings(new TextToSpeechSettings());
+
+		Assert.True(options.RemoveCodeBlocks);
+		Assert.True(options.StripBoldItalicCode);
+		Assert.True(options.StripHeadingMarks);
+		Assert.True(options.ShortenWebLinks);
+		Assert.True(options.StripBulletMarkers);
+		Assert.True(options.ExpandAbbreviations);
+		Assert.True(options.NormaliseWhitespace);
+	}
+}

--- a/Mutation.Ui/MainWindow.xaml.cs
+++ b/Mutation.Ui/MainWindow.xaml.cs
@@ -850,7 +850,8 @@ public sealed partial class MainWindow : Window, IDisposable
 			if (clipboardChanged)
 			{
 				_textToSpeech.Speak(trimmed, tts.Rate, tts.Volume, tts.VoiceName,
-					resumeIfSame: false, preprocess: tts.EnableSpeechPreprocessing);
+					resumeIfSame: false, preprocess: tts.EnableSpeechPreprocessing,
+					options: SpeechPreprocessingOptions.FromSettings(tts));
 				ShowStatus("Text to Speech", "Speaking new clipboard text.", InfoBarSeverity.Informational);
 			}
 			else
@@ -864,7 +865,8 @@ public sealed partial class MainWindow : Window, IDisposable
 		{
 			_textToSpeech.Speak(trimmed, tts.Rate, tts.Volume, tts.VoiceName,
 				resumeIfSame: true, preprocess: tts.EnableSpeechPreprocessing,
-				resumeRewindWordCount: tts.ResumeRewindWordCount);
+				resumeRewindWordCount: tts.ResumeRewindWordCount,
+				options: SpeechPreprocessingOptions.FromSettings(tts));
 			ShowStatus("Text to Speech", "Speaking…", InfoBarSeverity.Informational);
 			return;
 		}
@@ -972,7 +974,8 @@ public sealed partial class MainWindow : Window, IDisposable
 			// Synthesize off the UI thread so a long article does not freeze the window.
 			// A dedicated exporter writes to the file, leaving any live read untouched.
 			await Task.Run(() => _wavFileSpeechExporter.ExportToWavFile(
-				text, file.Path, tts.Rate, tts.Volume, tts.VoiceName, tts.EnableSpeechPreprocessing));
+				text, file.Path, tts.Rate, tts.Volume, tts.VoiceName, tts.EnableSpeechPreprocessing,
+				SpeechPreprocessingOptions.FromSettings(tts)));
 			ShowStatus("Speak to file", $"Saved audio to {file.Name}.", InfoBarSeverity.Success);
 		}
 		catch (Exception ex)
@@ -1041,7 +1044,8 @@ public sealed partial class MainWindow : Window, IDisposable
 		if (kind == ClipboardKind.Text && trimmed.Length > 0)
 		{
 			_textToSpeech.Speak(trimmed, tts.Rate, tts.Volume, tts.VoiceName,
-				resumeIfSame: false, preprocess: tts.EnableSpeechPreprocessing);
+				resumeIfSame: false, preprocess: tts.EnableSpeechPreprocessing,
+				options: SpeechPreprocessingOptions.FromSettings(tts));
 			ShowStatus("Text to Speech", "Speaking…", InfoBarSeverity.Informational);
 			return;
 		}

--- a/Mutation.Ui/Resources/HelpText.xaml
+++ b/Mutation.Ui/Resources/HelpText.xaml
@@ -24,7 +24,14 @@
 	<x:String x:Key="Help.Interface.DictationInsert">How transcripts reach the active app: Paste inserts via the clipboard, Type simulates keystrokes, and DoNotInsert leaves the text in Mutation only.</x:String>
 
 	<!-- Text to Speech -->
-	<x:String x:Key="Help.Tts.Preprocessing">Clean up text, such as expanding abbreviations and symbols, before it is spoken aloud.</x:String>
+	<x:String x:Key="Help.Tts.Preprocessing">Clean up text, such as expanding abbreviations and symbols, before it is spoken aloud. The individual rules below let you choose exactly which clean-ups run; this master switch turns all of them on or off at once.</x:String>
+	<x:String x:Key="Help.Tts.Preproc.RemoveCodeBlocks">Drop fenced code blocks (text between triple backticks) entirely so they are not read aloud.</x:String>
+	<x:String x:Key="Help.Tts.Preproc.StripBoldItalicCode">Remove bold, italic, and inline-code symbols (such as asterisks, underscores, and backticks), keeping the words between them.</x:String>
+	<x:String x:Key="Help.Tts.Preproc.StripHeadingMarks">Remove leading heading marks (one or more # symbols) so headings are read as plain text.</x:String>
+	<x:String x:Key="Help.Tts.Preproc.ShortenWebLinks">Replace long web links with a short spoken phrase such as "link to example.com" instead of reading the full address.</x:String>
+	<x:String x:Key="Help.Tts.Preproc.StripBulletMarkers">Remove leading bullet markers (such as -, *, or +) at the start of list items.</x:String>
+	<x:String x:Key="Help.Tts.Preproc.ExpandAbbreviations">Expand common abbreviations so they are spoken in full: e.g. becomes "for example", i.e. becomes "that is", etc. becomes "et cetera", and vs. becomes "versus".</x:String>
+	<x:String x:Key="Help.Tts.Preproc.NormaliseWhitespace">Collapse blank lines and runs of spaces into single spaces so paragraph breaks do not cause long pauses.</x:String>
 	<x:String x:Key="Help.Tts.SkipSentenceGrace">When skipping back, how long after a sentence starts that a back-press still steps to the previous sentence. After this window a back-press restarts the current sentence instead. A larger value makes stepping back easier; a smaller value favours re-reading the current sentence.</x:String>
 	<x:String x:Key="Help.Tts.ResumeRewindWords">When you resume reading after pausing, rewind this many words before where it stopped so you regain context of where you are. Set to 0 for no rewind: reading resumes from exactly where it stopped.</x:String>
 	<x:String x:Key="Help.Tts.ResumeRewindAfterPauseSeconds">When you resume after pausing, only rewind for context if the pause lasted longer than this many seconds. A quick pause resumes seamlessly from the exact word; a longer break rewinds first. Set to 0 to always rewind, however brief the pause.</x:String>

--- a/Mutation.Ui/Views/Settings/Pages/TtsSettingsPage.xaml
+++ b/Mutation.Ui/Views/Settings/Pages/TtsSettingsPage.xaml
@@ -28,6 +28,99 @@
 			</Button>
 		</StackPanel>
 
+		<StackPanel x:Name="PreprocessingRulesPanel" Spacing="8" Margin="20,0,0,0">
+			<TextBlock Text="Individual cleanup rules"
+					   Style="{StaticResource BodyStrongTextBlockStyle}" />
+			<TextBlock Text="Turn each clean-up on or off independently. These apply only while the master switch above is on."
+					   TextWrapping="Wrap"
+					   Style="{StaticResource CaptionTextBlockStyle}"
+					   Foreground="{ThemeResource TextFillColorTertiaryBrush}" />
+
+			<StackPanel Orientation="Horizontal" Spacing="8">
+				<ToggleSwitch x:Name="ToggleRemoveCodeBlocks"
+							  Header="Remove code blocks"
+							  AutomationProperties.HelpText="{StaticResource Help.Tts.Preproc.RemoveCodeBlocks}"
+							  OffContent="Off" OnContent="On"
+							  Toggled="ToggleRemoveCodeBlocks_Toggled" />
+				<controls:InfoHint Text="{StaticResource Help.Tts.Preproc.RemoveCodeBlocks}" VerticalAlignment="Center" />
+				<Button VerticalAlignment="Bottom" Click="BtnResetRemoveCodeBlocks_Click" ToolTipService.ToolTip="Reset to default" AutomationProperties.Name="Reset remove code blocks">
+					<FontIcon Glyph="&#xE72C;" FontFamily="Segoe Fluent Icons" FontSize="12" AutomationProperties.AccessibilityView="Raw" />
+				</Button>
+			</StackPanel>
+
+			<StackPanel Orientation="Horizontal" Spacing="8">
+				<ToggleSwitch x:Name="ToggleStripBoldItalicCode"
+							  Header="Strip bold, italic, and inline-code symbols"
+							  AutomationProperties.HelpText="{StaticResource Help.Tts.Preproc.StripBoldItalicCode}"
+							  OffContent="Off" OnContent="On"
+							  Toggled="ToggleStripBoldItalicCode_Toggled" />
+				<controls:InfoHint Text="{StaticResource Help.Tts.Preproc.StripBoldItalicCode}" VerticalAlignment="Center" />
+				<Button VerticalAlignment="Bottom" Click="BtnResetStripBoldItalicCode_Click" ToolTipService.ToolTip="Reset to default" AutomationProperties.Name="Reset strip bold, italic, and inline-code symbols">
+					<FontIcon Glyph="&#xE72C;" FontFamily="Segoe Fluent Icons" FontSize="12" AutomationProperties.AccessibilityView="Raw" />
+				</Button>
+			</StackPanel>
+
+			<StackPanel Orientation="Horizontal" Spacing="8">
+				<ToggleSwitch x:Name="ToggleStripHeadingMarks"
+							  Header="Strip heading marks"
+							  AutomationProperties.HelpText="{StaticResource Help.Tts.Preproc.StripHeadingMarks}"
+							  OffContent="Off" OnContent="On"
+							  Toggled="ToggleStripHeadingMarks_Toggled" />
+				<controls:InfoHint Text="{StaticResource Help.Tts.Preproc.StripHeadingMarks}" VerticalAlignment="Center" />
+				<Button VerticalAlignment="Bottom" Click="BtnResetStripHeadingMarks_Click" ToolTipService.ToolTip="Reset to default" AutomationProperties.Name="Reset strip heading marks">
+					<FontIcon Glyph="&#xE72C;" FontFamily="Segoe Fluent Icons" FontSize="12" AutomationProperties.AccessibilityView="Raw" />
+				</Button>
+			</StackPanel>
+
+			<StackPanel Orientation="Horizontal" Spacing="8">
+				<ToggleSwitch x:Name="ToggleShortenWebLinks"
+							  Header="Shorten web links"
+							  AutomationProperties.HelpText="{StaticResource Help.Tts.Preproc.ShortenWebLinks}"
+							  OffContent="Off" OnContent="On"
+							  Toggled="ToggleShortenWebLinks_Toggled" />
+				<controls:InfoHint Text="{StaticResource Help.Tts.Preproc.ShortenWebLinks}" VerticalAlignment="Center" />
+				<Button VerticalAlignment="Bottom" Click="BtnResetShortenWebLinks_Click" ToolTipService.ToolTip="Reset to default" AutomationProperties.Name="Reset shorten web links">
+					<FontIcon Glyph="&#xE72C;" FontFamily="Segoe Fluent Icons" FontSize="12" AutomationProperties.AccessibilityView="Raw" />
+				</Button>
+			</StackPanel>
+
+			<StackPanel Orientation="Horizontal" Spacing="8">
+				<ToggleSwitch x:Name="ToggleStripBulletMarkers"
+							  Header="Strip bullet markers"
+							  AutomationProperties.HelpText="{StaticResource Help.Tts.Preproc.StripBulletMarkers}"
+							  OffContent="Off" OnContent="On"
+							  Toggled="ToggleStripBulletMarkers_Toggled" />
+				<controls:InfoHint Text="{StaticResource Help.Tts.Preproc.StripBulletMarkers}" VerticalAlignment="Center" />
+				<Button VerticalAlignment="Bottom" Click="BtnResetStripBulletMarkers_Click" ToolTipService.ToolTip="Reset to default" AutomationProperties.Name="Reset strip bullet markers">
+					<FontIcon Glyph="&#xE72C;" FontFamily="Segoe Fluent Icons" FontSize="12" AutomationProperties.AccessibilityView="Raw" />
+				</Button>
+			</StackPanel>
+
+			<StackPanel Orientation="Horizontal" Spacing="8">
+				<ToggleSwitch x:Name="ToggleExpandAbbreviations"
+							  Header="Expand abbreviations"
+							  AutomationProperties.HelpText="{StaticResource Help.Tts.Preproc.ExpandAbbreviations}"
+							  OffContent="Off" OnContent="On"
+							  Toggled="ToggleExpandAbbreviations_Toggled" />
+				<controls:InfoHint Text="{StaticResource Help.Tts.Preproc.ExpandAbbreviations}" VerticalAlignment="Center" />
+				<Button VerticalAlignment="Bottom" Click="BtnResetExpandAbbreviations_Click" ToolTipService.ToolTip="Reset to default" AutomationProperties.Name="Reset expand abbreviations">
+					<FontIcon Glyph="&#xE72C;" FontFamily="Segoe Fluent Icons" FontSize="12" AutomationProperties.AccessibilityView="Raw" />
+				</Button>
+			</StackPanel>
+
+			<StackPanel Orientation="Horizontal" Spacing="8">
+				<ToggleSwitch x:Name="ToggleNormaliseWhitespace"
+							  Header="Normalise paragraph breaks and whitespace"
+							  AutomationProperties.HelpText="{StaticResource Help.Tts.Preproc.NormaliseWhitespace}"
+							  OffContent="Off" OnContent="On"
+							  Toggled="ToggleNormaliseWhitespace_Toggled" />
+				<controls:InfoHint Text="{StaticResource Help.Tts.Preproc.NormaliseWhitespace}" VerticalAlignment="Center" />
+				<Button VerticalAlignment="Bottom" Click="BtnResetNormaliseWhitespace_Click" ToolTipService.ToolTip="Reset to default" AutomationProperties.Name="Reset normalise paragraph breaks and whitespace">
+					<FontIcon Glyph="&#xE72C;" FontFamily="Segoe Fluent Icons" FontSize="12" AutomationProperties.AccessibilityView="Raw" />
+				</Button>
+			</StackPanel>
+		</StackPanel>
+
 		<StackPanel Spacing="4">
 			<StackPanel Orientation="Horizontal" Spacing="6">
 				<TextBlock Text="Skip-back grace window (milliseconds)" VerticalAlignment="Center" Style="{StaticResource BodyStrongTextBlockStyle}" />

--- a/Mutation.Ui/Views/Settings/Pages/TtsSettingsPage.xaml.cs
+++ b/Mutation.Ui/Views/Settings/Pages/TtsSettingsPage.xaml.cs
@@ -23,6 +23,14 @@ public sealed partial class TtsSettingsPage : UserControl
 		{
 			var tts = _settings.TextToSpeechSettings ??= new TextToSpeechSettings();
 			ToggleSpeechPreprocessing.IsOn = tts.EnableSpeechPreprocessing;
+			ToggleRemoveCodeBlocks.IsOn = tts.PreprocessRemoveCodeBlocks;
+			ToggleStripBoldItalicCode.IsOn = tts.PreprocessStripBoldItalicCode;
+			ToggleStripHeadingMarks.IsOn = tts.PreprocessStripHeadingMarks;
+			ToggleShortenWebLinks.IsOn = tts.PreprocessShortenWebLinks;
+			ToggleStripBulletMarkers.IsOn = tts.PreprocessStripBulletMarkers;
+			ToggleExpandAbbreviations.IsOn = tts.PreprocessExpandAbbreviations;
+			ToggleNormaliseWhitespace.IsOn = tts.PreprocessNormaliseWhitespace;
+			UpdatePreprocessingRulesEnabled();
 			NbSkipGrace.Value = tts.SkipSentenceGraceWindowMs;
 			NbResumeRewindWords.Value = tts.ResumeRewindWordCount;
 			NbResumeRewindAfterPauseSeconds.Value = tts.ResumeRewindAfterPauseSeconds;
@@ -35,6 +43,9 @@ public sealed partial class TtsSettingsPage : UserControl
 
 	private void ToggleSpeechPreprocessing_Toggled(object sender, RoutedEventArgs e)
 	{
+		// Keep the master state current even while suppressing persistence during load,
+		// so the per-rule panel's enabled state always reflects the master switch.
+		UpdatePreprocessingRulesEnabled();
 		if (_suppressEvents) return;
 		(_settings.TextToSpeechSettings ??= new TextToSpeechSettings()).EnableSpeechPreprocessing = ToggleSpeechPreprocessing.IsOn;
 	}
@@ -42,6 +53,98 @@ public sealed partial class TtsSettingsPage : UserControl
 	private void BtnResetPreproc_Click(object sender, RoutedEventArgs e)
 	{
 		ToggleSpeechPreprocessing.IsOn = SettingsDefaults.Tts.EnableSpeechPreprocessing;
+	}
+
+	// The individual rules only take effect while the master switch is on, so disable
+	// each rule toggle when it is off — screen readers then announce each rule as
+	// unavailable rather than letting a user toggle a control that does nothing.
+	private void UpdatePreprocessingRulesEnabled()
+	{
+		bool enabled = ToggleSpeechPreprocessing.IsOn;
+		ToggleRemoveCodeBlocks.IsEnabled = enabled;
+		ToggleStripBoldItalicCode.IsEnabled = enabled;
+		ToggleStripHeadingMarks.IsEnabled = enabled;
+		ToggleShortenWebLinks.IsEnabled = enabled;
+		ToggleStripBulletMarkers.IsEnabled = enabled;
+		ToggleExpandAbbreviations.IsEnabled = enabled;
+		ToggleNormaliseWhitespace.IsEnabled = enabled;
+	}
+
+	private void ToggleRemoveCodeBlocks_Toggled(object sender, RoutedEventArgs e)
+	{
+		if (_suppressEvents) return;
+		(_settings.TextToSpeechSettings ??= new TextToSpeechSettings()).PreprocessRemoveCodeBlocks = ToggleRemoveCodeBlocks.IsOn;
+	}
+
+	private void BtnResetRemoveCodeBlocks_Click(object sender, RoutedEventArgs e)
+	{
+		ToggleRemoveCodeBlocks.IsOn = SettingsDefaults.Tts.PreprocessRemoveCodeBlocks;
+	}
+
+	private void ToggleStripBoldItalicCode_Toggled(object sender, RoutedEventArgs e)
+	{
+		if (_suppressEvents) return;
+		(_settings.TextToSpeechSettings ??= new TextToSpeechSettings()).PreprocessStripBoldItalicCode = ToggleStripBoldItalicCode.IsOn;
+	}
+
+	private void BtnResetStripBoldItalicCode_Click(object sender, RoutedEventArgs e)
+	{
+		ToggleStripBoldItalicCode.IsOn = SettingsDefaults.Tts.PreprocessStripBoldItalicCode;
+	}
+
+	private void ToggleStripHeadingMarks_Toggled(object sender, RoutedEventArgs e)
+	{
+		if (_suppressEvents) return;
+		(_settings.TextToSpeechSettings ??= new TextToSpeechSettings()).PreprocessStripHeadingMarks = ToggleStripHeadingMarks.IsOn;
+	}
+
+	private void BtnResetStripHeadingMarks_Click(object sender, RoutedEventArgs e)
+	{
+		ToggleStripHeadingMarks.IsOn = SettingsDefaults.Tts.PreprocessStripHeadingMarks;
+	}
+
+	private void ToggleShortenWebLinks_Toggled(object sender, RoutedEventArgs e)
+	{
+		if (_suppressEvents) return;
+		(_settings.TextToSpeechSettings ??= new TextToSpeechSettings()).PreprocessShortenWebLinks = ToggleShortenWebLinks.IsOn;
+	}
+
+	private void BtnResetShortenWebLinks_Click(object sender, RoutedEventArgs e)
+	{
+		ToggleShortenWebLinks.IsOn = SettingsDefaults.Tts.PreprocessShortenWebLinks;
+	}
+
+	private void ToggleStripBulletMarkers_Toggled(object sender, RoutedEventArgs e)
+	{
+		if (_suppressEvents) return;
+		(_settings.TextToSpeechSettings ??= new TextToSpeechSettings()).PreprocessStripBulletMarkers = ToggleStripBulletMarkers.IsOn;
+	}
+
+	private void BtnResetStripBulletMarkers_Click(object sender, RoutedEventArgs e)
+	{
+		ToggleStripBulletMarkers.IsOn = SettingsDefaults.Tts.PreprocessStripBulletMarkers;
+	}
+
+	private void ToggleExpandAbbreviations_Toggled(object sender, RoutedEventArgs e)
+	{
+		if (_suppressEvents) return;
+		(_settings.TextToSpeechSettings ??= new TextToSpeechSettings()).PreprocessExpandAbbreviations = ToggleExpandAbbreviations.IsOn;
+	}
+
+	private void BtnResetExpandAbbreviations_Click(object sender, RoutedEventArgs e)
+	{
+		ToggleExpandAbbreviations.IsOn = SettingsDefaults.Tts.PreprocessExpandAbbreviations;
+	}
+
+	private void ToggleNormaliseWhitespace_Toggled(object sender, RoutedEventArgs e)
+	{
+		if (_suppressEvents) return;
+		(_settings.TextToSpeechSettings ??= new TextToSpeechSettings()).PreprocessNormaliseWhitespace = ToggleNormaliseWhitespace.IsOn;
+	}
+
+	private void BtnResetNormaliseWhitespace_Click(object sender, RoutedEventArgs e)
+	{
+		ToggleNormaliseWhitespace.IsOn = SettingsDefaults.Tts.PreprocessNormaliseWhitespace;
 	}
 
 	private void NbSkipGrace_ValueChanged(NumberBox sender, NumberBoxValueChangedEventArgs args)

--- a/Mutation.Ui/Views/Settings/SettingsDefaults.cs
+++ b/Mutation.Ui/Views/Settings/SettingsDefaults.cs
@@ -68,6 +68,17 @@ internal static class SettingsDefaults
 		public const int Rate = 8;
 		public const int Volume = 100;
 		public const bool EnableSpeechPreprocessing = true;
+
+		// Per-rule preprocessing defaults — all on, matching the previous
+		// all-or-nothing cleanup so existing users see no change.
+		public const bool PreprocessRemoveCodeBlocks = true;
+		public const bool PreprocessStripBoldItalicCode = true;
+		public const bool PreprocessStripHeadingMarks = true;
+		public const bool PreprocessShortenWebLinks = true;
+		public const bool PreprocessStripBulletMarkers = true;
+		public const bool PreprocessExpandAbbreviations = true;
+		public const bool PreprocessNormaliseWhitespace = true;
+
 		public const int SkipSentenceGraceWindowMs = 1500;
 		public const int MinSkipSentenceGraceWindowMs = 250;
 		public const int MaxSkipSentenceGraceWindowMs = 5000;


### PR DESCRIPTION
## Summary

The text-to-speech reader cleans up text before speaking it — stripping
heading marks and bold/italic/inline-code symbols, removing bullet markers
and code blocks, shortening web links to "link to {host}", expanding
abbreviations, and normalising whitespace. Until now the only control was a
single master switch: all seven rules ran together, or none did.

This change keeps that master switch as an overall on/off but exposes each
rule as its own toggle, so a user can — for example — keep bullet stripping
while turning off link shortening.

## What changed

- **New `SpeechPreprocessingOptions`** in the domain layer carries the seven
  per-rule flags (all default to on) plus a `FromSettings` mapper.
- **`PreprocessForSpeech`** now applies each rule only when its flag is on,
  in the original order, so the all-on result is byte-identical to the
  previous behaviour. The master `EnableSpeechPreprocessing` switch stays the
  call-site gate (off = no preprocessing at all).
- The options are threaded through `Speak`/`RunSpeak` and the WAV file
  exporter as an optional parameter (null = every rule on), so existing
  callers are unaffected.
- **Settings**: seven new persisted booleans on `TextToSpeechSettings`
  (default true) with matching `SettingsDefaults` constants. Existing users
  see no behaviour change.
- **Settings UI**: a labelled toggle per rule on the TTS settings page, each
  with help text and a reset button, consistent with the existing controls.
  The rule toggles disable while the master switch is off, so a screen reader
  announces them as unavailable rather than letting a user flip a control that
  does nothing.

## Accessibility

Every new control has a header (its accessible name), help text reachable via
the info hint and `AutomationProperties.HelpText`, and a reset button with an
explicit accessible name — matching the rest of the settings UI.

## Test plan

- `dotnet test --configuration Release` — all 478 tests pass, including 14 new
  tests in `SpeechPreprocessingTests.cs`.
- New tests assert each rule applies when its toggle is on and is skipped when
  off, that the all-on result matches the original single-method behaviour,
  that null options mean "all rules", and that `FromSettings` maps each flag
  faithfully (there were no tests over this logic before).

## Acceptance criteria

- [x] Each preprocessing rule exposed as its own toggle in TTS settings
- [x] Master "Enable speech preprocessing" switch retained as an overall gate
- [x] Each toggle persisted with all-on defaults (no change for existing users)
- [x] New controls reachable and labelled for screen-reader use (label + help + reset)
- [x] Unit tests assert each rule is applied or skipped per its toggle

Closes #147
