### PR TITLE
Verify microphone mute took effect; fail loudly on failure (#151)

### DIFF
--- a/Mutation.Tests/MuteStateControllerTests.cs
+++ b/Mutation.Tests/MuteStateControllerTests.cs
@@ -1,0 +1,202 @@
+using System;
+using System.Collections.Generic;
+using Mutation.Ui.Core;
+using Xunit;
+
+namespace Mutation.Tests;
+
+public class MuteStateControllerTests
+{
+	// Stands in for a real audio endpoint without any COM hardware. It can be
+	// made to throw (a stale proxy) or to silently drop the write (read-back
+	// mismatch) so the verify-and-retry logic can be exercised deterministically.
+	private sealed class FakeMuteEndpoint : IMuteEndpoint
+	{
+		private bool _mute;
+
+		public bool ThrowOnSet { get; set; }
+		public bool ThrowOnGet { get; set; }
+		// When true, the write is accepted but the read-back reports the opposite
+		// state — i.e. the mute did not actually take effect.
+		public bool ReadBackMismatch { get; set; }
+		public int SetCount { get; private set; }
+		public bool CurrentMute => _mute;
+
+		public FakeMuteEndpoint(bool initial = false) => _mute = initial;
+
+		public void SetMute(bool mute)
+		{
+			SetCount++;
+			if (ThrowOnSet)
+				throw new InvalidOperationException("stale proxy");
+			_mute = mute;
+		}
+
+		public bool GetMute()
+		{
+			if (ThrowOnGet)
+				throw new InvalidOperationException("stale proxy");
+			return ReadBackMismatch ? !_mute : _mute;
+		}
+	}
+
+	private sealed class FakeProvider : IMuteEndpointProvider
+	{
+		private readonly IReadOnlyList<IMuteEndpoint> _initial;
+		private readonly IReadOnlyList<IMuteEndpoint> _refreshed;
+
+		public int RefreshCount { get; private set; }
+
+		public FakeProvider(IReadOnlyList<IMuteEndpoint> initial, IReadOnlyList<IMuteEndpoint>? refreshed = null)
+		{
+			_initial = initial;
+			_refreshed = refreshed ?? initial;
+		}
+
+		public IReadOnlyList<IMuteEndpoint> GetEndpoints() => _initial;
+
+		public IReadOnlyList<IMuteEndpoint> RefreshEndpoints()
+		{
+			RefreshCount++;
+			return _refreshed;
+		}
+	}
+
+	[Fact]
+	public void Toggle_AllEndpointsHealthy_ConfirmsAndAdvancesState_WithoutRefresh()
+	{
+		var a = new FakeMuteEndpoint();
+		var b = new FakeMuteEndpoint();
+		var provider = new FakeProvider(new IMuteEndpoint[] { a, b });
+		var controller = new MuteStateController(provider);
+
+		var result = controller.Toggle();
+
+		Assert.True(result.Success);
+		Assert.True(result.IsMuted);
+		Assert.True(controller.IsMuted);
+		Assert.True(a.CurrentMute);
+		Assert.True(b.CurrentMute);
+		Assert.Equal(0, provider.RefreshCount);
+	}
+
+	[Fact]
+	public void Toggle_Twice_UnmutesBackToLive()
+	{
+		var a = new FakeMuteEndpoint();
+		var provider = new FakeProvider(new IMuteEndpoint[] { a });
+		var controller = new MuteStateController(provider);
+
+		controller.Toggle();
+		var result = controller.Toggle();
+
+		Assert.True(result.Success);
+		Assert.False(result.IsMuted);
+		Assert.False(controller.IsMuted);
+		Assert.False(a.CurrentMute);
+	}
+
+	[Fact]
+	public void Toggle_ReadBackMismatch_RetriesOnceWithFreshEndpoints_ThenSucceeds()
+	{
+		// The stale endpoint accepts the write but never actually mutes.
+		var stale = new FakeMuteEndpoint { ReadBackMismatch = true };
+		var fresh = new FakeMuteEndpoint();
+		var provider = new FakeProvider(new IMuteEndpoint[] { stale }, new IMuteEndpoint[] { fresh });
+		var controller = new MuteStateController(provider);
+
+		var result = controller.Toggle();
+
+		Assert.True(result.Success);
+		Assert.True(result.IsMuted);
+		Assert.Equal(1, provider.RefreshCount);
+		Assert.True(fresh.CurrentMute); // the fresh reference is what actually muted
+	}
+
+	[Fact]
+	public void Toggle_ExceptionOnFirstAttempt_RecoversWithFreshEndpoints()
+	{
+		var stale = new FakeMuteEndpoint { ThrowOnSet = true };
+		var fresh = new FakeMuteEndpoint();
+		var provider = new FakeProvider(new IMuteEndpoint[] { stale }, new IMuteEndpoint[] { fresh });
+		var controller = new MuteStateController(provider);
+
+		var result = controller.Toggle();
+
+		Assert.True(result.Success);
+		Assert.True(controller.IsMuted);
+		Assert.Equal(1, provider.RefreshCount);
+		Assert.True(fresh.CurrentMute);
+	}
+
+	[Fact]
+	public void Toggle_PartialFailure_OneEndpointBad_FailsFirstAttempt_ThenRetries()
+	{
+		var good = new FakeMuteEndpoint();
+		var bad = new FakeMuteEndpoint { ThrowOnGet = true };
+		var freshA = new FakeMuteEndpoint();
+		var freshB = new FakeMuteEndpoint();
+		var provider = new FakeProvider(
+			new IMuteEndpoint[] { good, bad },
+			new IMuteEndpoint[] { freshA, freshB });
+		var controller = new MuteStateController(provider);
+
+		var result = controller.Toggle();
+
+		Assert.True(result.Success);
+		Assert.Equal(1, provider.RefreshCount);
+		Assert.True(freshA.CurrentMute);
+		Assert.True(freshB.CurrentMute);
+	}
+
+	[Fact]
+	public void Toggle_PersistentFailure_ReturnsFailure_RetriesExactlyOnce_DoesNotAdvanceState()
+	{
+		var stale = new FakeMuteEndpoint { ThrowOnSet = true };
+		var stillStale = new FakeMuteEndpoint { ThrowOnSet = true };
+		var provider = new FakeProvider(new IMuteEndpoint[] { stale }, new IMuteEndpoint[] { stillStale });
+		var controller = new MuteStateController(provider);
+
+		var result = controller.Toggle();
+
+		Assert.False(result.Success);
+		Assert.False(result.IsMuted);   // reported state is the previous verified state
+		Assert.False(controller.IsMuted); // tracked state never advanced on failure
+		Assert.Equal(1, provider.RefreshCount); // retried once, not in a loop
+	}
+
+	[Fact]
+	public void Toggle_FailureWhileMuted_KeepsMutedState_NeverFalselyReportsLive()
+	{
+		// Starts muted; an unmute attempt that cannot be confirmed must leave the
+		// state muted rather than falsely reporting the mic is live.
+		var stale = new FakeMuteEndpoint(initial: true) { ThrowOnSet = true };
+		var provider = new FakeProvider(new IMuteEndpoint[] { stale });
+		var controller = new MuteStateController(provider, initialMuted: true);
+
+		var result = controller.Toggle();
+
+		Assert.False(result.Success);
+		Assert.True(result.IsMuted);
+		Assert.True(controller.IsMuted);
+	}
+
+	[Fact]
+	public void Toggle_NoEndpoints_ReturnsFailure_BecauseMuteCannotBeConfirmed()
+	{
+		var provider = new FakeProvider(Array.Empty<IMuteEndpoint>(), Array.Empty<IMuteEndpoint>());
+		var controller = new MuteStateController(provider);
+
+		var result = controller.Toggle();
+
+		Assert.False(result.Success);
+		Assert.False(result.IsMuted);
+		Assert.Equal(1, provider.RefreshCount);
+	}
+
+	[Fact]
+	public void Constructor_NullProvider_Throws()
+	{
+		Assert.Throws<ArgumentNullException>(() => new MuteStateController(null!));
+	}
+}

--- a/Mutation.Ui/Core/AudioDeviceManager.cs
+++ b/Mutation.Ui/Core/AudioDeviceManager.cs
@@ -1,4 +1,5 @@
 ﻿using CoreAudio;
+using Mutation.Ui.Core;
 using NAudio.Wave;
 using System;
 using System.Collections.Generic;
@@ -9,9 +10,10 @@ namespace Mutation.Ui;
 /// Manages enumeration and selection of audio capture devices as well as
 /// mute and unmute operations.  This keeps audio related responsibilities
 /// away from the WinForms logic in <see cref="MutationForm"/>.
-public class AudioDeviceManager
+public class AudioDeviceManager : IMuteEndpointProvider
 {
         private readonly MMDeviceEnumerator _deviceEnumerator;
+        private readonly MuteStateController _muteState;
         private IList<MMDevice> _captureDevices = new List<MMDevice>();
         private MMDevice? _microphone;
         private int _microphoneDeviceIndex = -1;
@@ -20,6 +22,7 @@ public class AudioDeviceManager
         {
                 _deviceEnumerator = deviceEnumerator ?? throw new ArgumentNullException(nameof(deviceEnumerator));
                 RefreshCaptureDevices();
+                _muteState = new MuteStateController(this, ReadInitialMuteState());
         }
 
         public IEnumerable<MMDevice> CaptureDevices => _captureDevices;
@@ -28,7 +31,10 @@ public class AudioDeviceManager
 
         public int MicrophoneDeviceIndex => _microphoneDeviceIndex;
 
-        public bool IsMuted => _microphone is { AudioEndpointVolume: { } volume } && volume.Mute;
+        // Reflects the aggregate mute state that was actually written to the
+        // capture devices and confirmed by read-back — not an optimistic guess
+        // and not a stale read of a single unrelated device instance.
+        public bool IsMuted => _muteState.IsMuted;
 
         public void RefreshCaptureDevices()
         {
@@ -92,19 +98,41 @@ public class AudioDeviceManager
                 _microphoneDeviceIndex = bestMatchIndex;
 	}
 
-        public void ToggleMute()
+        /// Flips the mute state on all capture devices, confirms the write by
+        /// reading it back, and retries once with fresh device references if the
+        /// write fails. Returns whether the new state was confirmed and the mute
+        /// state to report to the user.
+        public MuteToggleResult ToggleMute() => _muteState.Toggle();
+
+        IReadOnlyList<IMuteEndpoint> IMuteEndpointProvider.GetEndpoints() =>
+                BuildEndpoints();
+
+        IReadOnlyList<IMuteEndpoint> IMuteEndpointProvider.RefreshEndpoints()
         {
-                bool newMuteState = !IsMuted;
-                foreach (var mic in _captureDevices)
+                RefreshCaptureDevices();
+                return BuildEndpoints();
+        }
+
+        private IReadOnlyList<IMuteEndpoint> BuildEndpoints() =>
+                _captureDevices
+                        .Where(device => device != null)
+                        .Select(device => (IMuteEndpoint)new MmDeviceMuteEndpoint(device))
+                        .ToList();
+
+        // Best-effort read of the current device mute state at startup so the
+        // tracked state starts in sync with the hardware. Defaults to unmuted if
+        // no device can be read.
+        private bool ReadInitialMuteState()
+        {
+                foreach (var device in _captureDevices)
                 {
-                        if (mic == null)
-                                continue;
                         try
                         {
-                                if (mic.AudioEndpointVolume != null)
-                                        mic.AudioEndpointVolume.Mute = newMuteState;
+                                if (device?.AudioEndpointVolume is { } volume)
+                                        return volume.Mute;
                         }
                         catch { }
                 }
+                return false;
         }
 }

--- a/Mutation.Ui/Core/IMuteEndpoint.cs
+++ b/Mutation.Ui/Core/IMuteEndpoint.cs
@@ -1,0 +1,15 @@
+namespace Mutation.Ui.Core;
+
+/// <summary>
+/// A single audio endpoint whose mute state can be written and read back.
+/// Both operations may throw (for example, a stale CoreAudio COM proxy on a
+/// cached device), which callers treat as a failed mute.
+/// </summary>
+public interface IMuteEndpoint
+{
+	/// <summary>Writes the mute state. May throw on a stale/disconnected device.</summary>
+	void SetMute(bool mute);
+
+	/// <summary>Reads the current mute state back. May throw on a stale/disconnected device.</summary>
+	bool GetMute();
+}

--- a/Mutation.Ui/Core/IMuteEndpointProvider.cs
+++ b/Mutation.Ui/Core/IMuteEndpointProvider.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+
+namespace Mutation.Ui.Core;
+
+/// <summary>
+/// Supplies the audio endpoints to mute, and can re-enumerate fresh ones. The
+/// refresh exists so a mute that fails on a stale COM proxy can be retried
+/// against newly-acquired device references — the same recovery a manual app
+/// restart performed by hand.
+/// </summary>
+public interface IMuteEndpointProvider
+{
+	/// <summary>The endpoints to mute, using the currently-held device references.</summary>
+	IReadOnlyList<IMuteEndpoint> GetEndpoints();
+
+	/// <summary>Re-enumerates the capture devices and returns fresh endpoints.</summary>
+	IReadOnlyList<IMuteEndpoint> RefreshEndpoints();
+}

--- a/Mutation.Ui/Core/MmDeviceMuteEndpoint.cs
+++ b/Mutation.Ui/Core/MmDeviceMuteEndpoint.cs
@@ -1,0 +1,34 @@
+using CoreAudio;
+using System;
+
+namespace Mutation.Ui.Core;
+
+/// <summary>
+/// CoreAudio-backed <see cref="IMuteEndpoint"/> over a capture
+/// <see cref="MMDevice"/>. Reading or writing the mute flag touches the
+/// device's COM proxy, which can throw when the underlying device reference is
+/// stale — surfaced to the caller so it can retry against a fresh reference.
+/// </summary>
+public sealed class MmDeviceMuteEndpoint : IMuteEndpoint
+{
+	private readonly MMDevice _device;
+
+	public MmDeviceMuteEndpoint(MMDevice device)
+	{
+		_device = device ?? throw new ArgumentNullException(nameof(device));
+	}
+
+	public void SetMute(bool mute)
+	{
+		var volume = _device.AudioEndpointVolume
+			?? throw new InvalidOperationException("Device has no audio endpoint volume.");
+		volume.Mute = mute;
+	}
+
+	public bool GetMute()
+	{
+		var volume = _device.AudioEndpointVolume
+			?? throw new InvalidOperationException("Device has no audio endpoint volume.");
+		return volume.Mute;
+	}
+}

--- a/Mutation.Ui/Core/MuteStateController.cs
+++ b/Mutation.Ui/Core/MuteStateController.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Generic;
+
+namespace Mutation.Ui.Core;
+
+/// <summary>
+/// Tracks the microphone mute state and applies it with verification. A toggle
+/// writes the desired state to every endpoint and reads it back to confirm the
+/// write took effect; a thrown exception or a read-back mismatch on any endpoint
+/// is a failure. On failure it re-acquires fresh device references once and
+/// retries — reproducing, automatically, what a manual app restart did. The
+/// tracked <see cref="IsMuted"/> advances only on a confirmed success, so the
+/// UI never reports "muted" while a microphone is still live.
+/// </summary>
+public sealed class MuteStateController
+{
+	private readonly IMuteEndpointProvider _provider;
+	private bool _isMuted;
+
+	public MuteStateController(IMuteEndpointProvider provider, bool initialMuted = false)
+	{
+		_provider = provider ?? throw new ArgumentNullException(nameof(provider));
+		_isMuted = initialMuted;
+	}
+
+	/// <summary>The last confirmed mute state.</summary>
+	public bool IsMuted => _isMuted;
+
+	/// <summary>
+	/// Flips the mute state, verifying the write and retrying once with fresh
+	/// device references on failure. The tracked state advances only when the
+	/// new state is confirmed on every device.
+	/// </summary>
+	public MuteToggleResult Toggle()
+	{
+		bool desired = !_isMuted;
+
+		bool success = TryApplyAndVerify(_provider.GetEndpoints(), desired);
+		if (!success)
+		{
+			// Stale-proxy recovery: obtain fresh MMDevice / AudioEndpointVolume
+			// references and retry the mute exactly once before declaring failure.
+			success = TryApplyAndVerify(_provider.RefreshEndpoints(), desired);
+		}
+
+		if (success)
+			_isMuted = desired;
+
+		return new MuteToggleResult(success, _isMuted);
+	}
+
+	/// <summary>
+	/// Writes <paramref name="desiredMute"/> to every endpoint and confirms it by
+	/// read-back. Returns true only if all endpoints ended in the desired state.
+	/// An empty endpoint set is a failure: with nothing to write, the mute cannot
+	/// be confirmed to have taken effect.
+	/// </summary>
+	private static bool TryApplyAndVerify(IReadOnlyList<IMuteEndpoint> endpoints, bool desiredMute)
+	{
+		if (endpoints.Count == 0)
+			return false;
+
+		bool allConfirmed = true;
+		foreach (var endpoint in endpoints)
+		{
+			try
+			{
+				endpoint.SetMute(desiredMute);
+				if (endpoint.GetMute() != desiredMute)
+					allConfirmed = false;
+			}
+			catch
+			{
+				allConfirmed = false;
+			}
+		}
+
+		return allConfirmed;
+	}
+}

--- a/Mutation.Ui/Core/MuteToggleResult.cs
+++ b/Mutation.Ui/Core/MuteToggleResult.cs
@@ -1,0 +1,9 @@
+namespace Mutation.Ui.Core;
+
+/// <summary>
+/// Outcome of a mute toggle. <see cref="Success"/> is <c>true</c> only when the
+/// new state was written and confirmed by read-back on every target device.
+/// <see cref="IsMuted"/> is the confirmed state to report to the user — on
+/// failure it is the previous verified state, never an optimistic guess.
+/// </summary>
+public readonly record struct MuteToggleResult(bool Success, bool IsMuted);

--- a/Mutation.Ui/MainWindow.xaml.cs
+++ b/Mutation.Ui/MainWindow.xaml.cs
@@ -495,11 +495,26 @@ public sealed partial class MainWindow : Window, IDisposable
 
 	public void BtnToggleMic_Click(object? sender, RoutedEventArgs? e)
 	{
-		_audioDeviceManager.ToggleMute();
+		var result = _audioDeviceManager.ToggleMute();
+		// Drives the graphic off the confirmed state, so a failed mute never
+		// shows the muted icon.
 		UpdateMicrophoneToggleVisuals();
-		ShowStatus("Microphone", _audioDeviceManager.IsMuted ? "Microphone muted." : "Microphone is live.",
-			_audioDeviceManager.IsMuted ? InfoBarSeverity.Warning : InfoBarSeverity.Success);
-		BeepPlayer.Play(_audioDeviceManager.IsMuted ? BeepType.Mute : BeepType.Unmute);
+
+		if (result.Success)
+		{
+			ShowStatus("Microphone", result.IsMuted ? "Microphone muted." : "Microphone is live.",
+				result.IsMuted ? InfoBarSeverity.Warning : InfoBarSeverity.Success);
+			BeepPlayer.Play(result.IsMuted ? BeepType.Mute : BeepType.Unmute);
+		}
+		else
+		{
+			// The write failed or could not be confirmed — do not claim the mic
+			// is muted. Warn the user with the failure beep and an error message.
+			ShowStatus("Microphone",
+				"Could not change the microphone mute state. The microphone may still be live — please try again.",
+				InfoBarSeverity.Error);
+			BeepPlayer.Play(BeepType.Failure);
+		}
 	}
 
 	private async void BtnScreenshot_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
## What this fixes

Closes #151

The microphone mute control could tell the user they were muted while the
mic stayed live. Pressing mute played the mute sound and showed the muted
graphic, yet other people could still hear the user; only restarting the
app restored correct behaviour.

Two things caused the false confidence:

- `ToggleMute()` wrote the mute flag to each capture device inside a
  `try { } catch { }` that swallowed every error, returned `void`, and
  never read the value back — so a failed write (typically a stale
  CoreAudio COM proxy on a cached device) vanished silently.
- The beep and graphic were driven by `IsMuted`, which read the mute flag
  off a *different* device instance (the selected microphone) than the one
  the write targeted. The UI could therefore report "muted" from a stale
  flag while the live device was never muted.

## How it works now

A small, testable seam isolates the mute logic from the CoreAudio COM
types so the verify-and-retry behaviour can be unit-tested without audio
hardware:

- **`IMuteEndpoint`** — one device we can set and read the mute flag on;
  both operations may throw.
- **`IMuteEndpointProvider`** — hands out the endpoints and can
  re-enumerate fresh device references.
- **`MuteStateController`** — writes the desired state to every device,
  reads it back to confirm, and retries **once** against freshly-acquired
  device references when a write throws or the read-back disagrees. This
  reproduces automatically what a manual app restart used to do. The
  tracked mute state advances only on a confirmed success.
- **`MmDeviceMuteEndpoint`** — the thin CoreAudio adapter (mirrors the
  existing `CoreAudioCaptureLevelController` pattern).

`AudioDeviceManager` now delegates to the controller, `ToggleMute()`
returns a `MuteToggleResult`, and `IsMuted` reflects the aggregate state
that was actually written and verified.

In the UI, a confirmed toggle behaves exactly as before (mute/unmute beep,
graphic, status). On failure the app plays the failure beep, leaves the
graphic unchanged (so it never shows "muted" for a mute that did not take
effect), and shows an error in the status bar. This matters because a
blind user relies on the beep and graphic as the only confirmation that
muting worked — a false "you are muted" is worse than no signal.

## Acceptance criteria addressed

- [x] `ToggleMute()` writes the mute state, then reads `.Mute` back on each
      device; a thrown exception or read-back mismatch counts as failure.
- [x] `ToggleMute()` reports success/failure to the caller (returns
      `MuteToggleResult`) instead of `void`.
- [x] On confirmed success: mute/unmute beep, muted/live graphic, normal
      status message — as before.
- [x] On failure: failure beep, no muted graphic, error surfaced in the
      status bar.
- [x] Re-acquire fresh device references and retry once on a stale-proxy
      failure before declaring failure.
- [x] Reported mute state reflects the devices actually written and
      verified, not a stale read of one unrelated device instance.

## Test plan

`dotnet test --configuration Release` — all 509 tests pass, including 9
new `MuteStateControllerTests` covering:

- healthy devices confirm and advance state without a refresh;
- a second toggle unmutes;
- read-back mismatch triggers exactly one retry with fresh references, and
  the fresh reference is what actually mutes;
- a thrown write recovers via the retry;
- a partial failure (one bad device) fails the first attempt then retries;
- persistent failure returns failure, retries exactly once (no loop), and
  never advances the tracked state;
- a failed unmute while muted keeps the muted state (never falsely reports
  live);
- an empty device set is a failure (mute cannot be confirmed).

Manual verification of the live audio path (real hardware, stale-proxy
recovery) is left to a human, since it cannot be exercised in the unit
test environment.

## Notes

Related to but distinct from #150 (microphones missing from the device
list). This PR does not re-resolve the selected microphone during the
retry — waveform capture uses an integer device index, and device-list
refresh is #150's scope.
