### PR TITLE
Re-enumerate capture devices on hot-plug so the mute hotkey covers new mics

### DIFF
--- a/Mutation.Tests/MuteStateControllerTests.cs
+++ b/Mutation.Tests/MuteStateControllerTests.cs
@@ -199,4 +199,101 @@ public class MuteStateControllerTests
 	{
 		Assert.Throws<ArgumentNullException>(() => new MuteStateController(null!));
 	}
+
+	// A provider whose current endpoint set can grow, standing in for a
+	// microphone hot-plugged after the app started. GetEndpoints() reflects the
+	// latest set, exactly as AudioDeviceManager does after re-enumerating.
+	private sealed class MutableProvider : IMuteEndpointProvider
+	{
+		private IReadOnlyList<IMuteEndpoint> _current;
+
+		public int RefreshCount { get; private set; }
+
+		public MutableProvider(IReadOnlyList<IMuteEndpoint> initial) => _current = initial;
+
+		public void SetEndpoints(IReadOnlyList<IMuteEndpoint> endpoints) => _current = endpoints;
+
+		public IReadOnlyList<IMuteEndpoint> GetEndpoints() => _current;
+
+		public IReadOnlyList<IMuteEndpoint> RefreshEndpoints()
+		{
+			RefreshCount++;
+			return _current;
+		}
+	}
+
+	[Fact]
+	public void SynchronizeDevices_WhenMuted_AppliesMutedToNewlyAddedEndpoint()
+	{
+		var existing = new FakeMuteEndpoint();
+		var provider = new MutableProvider(new IMuteEndpoint[] { existing });
+		var controller = new MuteStateController(provider);
+
+		controller.Toggle(); // now muted; the existing mic is muted
+		Assert.True(controller.IsMuted);
+
+		// A mic is plugged in: it joins the current set, initially live.
+		var added = new FakeMuteEndpoint();
+		provider.SetEndpoints(new IMuteEndpoint[] { existing, added });
+
+		bool synced = controller.SynchronizeDevices();
+
+		Assert.True(synced);
+		Assert.True(added.CurrentMute);       // the new mic adopted the muted state
+		Assert.True(existing.CurrentMute);    // the existing mic stays muted
+		Assert.True(controller.IsMuted);      // tracked state is unchanged
+	}
+
+	[Fact]
+	public void SynchronizeDevices_WhenStartedMuted_MutesNewMic_WithoutAToggle()
+	{
+		var added = new FakeMuteEndpoint();
+		var provider = new MutableProvider(new IMuteEndpoint[] { added });
+		var controller = new MuteStateController(provider, initialMuted: true);
+
+		bool synced = controller.SynchronizeDevices();
+
+		Assert.True(synced);
+		Assert.True(added.CurrentMute);
+	}
+
+	[Fact]
+	public void SynchronizeDevices_WhenUnmuted_LeavesNewMicLive_AndDoesNotChangeState()
+	{
+		var added = new FakeMuteEndpoint(initial: true); // arrives muted at the OS level
+		var provider = new MutableProvider(new IMuteEndpoint[] { added });
+		var controller = new MuteStateController(provider); // unmuted
+
+		bool synced = controller.SynchronizeDevices();
+
+		Assert.True(synced);
+		Assert.False(added.CurrentMute);   // brought in line with the app's live state
+		Assert.False(controller.IsMuted);  // tracked state is unchanged
+	}
+
+	[Fact]
+	public void SynchronizeDevices_PartialFailure_ReportsFailure_DoesNotChangeState()
+	{
+		var good = new FakeMuteEndpoint();
+		var bad = new FakeMuteEndpoint { ThrowOnSet = true };
+		var provider = new MutableProvider(new IMuteEndpoint[] { good, bad });
+		var controller = new MuteStateController(provider, initialMuted: true);
+
+		bool synced = controller.SynchronizeDevices();
+
+		Assert.False(synced);
+		Assert.True(controller.IsMuted);           // state never advanced or flipped
+		Assert.Equal(0, provider.RefreshCount);    // synchronize does not re-enumerate itself
+	}
+
+	[Fact]
+	public void SynchronizeDevices_NoEndpoints_ReturnsFalse_WithoutThrowing()
+	{
+		var provider = new MutableProvider(Array.Empty<IMuteEndpoint>());
+		var controller = new MuteStateController(provider);
+
+		bool synced = controller.SynchronizeDevices();
+
+		Assert.False(synced);
+	}
 }

--- a/Mutation.Ui/App.xaml.cs
+++ b/Mutation.Ui/App.xaml.cs
@@ -190,6 +190,7 @@ public partial class App : Application
 			builder.Services.AddSingleton<ClipboardManager>();
 			builder.Services.AddSingleton<UiStateManager>();
 			builder.Services.AddSingleton<MMDeviceEnumerator>(_ => new MMDeviceEnumerator(Guid.NewGuid()));
+			builder.Services.AddSingleton<Mutation.Ui.Core.ICaptureDeviceChangeNotifier, Mutation.Ui.Core.MMDeviceCaptureDeviceChangeNotifier>();
 			builder.Services.AddSingleton<AudioDeviceManager>();
 			builder.Services.AddSingleton<Mutation.Ui.Core.ICaptureLevelController>(sp =>
 				new Mutation.Ui.Core.CoreAudioCaptureLevelController(

--- a/Mutation.Ui/Core/AudioDeviceManager.cs
+++ b/Mutation.Ui/Core/AudioDeviceManager.cs
@@ -14,18 +14,45 @@ public class AudioDeviceManager : IMuteEndpointProvider
 {
         private readonly MMDeviceEnumerator _deviceEnumerator;
         private readonly MuteStateController _muteState;
+        // Guards the capture-device list and the mute application against the
+        // background thread that OS device-change notifications arrive on: a
+        // hot-plug re-enumeration must not race the UI-thread mute toggle.
+        private readonly object _sync = new();
         private IList<MMDevice> _captureDevices = new List<MMDevice>();
         private MMDevice? _microphone;
         private int _microphoneDeviceIndex = -1;
 
-        public AudioDeviceManager(MMDeviceEnumerator deviceEnumerator)
+        public AudioDeviceManager(MMDeviceEnumerator deviceEnumerator, ICaptureDeviceChangeNotifier deviceChangeNotifier)
         {
                 _deviceEnumerator = deviceEnumerator ?? throw new ArgumentNullException(nameof(deviceEnumerator));
+                if (deviceChangeNotifier is null)
+                        throw new ArgumentNullException(nameof(deviceChangeNotifier));
                 RefreshCaptureDevices();
                 _muteState = new MuteStateController(this, ReadInitialMuteState());
+
+                // Subscribe only after _muteState exists, so a notification that
+                // arrives during construction cannot reach a half-built object.
+                deviceChangeNotifier.CaptureDevicesChanged += OnCaptureDevicesChanged;
         }
 
-        public IEnumerable<MMDevice> CaptureDevices => _captureDevices;
+        // When a microphone is added or removed at the OS level, re-enumerate so
+        // ToggleMute() acts on the current set, then re-apply the current mute
+        // state so a newly connected mic adopts it (muted stays muted).
+        private void OnCaptureDevicesChanged(object? sender, EventArgs e)
+        {
+                lock (_sync)
+                {
+                        RefreshCaptureDevices();
+                        _muteState.SynchronizeDevices();
+                }
+        }
+
+        public IEnumerable<MMDevice> CaptureDevices
+        {
+                // Return a snapshot: the backing list can be swapped out on a
+                // device-change notification thread while a caller enumerates.
+                get { lock (_sync) return _captureDevices.ToList(); }
+        }
 
         public MMDevice? Microphone => _microphone;
 
@@ -39,7 +66,10 @@ public class AudioDeviceManager : IMuteEndpointProvider
         public void RefreshCaptureDevices()
         {
                 var devices = _deviceEnumerator.EnumerateAudioEndPoints(DataFlow.Capture, DeviceState.Active);
-                _captureDevices = devices.ToList();
+                lock (_sync)
+                {
+                        _captureDevices = devices.ToList();
+                }
         }
 
         public void SelectMicrophone(MMDevice device)
@@ -102,17 +132,35 @@ public class AudioDeviceManager : IMuteEndpointProvider
         /// reading it back, and retries once with fresh device references if the
         /// write fails. Returns whether the new state was confirmed and the mute
         /// state to report to the user.
-        public MuteToggleResult ToggleMute() => _muteState.Toggle();
+        public MuteToggleResult ToggleMute()
+        {
+                // Serialize with the device-change handler so a hot-plug refresh
+                // cannot swap the device list out from under an in-flight toggle.
+                lock (_sync)
+                {
+                        return _muteState.Toggle();
+                }
+        }
 
-        IReadOnlyList<IMuteEndpoint> IMuteEndpointProvider.GetEndpoints() =>
-                BuildEndpoints();
+        IReadOnlyList<IMuteEndpoint> IMuteEndpointProvider.GetEndpoints()
+        {
+                lock (_sync)
+                {
+                        return BuildEndpoints();
+                }
+        }
 
         IReadOnlyList<IMuteEndpoint> IMuteEndpointProvider.RefreshEndpoints()
         {
-                RefreshCaptureDevices();
-                return BuildEndpoints();
+                lock (_sync)
+                {
+                        RefreshCaptureDevices();
+                        return BuildEndpoints();
+                }
         }
 
+        // Callers hold _sync; the lock is reentrant so RefreshCaptureDevices'
+        // own lock nests harmlessly.
         private IReadOnlyList<IMuteEndpoint> BuildEndpoints() =>
                 _captureDevices
                         .Where(device => device != null)

--- a/Mutation.Ui/Core/ICaptureDeviceChangeNotifier.cs
+++ b/Mutation.Ui/Core/ICaptureDeviceChangeNotifier.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace Mutation.Ui.Core;
+
+/// <summary>
+/// Notifies when the set of audio capture devices may have changed — a
+/// microphone plugged in, removed, enabled, or disabled at the OS level. It
+/// exists so <see cref="Mutation.Ui.AudioDeviceManager"/> can re-enumerate its
+/// devices in response to a hot-plug instead of only enumerating once at
+/// startup, without taking a direct dependency on the CoreAudio COM API.
+/// </summary>
+public interface ICaptureDeviceChangeNotifier
+{
+	/// <summary>
+	/// Raised when the audio device set changes. Handlers should re-enumerate
+	/// capture devices; the event carries no payload because the correct
+	/// response is always a full re-enumeration.
+	/// </summary>
+	event EventHandler? CaptureDevicesChanged;
+}

--- a/Mutation.Ui/Core/MMDeviceCaptureDeviceChangeNotifier.cs
+++ b/Mutation.Ui/Core/MMDeviceCaptureDeviceChangeNotifier.cs
@@ -1,0 +1,46 @@
+using CoreAudio;
+using System;
+
+namespace Mutation.Ui.Core;
+
+/// <summary>
+/// CoreAudio-backed <see cref="ICaptureDeviceChangeNotifier"/>. Wraps an
+/// <see cref="MMNotificationClient"/> — the CoreAudio object that registers for
+/// OS audio-endpoint notifications — over the shared
+/// <see cref="MMDeviceEnumerator"/>, and collapses its per-device events into a
+/// single <see cref="CaptureDevicesChanged"/> signal.
+///
+/// Any device add, remove, or state change triggers the signal — render
+/// devices included — because the correct response is always a cheap,
+/// idempotent re-enumeration of capture devices, and filtering by data-flow
+/// here would add COM lookups for no benefit.
+///
+/// Registered as an application-lifetime singleton, so it never unsubscribes;
+/// the retained <see cref="_notificationClient"/> field also keeps the
+/// callback-registered client alive for the life of the process.
+/// </summary>
+public sealed class MMDeviceCaptureDeviceChangeNotifier : ICaptureDeviceChangeNotifier
+{
+	private readonly MMNotificationClient _notificationClient;
+
+	public MMDeviceCaptureDeviceChangeNotifier(MMDeviceEnumerator enumerator)
+	{
+		if (enumerator is null)
+			throw new ArgumentNullException(nameof(enumerator));
+
+		_notificationClient = new MMNotificationClient(enumerator);
+
+		// Discard-lambda handlers: every one of these events means the same
+		// thing to us — "re-enumerate" — so their differing argument types are
+		// irrelevant here.
+		_notificationClient.DeviceAdded += (_, _) => Raise();
+		_notificationClient.DeviceRemoved += (_, _) => Raise();
+		_notificationClient.DeviceStateChanged += (_, _) => Raise();
+		_notificationClient.DefaultDeviceChanged += (_, _) => Raise();
+	}
+
+	/// <inheritdoc />
+	public event EventHandler? CaptureDevicesChanged;
+
+	private void Raise() => CaptureDevicesChanged?.Invoke(this, EventArgs.Empty);
+}

--- a/Mutation.Ui/Core/MuteStateController.cs
+++ b/Mutation.Ui/Core/MuteStateController.cs
@@ -50,6 +50,18 @@ public sealed class MuteStateController
 	}
 
 	/// <summary>
+	/// Re-applies the current confirmed mute state to the current endpoint set.
+	/// This is how a capture device that appeared after the last toggle — a
+	/// hot-plugged microphone — adopts the same state, so a mic connected while
+	/// the app is muted is muted too. It is best-effort: the tracked
+	/// <see cref="IsMuted"/> is never changed here (a real toggle owns state
+	/// transitions and their verification), and a failure is reported but not
+	/// acted on. Returns true only when every current endpoint confirmed the
+	/// state; an empty endpoint set returns false.
+	/// </summary>
+	public bool SynchronizeDevices() => TryApplyAndVerify(_provider.GetEndpoints(), _isMuted);
+
+	/// <summary>
 	/// Writes <paramref name="desiredMute"/> to every endpoint and confirms it by
 	/// read-back. Returns true only if all endpoints ended in the desired state.
 	/// An empty endpoint set is a failure: with nothing to write, the mute cannot


### PR DESCRIPTION
## What and why

The microphone mute/unmute hotkey is meant to silence **every** capture
device — a privacy guarantee a blind user relies on. But the list of devices
it acted on was built only once, at startup, so a microphone plugged in after
the app launched was never muted. Pressing mute left that mic live, with
nothing to signal the miss. This fixes that silent failure.

## What changed

The app now listens for OS audio device-change notifications. When a device is
added, removed, or changes state, it re-enumerates capture devices and re-applies
the current mute state, so:

- The hotkey always acts on the current set of microphones, including any
  connected mid-session.
- A microphone connected while the app is muted is muted too — state stays
  consistent across all mics.

New pieces, kept small and layered so the logic stays testable:

- **`ICaptureDeviceChangeNotifier`** — an interface over "the device set
  changed", so `AudioDeviceManager` reacts to hot-plugs without a direct
  dependency on the CoreAudio COM API.
- **`MMDeviceCaptureDeviceChangeNotifier`** — a thin CoreAudio wrapper around
  `MMNotificationClient` that collapses the per-device events into one
  `CaptureDevicesChanged` signal.
- **`MuteStateController.SynchronizeDevices()`** — re-applies the current
  confirmed mute state to the current endpoint set. Best-effort: it never
  changes the tracked state (a real toggle owns state transitions and their
  verification). This is where "a new mic adopts the current state" lives, and
  it is fully unit-tested.
- **`AudioDeviceManager`** — injects the notifier and, on a change, refreshes
  and synchronizes under a lock so the background notification thread never
  races the UI-thread mute toggle over the shared device list.

The issue's secondary note — that `IsMuted` was derived from a single device —
was already resolved by an earlier refactor: `IsMuted` reflects the aggregate
confirmed state via `MuteStateController`, so no further reconciliation was
needed.

## Test plan

- `dotnet test --configuration Release` — all 514 tests pass, including five new
  `MuteStateController.SynchronizeDevices` tests:
  - a newly added endpoint adopts the muted state while the app is muted;
  - a mic present when the app started muted is muted without a toggle;
  - when unmuted, sync leaves new devices live and does not change tracked state;
  - a partial failure reports failure and never advances/flips tracked state;
  - an empty endpoint set returns false without throwing.
- Manual (hardware): with the app muted, plug in a second microphone and confirm
  it comes up muted; with the app live, confirm a newly plugged mic stays live;
  press the mute hotkey after hot-plugging and confirm all mics toggle together.

## Notes

Any device change (render devices included) triggers a re-enumeration. Capture
re-enumeration is cheap and idempotent, so this is a deliberate simplicity
tradeoff over filtering each event by data-flow. `AudioDeviceManager` remains a
COM adapter that is exercised through hardware rather than unit tests, matching
the existing design; the new behavioural guarantee is tested at the
`MuteStateController` seam.

Closes #150
