### PR TITLE
Refresh mic input-level slider to real OS level on foreground (#152)

### DIFF
--- a/Mutation.Tests/MicrophoneLevelPinServiceTests.cs
+++ b/Mutation.Tests/MicrophoneLevelPinServiceTests.cs
@@ -174,6 +174,49 @@ public class MicrophoneLevelPinServiceTests
 	}
 
 	[Fact]
+	public void ReadCurrentLevel_ReturnsScaledValue_WhenReadable()
+	{
+		var controller = new FakeCaptureLevelController { Level = 0.37f };
+		var service = NewService(controller);
+
+		int? level = service.ReadCurrentLevel();
+
+		Assert.Equal(37, level);
+		Assert.Equal(0, controller.SetCount); // a pure read, never a write
+	}
+
+	[Fact]
+	public void ReadCurrentLevel_ReturnsNull_OnUnsupportedDevice()
+	{
+		// Supported is false but a stale Level lingers — the support gate must win so
+		// callers get "unknown" rather than a misleading value.
+		var controller = new FakeCaptureLevelController { Supported = false, Level = 0.42f };
+		var service = NewService(controller);
+
+		Assert.Null(service.ReadCurrentLevel());
+	}
+
+	[Fact]
+	public void ReadCurrentLevel_ReturnsNull_WhenLevelUnreadable()
+	{
+		// Supported device whose current level can't be read (transient failure): the
+		// caller must be able to leave its display untouched rather than reset it.
+		var controller = new FakeCaptureLevelController { Supported = true, Level = null };
+		var service = NewService(controller);
+
+		Assert.Null(service.ReadCurrentLevel());
+	}
+
+	[Fact]
+	public void ReadCurrentLevel_ClampsOutOfRangeScalar()
+	{
+		var controller = new FakeCaptureLevelController { Level = 1.5f };
+		var service = NewService(controller);
+
+		Assert.Equal(100, service.ReadCurrentLevel());
+	}
+
+	[Fact]
 	public void Constructor_RejectsNullController()
 	{
 		Assert.Throws<ArgumentNullException>(() => new MicrophoneLevelPinService(null!));

--- a/Mutation.Ui/Core/MicrophoneLevelPinService.cs
+++ b/Mutation.Ui/Core/MicrophoneLevelPinService.cs
@@ -53,6 +53,26 @@ public sealed class MicrophoneLevelPinService
 	/// </summary>
 	public bool ApplyLevel(int level) => WriteLevel(level);
 
+	/// <summary>
+	/// Reads the active device's current capture level as a 0–100 value for
+	/// display, or <c>null</c> when it cannot be read — an unsupported /
+	/// hardware-fixed device or a transient failure. This is a pure read: it never
+	/// writes the level or touches mute. Callers use it to sync a UI display to the
+	/// real OS level; the deliberate <c>null</c> (rather than a default) lets them
+	/// leave the display unchanged instead of showing a misleading value.
+	/// </summary>
+	public int? ReadCurrentLevel()
+	{
+		if (!_controller.IsLevelControlSupported)
+			return null;
+
+		if (_controller.GetLevelScalar() is not float scalar)
+			return null;
+
+		float bounded = scalar < 0f ? 0f : scalar > 1f ? 1f : scalar;
+		return (int)Math.Round(bounded * 100f);
+	}
+
 	private bool WriteLevel(int level)
 	{
 		if (!_controller.IsLevelControlSupported)

--- a/Mutation.Ui/MainWindow.xaml.cs
+++ b/Mutation.Ui/MainWindow.xaml.cs
@@ -39,7 +39,6 @@ public sealed partial class MainWindow : Window, IDisposable
 	private readonly ISpeechToTextService[] _speechServices;
 	private readonly Mutation.Ui.Core.AudioSessionManager _audioSessionManager;
 	private readonly Mutation.Ui.Core.MicrophoneLevelPinService _micLevelPinService;
-	private readonly Mutation.Ui.Core.ICaptureLevelController _captureLevelController;
 	private readonly TranscriptFormatter _transcriptFormatter;
 	private readonly ITextToSpeechService _textToSpeech;
 	private readonly IWavFileSpeechExporter _wavFileSpeechExporter;
@@ -115,8 +114,7 @@ public sealed partial class MainWindow : Window, IDisposable
 		ISettingsManager settingsManager,
 		Settings settings,
 		Mutation.Ui.Core.AudioSessionManager audioSessionManager,
-		Mutation.Ui.Core.MicrophoneLevelPinService micLevelPinService,
-		Mutation.Ui.Core.ICaptureLevelController captureLevelController)
+		Mutation.Ui.Core.MicrophoneLevelPinService micLevelPinService)
 	{
 		_clipboard = clipboard;
 		_uiStateManager = uiStateManager;
@@ -131,7 +129,6 @@ public sealed partial class MainWindow : Window, IDisposable
 
         _audioSessionManager = audioSessionManager;
         _micLevelPinService = micLevelPinService;
-        _captureLevelController = captureLevelController;
         _audioSessionManager.StateChanged += AudioSessionManager_StateChanged;
         _audioSessionManager.TranscriptReady += AudioSessionManager_TranscriptReady;
         _audioSessionManager.ErrorOccurred += AudioSessionManager_ErrorOccurred;
@@ -229,6 +226,50 @@ public sealed partial class MainWindow : Window, IDisposable
 		InitializeHotkeyVisuals();
 
 		this.Closed += MainWindow_Closed;
+		this.Activated += MainWindow_Activated;
+	}
+
+	// When Mutation returns to the foreground, re-sync the mic input-level slider to
+	// the OS's real current level: another app (Windows Settings, Zoom, OBS, …) may
+	// have changed it while Mutation was in the background, leaving the slider showing
+	// a stale value. Deactivation is ignored — there is nothing to refresh on the way
+	// out.
+	private void MainWindow_Activated(object sender, WindowActivatedEventArgs args)
+	{
+		if (args.WindowActivationState == WindowActivationState.Deactivated)
+			return;
+
+		RefreshMicLevelDisplayFromOs();
+	}
+
+	// Reads the microphone's actual current level from the OS and moves the slider to
+	// match. This is a display sync only: it never re-asserts the pin (that stays tied
+	// to recording start) and never writes the level back — the _micLevelControlsReady
+	// guard suppresses the SldMicLevel_ValueChanged side effect while the value is set
+	// programmatically. When the level is unreadable (hardware-fixed device or a
+	// transient failure) the slider is left as-is rather than reset to a misleading
+	// default. Setting SldMicLevel.Value still raises the slider's UIA ValueChanged
+	// automation event, so a screen-reader / ZoomText user is notified of the change.
+	private void RefreshMicLevelDisplayFromOs()
+	{
+		// _micLevelControlsReady is only true on a supported, initialized device; on a
+		// hardware-fixed device the control is disabled and there is nothing to sync.
+		if (!_micLevelControlsReady)
+			return;
+
+		if (_micLevelPinService.ReadCurrentLevel() is not int level)
+			return;
+
+		bool wasReady = _micLevelControlsReady;
+		_micLevelControlsReady = false;
+		try
+		{
+			SldMicLevel.Value = level;
+		}
+		finally
+		{
+			_micLevelControlsReady = wasReady;
+		}
 	}
 
 	private void ApplyMultiLineTextBoxPreferences()
@@ -1197,13 +1238,8 @@ public sealed partial class MainWindow : Window, IDisposable
 
 	// Current Windows capture level as a 0–100 value, or a sensible default when it
 	// cannot be read. Used to position the slider when no pinned value exists.
-	private int ReadCurrentMicLevelOrDefault()
-	{
-		float? scalar = _captureLevelController.GetLevelScalar();
-		if (scalar is float s)
-			return (int)Math.Round(Math.Clamp(s, 0f, 1f) * 100f);
-		return DefaultMicLevel;
-	}
+	private int ReadCurrentMicLevelOrDefault() =>
+		_micLevelPinService.ReadCurrentLevel() ?? DefaultMicLevel;
 
 	// Toggle pinning on/off. Turning it on captures the slider's current value as the
 	// pinned target and applies it immediately; turning it off stops re-asserting but


### PR DESCRIPTION
## What this does

The main window shows the microphone's capture level on a slider and can "pin"
a preferred level. Until now the slider only updated at a few moments (startup,
mic change, or when you drag it). If another app — Windows Settings, Zoom, OBS —
changed the microphone level while Mutation was in the background, the slider
kept showing the old value. It looked wrong until you switched microphones or
restarted.

This change makes the slider re-read the microphone's real level from the
operating system whenever the Mutation window is brought to the foreground, so
the displayed level always matches reality.

## How it works

- The window now listens for its `Activated` event. On activation (not on
  deactivation) it re-reads the current level and moves the slider to match.
- This is a **display sync only**. The programmatic slider update is guarded by
  the existing `_micLevelControlsReady` flag, so it does not trigger the
  slider's `ValueChanged` handler that would otherwise write the level back to
  the device. It also does **not** re-assert the pinned level — pinning stays
  tied to recording start, exactly as before. Foregrounding shows the true
  level; it never fights the user or the OS.
- If the level cannot be read (a hardware-fixed device, or a transient
  failure), the slider is left exactly as it is rather than reset to a
  misleading default.
- Setting the slider value still raises the standard accessibility
  (UIA `ValueChanged`) notification, so a ZoomText / screen-reader user is told
  the displayed level changed.

The actual read-and-convert logic lives in a new
`MicrophoneLevelPinService.ReadCurrentLevel()` method, which returns the level
as a 0–100 value or `null` when it cannot be read. Keeping it in the service
(rather than in the window) makes it unit-testable without audio hardware. The
existing `ReadCurrentMicLevelOrDefault()` now reuses it, which removed a
duplicated scalar-to-level conversion and a now-unused dependency on the window.

## Acceptance criteria addressed

- ✅ On foreground/activation, the slider is refreshed to the OS's actual level.
- ✅ The refresh does not re-assert or overwrite the OS level (guarded display
  sync, no `ValueChanged` write-back).
- ✅ The pin toggle stays consistent: the slider shows the true current level;
  re-asserting the pin remains tied to recording start.
- ✅ Unreadable level (`null`) is handled gracefully — the slider is left as-is,
  never crashes, never reset to a misleading default.
- ✅ Accessibility: the programmatic value change raises the correct automation
  value-changed notification.

## Out of scope (noted in the issue)

Subscribing to live OS volume-change notifications so the slider stays current
without foregrounding is a larger future enhancement. This PR covers only the
on-activation refresh the user asked for.

## Test plan

- `dotnet test --configuration Release` — all **518** tests pass, including 4
  new tests for `ReadCurrentLevel()`:
  - returns the scaled 0–100 value for a readable level (and never writes)
  - returns `null` on an unsupported/hardware-fixed device
  - returns `null` when the level is unreadable (transient failure)
  - clamps an out-of-range scalar to 100
- Manual: with Mutation running, change the mic level in Windows Settings while
  Mutation is in the background, then click back to Mutation — the slider
  updates to the new level.

Closes #152
