### PR TITLE
Confirm before deleting an LLM prompt (#163)

### DIFF
--- a/Mutation.Tests/PromptDeletionMessagesTests.cs
+++ b/Mutation.Tests/PromptDeletionMessagesTests.cs
@@ -1,0 +1,58 @@
+using Mutation.Ui.Services;
+using Xunit;
+
+namespace Mutation.Tests;
+
+public class PromptDeletionMessagesTests
+{
+	[Fact]
+	public void BuildConfirmation_NamedPrompt_QuotesNameAndWarnsIrreversible()
+	{
+		string message = PromptDeletionMessages.BuildConfirmation("Summarize");
+
+		Assert.Equal("Delete prompt 'Summarize'? This cannot be undone.", message);
+	}
+
+	[Fact]
+	public void BuildConfirmation_TrimsSurroundingWhitespaceInName()
+	{
+		string message = PromptDeletionMessages.BuildConfirmation("  Summarize  ");
+
+		Assert.Equal("Delete prompt 'Summarize'? This cannot be undone.", message);
+	}
+
+	[Theory]
+	[InlineData(null)]
+	[InlineData("")]
+	[InlineData("   ")]
+	public void BuildConfirmation_BlankName_FallsBackToNeutralLabel(string? name)
+	{
+		string message = PromptDeletionMessages.BuildConfirmation(name);
+
+		Assert.Equal("Delete this prompt? This cannot be undone.", message);
+	}
+
+	[Fact]
+	public void BuildDeleted_NamedPrompt_ReportsRemoval()
+	{
+		Assert.Equal("Deleted prompt 'Summarize'.", PromptDeletionMessages.BuildDeleted("Summarize"));
+	}
+
+	[Fact]
+	public void BuildDeleted_BlankName_FallsBackToNeutralLabel()
+	{
+		Assert.Equal("Deleted this prompt.", PromptDeletionMessages.BuildDeleted("  "));
+	}
+
+	[Fact]
+	public void BuildCancelled_NamedPrompt_ReportsCancellation()
+	{
+		Assert.Equal("Deletion of prompt 'Summarize' cancelled.", PromptDeletionMessages.BuildCancelled("Summarize"));
+	}
+
+	[Fact]
+	public void BuildCancelled_BlankName_FallsBackToNeutralLabel()
+	{
+		Assert.Equal("Deletion of this prompt cancelled.", PromptDeletionMessages.BuildCancelled(null));
+	}
+}

--- a/Mutation.Tests/PromptDeletionMessagesTests.cs
+++ b/Mutation.Tests/PromptDeletionMessagesTests.cs
@@ -55,4 +55,25 @@ public class PromptDeletionMessagesTests
 	{
 		Assert.Equal("Deletion of this prompt cancelled.", PromptDeletionMessages.BuildCancelled(null));
 	}
+
+	[Fact]
+	public void BuildFailed_WithReason_IncludesTrimmedReason()
+	{
+		Assert.Equal("Could not delete prompt 'Summarize': disk full", PromptDeletionMessages.BuildFailed("Summarize", "  disk full  "));
+	}
+
+	[Theory]
+	[InlineData(null)]
+	[InlineData("")]
+	[InlineData("   ")]
+	public void BuildFailed_BlankReason_OmitsReasonSuffix(string? reason)
+	{
+		Assert.Equal("Could not delete prompt 'Summarize'.", PromptDeletionMessages.BuildFailed("Summarize", reason));
+	}
+
+	[Fact]
+	public void BuildFailed_BlankName_FallsBackToNeutralLabel()
+	{
+		Assert.Equal("Could not delete this prompt.", PromptDeletionMessages.BuildFailed(" ", null));
+	}
 }

--- a/Mutation.Ui/MainWindow.xaml.cs
+++ b/Mutation.Ui/MainWindow.xaml.cs
@@ -2219,10 +2219,20 @@ public sealed partial class MainWindow : Window, IDisposable
             return;
         }
 
-        if (_promptLibrary.DeletePrompt(prompt))
+        try
         {
-            ShowStatus(PromptDeletionMessages.ConfirmationTitle, PromptDeletionMessages.BuildDeleted(name), InfoBarSeverity.Success);
-            BeepPlayer.Play(BeepType.Success);
+            if (_promptLibrary.DeletePrompt(prompt))
+            {
+                ShowStatus(PromptDeletionMessages.ConfirmationTitle, PromptDeletionMessages.BuildDeleted(name), InfoBarSeverity.Success);
+                BeepPlayer.Play(BeepType.Success);
+            }
+        }
+        catch (Exception ex)
+        {
+            // Persisting the removal can fail (e.g. the settings file cannot be
+            // written). Fail loudly rather than let the async void swallow it.
+            ShowStatus(PromptDeletionMessages.ConfirmationTitle, PromptDeletionMessages.BuildFailed(name, ex.Message), InfoBarSeverity.Error);
+            BeepPlayer.Play(BeepType.Failure);
         }
     }
 

--- a/Mutation.Ui/MainWindow.xaml.cs
+++ b/Mutation.Ui/MainWindow.xaml.cs
@@ -2188,10 +2188,42 @@ public sealed partial class MainWindow : Window, IDisposable
             _promptLibrary?.OpenEditDialog(prompt);
     }
 
-    private void BtnDeletePrompt_Click(object sender, RoutedEventArgs e)
+    private async void BtnDeletePrompt_Click(object sender, RoutedEventArgs e)
     {
-        if (sender is Button btn && btn.Tag is LlmSettings.LlmPrompt prompt)
-            _promptLibrary?.DeletePrompt(prompt);
+        if (sender is not Button btn || btn.Tag is not LlmSettings.LlmPrompt prompt || _promptLibrary is null)
+            return;
+
+        string name = prompt.Name;
+        string confirmation = PromptDeletionMessages.BuildConfirmation(name);
+
+        var dialog = new ContentDialog
+        {
+            Title = PromptDeletionMessages.ConfirmationTitle,
+            Content = new TextBlock { Text = confirmation, TextWrapping = TextWrapping.Wrap },
+            PrimaryButtonText = "Delete",
+            CloseButtonText = "Cancel",
+            // Cancel is the safe default so a stray Enter never deletes a prompt.
+            DefaultButton = ContentDialogButton.Close,
+            XamlRoot = (this.Content as FrameworkElement)?.XamlRoot,
+        };
+        AutomationProperties.SetName(dialog, PromptDeletionMessages.ConfirmationTitle);
+        AutomationProperties.SetHelpText(dialog, confirmation);
+
+        var result = await ShowDialogAsync(dialog);
+        if (result != ContentDialogResult.Primary)
+        {
+            // Covers an explicit Cancel and the guarded case where another
+            // dialog was already open (ShowDialogAsync returns None): nothing
+            // is deleted, and the outcome is announced for the screen reader.
+            ShowStatus(PromptDeletionMessages.ConfirmationTitle, PromptDeletionMessages.BuildCancelled(name), InfoBarSeverity.Informational);
+            return;
+        }
+
+        if (_promptLibrary.DeletePrompt(prompt))
+        {
+            ShowStatus(PromptDeletionMessages.ConfirmationTitle, PromptDeletionMessages.BuildDeleted(name), InfoBarSeverity.Success);
+            BeepPlayer.Play(BeepType.Success);
+        }
     }
 
     private void BtnRunPrompt_Click(object sender, RoutedEventArgs e)

--- a/Mutation.Ui/MainWindow.xaml.cs
+++ b/Mutation.Ui/MainWindow.xaml.cs
@@ -2226,6 +2226,14 @@ public sealed partial class MainWindow : Window, IDisposable
                 ShowStatus(PromptDeletionMessages.ConfirmationTitle, PromptDeletionMessages.BuildDeleted(name), InfoBarSeverity.Success);
                 BeepPlayer.Play(BeepType.Success);
             }
+            else
+            {
+                // The prompt was already gone (removed elsewhere between the
+                // click and the confirmation). Announce it rather than stay
+                // silent after the user confirmed a deletion.
+                ShowStatus(PromptDeletionMessages.ConfirmationTitle, PromptDeletionMessages.BuildFailed(name, "the prompt was no longer in the library"), InfoBarSeverity.Warning);
+                BeepPlayer.Play(BeepType.Failure);
+            }
         }
         catch (Exception ex)
         {

--- a/Mutation.Ui/Services/PromptDeletionMessages.cs
+++ b/Mutation.Ui/Services/PromptDeletionMessages.cs
@@ -1,0 +1,38 @@
+using System;
+
+namespace Mutation.Ui.Services;
+
+/// <summary>
+/// Builds the user-facing wording shown when deleting an LLM prompt: the
+/// confirmation question and the outcome announcements. Kept UI-free (no
+/// dialog, no InfoBar) so the phrasing a screen-reader user hears is
+/// centralized, consistent, and unit-testable in isolation.
+/// </summary>
+internal static class PromptDeletionMessages
+{
+	/// <summary>Fallback label when a prompt has no usable name.</summary>
+	internal const string UnnamedPrompt = "this prompt";
+
+	internal const string ConfirmationTitle = "Delete prompt";
+
+	/// <summary>Question shown in the confirmation dialog before removal.</summary>
+	internal static string BuildConfirmation(string? name) =>
+		$"Delete {Describe(name)}? This cannot be undone.";
+
+	/// <summary>Announcement after a prompt was actually removed.</summary>
+	internal static string BuildDeleted(string? name) =>
+		$"Deleted {Describe(name)}.";
+
+	/// <summary>Announcement when the user cancels the deletion.</summary>
+	internal static string BuildCancelled(string? name) =>
+		$"Deletion of {Describe(name)} cancelled.";
+
+	/// <summary>
+	/// Renders a prompt reference for a sentence: a quoted name when one is
+	/// present, or a neutral fallback when the name is missing or blank.
+	/// </summary>
+	private static string Describe(string? name) =>
+		string.IsNullOrWhiteSpace(name)
+			? UnnamedPrompt
+			: $"prompt '{name.Trim()}'";
+}

--- a/Mutation.Ui/Services/PromptDeletionMessages.cs
+++ b/Mutation.Ui/Services/PromptDeletionMessages.cs
@@ -27,6 +27,12 @@ internal static class PromptDeletionMessages
 	internal static string BuildCancelled(string? name) =>
 		$"Deletion of {Describe(name)} cancelled.";
 
+	/// <summary>Announcement when the deletion could not be completed.</summary>
+	internal static string BuildFailed(string? name, string? reason) =>
+		string.IsNullOrWhiteSpace(reason)
+			? $"Could not delete {Describe(name)}."
+			: $"Could not delete {Describe(name)}: {reason.Trim()}";
+
 	/// <summary>
 	/// Renders a prompt reference for a sentence: a quoted name when one is
 	/// present, or a neutral fallback when the name is missing or blank.

--- a/Mutation.Ui/Services/PromptLibraryController.cs
+++ b/Mutation.Ui/Services/PromptLibraryController.cs
@@ -95,13 +95,22 @@ internal sealed class PromptLibraryController
 		};
 	}
 
-	public void DeletePrompt(LlmSettings.LlmPrompt prompt)
+	/// <summary>
+	/// Removes the prompt, persists, and refreshes the list. Returns
+	/// <c>true</c> when a prompt was actually removed so the caller can
+	/// announce an accurate outcome; <c>false</c> when there was nothing to
+	/// remove (null prompt, no settings, or the prompt was already gone).
+	/// </summary>
+	public bool DeletePrompt(LlmSettings.LlmPrompt prompt)
 	{
 		if (prompt == null || _settings.LlmSettings == null)
-			return;
+			return false;
 
-		_settings.LlmSettings.Prompts.Remove(prompt);
+		if (!_settings.LlmSettings.Prompts.Remove(prompt))
+			return false;
+
 		SaveAndRefresh();
+		return true;
 	}
 
 	private IReadOnlyList<string> GetAvailableModelNames()


### PR DESCRIPTION
## What and why

Deleting a prompt from the LLM prompt library used to remove it and write the
change to disk immediately — with no confirmation, no screen-reader
announcement, no beep, and no undo. Because each row's **Delete** button sits
right beside **Edit** and **Run**, a single stray Enter while tabbing through
the list destroyed a carefully built prompt (name, model, hotkey, and full
instruction text) silently. A screen-reader user would only discover the loss
later, when the prompt's hotkey stopped working.

## What changed

- **Confirmation before removal.** Deleting now opens a confirmation dialog
  ("Delete prompt 'X'? This cannot be undone."). Its default button is
  **Cancel**, so a stray Enter dismisses the dialog instead of deleting.
- **Spoken outcome.** After a prompt is actually removed, the status InfoBar
  announces the result and a success beep plays. Cancelling is announced too,
  so the screen-reader user always hears what happened.
- **Accurate reporting.** `DeletePrompt` now reports whether it actually
  removed a prompt, so the announcement never claims a deletion that did not
  happen. The confirmation path also covers the case where another dialog is
  already open — in that case nothing is deleted.
- **No new silent failure.** The handler is an `async void`; if persisting the
  removal fails (e.g. the settings file cannot be written), the failure is
  announced with an error status and a failure beep rather than being
  swallowed by the global crash handler.
- **Testable wording.** The user-facing phrasing is extracted into a small,
  UI-free `PromptDeletionMessages` helper so the accessible messages are
  centralized and unit-tested. (The prompt-library controller holds a WinUI
  `ListView` and cannot be built in a plain unit test, so this helper is the
  testable seam.)

## Files

- `Mutation.Ui/Services/PromptDeletionMessages.cs` — new pure helper for the
  confirmation question and the deleted/cancelled announcements, with a
  neutral fallback for an unnamed prompt.
- `Mutation.Ui/Services/PromptLibraryController.cs` — `DeletePrompt` returns
  whether a prompt was removed.
- `Mutation.Ui/MainWindow.xaml.cs` — the Delete handler now confirms, deletes
  on confirm, and announces the outcome with a beep.
- `Mutation.Tests/PromptDeletionMessagesTests.cs` — tests for the helper.

## Test plan

- `dotnet test --configuration Release` — all 536 tests pass, including 14 new
  cases for `PromptDeletionMessages` (named prompt, whitespace-trimmed name,
  and blank/null-name fallback across the confirmation, both announcements,
  and the failure message with and without a reason).
- Manual, with a screen reader: tab to a prompt's **Delete** button and press
  Enter. Confirm the dialog opens, Cancel is the focused default, pressing
  Enter/Escape cancels without deleting (and the cancellation is announced),
  and choosing **Delete** removes the prompt with a spoken confirmation and a
  beep.

Closes #163
