### PR TITLE
Surface silent core and prompt hotkey registration failures (#162)

### DIFF
--- a/Mutation.Tests/HotkeyBindingFailureTests.cs
+++ b/Mutation.Tests/HotkeyBindingFailureTests.cs
@@ -1,0 +1,130 @@
+using CognitiveSupport;
+using Mutation.Ui.Services;
+
+namespace Mutation.Tests;
+
+public class HotkeyBindingFailureTests
+{
+	[Theory]
+	[InlineData("Ctrl+C")]
+	[InlineData("Ctrl+Shift+F5")]
+	[InlineData("Ctrl+Alt+S")]
+	public void ClassifyConfiguredHotkey_ValidHotkey_ReturnsNull(string input)
+	{
+		Assert.Null(HotkeyManager.ClassifyConfiguredHotkey("Some action", input, allowEmpty: true));
+	}
+
+	[Theory]
+	[InlineData("NotAKey")]
+	[InlineData("Ctrl+Shift")]
+	[InlineData("Ctrl+Bogus")]
+	public void ClassifyConfiguredHotkey_InvalidHotkey_ReturnsFailureWithReason(string input)
+	{
+		var failure = HotkeyManager.ClassifyConfiguredHotkey("Start/stop dictation", input, allowEmpty: true);
+
+		Assert.NotNull(failure);
+		Assert.Equal("Start/stop dictation", failure!.Description);
+		Assert.Equal(input.Trim(), failure.Hotkey);
+		Assert.False(string.IsNullOrWhiteSpace(failure.Reason));
+	}
+
+	[Theory]
+	[InlineData(null)]
+	[InlineData("")]
+	[InlineData("   ")]
+	public void ClassifyConfiguredHotkey_EmptyWhenAllowed_ReturnsNull(string? input)
+	{
+		Assert.Null(HotkeyManager.ClassifyConfiguredHotkey("Optional action", input, allowEmpty: true));
+	}
+
+	[Fact]
+	public void ClassifyConfiguredHotkey_EmptyWhenNotAllowed_ReturnsFailure()
+	{
+		var failure = HotkeyManager.ClassifyConfiguredHotkey("Required action", "", allowEmpty: false);
+
+		Assert.NotNull(failure);
+		Assert.Equal("Required action", failure!.Description);
+		Assert.Equal("Enter a hotkey.", failure.Reason);
+	}
+
+	[Fact]
+	public void BuildFailureMessage_EmptyList_ReturnsEmptyString()
+	{
+		Assert.Equal(string.Empty, HotkeyManager.BuildFailureMessage(new List<HotkeyManager.HotkeyBindingFailure>()));
+	}
+
+	[Fact]
+	public void BuildFailureMessage_WithHotkey_IncludesDescriptionHotkeyAndReason()
+	{
+		var failures = new List<HotkeyManager.HotkeyBindingFailure>
+		{
+			new("Start/stop dictation", "Ctrl+Alt+S", "The shortcut is already registered by another application."),
+		};
+
+		var message = HotkeyManager.BuildFailureMessage(failures);
+
+		Assert.Equal("• Start/stop dictation (Ctrl+Alt+S): The shortcut is already registered by another application.", message);
+	}
+
+	[Fact]
+	public void BuildFailureMessage_WithoutHotkey_OmitsParentheses()
+	{
+		var failures = new List<HotkeyManager.HotkeyBindingFailure>
+		{
+			new("Ctrl+A → Ctrl+B", "", "Both hotkeys must be configured."),
+		};
+
+		var message = HotkeyManager.BuildFailureMessage(failures);
+
+		Assert.Equal("• Ctrl+A → Ctrl+B: Both hotkeys must be configured.", message);
+	}
+
+	[Fact]
+	public void BuildFailureMessage_MultipleFailures_OneLinePerFailure()
+	{
+		var failures = new List<HotkeyManager.HotkeyBindingFailure>
+		{
+			new("Action one", "Ctrl+1", "reason one"),
+			new("Action two", "Ctrl+2", "reason two"),
+		};
+
+		var message = HotkeyManager.BuildFailureMessage(failures);
+
+		var lines = message.Split(Environment.NewLine);
+		Assert.Equal(2, lines.Length);
+		Assert.Contains("Action one", lines[0]);
+		Assert.Contains("Action two", lines[1]);
+	}
+
+	[Fact]
+	public void ToBindingFailures_SkipsSuccessesAndKeepsFailures()
+	{
+		var okMap = new HotKeyRouterSettings.HotKeyRouterMap("Ctrl+A", "Ctrl+B");
+		var badMap = new HotKeyRouterSettings.HotKeyRouterMap("Ctrl+C", "Ctrl+D");
+		var results = new List<HotkeyManager.HotkeyRegistrationResult>
+		{
+			new(okMap, "CTRL+A", true, 1, null),
+			new(badMap, "CTRL+C", false, -1, "The shortcut is already registered by another application."),
+		};
+
+		var failures = HotkeyManager.ToBindingFailures(results);
+
+		var failure = Assert.Single(failures);
+		Assert.Equal("Ctrl+C → Ctrl+D", failure.Description);
+		Assert.Equal(string.Empty, failure.Hotkey);
+		Assert.Equal("The shortcut is already registered by another application.", failure.Reason);
+	}
+
+	[Fact]
+	public void ToBindingFailures_MissingErrorMessage_UsesUnknownError()
+	{
+		var badMap = new HotKeyRouterSettings.HotKeyRouterMap("Ctrl+C", "Ctrl+D");
+		var results = new List<HotkeyManager.HotkeyRegistrationResult>
+		{
+			new(badMap, "CTRL+C", false, -1, null),
+		};
+
+		var failure = Assert.Single(HotkeyManager.ToBindingFailures(results));
+		Assert.Equal("Unknown error.", failure.Reason);
+	}
+}

--- a/Mutation.Ui/App.xaml.cs
+++ b/Mutation.Ui/App.xaml.cs
@@ -319,46 +319,20 @@ public partial class App : Application
 			ocrMgr.InitializeWindow(_window);
 
                         var hkManager = _host.Services.GetRequiredService<HotkeyManager>();
+                        // Register core, prompt, and router hotkeys, then surface any that could not be
+                        // bound the same way (dialog + failure beep). AttachHotkeyManager registers the
+                        // prompt and router hotkeys and RegisterCoreHotkeys registers the core ones; both
+                        // return the failures they encountered.
+                        var hotkeyFailures = new List<HotkeyManager.HotkeyBindingFailure>();
                         if (_window is MainWindow main)
                         {
-                                main.AttachHotkeyManager(hkManager);
-                                main.RegisterCoreHotkeys(hkManager);
+                                hotkeyFailures.AddRange(main.AttachHotkeyManager(hkManager));
+                                hotkeyFailures.AddRange(main.RegisterCoreHotkeys(hkManager));
                         }
                         var settingsSvc = _host.Services.GetRequiredService<Settings>();
 
-                        // Core hotkey registration is now performed by main.RegisterCoreHotkeys above.
-
-                        _ = hkManager.RegisterRouterHotkeys();
-
-			if (hkManager.FailedRegistrations.Count > 0)
-			{
-				const string title = "Hotkeys Not Registered";
-				string message = "The following hotkeys could not be registered and may be in use by another application:\n\n" +
-										  string.Join("\n", hkManager.FailedRegistrations);
-
-				if (_window.Content is FrameworkElement fe && fe.XamlRoot is not null)
-				{
-					var dialog = new ContentDialog
-					{
-						Title = title,
-						Content = new TextBlock { Text = message, TextWrapping = Microsoft.UI.Xaml.TextWrapping.Wrap },
-						CloseButtonText = "OK",
-						XamlRoot = fe.XamlRoot
-					};
-					// Provide accessible name/help text for screen readers
-					Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(dialog, title);
-					Microsoft.UI.Xaml.Automation.AutomationProperties.SetHelpText(dialog, message);
-					await dialog.ShowAsync();
-				}
-				else
-				{
-					System.Windows.Forms.MessageBox.Show(
-							  message,
-							  title,
-							  System.Windows.Forms.MessageBoxButtons.OK,
-							  System.Windows.Forms.MessageBoxIcon.Warning);
-				}
-			}
+			if (hotkeyFailures.Count > 0 && _window is MainWindow mainWindow)
+				await mainWindow.ShowHotkeyBindingFailuresAsync(hotkeyFailures);
 
 			_window.Closed += async (_, __) =>
 			{

--- a/Mutation.Ui/MainWindow.xaml.cs
+++ b/Mutation.Ui/MainWindow.xaml.cs
@@ -195,7 +195,8 @@ public sealed partial class MainWindow : Window, IDisposable
                 _settingsManager,
                 _transcriptFormatter,
                 LstPrompts,
-                ExecutePrompt);
+                ExecutePrompt,
+                failures => _ = ShowHotkeyBindingFailuresAsync(failures));
             _promptLibrary.Initialize();
 
 		var tooltipManager = new TooltipManager(_settings);
@@ -305,29 +306,37 @@ public sealed partial class MainWindow : Window, IDisposable
 		yield return TxtOcr;
 	}
 
-	public void AttachHotkeyManager(HotkeyManager hotkeyManager)
+	public IReadOnlyList<HotkeyManager.HotkeyBindingFailure> AttachHotkeyManager(HotkeyManager hotkeyManager)
 	{
 		_hotkeyManager = hotkeyManager;
-		_promptLibrary?.AttachHotkeyManager(hotkeyManager);
-		_hotkeyManager.RegisterRouterHotkeys();
+
+		var failures = new List<HotkeyManager.HotkeyBindingFailure>();
+		if (_promptLibrary is not null)
+			failures.AddRange(_promptLibrary.AttachHotkeyManager(hotkeyManager));
+
+		var routerResults = _hotkeyManager.RegisterRouterHotkeys();
+		failures.AddRange(HotkeyManager.ToBindingFailures(routerResults));
+		return failures;
 	}
 
-	internal void RegisterCoreHotkeys(HotkeyManager hk)
+	internal IReadOnlyList<HotkeyManager.HotkeyBindingFailure> RegisterCoreHotkeys(HotkeyManager hk)
 	{
 		var ocr = _settings.AzureComputerVisionSettings;
 		var stt = _settings.SpeechToTextSettings;
 		var tts = _settings.TextToSpeechSettings;
 		var aud = _settings.AudioSettings;
 
+		var failures = new List<HotkeyManager.HotkeyBindingFailure>();
+
 		if (!string.IsNullOrWhiteSpace(ocr?.ScreenshotHotKey))
-			TryRegister(hk, ocr.ScreenshotHotKey!, async () =>
+			TryRegister(hk, failures, "Screenshot to clipboard", ocr.ScreenshotHotKey!, async () =>
 			{
 				try { await _ocrManager.TakeScreenshotToClipboardAsync(); }
 				catch (Exception ex) { await ShowErrorDialog("Screenshot Error", ex); }
 			});
 
 		if (!string.IsNullOrWhiteSpace(ocr?.ScreenshotOcrHotKey))
-			TryRegister(hk, ocr.ScreenshotOcrHotKey!, async () =>
+			TryRegister(hk, failures, "Screenshot and OCR", ocr.ScreenshotOcrHotKey!, async () =>
 			{
 				try
 				{
@@ -340,7 +349,7 @@ public sealed partial class MainWindow : Window, IDisposable
 			});
 
 		if (!string.IsNullOrWhiteSpace(ocr?.ScreenshotLeftToRightTopToBottomOcrHotKey))
-			TryRegister(hk, ocr.ScreenshotLeftToRightTopToBottomOcrHotKey!, async () =>
+			TryRegister(hk, failures, "Screenshot and OCR (left-to-right)", ocr.ScreenshotLeftToRightTopToBottomOcrHotKey!, async () =>
 			{
 				try
 				{
@@ -353,7 +362,7 @@ public sealed partial class MainWindow : Window, IDisposable
 			});
 
 		if (!string.IsNullOrWhiteSpace(ocr?.OcrHotKey))
-			TryRegister(hk, ocr.OcrHotKey!, async () =>
+			TryRegister(hk, failures, "OCR clipboard image", ocr.OcrHotKey!, async () =>
 			{
 				try
 				{
@@ -366,7 +375,7 @@ public sealed partial class MainWindow : Window, IDisposable
 			});
 
 		if (!string.IsNullOrWhiteSpace(ocr?.OcrLeftToRightTopToBottomHotKey))
-			TryRegister(hk, ocr.OcrLeftToRightTopToBottomHotKey!, async () =>
+			TryRegister(hk, failures, "OCR clipboard image (left-to-right)", ocr.OcrLeftToRightTopToBottomHotKey!, async () =>
 			{
 				try
 				{
@@ -379,54 +388,57 @@ public sealed partial class MainWindow : Window, IDisposable
 			});
 
 		if (!string.IsNullOrWhiteSpace(aud?.MicrophoneToggleMuteHotKey))
-			TryRegister(hk, aud.MicrophoneToggleMuteHotKey!, () =>
+			TryRegister(hk, failures, "Toggle microphone mute", aud.MicrophoneToggleMuteHotKey!, () =>
 				DispatcherQueue.TryEnqueue(() => BtnToggleMic_Click(null!, null!)));
 
 		if (!string.IsNullOrWhiteSpace(stt?.SpeechToTextHotKey))
-			TryRegister(hk, stt.SpeechToTextHotKey!, () =>
+			TryRegister(hk, failures, "Start/stop dictation", stt.SpeechToTextHotKey!, () =>
 				DispatcherQueue.TryEnqueue(async () => await StartStopSpeechToTextAsync(false)));
 
 		if (!string.IsNullOrWhiteSpace(stt?.SpeechToTextWithLlmProcessingHotKey))
-			TryRegister(hk, stt.SpeechToTextWithLlmProcessingHotKey!, () =>
+			TryRegister(hk, failures, "Start/stop dictation with LLM processing", stt.SpeechToTextWithLlmProcessingHotKey!, () =>
 				DispatcherQueue.TryEnqueue(async () => await StartStopSpeechToTextAsync(true)));
 
 		if (!string.IsNullOrWhiteSpace(tts?.SpeakClipboard))
-			TryRegister(hk, tts.SpeakClipboard!, () =>
+			TryRegister(hk, failures, "Speak clipboard", tts.SpeakClipboard!, () =>
 				DispatcherQueue.TryEnqueue(() => BtnTextToSpeech_Click(null!, null!)));
 
 		if (!string.IsNullOrWhiteSpace(tts?.SpeakSelectionHotKey))
-			TryRegister(hk, tts.SpeakSelectionHotKey!, () =>
+			TryRegister(hk, failures, "Speak selection", tts.SpeakSelectionHotKey!, () =>
 				DispatcherQueue.TryEnqueue(() => SpeakActiveSelectionAsync()));
 
 		if (!string.IsNullOrWhiteSpace(tts?.RestartFromBeginningHotKey))
-			TryRegister(hk, tts.RestartFromBeginningHotKey!, () =>
+			TryRegister(hk, failures, "Restart speech from beginning", tts.RestartFromBeginningHotKey!, () =>
 				DispatcherQueue.TryEnqueue(() => BtnRestartTts_Click(null!, null!)));
 
 		if (!string.IsNullOrWhiteSpace(tts?.SkipSentenceBackwardHotKey))
-			TryRegister(hk, tts.SkipSentenceBackwardHotKey!, () =>
+			TryRegister(hk, failures, "Skip to previous sentence", tts.SkipSentenceBackwardHotKey!, () =>
 				DispatcherQueue.TryEnqueue(() => BtnSkipSentenceBack_Click(null!, null!)));
 
 		if (!string.IsNullOrWhiteSpace(tts?.SkipSentenceForwardHotKey))
-			TryRegister(hk, tts.SkipSentenceForwardHotKey!, () =>
+			TryRegister(hk, failures, "Skip to next sentence", tts.SkipSentenceForwardHotKey!, () =>
 				DispatcherQueue.TryEnqueue(() => BtnSkipSentenceForward_Click(null!, null!)));
 
 		if (!string.IsNullOrWhiteSpace(tts?.SpeakToFileHotKey))
-			TryRegister(hk, tts.SpeakToFileHotKey!, () =>
+			TryRegister(hk, failures, "Speak to file", tts.SpeakToFileHotKey!, () =>
 				DispatcherQueue.TryEnqueue(() => BtnSpeakToFile_Click(null!, null!)));
 
 		if (!string.IsNullOrWhiteSpace(tts?.SpeakPositionHotKey))
-			TryRegister(hk, tts.SpeakPositionHotKey!, () =>
+			TryRegister(hk, failures, "Announce speech position", tts.SpeakPositionHotKey!, () =>
 				DispatcherQueue.TryEnqueue(() => BtnSpeakPosition_Click(null!, null!)));
 
 		if (!string.IsNullOrWhiteSpace(tts?.PauseResumeHotKey))
-			TryRegister(hk, tts.PauseResumeHotKey!, () =>
+			TryRegister(hk, failures, "Pause/resume speech", tts.PauseResumeHotKey!, () =>
 				DispatcherQueue.TryEnqueue(() => BtnPauseResume_Click(null!, null!)));
+
+		return failures;
 	}
 
-	private static void TryRegister(HotkeyManager hk, string hotkey, Action callback)
+	private static void TryRegister(HotkeyManager hk, List<HotkeyManager.HotkeyBindingFailure> failures, string description, string hotkey, Action callback)
 	{
-		try { hk.RegisterHotkey(Hotkey.Parse(hotkey), callback); }
-		catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"Hotkey '{hotkey}' parse/register failed: {ex.Message}"); }
+		var failure = hk.TryRegisterCore(description, hotkey, callback);
+		if (failure is not null)
+			failures.Add(failure);
 	}
 
 	private void RestorePersistedSpeechServiceSelection()
@@ -2099,17 +2111,17 @@ public sealed partial class MainWindow : Window, IDisposable
 			System.Diagnostics.Debug.WriteLine($"ApplyLiveSettings (tts) failed: {ex.Message}");
 		}
 
-		IReadOnlyList<HotkeyManager.HotkeyRegistrationResult>? routerResults = null;
+		var hotkeyFailures = new List<HotkeyManager.HotkeyBindingFailure>();
 		try
 		{
 			if (_hotkeyManager is not null)
 			{
 				_hotkeyManager.ClearAllForRebind();
-				RegisterCoreHotkeys(_hotkeyManager);
-				routerResults = _hotkeyManager.RegisterRouterHotkeys();
-				_hotkeyManager.RegisterPromptHotkeys(
+				hotkeyFailures.AddRange(RegisterCoreHotkeys(_hotkeyManager));
+				hotkeyFailures.AddRange(HotkeyManager.ToBindingFailures(_hotkeyManager.RegisterRouterHotkeys()));
+				hotkeyFailures.AddRange(_hotkeyManager.RegisterPromptHotkeys(
 					_settings.LlmSettings?.Prompts ?? Enumerable.Empty<LlmSettings.LlmPrompt>(),
-					ExecutePrompt);
+					ExecutePrompt));
 			}
 		}
 		catch (Exception ex)
@@ -2117,47 +2129,48 @@ public sealed partial class MainWindow : Window, IDisposable
 			System.Diagnostics.Debug.WriteLine($"ApplyLiveSettings (hotkeys) failed: {ex.Message}");
 		}
 
-		if (routerResults is not null)
-		{
-			var failures = routerResults.Where(r => !r.Success).ToList();
-			if (failures.Count > 0)
-				_ = ShowRouterBindingFailuresAsync(failures);
-		}
+		if (hotkeyFailures.Count > 0)
+			_ = ShowHotkeyBindingFailuresAsync(hotkeyFailures);
 	}
 
-	private async Task ShowRouterBindingFailuresAsync(IReadOnlyList<HotkeyManager.HotkeyRegistrationResult> failures)
+	// Surfaces hotkey binding failures (core, router, and prompt) the same way: a failure beep
+	// plus an accessible dialog listing each unbound hotkey and why it could not be registered.
+	internal async Task ShowHotkeyBindingFailuresAsync(IReadOnlyList<HotkeyManager.HotkeyBindingFailure> failures)
 	{
+		if (failures is null || failures.Count == 0)
+			return;
+
+		try { BeepPlayer.Play(BeepType.Failure); }
+		catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"Hotkey failure beep failed: {ex.Message}"); }
+
 		try
 		{
-			if (Content is not FrameworkElement rootElement)
+			if (Content is not FrameworkElement rootElement || rootElement.XamlRoot is null)
 				return;
 
-			var lines = failures.Select(f =>
-			{
-				var from = string.IsNullOrWhiteSpace(f.Map?.FromHotKey) ? "(empty)" : f.Map!.FromHotKey;
-				var to = string.IsNullOrWhiteSpace(f.Map?.ToHotKey) ? "(empty)" : f.Map!.ToHotKey;
-				var reason = string.IsNullOrWhiteSpace(f.ErrorMessage) ? "Unknown error." : f.ErrorMessage;
-				return $"• {from} → {to}: {reason}";
-			});
+			const string title = "Some hotkeys could not be registered";
+			string message = HotkeyManager.BuildFailureMessage(failures);
 
 			var dialog = new ContentDialog
 			{
-				Title = "Some hotkey router mappings could not be registered",
+				Title = title,
 				Content = new TextBlock
 				{
-					Text = string.Join(Environment.NewLine, lines),
+					Text = message,
 					TextWrapping = TextWrapping.Wrap,
 				},
 				CloseButtonText = "OK",
 				XamlRoot = rootElement.XamlRoot,
 				RequestedTheme = rootElement.ActualTheme,
 			};
+			Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(dialog, title);
+			Microsoft.UI.Xaml.Automation.AutomationProperties.SetHelpText(dialog, message);
 
 			await ShowDialogAsync(dialog);
 		}
 		catch (Exception ex)
 		{
-			System.Diagnostics.Debug.WriteLine($"ShowRouterBindingFailures failed: {ex.Message}");
+			System.Diagnostics.Debug.WriteLine($"ShowHotkeyBindingFailures failed: {ex.Message}");
 		}
 	}
 

--- a/Mutation.Ui/Services/HotkeyManager.cs
+++ b/Mutation.Ui/Services/HotkeyManager.cs
@@ -42,6 +42,61 @@ public class HotkeyManager : IDisposable
 
         public sealed record HotkeyRegistrationResult(HotKeyRouterSettings.HotKeyRouterMap Map, string NormalizedHotkey, bool Success, int Id, string? ErrorMessage);
 
+        // A single hotkey that could not be bound, described in user-facing terms so it can be
+        // shown in a dialog the same way router failures are. Description is a human label for
+        // the action (e.g. "Start/stop dictation") or the prompt name; Hotkey is the configured
+        // text; Reason explains why it failed (parse error or registration conflict).
+        public sealed record HotkeyBindingFailure(string Description, string Hotkey, string Reason);
+
+        // Pure classification of a configured hotkey string. Returns a failure when the text is
+        // absent (and not allowed) or cannot be parsed. Registration conflicts are detected later,
+        // during the actual RegisterHotKey call. Kept static and side-effect-free so it is unit
+        // testable without a window handle.
+        public static HotkeyBindingFailure? ClassifyConfiguredHotkey(string description, string? hotkeyText, bool allowEmpty)
+        {
+                if (string.IsNullOrWhiteSpace(hotkeyText))
+                        return allowEmpty ? null : new HotkeyBindingFailure(description, string.Empty, "Enter a hotkey.");
+
+                string? error = HotkeyValidator.Validate(hotkeyText, allowSendKeysSyntax: false);
+                return error is null ? null : new HotkeyBindingFailure(description, hotkeyText.Trim(), error);
+        }
+
+        // Builds the bulleted message body shown to the user for a set of binding failures.
+        public static string BuildFailureMessage(IReadOnlyList<HotkeyBindingFailure> failures)
+        {
+                if (failures is null || failures.Count == 0)
+                        return string.Empty;
+
+                var lines = failures.Select(f =>
+                {
+                        var reason = string.IsNullOrWhiteSpace(f.Reason) ? "Unknown error." : f.Reason;
+                        return string.IsNullOrWhiteSpace(f.Hotkey)
+                                ? $"• {f.Description}: {reason}"
+                                : $"• {f.Description} ({f.Hotkey}): {reason}";
+                });
+                return string.Join(Environment.NewLine, lines);
+        }
+
+        // Projects the failed entries of a router registration pass into the shared failure shape
+        // (Description = "from -> to") so router, core, and prompt failures render identically.
+        public static IReadOnlyList<HotkeyBindingFailure> ToBindingFailures(IReadOnlyList<HotkeyRegistrationResult> results)
+        {
+                if (results is null || results.Count == 0)
+                        return Array.Empty<HotkeyBindingFailure>();
+
+                var failures = new List<HotkeyBindingFailure>();
+                foreach (var r in results)
+                {
+                        if (r.Success)
+                                continue;
+                        var from = string.IsNullOrWhiteSpace(r.Map?.FromHotKey) ? "(empty)" : r.Map!.FromHotKey!;
+                        var to = string.IsNullOrWhiteSpace(r.Map?.ToHotKey) ? "(empty)" : r.Map!.ToHotKey!;
+                        var reason = string.IsNullOrWhiteSpace(r.ErrorMessage) ? "Unknown error." : r.ErrorMessage!;
+                        failures.Add(new HotkeyBindingFailure($"{from} → {to}", string.Empty, reason));
+                }
+                return failures;
+        }
+
         private readonly struct HotkeyRegistrationAttempt
         {
                 public HotkeyRegistrationAttempt(string normalizedHotkey, int id, bool success, string? errorMessage)
@@ -123,6 +178,27 @@ public class HotkeyManager : IDisposable
 	        {
 	                var attempt = RegisterHotkeyInternal(hotkey, callback, isRouter: false);
 	                return attempt.Id;
+	        }
+
+	        // Registers a core (non-router) hotkey and returns a failure description when the
+	        // configured text cannot be parsed or the shortcut cannot be bound. Returns null on
+	        // success. This replaces the old fire-and-forget TryRegister that swallowed both the
+	        // parse exception and the registration conflict to Debug output only.
+	        public HotkeyBindingFailure? TryRegisterCore(string description, string? hotkeyText, Action callback)
+	        {
+	                var parseFailure = ClassifyConfiguredHotkey(description, hotkeyText, allowEmpty: true);
+	                if (parseFailure is not null)
+	                {
+	                        Log($"Core hotkey '{hotkeyText}' ({description}) invalid: {parseFailure.Reason}");
+	                        return parseFailure;
+	                }
+
+	                var attempt = RegisterHotkeyInternal(Hotkey.Parse(hotkeyText!), callback, isRouter: false);
+	                if (attempt.Success)
+	                        return null;
+
+	                return new HotkeyBindingFailure(description, hotkeyText!.Trim(),
+	                        attempt.ErrorMessage ?? "The shortcut could not be registered.");
 	        }
 
 	        private HotkeyRegistrationAttempt RegisterHotkeyInternal(Hotkey hotkey, Action callback, bool isRouter)
@@ -279,37 +355,47 @@ public class HotkeyManager : IDisposable
                 _routerFailedRegistrations.Clear();
         }
 
-        public void RegisterPromptHotkeys(IEnumerable<LlmSettings.LlmPrompt> prompts, Action<LlmSettings.LlmPrompt> callback)
+        // Registers each prompt's optional hotkey and returns the ones that could not be bound,
+        // labelled by prompt name, so the caller can surface them the same way router and core
+        // failures are surfaced.
+        public IReadOnlyList<HotkeyBindingFailure> RegisterPromptHotkeys(IEnumerable<LlmSettings.LlmPrompt> prompts, Action<LlmSettings.LlmPrompt> callback)
         {
             ClearPromptHotkeys();
-            if (prompts == null) return;
+            var failures = new List<HotkeyBindingFailure>();
+            if (prompts == null) return failures;
 
             foreach (var prompt in prompts)
             {
                 if (string.IsNullOrWhiteSpace(prompt.Hotkey)) continue;
 
-                try
-                {
-                    var hotkey = Hotkey.Parse(prompt.Hotkey);
-                    var attempt = RegisterHotkeyInternal(hotkey, () => callback(prompt), isRouter: false); // Treat as core or unique type? 
-                    // reusing RegisterHotkeyInternal. 'isRouter' tracks failures separately. 
-                    // Let's treat prompts as core for failure tracking for now, or add a flag. 
-                    // The current method separates core vs router. 
-                    // If I pass isRouter=false, it adds to FailedRegistrations and _coreFailedRegistrations.
-                    // This seems acceptable.
+                string description = string.IsNullOrWhiteSpace(prompt.Name) ? "(unnamed prompt)" : prompt.Name;
 
-                    if (attempt.Success && attempt.Id > 0)
+                var parseFailure = ClassifyConfiguredHotkey(description, prompt.Hotkey, allowEmpty: true);
+                if (parseFailure is not null)
+                {
+                    Log($"Prompt hotkey invalid: {description} ({prompt.Hotkey}) - {parseFailure.Reason}");
+                    failures.Add(parseFailure);
+                    continue;
+                }
+
+                var attempt = RegisterHotkeyInternal(Hotkey.Parse(prompt.Hotkey), () => callback(prompt), isRouter: false);
+                if (attempt.Success)
+                {
+                    if (attempt.Id > 0)
                     {
                         _promptIds.Add(attempt.Id);
                         _promptNormalizedHotkeys[attempt.Id] = attempt.NormalizedHotkey;
                     }
                 }
-                catch (Exception ex)
+                else
                 {
-                    Log($"Prompt hotkey failed: {prompt.Name} ({prompt.Hotkey}) - {ex.Message}");
-                    FailedRegistrations.Add(prompt.Hotkey);
+                    Log($"Prompt hotkey registration FAILED: {description} ({prompt.Hotkey}) - {attempt.ErrorMessage}");
+                    failures.Add(new HotkeyBindingFailure(description, prompt.Hotkey.Trim(),
+                        attempt.ErrorMessage ?? "The shortcut could not be registered."));
                 }
             }
+
+            return failures;
         }
 
         public void ClearPromptHotkeys()

--- a/Mutation.Ui/Services/HotkeyManager.cs
+++ b/Mutation.Ui/Services/HotkeyManager.cs
@@ -19,26 +19,20 @@ public class HotkeyManager : IDisposable
 	private readonly Dictionary<int, Action> _callbacks = new();
 	// Track a normalized representation of each registered hotkey so we can avoid
 	// attempting duplicate registrations (which Windows will report as a failure
-	// even though one instance is already active). This prevents false positives
-	// in the FailedRegistrations list when router hotkeys are refreshed.
+	// even though one instance is already active).
 	private readonly HashSet<string> _registeredHotkeys = new(StringComparer.Ordinal);
     private readonly List<int> _routerIds = new();
     private readonly Dictionary<int, string> _routerNormalizedHotkeys = new();
-    private readonly List<string> _routerFailedRegistrations = new();
 
     private readonly List<int> _promptIds = new();
     private readonly Dictionary<int, string> _promptNormalizedHotkeys = new();
 
-	private readonly List<string> _coreFailedRegistrations = new();
 	private readonly Settings _settings;
 	private static SynchronizationContext? s_uiCtx;
 	private int _id;
 	private IntPtr _prevWndProc;
 	private WndProcDelegate? _newWndProc;
 	private GCHandle _wndProcHandle;
-
-		public List<string> FailedRegistrations { get; } = new(); // aggregate (router + core)
-		public IReadOnlyList<string> CoreFailedRegistrations => _coreFailedRegistrations; // only core (non-router) failures
 
         public sealed record HotkeyRegistrationResult(HotKeyRouterSettings.HotKeyRouterMap Map, string NormalizedHotkey, bool Success, int Id, string? ErrorMessage);
 
@@ -176,7 +170,7 @@ public class HotkeyManager : IDisposable
 
 	        public int RegisterHotkey(Hotkey hotkey, Action callback)
 	        {
-	                var attempt = RegisterHotkeyInternal(hotkey, callback, isRouter: false);
+	                var attempt = RegisterHotkeyInternal(hotkey, callback);
 	                return attempt.Id;
 	        }
 
@@ -193,7 +187,7 @@ public class HotkeyManager : IDisposable
 	                        return parseFailure;
 	                }
 
-	                var attempt = RegisterHotkeyInternal(Hotkey.Parse(hotkeyText!), callback, isRouter: false);
+	                var attempt = RegisterHotkeyInternal(Hotkey.Parse(hotkeyText!), callback);
 	                if (attempt.Success)
 	                        return null;
 
@@ -201,19 +195,12 @@ public class HotkeyManager : IDisposable
 	                        attempt.ErrorMessage ?? "The shortcut could not be registered.");
 	        }
 
-	        private HotkeyRegistrationAttempt RegisterHotkeyInternal(Hotkey hotkey, Action callback, bool isRouter)
+	        private HotkeyRegistrationAttempt RegisterHotkeyInternal(Hotkey hotkey, Action callback)
         {
                 string norm = NormalizeHotkey(hotkey);
                 if (_registeredHotkeys.Contains(norm))
                 {
                         Log($"Duplicate hotkey detected: {norm}");
-	                        if (isRouter)
-	                                _routerFailedRegistrations.Add(hotkey.ToString());
-	                        else
-	                        {
-	                                FailedRegistrations.Add(hotkey.ToString());
-	                                _coreFailedRegistrations.Add(hotkey.ToString());
-	                        }
                         return new HotkeyRegistrationAttempt(norm, -1, success: false, errorMessage: "The shortcut is already registered.");
                 }
 
@@ -249,13 +236,6 @@ public class HotkeyManager : IDisposable
                 }
                 message ??= "Failed to register the shortcut.";
 
-				if (isRouter)
-					_routerFailedRegistrations.Add(hotkey.ToString());
-				else
-				{
-					FailedRegistrations.Add(hotkey.ToString());
-					_coreFailedRegistrations.Add(hotkey.ToString());
-				}
                 Log($"Hotkey registration FAILED: {norm} (error={error})");
                 return new HotkeyRegistrationAttempt(norm, id, false, message);
         }
@@ -270,10 +250,6 @@ public class HotkeyManager : IDisposable
 
 	        public IReadOnlyList<HotkeyRegistrationResult> RegisterRouterHotkeys(IEnumerable<HotKeyRouterSettings.HotKeyRouterMap> mappings)
         {
-                foreach (var previous in _routerFailedRegistrations)
-				FailedRegistrations.Remove(previous); // keep core failures intact
-                _routerFailedRegistrations.Clear();
-
                 var results = new List<HotkeyRegistrationResult>();
 
                 foreach (var map in mappings)
@@ -287,7 +263,7 @@ public class HotkeyManager : IDisposable
 			                        try
 			                        {
 			                                var hotkey = Hotkey.Parse(map.FromHotKey!);
-			                                var attempt = RegisterHotkeyInternal(hotkey, () => SendHotkeyAfterDelay(map.ToHotKey!, Constants.FailureSendHotkeyDelay), isRouter: true);
+			                                var attempt = RegisterHotkeyInternal(hotkey, () => SendHotkeyAfterDelay(map.ToHotKey!, Constants.FailureSendHotkeyDelay));
                                 if (attempt.Success)
                                 {
                                         if (attempt.Id > 0)
@@ -301,16 +277,12 @@ public class HotkeyManager : IDisposable
                                 }
                                 else
                                 {
-                                        var failureKey = hotkey.ToString();
-                                        _routerFailedRegistrations.Add(failureKey);
                                         Log($"Router registration FAILED: From='{map.FromHotKey}' -> To='{map.ToHotKey}' ({attempt.ErrorMessage})");
                                         results.Add(new HotkeyRegistrationResult(map, attempt.NormalizedHotkey, false, attempt.Id, attempt.ErrorMessage ?? "The shortcut could not be registered."));
                                 }
                         }
                         catch (Exception ex)
                         {
-                                FailedRegistrations.Add(map.FromHotKey ?? string.Empty);
-                                _routerFailedRegistrations.Add(map.FromHotKey ?? string.Empty);
                                 Log($"Router registration FAILED: From='{map.FromHotKey}' -> To='{map.ToHotKey}' ({ex.Message})");
                                 results.Add(new HotkeyRegistrationResult(map, map.FromHotKey ?? string.Empty, false, -1, ex.Message));
                         }
@@ -350,9 +322,6 @@ public class HotkeyManager : IDisposable
                 }
 
                 _routerIds.Clear();
-                foreach (var previous in _routerFailedRegistrations)
-                        FailedRegistrations.Remove(previous);
-                _routerFailedRegistrations.Clear();
         }
 
         // Registers each prompt's optional hotkey and returns the ones that could not be bound,
@@ -378,7 +347,7 @@ public class HotkeyManager : IDisposable
                     continue;
                 }
 
-                var attempt = RegisterHotkeyInternal(Hotkey.Parse(prompt.Hotkey), () => callback(prompt), isRouter: false);
+                var attempt = RegisterHotkeyInternal(Hotkey.Parse(prompt.Hotkey), () => callback(prompt));
                 if (attempt.Success)
                 {
                     if (attempt.Id > 0)
@@ -426,14 +395,11 @@ public class HotkeyManager : IDisposable
                 _registeredHotkeys.Clear();
         }
 
-        // Clears ALL registrations (core + router + prompt) and the failure lists so the
-        // caller can re-register everything from a (possibly mutated) Settings instance.
+        // Clears ALL registrations (core + router + prompt) so the caller can
+        // re-register everything from a (possibly mutated) Settings instance.
         public void ClearAllForRebind()
         {
                 UnregisterAll();
-                FailedRegistrations.Clear();
-                _coreFailedRegistrations.Clear();
-                _routerFailedRegistrations.Clear();
         }
 
 	private IntPtr WndProc(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam)

--- a/Mutation.Ui/Services/PromptLibraryController.cs
+++ b/Mutation.Ui/Services/PromptLibraryController.cs
@@ -14,6 +14,7 @@ internal sealed class PromptLibraryController
 	private readonly TranscriptFormatter _transcriptFormatter;
 	private readonly ListView _promptListView;
 	private readonly Action<LlmSettings.LlmPrompt> _executePrompt;
+	private readonly Action<IReadOnlyList<HotkeyManager.HotkeyBindingFailure>>? _reportHotkeyFailures;
 
 	private HotkeyManager? _hotkeyManager;
 
@@ -22,13 +23,15 @@ internal sealed class PromptLibraryController
 		ISettingsManager settingsManager,
 		TranscriptFormatter transcriptFormatter,
 		ListView promptListView,
-		Action<LlmSettings.LlmPrompt> executePrompt)
+		Action<LlmSettings.LlmPrompt> executePrompt,
+		Action<IReadOnlyList<HotkeyManager.HotkeyBindingFailure>>? reportHotkeyFailures = null)
 	{
 		_settings = settings ?? throw new ArgumentNullException(nameof(settings));
 		_settingsManager = settingsManager ?? throw new ArgumentNullException(nameof(settingsManager));
 		_transcriptFormatter = transcriptFormatter ?? throw new ArgumentNullException(nameof(transcriptFormatter));
 		_promptListView = promptListView ?? throw new ArgumentNullException(nameof(promptListView));
 		_executePrompt = executePrompt ?? throw new ArgumentNullException(nameof(executePrompt));
+		_reportHotkeyFailures = reportHotkeyFailures;
 	}
 
 	public void Initialize()
@@ -37,11 +40,12 @@ internal sealed class PromptLibraryController
 			_promptListView.ItemsSource = _settings.LlmSettings.Prompts;
 	}
 
-	public void AttachHotkeyManager(HotkeyManager hotkeyManager)
+	public IReadOnlyList<HotkeyManager.HotkeyBindingFailure> AttachHotkeyManager(HotkeyManager hotkeyManager)
 	{
 		_hotkeyManager = hotkeyManager ?? throw new ArgumentNullException(nameof(hotkeyManager));
 		if (_settings.LlmSettings?.Prompts != null)
-			_hotkeyManager.RegisterPromptHotkeys(_settings.LlmSettings.Prompts, _executePrompt);
+			return _hotkeyManager.RegisterPromptHotkeys(_settings.LlmSettings.Prompts, _executePrompt);
+		return Array.Empty<HotkeyManager.HotkeyBindingFailure>();
 	}
 
 	public LlmSettings.LlmPrompt? GetAutoRunPrompt()
@@ -119,6 +123,11 @@ internal sealed class PromptLibraryController
 		_promptListView.ItemsSource = null;
 		_promptListView.ItemsSource = _settings.LlmSettings.Prompts;
 
-		_hotkeyManager?.RegisterPromptHotkeys(_settings.LlmSettings.Prompts, _executePrompt);
+		if (_hotkeyManager is null)
+			return;
+
+		var failures = _hotkeyManager.RegisterPromptHotkeys(_settings.LlmSettings.Prompts, _executePrompt);
+		if (failures.Count > 0)
+			_reportHotkeyFailures?.Invoke(failures);
 	}
 }

--- a/Mutation.Ui/Views/PromptEditorWindow.xaml
+++ b/Mutation.Ui/Views/PromptEditorWindow.xaml
@@ -5,6 +5,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:controls="using:Mutation.Ui.Views.SettingsUi.Controls"
     mc:Ignorable="d"
     Title="Edit Prompt">
 
@@ -30,7 +31,12 @@
             </Grid.RowDefinitions>
 
             <TextBox x:Name="TxtName" Header="Name" PlaceholderText="e.g. Summarize" Grid.Column="0" />
-            <TextBox x:Name="TxtHotkey" Header="Hotkey" PlaceholderText="e.g. CTRL+ALT+S" Grid.Column="1" />
+            <controls:HotkeyEditor x:Name="HkPromptHotkey"
+                                   Header="Hotkey"
+                                   HelpText="Optional global shortcut that runs this prompt."
+                                   AllowEmpty="True"
+                                   Grid.Column="1"
+                                   VerticalAlignment="Bottom" />
 
             <ComboBox x:Name="CmbModel"
                       Header="Model"

--- a/Mutation.Ui/Views/PromptEditorWindow.xaml.cs
+++ b/Mutation.Ui/Views/PromptEditorWindow.xaml.cs
@@ -1,6 +1,7 @@
 using CognitiveSupport;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Mutation.Ui.Services;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -64,7 +65,7 @@ public sealed partial class PromptEditorWindow : Window
 
             // Populate fields
             TxtName.Text = Prompt.Name;
-            TxtHotkey.Text = Prompt.Hotkey;
+            HkPromptHotkey.Hotkey = Prompt.Hotkey ?? string.Empty;
             TxtContent.Text = Prompt.Content;
             ChkAutoRun.IsChecked = Prompt.AutoRun;
 
@@ -87,9 +88,21 @@ public sealed partial class PromptEditorWindow : Window
             return;
         }
 
+        // Reject an invalid hotkey before saving so a typo cannot silently fail to bind later.
+        string hotkey = (HkPromptHotkey.Hotkey ?? string.Empty).Trim();
+        if (!string.IsNullOrEmpty(hotkey))
+        {
+            string? hotkeyError = HotkeyValidator.Validate(hotkey, allowSendKeysSyntax: false);
+            if (hotkeyError is not null)
+            {
+                ShowError($"Hotkey is not valid: {hotkeyError}");
+                return;
+            }
+        }
+
         // Update object
         Prompt.Name = TxtName.Text;
-        Prompt.Hotkey = TxtHotkey.Text; // Basic text for now, could implement validation later
+        Prompt.Hotkey = hotkey;
         Prompt.Content = TxtContent.Text;
         Prompt.AutoRun = ChkAutoRun.IsChecked ?? false;
         Prompt.ModelName = CmbModel.SelectedItem as string ?? LlmSettings.DefaultModel;


### PR DESCRIPTION
Closes #162

## Problem

Global-hotkey registration failures on the **core** and **prompt** paths
were only written to debug output. When a shortcut collided with another
app or the configured text could not be parsed, the hotkey simply never
fired — no dialog, no beep, no status message. For a user who drives the
app almost entirely by hotkey, a collision or a typo was invisible and
undiagnosable. Router-hotkey failures were already surfaced with a dialog,
so the core and prompt paths were the odd ones out.

The worst case was a **typo**: `MainWindow.TryRegister` caught the parse
exception and only logged it, so a mistyped core hotkey never even reached
the failure list the startup dialog reads from. On settings-apply, only
router failures were shown.

## What changed

The three registration paths (core, router, prompt) now report failures
through one shared shape and are surfaced the same way: a failure beep
plus a single accessible dialog listing each hotkey that could not be
bound and why.

- **`HotkeyManager`** — a new `HotkeyBindingFailure` record plus three
  pure, unit-testable helpers: `ClassifyConfiguredHotkey` (catches the
  previously-swallowed parse errors), `BuildFailureMessage` (renders the
  dialog text), and `ToBindingFailures` (maps router results into the
  shared shape). `TryRegisterCore` returns the failure reason instead of
  discarding it, and `RegisterPromptHotkeys` returns per-prompt failures
  labelled by prompt name.
- **`MainWindow`** — `RegisterCoreHotkeys` collects failures with a
  human-readable label for each action; `ShowHotkeyBindingFailuresAsync`
  plays the failure beep and shows one dialog for core, router, and prompt
  failures on settings-apply.
- **App startup** — collects and surfaces all hotkey failures the same
  way, and drops a redundant second router registration.
- **`PromptLibraryController`** — reports prompt-hotkey failures after a
  prompt is added or edited.
- **`PromptEditorWindow`** — the raw hotkey text box is replaced with the
  validating `HotkeyEditor` control, and an invalid hotkey is now rejected
  on save instead of being stored as unvalidated text.

## Accessibility

The dialog carries an automation name and help text so a screen reader
announces the full list of failures, and the failure beep gives an
immediate non-visual cue. Each failing hotkey is named by its action
(e.g. "Start/stop dictation") or prompt name, not just the raw key
string.

## Test plan

- `dotnet test --configuration Release` — all 538 tests pass, including 15
  new tests covering failure classification, message formatting, and the
  router-result mapping.
- Manual (device-dependent, not automated): configure a core hotkey that
  collides with another app or contains a typo → on startup and on
  settings-apply a dialog lists the failure and the failure beep plays.
  Add a prompt with an invalid hotkey in the prompt editor → save is
  blocked with an inline validation message.

## Notes

Registration itself uses the Win32 `RegisterHotKey` P/Invoke, which needs
a live window handle, so the collision path cannot be unit-tested. The new
tests target the pure classification and formatting logic (which is where
the silent parse-failure bug lived); the validation reuse in the prompt
editor is covered by the existing `HotkeyValidator` tests.
