### PR TITLE
Save and restore the clipboard around speak-selection (#181)

### DIFF
--- a/Mutation.Tests/ClipboardRetryTests.cs
+++ b/Mutation.Tests/ClipboardRetryTests.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Threading.Tasks;
+using Mutation.Ui.Services;
+using Xunit;
+
+namespace Mutation.Tests;
+
+public class ClipboardRetryTests
+{
+	[Fact]
+	public async Task TryAsync_ReturnsTrue_WhenOperationSucceedsFirstTry()
+	{
+		int calls = 0;
+		bool result = await ClipboardRetry.TryAsync(() => { calls++; return Task.CompletedTask; });
+
+		Assert.True(result);
+		Assert.Equal(1, calls);
+	}
+
+	[Fact]
+	public async Task TryAsync_RetriesAndSucceeds_AfterTransientFailures()
+	{
+		int calls = 0;
+		bool result = await ClipboardRetry.TryAsync(() =>
+		{
+			calls++;
+			if (calls < 3)
+				throw new InvalidOperationException("clipboard busy");
+			return Task.CompletedTask;
+		}, attempts: 5, delayMs: 1);
+
+		Assert.True(result);
+		Assert.Equal(3, calls);
+	}
+
+	[Fact]
+	public async Task TryAsync_ReturnsFalse_WhenEveryAttemptFails()
+	{
+		int calls = 0;
+		bool result = await ClipboardRetry.TryAsync(() =>
+		{
+			calls++;
+			throw new InvalidOperationException("clipboard busy");
+		}, attempts: 3, delayMs: 1);
+
+		Assert.False(result);
+		Assert.Equal(3, calls);
+	}
+
+	[Fact]
+	public async Task TryAsync_Throws_OnNullOperation()
+	{
+		await Assert.ThrowsAsync<ArgumentNullException>(() => ClipboardRetry.TryAsync(null!));
+	}
+
+	[Fact]
+	public async Task TryAsync_Throws_OnNonPositiveAttempts()
+	{
+		await Assert.ThrowsAsync<ArgumentOutOfRangeException>(
+			() => ClipboardRetry.TryAsync(() => Task.CompletedTask, attempts: 0));
+	}
+}

--- a/Mutation.Tests/ClipboardSnapshotTests.cs
+++ b/Mutation.Tests/ClipboardSnapshotTests.cs
@@ -1,0 +1,32 @@
+using Mutation.Ui.Services;
+using Xunit;
+
+namespace Mutation.Tests;
+
+public class ClipboardSnapshotTests
+{
+	[Fact]
+	public void HasContent_False_WhenEmpty()
+	{
+		Assert.False(new ClipboardSnapshot().HasContent);
+	}
+
+	[Fact]
+	public void HasContent_False_WhenTextEmptyAndImageZeroLength()
+	{
+		var snapshot = new ClipboardSnapshot { Text = "", PngImageBytes = new byte[0] };
+		Assert.False(snapshot.HasContent);
+	}
+
+	[Fact]
+	public void HasContent_True_WhenTextPresent()
+	{
+		Assert.True(new ClipboardSnapshot { Text = "hello" }.HasContent);
+	}
+
+	[Fact]
+	public void HasContent_True_WhenImagePresent()
+	{
+		Assert.True(new ClipboardSnapshot { PngImageBytes = new byte[] { 1, 2, 3 } }.HasContent);
+	}
+}

--- a/Mutation.Ui/MainWindow.xaml.cs
+++ b/Mutation.Ui/MainWindow.xaml.cs
@@ -1060,6 +1060,11 @@ public sealed partial class MainWindow : Window, IDisposable
 			return;
 		}
 
+		// Save whatever the user has on the clipboard before Ctrl+C destroys it.
+		ClipboardSnapshot? saved = null;
+		try { saved = await _clipboard.TryCaptureSnapshotAsync(); }
+		catch { /* snapshot is best-effort; reading the selection still works without it */ }
+
 		uint before = GetClipboardSequenceNumber();
 		try { await Task.Run(() => HotkeyManager.SendHotkey("Ctrl+C")); }
 		catch { /* sending may fail if focus is on a non-input control */ }
@@ -1081,7 +1086,39 @@ public sealed partial class MainWindow : Window, IDisposable
 			return;
 		}
 
-		BtnTextToSpeech_Click(null, null);
+		// Read the copied selection now, so the clipboard can be restored
+		// before speaking rather than after.
+		var (kind, selectionText) = await _clipboard.InspectAsync();
+		string trimmed = (selectionText ?? string.Empty).Trim();
+
+		if (saved is not null)
+		{
+			bool restored = false;
+			try { restored = await _clipboard.TryRestoreSnapshotAsync(saved); }
+			catch { /* fall through to the failure announcement */ }
+
+			if (!restored)
+			{
+				BeepPlayer.Play(BeepType.Failure);
+				ShowStatus("Text to Speech",
+					"Could not restore your previous clipboard content; the clipboard now holds the copied selection.",
+					InfoBarSeverity.Warning);
+			}
+		}
+
+		if (kind != ClipboardKind.Text || trimmed.Length == 0)
+		{
+			AnnounceUnreadableClipboard(kind, tts);
+			return;
+		}
+
+		if (_textToSpeech.IsSpeaking)
+			_textToSpeech.Stop();
+
+		_textToSpeech.Speak(trimmed, tts.Rate, tts.Volume, tts.VoiceName,
+			resumeIfSame: false, preprocess: tts.EnableSpeechPreprocessing,
+			options: SpeechPreprocessingOptions.FromSettings(tts));
+		ShowStatus("Text to Speech", "Speaking…", InfoBarSeverity.Informational);
 	}
 
 	private void AnnounceSelectionUnavailable(string message, TextToSpeechSettings tts)

--- a/Mutation.Ui/Services/ClipboardManager.cs
+++ b/Mutation.Ui/Services/ClipboardManager.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.InteropServices.WindowsRuntime;
 using System.Threading.Tasks;
 using Windows.ApplicationModel.DataTransfer;
 using Windows.Graphics.Imaging;
@@ -72,6 +73,84 @@ public class ClipboardManager
 	{
 		var content = Clipboard.GetContent();
 		return content.Contains(StandardDataFormats.Text) ? await content.GetTextAsync() : string.Empty;
+	}
+
+	/// <summary>
+	/// Captures the current clipboard content (text and/or bitmap) so it can
+	/// be restored later. Returns null when nothing capturable is present or
+	/// the clipboard could not be read.
+	/// </summary>
+	public virtual async Task<ClipboardSnapshot?> TryCaptureSnapshotAsync()
+	{
+		string? text = null;
+		byte[]? pngBytes = null;
+
+		bool read = await ClipboardRetry.TryAsync(async () =>
+		{
+			var content = Clipboard.GetContent();
+
+			if (content.Contains(StandardDataFormats.Text))
+				text = await content.GetTextAsync();
+
+			if (content.Contains(StandardDataFormats.Bitmap))
+			{
+				IRandomAccessStreamReference? streamRef = await content.GetBitmapAsync();
+				if (streamRef != null)
+				{
+					using var stream = await streamRef.OpenReadAsync();
+					var decoder = await BitmapDecoder.CreateAsync(stream);
+					using var bitmap = await decoder.GetSoftwareBitmapAsync();
+					pngBytes = await EncodeToPngAsync(bitmap);
+				}
+			}
+		});
+
+		if (!read)
+			return null;
+
+		var snapshot = new ClipboardSnapshot { Text = text, PngImageBytes = pngBytes };
+		return snapshot.HasContent ? snapshot : null;
+	}
+
+	/// <summary>
+	/// Puts a previously captured snapshot back on the clipboard.
+	/// Returns false when the clipboard stayed unavailable after retries.
+	/// </summary>
+	public virtual Task<bool> TryRestoreSnapshotAsync(ClipboardSnapshot snapshot)
+	{
+		if (snapshot is null || !snapshot.HasContent)
+			return Task.FromResult(false);
+
+		return ClipboardRetry.TryAsync(async () =>
+		{
+			var data = new DataPackage();
+
+			if (!string.IsNullOrEmpty(snapshot.Text))
+				data.SetText(snapshot.Text);
+
+			if (snapshot.PngImageBytes is { Length: > 0 })
+			{
+				var stream = new InMemoryRandomAccessStream();
+				await stream.WriteAsync(snapshot.PngImageBytes.AsBuffer());
+				stream.Seek(0);
+				data.SetBitmap(RandomAccessStreamReference.CreateFromStream(stream));
+			}
+
+			Clipboard.SetContent(data);
+		});
+	}
+
+	private static async Task<byte[]> EncodeToPngAsync(SoftwareBitmap bitmap)
+	{
+		using var stream = new InMemoryRandomAccessStream();
+		var encoder = await BitmapEncoder.CreateAsync(BitmapEncoder.PngEncoderId, stream);
+		encoder.SetSoftwareBitmap(bitmap);
+		await encoder.FlushAsync();
+
+		var bytes = new byte[stream.Size];
+		stream.Seek(0);
+		await stream.ReadAsync(bytes.AsBuffer(), (uint)stream.Size, InputStreamOptions.None);
+		return bytes;
 	}
 
 	public async Task SetImageAsync(SoftwareBitmap bitmap)

--- a/Mutation.Ui/Services/ClipboardRetry.cs
+++ b/Mutation.Ui/Services/ClipboardRetry.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Mutation.Ui.Services;
+
+/// <summary>
+/// Retry policy for clipboard operations. Another process can hold the
+/// clipboard open at any moment, making reads and writes fail transiently,
+/// so callers wrap them in a short retry loop instead of failing outright.
+/// </summary>
+public static class ClipboardRetry
+{
+	public const int DefaultAttempts = 5;
+	public const int DefaultDelayMs = 100;
+
+	/// <summary>
+	/// Runs <paramref name="operation"/> until it succeeds, retrying up to
+	/// <paramref name="attempts"/> times with <paramref name="delayMs"/>
+	/// between tries. Returns true on success, false when every try threw.
+	/// </summary>
+	public static async Task<bool> TryAsync(
+		Func<Task> operation, int attempts = DefaultAttempts, int delayMs = DefaultDelayMs)
+	{
+		if (operation is null)
+			throw new ArgumentNullException(nameof(operation));
+		if (attempts < 1)
+			throw new ArgumentOutOfRangeException(nameof(attempts));
+
+		for (int attempt = 1; attempt <= attempts; attempt++)
+		{
+			try
+			{
+				await operation().ConfigureAwait(false);
+				return true;
+			}
+			catch when (attempt < attempts)
+			{
+				await Task.Delay(delayMs).ConfigureAwait(false);
+			}
+			catch
+			{
+				return false;
+			}
+		}
+
+		return false;
+	}
+}

--- a/Mutation.Ui/Services/ClipboardSnapshot.cs
+++ b/Mutation.Ui/Services/ClipboardSnapshot.cs
@@ -1,0 +1,17 @@
+namespace Mutation.Ui.Services;
+
+/// <summary>
+/// A saved copy of the clipboard's content, captured before an operation
+/// that overwrites the clipboard so it can be put back afterwards.
+/// </summary>
+public sealed class ClipboardSnapshot
+{
+	public string? Text { get; init; }
+
+	/// <summary>Clipboard bitmap encoded as PNG, when the clipboard held an image.</summary>
+	public byte[]? PngImageBytes { get; init; }
+
+	/// <summary>True when there is anything worth restoring.</summary>
+	public bool HasContent =>
+		!string.IsNullOrEmpty(Text) || (PngImageBytes is { Length: > 0 });
+}


### PR DESCRIPTION
Closes #181

## Summary

The "read selection aloud" feature copies the foreground app's selection by sending Ctrl+C, which previously overwrote the user's clipboard permanently — every use silently destroyed whatever was on the clipboard.

Now `SpeakActiveSelectionAsync`:

1. Snapshots the current clipboard (text and/or bitmap, encoded as PNG) before sending Ctrl+C.
2. Waits for the copy as before, then immediately reads the copied selection text.
3. Restores the snapshot with a contention-retry loop (5 attempts, 100 ms apart) before speech starts, so speaking no longer depends on the clipboard keeping the selection.
4. Speaks the captured selection directly, keeping the previous stop-then-speak behaviour when speech is already running.

If the restore fails after all retries, the app plays the failure beep and shows a warning in the status area saying the clipboard now holds the copied selection, instead of failing silently. An empty prior clipboard is simply skipped — there is nothing to restore.

New pieces, each in its own file per project convention:

- `ClipboardSnapshot` — the saved clipboard content (text and/or PNG bytes) with a `HasContent` check.
- `ClipboardRetry` — a small retry policy for clipboard reads/writes, since another process can hold the clipboard open at any moment.
- `ClipboardManager.TryCaptureSnapshotAsync` / `TryRestoreSnapshotAsync` — virtual, so tests can fake them like the existing `TestClipboard` pattern.

## Test plan

- 9 new unit tests: `ClipboardSnapshotTests` (HasContent semantics) and `ClipboardRetryTests` (first-try success, retry-then-succeed, give-up after max attempts, argument validation).
- Full suite: `dotnet test --configuration Release` — 531 passed, 0 failed.
- Manual check for reviewers: copy something, trigger the speak-selection hotkey in another app with text selected, then paste — the original clipboard content should still be there while the selection is spoken.

## Notes

- The restore-failure announcement uses the failure beep plus a status warning rather than spoken text, because the selection speech starts immediately afterwards and would talk over a spoken announcement.
