### PR TITLE
Announce every status InfoBar update to screen readers (#164)

### DIFF
--- a/Mutation.Tests/StatusAnnouncementTests.cs
+++ b/Mutation.Tests/StatusAnnouncementTests.cs
@@ -1,0 +1,54 @@
+using Microsoft.UI.Xaml.Automation.Peers;
+using Microsoft.UI.Xaml.Controls;
+using Mutation.Ui.Core;
+using Xunit;
+
+namespace Mutation.Tests;
+
+public class StatusAnnouncementTests
+{
+	[Fact]
+	public void ComposeText_JoinsTitleAndMessage()
+	{
+		Assert.Equal("Speech to Text: Transcript ready.",
+			StatusAnnouncement.ComposeText("Speech to Text", "Transcript ready."));
+	}
+
+	[Fact]
+	public void ComposeText_TitleOnly_ReturnsTitle()
+	{
+		Assert.Equal("Microphone", StatusAnnouncement.ComposeText("Microphone", "  "));
+	}
+
+	[Fact]
+	public void ComposeText_MessageOnly_ReturnsMessage()
+	{
+		Assert.Equal("Transcript ready.", StatusAnnouncement.ComposeText(null, "Transcript ready."));
+	}
+
+	[Fact]
+	public void ComposeText_BothEmpty_ReturnsEmpty()
+	{
+		Assert.Equal(string.Empty, StatusAnnouncement.ComposeText(null, ""));
+	}
+
+	[Theory]
+	[InlineData(InfoBarSeverity.Error, AutomationNotificationKind.ActionAborted)]
+	[InlineData(InfoBarSeverity.Success, AutomationNotificationKind.ActionCompleted)]
+	[InlineData(InfoBarSeverity.Warning, AutomationNotificationKind.Other)]
+	[InlineData(InfoBarSeverity.Informational, AutomationNotificationKind.Other)]
+	public void GetKind_MapsSeverity(InfoBarSeverity severity, AutomationNotificationKind expected)
+	{
+		Assert.Equal(expected, StatusAnnouncement.GetKind(severity));
+	}
+
+	[Theory]
+	[InlineData(InfoBarSeverity.Error, AutomationNotificationProcessing.ImportantMostRecent)]
+	[InlineData(InfoBarSeverity.Warning, AutomationNotificationProcessing.ImportantMostRecent)]
+	[InlineData(InfoBarSeverity.Success, AutomationNotificationProcessing.MostRecent)]
+	[InlineData(InfoBarSeverity.Informational, AutomationNotificationProcessing.MostRecent)]
+	public void GetProcessing_ErrorsAndWarningsInterrupt(InfoBarSeverity severity, AutomationNotificationProcessing expected)
+	{
+		Assert.Equal(expected, StatusAnnouncement.GetProcessing(severity));
+	}
+}

--- a/Mutation.Ui/Core/StatusAnnouncement.cs
+++ b/Mutation.Ui/Core/StatusAnnouncement.cs
@@ -1,0 +1,44 @@
+using Microsoft.UI.Xaml.Automation.Peers;
+using Microsoft.UI.Xaml.Controls;
+
+namespace Mutation.Ui.Core;
+
+/// <summary>
+/// Composes the UIA notification raised for every status InfoBar update.
+/// WinUI only announces the InfoBar on its closed→open transition, so text
+/// changes while the bar is already open must be announced explicitly.
+/// </summary>
+public static class StatusAnnouncement
+{
+	public const string ActivityId = "Mutation.Status";
+
+	public static string ComposeText(string? title, string? message)
+	{
+		bool hasTitle = !string.IsNullOrWhiteSpace(title);
+		bool hasMessage = !string.IsNullOrWhiteSpace(message);
+
+		if (hasTitle && hasMessage)
+			return $"{title}: {message}";
+		if (hasTitle)
+			return title!;
+		if (hasMessage)
+			return message!;
+		return string.Empty;
+	}
+
+	public static AutomationNotificationKind GetKind(InfoBarSeverity severity) =>
+		severity switch
+		{
+			InfoBarSeverity.Error => AutomationNotificationKind.ActionAborted,
+			InfoBarSeverity.Success => AutomationNotificationKind.ActionCompleted,
+			_ => AutomationNotificationKind.Other,
+		};
+
+	// Errors and warnings interrupt whatever the screen reader is saying;
+	// routine updates stay polite. "MostRecent" keeps rapid sequences
+	// (Recording… → Transcribing… → done) from queueing stale messages.
+	public static AutomationNotificationProcessing GetProcessing(InfoBarSeverity severity) =>
+		severity is InfoBarSeverity.Error or InfoBarSeverity.Warning
+			? AutomationNotificationProcessing.ImportantMostRecent
+			: AutomationNotificationProcessing.MostRecent;
+}

--- a/Mutation.Ui/MainWindow.xaml.cs
+++ b/Mutation.Ui/MainWindow.xaml.cs
@@ -1784,6 +1784,7 @@ public sealed partial class MainWindow : Window, IDisposable
 			StatusInfoBar.IsOpen = true;
 			AutomationProperties.SetName(StatusInfoBar, $"{title} status");
 			AutomationProperties.SetHelpText(StatusInfoBar, message);
+			AnnounceStatus(title, message, severity);
 			_statusDismissTimer.Stop();
 			_statusDismissTimer.Start();
 		}
@@ -1792,6 +1793,25 @@ public sealed partial class MainWindow : Window, IDisposable
 			Update();
 		else
 			DispatcherQueue.TryEnqueue(Update);
+	}
+
+	private void AnnounceStatus(string title, string message, InfoBarSeverity severity)
+	{
+		// WinUI announces the InfoBar only on its closed→open transition; the
+		// bar stays open 6 s between updates, so raise an explicit UIA
+		// notification for every status change (issue #164).
+		string announcement = StatusAnnouncement.ComposeText(title, message);
+		if (announcement.Length == 0)
+			return;
+
+		// CreatePeerForElement (not FromElement) so the announcement also
+		// fires when no peer exists yet, e.g. the very first status.
+		var peer = Microsoft.UI.Xaml.Automation.Peers.FrameworkElementAutomationPeer.CreatePeerForElement(StatusInfoBar);
+		peer?.RaiseNotificationEvent(
+			StatusAnnouncement.GetKind(severity),
+			StatusAnnouncement.GetProcessing(severity),
+			announcement,
+			StatusAnnouncement.ActivityId);
 	}
 
 	private void StatusDismissTimer_Tick(object? sender, object e)


### PR DESCRIPTION
## Summary

The main window's status InfoBar is the app's primary feedback channel, but WinUI only raises a screen-reader announcement when the bar transitions from closed to open. Because `ShowStatus` keeps the bar open for 6 seconds, any update arriving inside that window — typically the ones that matter most, like "Transcript ready." or an error — silently replaced the text and was never spoken.

`ShowStatus` now raises an explicit UIA notification on every call, so each status change is announced regardless of whether the bar was already open.

## Changes

- **`Mutation.Ui/Core/StatusAnnouncement.cs`** (new) — a small pure helper that composes the spoken text ("Title: message", tolerating empty parts) and maps InfoBar severity to the UIA notification kind and processing mode. Errors and warnings use `ImportantMostRecent` so they interrupt current speech; routine informational/success updates use polite `MostRecent` so rapid sequences (Recording… → Transcribing… → done) don't queue stale messages.
- **`Mutation.Ui/MainWindow.xaml.cs`** — `ShowStatus` now calls a new `AnnounceStatus` method that raises `RaiseNotificationEvent` on the InfoBar's automation peer. It uses `CreatePeerForElement` so the very first status (before any peer exists) is also announced.
- **`Mutation.Tests/StatusAnnouncementTests.cs`** (new) — covers text composition edge cases and the severity → kind/processing mappings.

Closes #164

## Test plan

- `dotnet test --configuration Release` — 543 tests pass, including 12 new ones for the announcement helper.
- Manual check with a screen reader: trigger a dictation cycle and confirm each status ("Recording…", "Transcribing…", "Transcript ready.") is spoken, including updates that land while the bar is still open, and that an error status interrupts ongoing speech.
