### PR TITLE
Play default beeps asynchronously instead of blocking the UI thread

### DIFF
--- a/CognitiveSupport/BeepPlayer.cs
+++ b/CognitiveSupport/BeepPlayer.cs
@@ -29,6 +29,7 @@ public static class BeepPlayer
 	private static SoundPlayer? _playerMute;
 	private static SoundPlayer? _playerUnmute;
 	private static SoundPlayer? _previewPlayer;
+	private static readonly Dictionary<BeepType, (SoundPlayer Player, MemoryStream Stream)> _defaultPlayers = new();
 	public static IReadOnlyList<string> LastInitializationIssues { get; private set; } = Array.Empty<string>();
 
 	public static void Initialize(Settings settings)
@@ -106,32 +107,37 @@ public static class BeepPlayer
 		return false;
 	}
 
+	// Default beeps are synthesized once into in-memory WAVs and played through
+	// SoundPlayer.Play (asynchronous), so they never block the calling thread the
+	// way Console.Beep did (issue #169).
 	private static void PlayDefault(BeepType type)
 	{
-		switch (type)
+		SoundPlayer player;
+		lock (SyncLock)
 		{
-			case BeepType.Start:
-				Console.Beep(DefaultStartFrequency, DefaultStartDuration);
-				break;
-			case BeepType.Success:
-				foreach (var (frequency, duration) in DefaultSuccessSequence)
-					Console.Beep(frequency, duration);
-				break;
-			case BeepType.Failure:
-				for (var i = 0; i < DefaultFailureRepeats; i++)
-					Console.Beep(DefaultFailureFrequency, DefaultFailureDuration);
-				break;
-			case BeepType.End:
-				Console.Beep(DefaultEndFrequency, DefaultEndDuration);
-				break;
-			case BeepType.Mute:
-				Console.Beep(DefaultMuteFrequency, DefaultMuteDuration);
-				break;
-			case BeepType.Unmute:
-				Console.Beep(DefaultUnmuteFrequency, DefaultUnmuteDuration);
-				break;
+			if (!_defaultPlayers.TryGetValue(type, out var cached))
+			{
+				var wav = BeepToneSynthesizer.SynthesizeWav(GetDefaultSequence(type));
+				var stream = new MemoryStream(wav, writable: false);
+				cached = (new SoundPlayer(stream), stream);
+				cached.Player.Load();
+				_defaultPlayers[type] = cached;
+			}
+			player = cached.Player;
 		}
+		player.Play();
 	}
+
+	public static IReadOnlyList<(int Frequency, int Duration)> GetDefaultSequence(BeepType type) => type switch
+	{
+		BeepType.Start => new[] { (DefaultStartFrequency, DefaultStartDuration) },
+		BeepType.Success => DefaultSuccessSequence,
+		BeepType.Failure => Enumerable.Repeat((DefaultFailureFrequency, DefaultFailureDuration), DefaultFailureRepeats).ToArray(),
+		BeepType.End => new[] { (DefaultEndFrequency, DefaultEndDuration) },
+		BeepType.Mute => new[] { (DefaultMuteFrequency, DefaultMuteDuration) },
+		BeepType.Unmute => new[] { (DefaultUnmuteFrequency, DefaultUnmuteDuration) },
+		_ => throw new ArgumentOutOfRangeException(nameof(type))
+	};
 
 	// Plays an arbitrary .wav file for previewing (e.g. from the settings dialog),
 	// independent of the UseCustomBeeps toggle and the cached per-type players.
@@ -177,5 +183,11 @@ public static class BeepPlayer
 		_playerEnd = null;
 		_playerMute = null;
 		_playerUnmute = null;
+		foreach (var (player, stream) in _defaultPlayers.Values)
+		{
+			player.Dispose();
+			stream.Dispose();
+		}
+		_defaultPlayers.Clear();
 	}
 }

--- a/CognitiveSupport/BeepToneSynthesizer.cs
+++ b/CognitiveSupport/BeepToneSynthesizer.cs
@@ -1,0 +1,89 @@
+namespace CognitiveSupport;
+
+// Synthesizes Console.Beep-like square-wave tone sequences into in-memory WAV
+// data so default beeps can be played through the non-blocking SoundPlayer
+// path instead of the thread-blocking Console.Beep API.
+public static class BeepToneSynthesizer
+{
+	public const int SampleRate = 22050;
+	public const int InterSegmentGapMs = 50;
+	private const short Amplitude = 8000;
+	private const int FadeMs = 5;
+
+	// Builds a complete PCM 16-bit mono WAV containing the given tone segments,
+	// separated by short silences so consecutive beeps stay audibly distinct.
+	public static byte[] SynthesizeWav(IReadOnlyList<(int Frequency, int DurationMs)> segments)
+	{
+		ArgumentNullException.ThrowIfNull(segments);
+		if (segments.Count == 0)
+			throw new ArgumentException("At least one tone segment is required.", nameof(segments));
+
+		var samples = new List<short>();
+		for (var i = 0; i < segments.Count; i++)
+		{
+			if (i > 0)
+				samples.AddRange(new short[MsToSamples(InterSegmentGapMs)]);
+			AppendTone(samples, segments[i].Frequency, segments[i].DurationMs);
+		}
+
+		return WrapInWavContainer(samples);
+	}
+
+	private static int MsToSamples(int milliseconds) => SampleRate * milliseconds / 1000;
+
+	private static void AppendTone(List<short> samples, int frequency, int durationMs)
+	{
+		if (frequency <= 0)
+			throw new ArgumentOutOfRangeException(nameof(frequency));
+		if (durationMs <= 0)
+			throw new ArgumentOutOfRangeException(nameof(durationMs));
+
+		var count = MsToSamples(durationMs);
+		var fadeSamples = Math.Min(MsToSamples(FadeMs), count / 2);
+		var samplesPerHalfPeriod = Math.Max(1, SampleRate / (2 * frequency));
+
+		for (var i = 0; i < count; i++)
+		{
+			// Square wave, matching the timbre of Console.Beep.
+			var value = ((i / samplesPerHalfPeriod) % 2 == 0) ? Amplitude : (short)-Amplitude;
+
+			// Linear fade at both ends to avoid audible clicks.
+			double gain = 1.0;
+			if (fadeSamples > 0)
+			{
+				if (i < fadeSamples)
+					gain = (double)i / fadeSamples;
+				else if (i >= count - fadeSamples)
+					gain = (double)(count - 1 - i) / fadeSamples;
+			}
+			samples.Add((short)(value * gain));
+		}
+	}
+
+	private static byte[] WrapInWavContainer(List<short> samples)
+	{
+		const short bitsPerSample = 16;
+		const short channels = 1;
+		var dataByteCount = samples.Count * 2;
+
+		using var stream = new MemoryStream();
+		using var writer = new BinaryWriter(stream);
+		writer.Write("RIFF"u8);
+		writer.Write(36 + dataByteCount);
+		writer.Write("WAVE"u8);
+		writer.Write("fmt "u8);
+		writer.Write(16); // fmt chunk size
+		writer.Write((short)1); // PCM
+		writer.Write(channels);
+		writer.Write(SampleRate);
+		writer.Write(SampleRate * channels * bitsPerSample / 8); // byte rate
+		writer.Write((short)(channels * bitsPerSample / 8)); // block align
+		writer.Write(bitsPerSample);
+		writer.Write("data"u8);
+		writer.Write(dataByteCount);
+		foreach (var sample in samples)
+			writer.Write(sample);
+		writer.Flush();
+		return stream.ToArray();
+	}
+}

--- a/Mutation.Tests/BeepToneSynthesizerTests.cs
+++ b/Mutation.Tests/BeepToneSynthesizerTests.cs
@@ -1,0 +1,111 @@
+using CognitiveSupport;
+
+namespace Mutation.Tests;
+
+public class BeepToneSynthesizerTests
+{
+	private static byte[] Wav(params (int Frequency, int DurationMs)[] segments)
+		=> BeepToneSynthesizer.SynthesizeWav(segments);
+
+	private static short[] Samples(byte[] wav)
+	{
+		const int headerBytes = 44;
+		var samples = new short[(wav.Length - headerBytes) / 2];
+		Buffer.BlockCopy(wav, headerBytes, samples, 0, wav.Length - headerBytes);
+		return samples;
+	}
+
+	[Fact]
+	public void SynthesizeWav_ProducesValidRiffWaveHeader()
+	{
+		var wav = Wav((970, 80));
+
+		Assert.Equal("RIFF", System.Text.Encoding.ASCII.GetString(wav, 0, 4));
+		Assert.Equal("WAVE", System.Text.Encoding.ASCII.GetString(wav, 8, 4));
+		Assert.Equal("fmt ", System.Text.Encoding.ASCII.GetString(wav, 12, 4));
+		Assert.Equal("data", System.Text.Encoding.ASCII.GetString(wav, 36, 4));
+		Assert.Equal(wav.Length - 8, BitConverter.ToInt32(wav, 4));
+		Assert.Equal(wav.Length - 44, BitConverter.ToInt32(wav, 40));
+		Assert.Equal(1, BitConverter.ToInt16(wav, 20)); // PCM
+		Assert.Equal(1, BitConverter.ToInt16(wav, 22)); // mono
+		Assert.Equal(BeepToneSynthesizer.SampleRate, BitConverter.ToInt32(wav, 24));
+		Assert.Equal(16, BitConverter.ToInt16(wav, 34)); // bits per sample
+	}
+
+	[Fact]
+	public void SynthesizeWav_SingleSegment_HasExpectedSampleCount()
+	{
+		var wav = Wav((500, 200));
+
+		var expected = BeepToneSynthesizer.SampleRate * 200 / 1000;
+		Assert.Equal(expected, Samples(wav).Length);
+	}
+
+	[Fact]
+	public void SynthesizeWav_MultiSegment_IncludesGapsBetweenSegments()
+	{
+		var wav = Wav((300, 100), (300, 100), (300, 100));
+
+		var toneSamples = BeepToneSynthesizer.SampleRate * 100 / 1000;
+		var gapSamples = BeepToneSynthesizer.SampleRate * BeepToneSynthesizer.InterSegmentGapMs / 1000;
+		Assert.Equal(3 * toneSamples + 2 * gapSamples, Samples(wav).Length);
+	}
+
+	[Fact]
+	public void SynthesizeWav_ToneIsNotSilent()
+	{
+		var samples = Samples(Wav((970, 80)));
+
+		Assert.Contains(samples, s => Math.Abs((int)s) > 1000);
+	}
+
+	[Fact]
+	public void SynthesizeWav_GapBetweenSegmentsIsSilent()
+	{
+		var samples = Samples(Wav((300, 100), (300, 100)));
+
+		var toneSamples = BeepToneSynthesizer.SampleRate * 100 / 1000;
+		var gapSamples = BeepToneSynthesizer.SampleRate * BeepToneSynthesizer.InterSegmentGapMs / 1000;
+		var gap = samples.Skip(toneSamples).Take(gapSamples);
+		Assert.All(gap, s => Assert.Equal(0, s));
+	}
+
+	[Fact]
+	public void SynthesizeWav_EmptySequence_Throws()
+	{
+		Assert.Throws<ArgumentException>(() => Wav());
+	}
+
+	[Theory]
+	[InlineData(0, 100)]
+	[InlineData(440, 0)]
+	public void SynthesizeWav_InvalidSegment_Throws(int frequency, int durationMs)
+	{
+		Assert.Throws<ArgumentOutOfRangeException>(() => Wav((frequency, durationMs)));
+	}
+
+	[Theory]
+	[InlineData(BeepType.Start)]
+	[InlineData(BeepType.Success)]
+	[InlineData(BeepType.Failure)]
+	[InlineData(BeepType.End)]
+	[InlineData(BeepType.Mute)]
+	[InlineData(BeepType.Unmute)]
+	public void GetDefaultSequence_EveryBeepType_SynthesizesValidWav(BeepType type)
+	{
+		var sequence = BeepPlayer.GetDefaultSequence(type);
+
+		Assert.NotEmpty(sequence);
+		var wav = BeepToneSynthesizer.SynthesizeWav(sequence);
+		Assert.True(wav.Length > 44);
+	}
+
+	[Fact]
+	public void GetDefaultSequence_Failure_RepeatsThreeTimes()
+	{
+		var sequence = BeepPlayer.GetDefaultSequence(BeepType.Failure);
+
+		Assert.Equal(BeepPlayer.DefaultFailureRepeats, sequence.Count);
+		Assert.All(sequence, s => Assert.Equal((BeepPlayer.DefaultFailureFrequency, BeepPlayer.DefaultFailureDuration), s));
+	}
+}


### PR DESCRIPTION
Closes #169

## Summary

Default beeps were played with `Console.Beep`, which blocks the calling thread for the full beep duration — and every call site runs on the UI thread. A mute toggle froze the UI (including screen-reader UIA responses) for 200 ms, a failure beep for 300 ms.

This change synthesizes each default beep sequence once into an in-memory WAV (a square wave, matching the timbre of `Console.Beep`) and plays it through the same asynchronous `SoundPlayer` path that custom .wav beeps already use. `BeepPlayer.Play` is now non-blocking for defaults and custom beeps alike; no call sites needed changes.

Details:

- New `BeepToneSynthesizer` produces 16-bit mono PCM WAV data from a list of (frequency, duration) segments, with a 50 ms silence between segments so multi-beep sequences (success, the 3× failure beep) stay audibly distinct, and a 5 ms fade at each segment edge to avoid clicks.
- `BeepPlayer` lazily builds and caches one `SoundPlayer` per beep type from the synthesized WAV; the cache is disposed and rebuilt alongside the existing player lifecycle.
- The default tone definitions (frequencies, durations, repeat count) are unchanged, so the beeps sound the same as before.

## Test plan

- 10 new unit tests in `BeepToneSynthesizerTests` cover WAV header validity, sample counts, tone/gap content, argument validation, and that every `BeepType` has a synthesizable default sequence.
- Full suite: `dotnet test --configuration Release` — 572 passed, 0 failed.
- Manual check (recommended for reviewer): toggle mute with the hotkey and confirm the beep sounds correct and the UI/screen reader responds instantly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
