### PR TITLE
Send transcript paste as parseable Ctrl+V chord off the UI thread (#170)

### DIFF
--- a/Mutation.Tests/HotkeyTests.cs
+++ b/Mutation.Tests/HotkeyTests.cs
@@ -136,6 +136,29 @@ public class HotkeyTests
 		Assert.Throws<NotSupportedException>(() => Hotkey.Parse("Ctrl+Bogus"));
 	}
 
+	// ----- Paste chord (issue #170) -----
+
+	[Fact]
+	public void Parse_PasteChord_ParsesToControlV()
+	{
+		// The transcript-insertion paste path must use this exact chord so it
+		// takes the SendInput route instead of the SendKeys.SendWait fallback.
+		var hk = Hotkey.Parse("Ctrl+V");
+		Assert.True(hk.Control);
+		Assert.False(hk.Alt);
+		Assert.False(hk.Shift);
+		Assert.False(hk.Win);
+		Assert.Equal(VirtualKey.V, hk.Key);
+	}
+
+	[Fact]
+	public void Parse_CaretSyntax_IsNotSupported()
+	{
+		// "^v" is WinForms SendKeys syntax, not a parseable chord; sending it
+		// forced every paste through the exception-driven SendWait fallback.
+		Assert.Throws<NotSupportedException>(() => Hotkey.Parse("^v"));
+	}
+
 	// ----- ToString -----
 
 	[Fact]

--- a/Mutation.Ui/MainWindow.xaml.cs
+++ b/Mutation.Ui/MainWindow.xaml.cs
@@ -2008,11 +2008,15 @@ public sealed partial class MainWindow : Window, IDisposable
 		{
 			case DictationInsertOption.SendKeys:
 				BeepPlayer.Play(BeepType.Start);
-				HotkeyManager.SendText(text);
+				// Off the UI thread: SendInput can stall on the foreground app
+				// and must never block or pump messages mid-finalization.
+				_ = Task.Run(() => HotkeyManager.SendText(text));
 				break;
 			case DictationInsertOption.Paste:
 				_clipboard.SetText(text);
-				HotkeyManager.SendHotkey("^v");
+				// "Ctrl+V" (not "^v"): Hotkey.Parse has no caret syntax, so the
+				// literal would throw and drop to the SendKeys.SendWait fallback.
+				_ = Task.Run(() => HotkeyManager.SendHotkey("Ctrl+V"));
 				break;
 		}
 	}


### PR DESCRIPTION
Closes #170

## Summary

Every dictation, LLM-prompt, and format-transcript cycle ends by pasting the result into the active application. That paste was sent as the chord `"^v"`, which the app's hotkey parser does not understand — so every paste threw an exception, fell back to the WinForms `SendKeys.SendWait` API, and ran it synchronously on the UI thread. That blocked the window until the target application finished processing the keystrokes, and pumped messages while waiting, allowing hotkeys to re-enter mid-finalization.

Two changes in `InsertIntoActiveApplication`:

- The paste chord is now `"Ctrl+V"`, which parses correctly and takes the intended `SendInput` path. The `SendKeys` fallback remains only for genuine `SendInput` failures.
- Both insert options (Paste and SendKeys character injection) now dispatch the send to a background thread with `Task.Run`, mirroring the existing pattern in `SpeakActiveSelectionAsync`. The clipboard write stays on the UI thread. The up-to-200 ms modifier-release wait (common when dictation is stopped with SHIFT+ALT+U held) now happens off the UI thread.

## Tests

- `Parse_PasteChord_ParsesToControlV` — pins the exact chord the insertion path uses to Control+V, so the SendInput route is taken.
- `Parse_CaretSyntax_IsNotSupported` — documents that `"^v"` is rejected by the parser, guarding against reintroducing the literal.

## Test plan

- `dotnet test --configuration Release` — 590 passed, 0 failed.
- Manual: dictate into another app with insert option **Paste**; the transcript should appear via paste with no UI stall, and the success beep/status should fire immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
