### PR TITLE
Disable 100s HTTP client default timeouts capping configured timeouts

### DIFF
--- a/CognitiveSupport/AnthropicLlmService.cs
+++ b/CognitiveSupport/AnthropicLlmService.cs
@@ -32,6 +32,10 @@ public class AnthropicLlmService : ILlmService
 
 		_apiKey = apiKey;
 		_httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+		// HttpClient's default 100 s Timeout would silently cap the escalating
+		// per-attempt timeouts below; the per-attempt CancellationTokenSource in
+		// CreateChatCompletion is the sole timeout authority.
+		_httpClient.Timeout = Timeout.InfiniteTimeSpan;
 		_timeoutSeconds = timeoutSeconds > 0 ? timeoutSeconds : 60;
 		_retryCount = retryCount < 0 ? 0 : retryCount;
 		_modelConfigs = models.ToDictionary(m => m.Name, m => m, StringComparer.OrdinalIgnoreCase);

--- a/CognitiveSupport/LlmService.cs
+++ b/CognitiveSupport/LlmService.cs
@@ -33,7 +33,12 @@ public class LlmService : ILlmService
 
 		foreach (var model in modelList)
 		{
-			_chatClients[model.Name] = new ChatClient(model.Name, apiKey);
+			// Options disable the SDK's 100 s default network timeout so the
+			// escalating per-attempt timeouts below are the real authority.
+			_chatClients[model.Name] = new ChatClient(
+				model.Name,
+				new ApiKeyCredential(apiKey),
+				OpenAiClientOptionsFactory.Create());
 			_modelConfigs[model.Name] = model;
 		}
 	}

--- a/CognitiveSupport/OpenAiClientOptionsFactory.cs
+++ b/CognitiveSupport/OpenAiClientOptionsFactory.cs
@@ -1,0 +1,24 @@
+using OpenAI;
+
+namespace CognitiveSupport;
+
+/// <summary>
+/// Builds <see cref="OpenAIClientOptions"/> for every OpenAI SDK client the app
+/// creates. The SDK's default network timeout is 100 seconds, which silently
+/// caps the configurable escalating per-attempt timeouts (e.g. 300 s file
+/// transcription). The transport timeout is disabled here; per-attempt
+/// CancellationTokenSources remain the sole timeout authority.
+/// </summary>
+public static class OpenAiClientOptionsFactory
+{
+	public static OpenAIClientOptions Create(Uri? endpoint = null)
+	{
+		var options = new OpenAIClientOptions
+		{
+			NetworkTimeout = Timeout.InfiniteTimeSpan
+		};
+		if (endpoint is not null)
+			options.Endpoint = endpoint;
+		return options;
+	}
+}

--- a/Mutation.Tests/AnthropicLlmServiceTimeoutTests.cs
+++ b/Mutation.Tests/AnthropicLlmServiceTimeoutTests.cs
@@ -1,0 +1,20 @@
+using CognitiveSupport;
+
+namespace Mutation.Tests;
+
+public class AnthropicLlmServiceTimeoutTests
+{
+	[Fact]
+	public void Constructor_DisablesHttpClientTimeout()
+	{
+		using var httpClient = new HttpClient();
+		Assert.Equal(TimeSpan.FromSeconds(100), httpClient.Timeout);
+
+		_ = new AnthropicLlmService(
+			"test-key",
+			new[] { new LlmModelConfig("claude-fable-5", LlmProvider.Anthropic, customTemperature: null) },
+			httpClient);
+
+		Assert.Equal(Timeout.InfiniteTimeSpan, httpClient.Timeout);
+	}
+}

--- a/Mutation.Tests/OpenAiClientOptionsFactoryTests.cs
+++ b/Mutation.Tests/OpenAiClientOptionsFactoryTests.cs
@@ -1,0 +1,26 @@
+using CognitiveSupport;
+
+namespace Mutation.Tests;
+
+public class OpenAiClientOptionsFactoryTests
+{
+	[Fact]
+	public void Create_DisablesNetworkTimeout()
+	{
+		var options = OpenAiClientOptionsFactory.Create();
+
+		Assert.Equal(Timeout.InfiniteTimeSpan, options.NetworkTimeout);
+		Assert.Null(options.Endpoint);
+	}
+
+	[Fact]
+	public void Create_SetsEndpoint_WhenProvided()
+	{
+		var endpoint = new Uri("https://example.com/v1/");
+
+		var options = OpenAiClientOptionsFactory.Create(endpoint);
+
+		Assert.Equal(Timeout.InfiniteTimeSpan, options.NetworkTimeout);
+		Assert.Equal(endpoint, options.Endpoint);
+	}
+}

--- a/Mutation.Ui/App.xaml.cs
+++ b/Mutation.Ui/App.xaml.cs
@@ -548,13 +548,13 @@ public partial class App : Application
 			{
 				baseDomain = baseDomain.TrimEnd('/') + "/v1/";
 			}
-			var options = new OpenAIClientOptions { Endpoint = new Uri(baseDomain) };
+			var options = OpenAiClientOptionsFactory.Create(new Uri(baseDomain));
 			var client = new OpenAIClient(new ApiKeyCredential(apiKey), options);
 			audioClient = client.GetAudioClient(modelId);
 		}
 		else
 		{
-			audioClient = new AudioClient(modelId, new ApiKeyCredential(apiKey));
+			audioClient = new AudioClient(modelId, new ApiKeyCredential(apiKey), OpenAiClientOptionsFactory.Create());
 		}
 
 		return new OpenAiSpeechToTextService(


### PR DESCRIPTION
Closes #176

## Summary

The app lets the user configure escalating per-attempt timeouts for long transcriptions and LLM calls (120/180/240 s on retries, up to 300 s for file transcription), but the underlying HTTP clients kept their default transport timeout of about 100 seconds. Every request was therefore aborted at 100 s no matter what the user configured, so long uploads could never succeed.

This change disables the transport-level timeout in all three places and leaves the per-attempt `CancellationTokenSource` as the single timeout authority:

- `AnthropicLlmService` now sets the injected `HttpClient`'s `Timeout` to infinite in its constructor, so the fix applies regardless of how the client is registered.
- A new `OpenAiClientOptionsFactory` builds `OpenAIClientOptions` with `NetworkTimeout` disabled (and an optional endpoint), used when constructing the OpenAI `ChatClient`s in `LlmService` and both `AudioClient` variants for Whisper transcription in `App.xaml.cs`.

## Test plan

- New `AnthropicLlmServiceTimeoutTests` verifies the constructor replaces the 100 s default with an infinite timeout.
- New `OpenAiClientOptionsFactoryTests` verifies the factory disables the network timeout and honors a custom endpoint.
- Full suite: `dotnet test --configuration Release` — 591 passed, 0 failed.
- Manual check (optional): transcribe an uploaded audio file that takes longer than 100 s with a 300 s timeout configured; it should now complete instead of failing after repeated 100 s aborts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
