### PR TITLE
Announce Listening only after the recorder starts; bound the lock wait

### DIFF
--- a/Mutation.Tests/SpeechToTextManagerStartTimeoutTests.cs
+++ b/Mutation.Tests/SpeechToTextManagerStartTimeoutTests.cs
@@ -1,0 +1,129 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using CognitiveSupport;
+using Mutation.Ui;
+
+namespace Mutation.Tests;
+
+// Covers issue #177: starting a recording while a previous transcription still
+// holds the recorder lock must fail fast with RecorderBusyException instead of
+// waiting indefinitely, and a busy timeout must not leave an orphaned empty
+// session file behind.
+public class SpeechToTextManagerStartTimeoutTests : IDisposable
+{
+	private readonly string _tempDirectory;
+	private readonly Settings _settings;
+	private readonly SpeechToTextManager _manager;
+
+	public SpeechToTextManagerStartTimeoutTests()
+	{
+		_tempDirectory = Path.Combine(Path.GetTempPath(), "MutationTests_" + Guid.NewGuid().ToString("N"));
+		Directory.CreateDirectory(_tempDirectory);
+		_settings = new Settings
+		{
+			SpeechToTextSettings = new SpeechToTextSettings
+			{
+				TempDirectory = _tempDirectory
+			}
+		};
+		_manager = new SpeechToTextManager(_settings);
+	}
+
+	public void Dispose()
+	{
+		_manager.Dispose();
+		try
+		{
+			Directory.Delete(_tempDirectory, recursive: true);
+		}
+		catch (IOException)
+		{
+		}
+		catch (UnauthorizedAccessException)
+		{
+		}
+	}
+
+	private string CreateSessionFile()
+	{
+		string sessionsDirectory = Path.Combine(_tempDirectory, Constants.SessionsDirectoryName);
+		Directory.CreateDirectory(sessionsDirectory);
+		string path = Path.Combine(sessionsDirectory, "session_2026-01-01_00-00-00.ogg");
+		File.WriteAllBytes(path, new byte[] { 1, 2, 3 });
+		return path;
+	}
+
+	[Fact]
+	public async Task StartRecording_WhileTranscriptionHoldsLock_ThrowsRecorderBusy()
+	{
+		string sessionPath = CreateSessionFile();
+		var session = _manager.GetSessions().Single();
+
+		using var serviceEntered = new SemaphoreSlim(0);
+		using var releaseService = new SemaphoreSlim(0);
+		var service = new BlockingSpeechToTextService(serviceEntered, releaseService);
+
+		Task<string> transcription = _manager.TranscribeExistingRecordingAsync(
+			service, session, string.Empty, CancellationToken.None);
+
+		// Wait until the transcription is inside the service call, i.e. holding the lock.
+		Assert.True(await serviceEntered.WaitAsync(TimeSpan.FromSeconds(10)));
+
+		await Assert.ThrowsAsync<RecorderBusyException>(() =>
+			_manager.StartRecordingAsync(0, lockTimeout: TimeSpan.FromMilliseconds(100)));
+
+		releaseService.Release();
+		Assert.Equal("done", await transcription);
+	}
+
+	[Fact]
+	public async Task StartRecording_BusyTimeout_LeavesNoOrphanSessionFile()
+	{
+		string sessionPath = CreateSessionFile();
+		var session = _manager.GetSessions().Single();
+
+		using var serviceEntered = new SemaphoreSlim(0);
+		using var releaseService = new SemaphoreSlim(0);
+		var service = new BlockingSpeechToTextService(serviceEntered, releaseService);
+
+		Task<string> transcription = _manager.TranscribeExistingRecordingAsync(
+			service, session, string.Empty, CancellationToken.None);
+		Assert.True(await serviceEntered.WaitAsync(TimeSpan.FromSeconds(10)));
+
+		await Assert.ThrowsAsync<RecorderBusyException>(() =>
+			_manager.StartRecordingAsync(0, lockTimeout: TimeSpan.FromMilliseconds(100)));
+
+		releaseService.Release();
+		await transcription;
+
+		// Only the pre-existing session file may remain — the failed start must
+		// not have created a new empty one.
+		var remaining = _manager.GetSessions();
+		Assert.Single(remaining);
+		Assert.Equal(sessionPath, remaining[0].FilePath);
+	}
+
+	private sealed class BlockingSpeechToTextService : ISpeechToTextService
+	{
+		private readonly SemaphoreSlim _entered;
+		private readonly SemaphoreSlim _release;
+
+		public BlockingSpeechToTextService(SemaphoreSlim entered, SemaphoreSlim release)
+		{
+			_entered = entered;
+			_release = release;
+		}
+
+		public string ServiceName { get; init; } = "Blocking";
+
+		public async Task<string> ConvertAudioToText(string speechToTextPrompt, string audioffilePath, CancellationToken overallCancellationToken, int? timeoutSeconds = null)
+		{
+			_entered.Release();
+			await _release.WaitAsync(overallCancellationToken);
+			return "done";
+		}
+	}
+}

--- a/Mutation.Ui/Core/AudioSessionManager.cs
+++ b/Mutation.Ui/Core/AudioSessionManager.cs
@@ -171,14 +171,16 @@ public class AudioSessionManager : IDisposable
                 if (levelResult.Failed)
                     BeepPlayer.Play(BeepType.Failure);
 
+                // Announce "Listening" only after the recorder has actually
+                // started; announcing earlier would tell a screen-reader user
+                // the microphone is live while a lingering transcription still
+                // holds the recorder lock and audio is being lost.
+                var session = await _speechManager.StartRecordingAsync(_audioDeviceManager.MicrophoneDeviceIndex);
                 StatusMessage?.Invoke(this, levelResult.Failed
                     ? "Listening — but the pinned microphone level could not be applied; recording at the current level."
                     : "Listening for audio...");
-                StateChanged?.Invoke(this, EventArgs.Empty); // Notify UI to update buttons (Stop)
-
-                var session = await _speechManager.StartRecordingAsync(_audioDeviceManager.MicrophoneDeviceIndex);
                 RefreshSessions(session);
-                StateChanged?.Invoke(this, EventArgs.Empty);
+                StateChanged?.Invoke(this, EventArgs.Empty); // Notify UI to update buttons (Stop)
             }
             else
             {
@@ -206,6 +208,12 @@ public class AudioSessionManager : IDisposable
                     StateChanged?.Invoke(this, EventArgs.Empty);
                 }
             }
+        }
+        catch (RecorderBusyException)
+        {
+            BeepPlayer.Play(BeepType.Failure);
+            StatusMessage?.Invoke(this, "Still finishing the previous operation — try again shortly.");
+            StateChanged?.Invoke(this, EventArgs.Empty);
         }
         catch (Exception ex)
         {

--- a/Mutation.Ui/Core/RecorderBusyException.cs
+++ b/Mutation.Ui/Core/RecorderBusyException.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace Mutation.Ui;
+
+/// <summary>
+/// Thrown when a new recording cannot start because the audio recorder lock
+/// is still held by a previous operation (typically an in-flight
+/// transcription). Callers surface this as "still busy" feedback instead of
+/// a generic error.
+/// </summary>
+public sealed class RecorderBusyException : Exception
+{
+	public RecorderBusyException(string message)
+		: base(message)
+	{
+	}
+}

--- a/Mutation.Ui/Core/SpeechToTextManager.cs
+++ b/Mutation.Ui/Core/SpeechToTextManager.cs
@@ -132,16 +132,31 @@ public class SpeechToTextManager : IDisposable
 		}
 	}
 
-	public async Task<SpeechSession> StartRecordingAsync(int microphoneDeviceIndex)
-	{
-		EnsureSessionsDirectory();
-		string path = await CreateSessionFileAsync(".ogg").ConfigureAwait(false);
-		if (!TryCreateSession(path, out var session))
-			throw new InvalidOperationException($"Generated session path '{Path.GetFileName(path)}' could not be parsed.");
+	/// <summary>
+	/// Bounded wait for the recorder lock when starting a recording. A previous
+	/// transcription can hold the lock across its whole network call, so an
+	/// unbounded wait would leave the app claiming to listen while capturing
+	/// nothing. Tests inject a shorter value via <see cref="StartRecordingAsync(int, TimeSpan?)"/>.
+	/// </summary>
+	private static readonly TimeSpan DefaultStartRecordingLockTimeout = TimeSpan.FromSeconds(5);
 
-		await _state.AudioRecorderLock.WaitAsync().ConfigureAwait(false);
+	public async Task<SpeechSession> StartRecordingAsync(int microphoneDeviceIndex, TimeSpan? lockTimeout = null)
+	{
+		bool acquired = await _state.AudioRecorderLock
+			.WaitAsync(lockTimeout ?? DefaultStartRecordingLockTimeout)
+			.ConfigureAwait(false);
+		if (!acquired)
+			throw new RecorderBusyException("The previous operation is still finishing; recording could not start.");
+
 		try
 		{
+			// Create the session file only after winning the lock so a busy
+			// timeout leaves no orphaned empty session in the history.
+			EnsureSessionsDirectory();
+			string path = await CreateSessionFileAsync(".ogg").ConfigureAwait(false);
+			if (!TryCreateSession(path, out var session))
+				throw new InvalidOperationException($"Generated session path '{Path.GetFileName(path)}' could not be parsed.");
+
 			lock (_sessionLock)
 			{
 				_currentRecordingSession = session;
@@ -149,13 +164,13 @@ public class SpeechToTextManager : IDisposable
 
 			_audioRecorder = new CognitiveSupport.AudioRecorder();
 			_audioRecorder.StartRecording(microphoneDeviceIndex, path, BuildSilenceOptions());
+
+			return session;
 		}
 		finally
 		{
 			_state.AudioRecorderLock.Release();
 		}
-
-		return session;
 	}
 
 	public async Task<string> StopRecordingAndTranscribeAsync(ISpeechToTextService service, string prompt, CancellationToken token)


### PR DESCRIPTION
Closes #177

## Summary

The "Listening for audio..." status and the recording state change used to fire before the recorder actually started. Because `StartRecordingAsync` waited on the recorder lock with no timeout — and a lingering transcription holds that lock across its entire network call — the app could tell a screen-reader user it was listening while the microphone captured nothing, silently losing everything spoken.

This change makes the status line truthful and the wait bounded:

- **Announce after start.** `AudioSessionManager` now emits the "Listening" status and `StateChanged` only after `StartRecordingAsync` returns, so the announcement means the microphone is genuinely capturing.
- **Bounded lock wait.** `SpeechToTextManager.StartRecordingAsync` waits on the recorder lock for at most 5 seconds (injectable for tests). On timeout it throws the new `RecorderBusyException` instead of waiting forever.
- **Clear busy feedback.** `AudioSessionManager` catches that exception, plays the failure beep, and reports "Still finishing the previous operation — try again shortly." — an explicit signal in place of a silent, indefinite hang.
- **No orphan files.** The session file is now created only after the lock is won, so a busy timeout no longer leaves an empty session in the history.

## Test plan

- `SpeechToTextManagerStartTimeoutTests.StartRecording_WhileTranscriptionHoldsLock_ThrowsRecorderBusy` — a transcription holding the lock makes a recording start fail fast with `RecorderBusyException`.
- `SpeechToTextManagerStartTimeoutTests.StartRecording_BusyTimeout_LeavesNoOrphanSessionFile` — the failed start creates no empty session file.
- Full suite: `dotnet test --configuration Release` — 600 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
