### PR TITLE
Store dictation recordings in a user-private temp directory (#159)

### DIFF
--- a/Mutation.Tests/TempDirectoryMigrationTests.cs
+++ b/Mutation.Tests/TempDirectoryMigrationTests.cs
@@ -1,0 +1,121 @@
+using System;
+using System.IO;
+using CognitiveSupport;
+using Mutation.Ui.Services;
+using Mutation.Ui.Views.SettingsUi;
+
+namespace Mutation.Tests;
+
+// Covers the move of the default dictation temp directory from the
+// world-readable C:\Temp\Mutation to %LOCALAPPDATA%\Mutation (#159):
+// the settings rewrite rules and the best-effort recording migration.
+public class TempDirectoryMigrationTests : IDisposable
+{
+	private readonly string _root;
+
+	public TempDirectoryMigrationTests()
+	{
+		_root = Path.Combine(Path.GetTempPath(), $"mutation-tempdir-{Guid.NewGuid():N}");
+		Directory.CreateDirectory(_root);
+	}
+
+	public void Dispose()
+	{
+		if (Directory.Exists(_root))
+			Directory.Delete(_root, recursive: true);
+	}
+
+	private static Settings EnsureSettingsOn(string? tempDirectory)
+	{
+		var settings = new Settings
+		{
+			SpeechToTextSettings = new SpeechToTextSettings { TempDirectory = tempDirectory }
+		};
+		var manager = new SettingsManager("unused.json");
+		manager.EnsureSettings(settings, isNewFile: false);
+		return settings;
+	}
+
+	[Fact]
+	public void DefaultTempDirectory_IsUnderLocalAppData()
+	{
+		string localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+		Assert.StartsWith(localAppData, SettingsDefaults.Speech.TempDirectory, StringComparison.OrdinalIgnoreCase);
+	}
+
+	[Fact]
+	public void EnsureSettings_MissingTempDirectory_GetsProfileDefault()
+	{
+		var settings = EnsureSettingsOn(null);
+		Assert.Equal(SettingsDefaults.Speech.TempDirectory, settings.SpeechToTextSettings!.TempDirectory);
+	}
+
+	[Theory]
+	[InlineData(@"C:\Temp\Mutation")]
+	[InlineData(@"c:\temp\mutation")]
+	[InlineData(@"C:\Temp\Mutation\")]
+	public void EnsureSettings_LegacyDefault_IsRewrittenToProfileDefault(string legacy)
+	{
+		var settings = EnsureSettingsOn(legacy);
+		Assert.Equal(SettingsDefaults.Speech.TempDirectory, settings.SpeechToTextSettings!.TempDirectory);
+	}
+
+	[Fact]
+	public void EnsureSettings_CustomTempDirectory_IsKept()
+	{
+		var settings = EnsureSettingsOn(@"D:\MyRecordings");
+		Assert.Equal(@"D:\MyRecordings", settings.SpeechToTextSettings!.TempDirectory);
+	}
+
+	[Fact]
+	public void MigrateSessions_MovesRecordingsAndRemovesEmptyLegacyDirs()
+	{
+		string legacy = Path.Combine(_root, "legacy");
+		string target = Path.Combine(_root, "new");
+		string legacySessions = Path.Combine(legacy, "Sessions");
+		Directory.CreateDirectory(legacySessions);
+		File.WriteAllText(Path.Combine(legacySessions, "session_2026-01-01_10-00-00.ogg"), "audio");
+
+		SessionRecordingsMigrator.MigrateSessions(legacy, target);
+
+		Assert.True(File.Exists(Path.Combine(target, "Sessions", "session_2026-01-01_10-00-00.ogg")));
+		Assert.False(Directory.Exists(legacy));
+	}
+
+	[Fact]
+	public void MigrateSessions_DoesNotOverwriteExistingRecording()
+	{
+		string legacy = Path.Combine(_root, "legacy");
+		string target = Path.Combine(_root, "new");
+		Directory.CreateDirectory(Path.Combine(legacy, "Sessions"));
+		Directory.CreateDirectory(Path.Combine(target, "Sessions"));
+		File.WriteAllText(Path.Combine(legacy, "Sessions", "session_a.ogg"), "old");
+		File.WriteAllText(Path.Combine(target, "Sessions", "session_a.ogg"), "new");
+
+		SessionRecordingsMigrator.MigrateSessions(legacy, target);
+
+		Assert.Equal("new", File.ReadAllText(Path.Combine(target, "Sessions", "session_a.ogg")));
+	}
+
+	[Fact]
+	public void MigrateSessions_MissingLegacyDirectory_IsANoOp()
+	{
+		string target = Path.Combine(_root, "new");
+		SessionRecordingsMigrator.MigrateSessions(Path.Combine(_root, "absent"), target);
+		Assert.False(Directory.Exists(Path.Combine(target, "Sessions")));
+	}
+
+	[Fact]
+	public void MigrateSessions_LeavesNonSessionFilesBehind()
+	{
+		string legacy = Path.Combine(_root, "legacy");
+		string target = Path.Combine(_root, "new");
+		string legacySessions = Path.Combine(legacy, "Sessions");
+		Directory.CreateDirectory(legacySessions);
+		File.WriteAllText(Path.Combine(legacySessions, "notes.txt"), "keep");
+
+		SessionRecordingsMigrator.MigrateSessions(legacy, target);
+
+		Assert.True(File.Exists(Path.Combine(legacySessions, "notes.txt")));
+	}
+}

--- a/Mutation.Ui/Services/SessionRecordingsMigrator.cs
+++ b/Mutation.Ui/Services/SessionRecordingsMigrator.cs
@@ -1,0 +1,69 @@
+using CognitiveSupport;
+using System;
+using System.IO;
+
+namespace Mutation.Ui.Services;
+
+// Moves retained dictation recordings from the old world-readable default
+// (C:\Temp\Mutation) into the new user-profile temp directory the first time
+// settings are upgraded. Best-effort: a file that cannot be moved is left
+// behind rather than failing startup — the recordings are convenience data,
+// not something worth blocking the app over.
+internal static class SessionRecordingsMigrator
+{
+	internal static void MigrateSessions(string legacyTempDirectory, string newTempDirectory)
+	{
+		try
+		{
+			string legacySessions = Path.Combine(legacyTempDirectory, Constants.SessionsDirectoryName);
+			string newSessions = Path.Combine(newTempDirectory, Constants.SessionsDirectoryName);
+
+			if (!Directory.Exists(legacySessions))
+				return;
+			if (string.Equals(Path.GetFullPath(legacySessions), Path.GetFullPath(newSessions), StringComparison.OrdinalIgnoreCase))
+				return;
+
+			Directory.CreateDirectory(newSessions);
+
+			foreach (string file in Directory.GetFiles(legacySessions, "session_*"))
+			{
+				string destination = Path.Combine(newSessions, Path.GetFileName(file));
+				try
+				{
+					if (!File.Exists(destination))
+						File.Move(file, destination);
+				}
+				catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+				{
+					ErrorLogger.LogInfo("SessionMigration", $"Could not move '{file}' to '{destination}'");
+					ErrorLogger.LogError("SessionMigration", ex);
+				}
+			}
+
+			TryDeleteIfEmpty(legacySessions);
+			TryDeleteIfEmpty(legacyTempDirectory);
+		}
+		catch (Exception ex)
+		{
+			ErrorLogger.LogError("SessionMigration", ex);
+		}
+	}
+
+	private static void TryDeleteIfEmpty(string directory)
+	{
+		try
+		{
+			if (Directory.Exists(directory)
+				&& Directory.GetFiles(directory).Length == 0
+				&& Directory.GetDirectories(directory).Length == 0)
+			{
+				Directory.Delete(directory);
+			}
+		}
+		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+		{
+			ErrorLogger.LogInfo("SessionMigration", $"Could not remove empty legacy directory '{directory}'");
+			ErrorLogger.LogError("SessionMigration", ex);
+		}
+	}
+}

--- a/Mutation.Ui/Services/SettingsManager.cs
+++ b/Mutation.Ui/Services/SettingsManager.cs
@@ -1,4 +1,5 @@
 ﻿using CognitiveSupport;
+using Mutation.Ui.Views.SettingsUi;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Linq;
@@ -346,7 +347,14 @@ internal class SettingsManager : ISettingsManager
 		}
 		if (string.IsNullOrWhiteSpace(speechToTextSettings.TempDirectory))
 		{
-			speechToTextSettings.TempDirectory = @"C:\Temp\Mutation";
+			speechToTextSettings.TempDirectory = SettingsDefaults.Speech.TempDirectory;
+			somethingWasMissing = true;
+		}
+		else if (IsLegacyTempDirectory(speechToTextSettings.TempDirectory))
+		{
+			// The old default under C:\ was readable by every local user; only an
+			// unchanged default is rewritten — an explicitly different path is kept.
+			speechToTextSettings.TempDirectory = SettingsDefaults.Speech.TempDirectory;
 			somethingWasMissing = true;
 		}
 
@@ -974,6 +982,14 @@ End of summary.
 		}
 	}
 
+	internal static bool IsLegacyTempDirectory(string? tempDirectory)
+	{
+		if (string.IsNullOrWhiteSpace(tempDirectory))
+			return false;
+		string normalized = tempDirectory.Trim().TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+		return string.Equals(normalized, SettingsDefaults.Speech.LegacyTempDirectory, StringComparison.OrdinalIgnoreCase);
+	}
+
 	public void SaveSettingsToFile(Settings settings)
 	{
 		string json = JsonConvert.SerializeObject(settings, Formatting.Indented, _jsonSerializerSettings);
@@ -1009,9 +1025,18 @@ End of summary.
         string json = File.ReadAllText(SettingsFileFullPath);
         Settings settings = JsonConvert.DeserializeObject<Settings>(json, _jsonSerializerSettings) ?? new Settings();
 
+        bool hadLegacyTempDirectory = IsLegacyTempDirectory(settings.SpeechToTextSettings?.TempDirectory);
+
         if (EnsureSettings(settings, isNewFile: newFile))
         {
             SaveSettingsToFile(settings);
+        }
+
+        if (hadLegacyTempDirectory)
+        {
+            SessionRecordingsMigrator.MigrateSessions(
+                SettingsDefaults.Speech.LegacyTempDirectory,
+                settings.SpeechToTextSettings!.TempDirectory!);
         }
 
         return settings;

--- a/Mutation.Ui/Views/Settings/SettingsDefaults.cs
+++ b/Mutation.Ui/Views/Settings/SettingsDefaults.cs
@@ -1,4 +1,6 @@
 using CognitiveSupport;
+using System;
+using System.IO;
 
 namespace Mutation.Ui.Views.SettingsUi;
 
@@ -38,7 +40,13 @@ internal static class SettingsDefaults
 	{
 		public const string SpeechToTextHotKey = "SHIFT+ALT+U";
 		public const string SpeechToTextWithLlmProcessingHotKey = "SHIFT+ALT+I";
-		public const string TempDirectory = @"C:\Temp\Mutation";
+		// Recordings hold dictated speech (often personal or sensitive), so the
+		// default lives under the user profile where ACLs block other local users.
+		// The pre-existing C:\Temp default was world-readable; EnsureSettings
+		// rewrites it and session files are migrated on first run.
+		public static readonly string TempDirectory = Path.Combine(
+			Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Mutation");
+		public const string LegacyTempDirectory = @"C:\Temp\Mutation";
 		public const int FileTranscriptionTimeoutSeconds = 300;
 		// Retained-session count: default and UI bounds mirror the domain so the dialog,
 		// the load-time clamp, and cleanup all agree on one source of truth.


### PR DESCRIPTION
Closes #159

## Summary

Dictation recordings were retained under the default temp directory `C:\Temp\Mutation`. Directories created directly under `C:\` are readable by every local user, so on a shared machine other users could read the retained voice recordings.

This change moves the default to the user profile and migrates existing recordings:

- The default `TempDirectory` is now `%LOCALAPPDATA%\Mutation`, defined once in `SettingsDefaults.Speech` and used by `SettingsManager.EnsureSettings`, so it inherits the user profile's access control instead of the world-readable `C:\` defaults.
- On load, a settings file still holding the old default (`C:\Temp\Mutation`, compared case-insensitively and ignoring a trailing slash) is rewritten to the new default. A path the user explicitly changed to anything else is left untouched.
- When that rewrite happens, a new `SessionRecordingsMigrator` moves the retained `session_*` files from the old `Sessions` folder to the new one. The move is best effort: a file that cannot be moved is logged and left behind, an existing file at the destination is never overwritten, and the old directories are removed only when empty. Migration failures never block startup.
- The directory remains fully configurable in the Speech settings page; the "reset to default" action there now produces the new profile-local path automatically.

The issue also suggested considering a "delete recordings on exit" toggle. That is a separate feature rather than part of this security fix, and is not included here.

## Test plan

- New `TempDirectoryMigrationTests` (8 tests): default lives under `%LOCALAPPDATA%`; a missing or legacy-default `TempDirectory` is rewritten while a custom path is kept; the migrator moves recordings, removes emptied legacy folders, never overwrites existing destination files, leaves non-session files behind, and no-ops when there is nothing to migrate.
- Existing `SettingsDefaultsParityTests` confirms the dialog default and `EnsureSettings` stay in sync with the new value.
- Full quality gate: `dotnet test --configuration Release` — 608 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
