### PR TITLE
Surface settings save failures with InfoBar, UIA announcement, and beep

### DIFF
--- a/Mutation.Tests/SettingsFailureFeedbackTests.cs
+++ b/Mutation.Tests/SettingsFailureFeedbackTests.cs
@@ -1,0 +1,59 @@
+using System;
+using System.IO;
+using Mutation.Ui.Views.SettingsUi;
+using Xunit;
+
+namespace Mutation.Tests;
+
+public class SettingsFailureFeedbackTests
+{
+	[Fact]
+	public void ComposeMessage_IncludesExceptionMessageAndRetryGuidance()
+	{
+		string message = SettingsFailureFeedback.ComposeMessage(
+			new IOException("The file is locked by another process."));
+
+		Assert.StartsWith("The file is locked by another process.", message);
+		Assert.Contains("Your changes were not saved.", message);
+		Assert.Contains("press Save again", message);
+	}
+
+	[Fact]
+	public void ComposeMessage_UnwrapsToInnermostException()
+	{
+		var wrapped = new InvalidOperationException(
+			"Serialization failed.",
+			new UnauthorizedAccessException("Access to the path is denied."));
+
+		string message = SettingsFailureFeedback.ComposeMessage(wrapped);
+
+		Assert.StartsWith("Access to the path is denied.", message);
+		Assert.DoesNotContain("Serialization failed.", message);
+	}
+
+	[Fact]
+	public void ComposeMessage_NullException_UsesFallbackText()
+	{
+		string message = SettingsFailureFeedback.ComposeMessage(null);
+
+		Assert.StartsWith("An unknown error occurred.", message);
+		Assert.Contains("Your changes were not saved.", message);
+	}
+
+	[Fact]
+	public void ComposeMessage_BlankExceptionMessage_UsesFallbackText()
+	{
+		string message = SettingsFailureFeedback.ComposeMessage(new Exception("   "));
+
+		Assert.StartsWith("An unknown error occurred.", message);
+	}
+
+	[Fact]
+	public void ComposeOpenJsonMessage_ReturnsInnermostDetailOnly()
+	{
+		string message = SettingsFailureFeedback.ComposeOpenJsonMessage(
+			new Exception("outer", new Exception("No application is associated.")));
+
+		Assert.Equal("No application is associated.", message);
+	}
+}

--- a/Mutation.Ui/Views/Settings/SettingsFailureFeedback.cs
+++ b/Mutation.Ui/Views/Settings/SettingsFailureFeedback.cs
@@ -1,0 +1,30 @@
+using System;
+
+namespace Mutation.Ui.Views.SettingsUi;
+
+// Composes the user-facing text shown (and announced via UIA) when a Settings
+// dialog operation fails — saving the settings file or opening it in an
+// external editor. Kept free of WinUI types so it is unit-testable.
+public static class SettingsFailureFeedback
+{
+	public const string SaveTitle = "Save failed";
+	public const string OpenJsonTitle = "Could not open settings file";
+
+	public static string ComposeMessage(Exception? exception) =>
+		$"{ExtractDetail(exception)} Your changes were not saved. Fix the problem and press Save again, or press Cancel to discard the changes.";
+
+	public static string ComposeOpenJsonMessage(Exception? exception) =>
+		ExtractDetail(exception);
+
+	// Innermost exception message — the actionable cause (e.g. the IOException
+	// under a serialization wrapper), not the generic outer wrapper text.
+	private static string ExtractDetail(Exception? exception)
+	{
+		Exception? innermost = exception;
+		while (innermost?.InnerException is not null)
+			innermost = innermost.InnerException;
+
+		string detail = innermost?.Message?.Trim() ?? string.Empty;
+		return detail.Length == 0 ? "An unknown error occurred." : detail;
+	}
+}

--- a/Mutation.Ui/Views/SettingsDialog.xaml
+++ b/Mutation.Ui/Views/SettingsDialog.xaml
@@ -36,6 +36,7 @@
 			<RowDefinition Height="Auto" />
 			<RowDefinition Height="*" />
 			<RowDefinition Height="Auto" />
+			<RowDefinition Height="Auto" />
 		</Grid.RowDefinitions>
 		<Grid.ColumnDefinitions>
 			<ColumnDefinition Width="280" />
@@ -103,7 +104,13 @@
 			</ScrollViewer>
 		</Border>
 
-		<StackPanel Grid.Row="2" Grid.ColumnSpan="2"
+		<InfoBar x:Name="SaveErrorBar"
+				 Grid.Row="2" Grid.ColumnSpan="2"
+				 Severity="Error"
+				 IsOpen="False"
+				 IsClosable="True" />
+
+		<StackPanel Grid.Row="3" Grid.ColumnSpan="2"
 					Orientation="Horizontal"
 					Spacing="12"
 					HorizontalAlignment="Right"

--- a/Mutation.Ui/Views/SettingsDialog.xaml.cs
+++ b/Mutation.Ui/Views/SettingsDialog.xaml.cs
@@ -9,6 +9,7 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
 using Windows.System;
 using CognitiveSupport;
+using Mutation.Ui.Core;
 using Mutation.Ui.Services;
 using Mutation.Ui.Views.SettingsUi;
 using Mutation.Ui.Views.SettingsUi.Pages;
@@ -223,7 +224,28 @@ public sealed partial class SettingsDialog : ContentDialog
 		catch (Exception ex)
 		{
 			System.Diagnostics.Debug.WriteLine($"Failed to open settings JSON: {ex.Message}");
+			ShowFailure(SettingsFailureFeedback.OpenJsonTitle, SettingsFailureFeedback.ComposeOpenJsonMessage(ex));
 		}
+	}
+
+	// Surfaces a failure inside the dialog: error InfoBar for sighted users,
+	// an assertive UIA notification for screen readers, and the failure beep.
+	private void ShowFailure(string title, string message)
+	{
+		SaveErrorBar.Title = title;
+		SaveErrorBar.Message = message;
+		SaveErrorBar.IsOpen = true;
+		AutomationProperties.SetName(SaveErrorBar, $"{title} status");
+		AutomationProperties.SetHelpText(SaveErrorBar, message);
+
+		var peer = Microsoft.UI.Xaml.Automation.Peers.FrameworkElementAutomationPeer.CreatePeerForElement(SaveErrorBar);
+		peer?.RaiseNotificationEvent(
+			StatusAnnouncement.GetKind(InfoBarSeverity.Error),
+			StatusAnnouncement.GetProcessing(InfoBarSeverity.Error),
+			StatusAnnouncement.ComposeText(title, message),
+			StatusAnnouncement.ActivityId);
+
+		BeepPlayer.Play(BeepType.Failure);
 	}
 
 	private void SettingsDialog_PrimaryButtonClick(ContentDialog sender, ContentDialogButtonClickEventArgs args)
@@ -238,6 +260,7 @@ public sealed partial class SettingsDialog : ContentDialog
 		{
 			args.Cancel = true;
 			System.Diagnostics.Debug.WriteLine($"SettingsDialog save failed: {ex}");
+			ShowFailure(SettingsFailureFeedback.SaveTitle, SettingsFailureFeedback.ComposeMessage(ex));
 		}
 	}
 


### PR DESCRIPTION
## Summary

When saving settings failed (a locked file, read-only disk, or serialization error), the Settings dialog silently refused to close: the exception was swallowed, and the only trace was a debug-output line. A screen-reader user pressing Save had no way to tell the press even registered.

This change surfaces the failure three ways, keeping the dialog open so the user can retry or copy their values:

- An error InfoBar inside the dialog shows what went wrong, with guidance to fix and press Save again or Cancel to discard.
- A UIA notification (assertive, interrupting) announces the failure to screen readers, using the existing `StatusAnnouncement` mapping.
- The failure beep plays, matching the app's audio-feedback conventions.

The same feedback now applies when the "Open Mutation.json" button fails to launch an external editor.

Message composition lives in a new WinUI-free helper, `SettingsFailureFeedback`, which unwraps to the innermost exception message (the actionable cause) and falls back to generic text when no message is available.

Closes #165

## Test plan

- 5 new unit tests in `SettingsFailureFeedbackTests` cover message composition: retry guidance included, innermost exception unwrapping, null-exception and blank-message fallbacks, and open-JSON detail-only text.
- Full quality gate: `dotnet test --configuration Release` — 605 passed, 0 failed.
- Manual check (recommended for a reviewer with the app running): make `Mutation.json` read-only, open Settings, change a value, press Save — the dialog should stay open, show the error InfoBar, announce it via the screen reader, and play the failure beep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
