### PR TITLE
Make settings search screen-reader accessible; name search box and Advanced toggle

### DIFF
--- a/Mutation.Tests/SettingsSearchStatusTests.cs
+++ b/Mutation.Tests/SettingsSearchStatusTests.cs
@@ -1,0 +1,48 @@
+using Mutation.Ui.Views.SettingsUi;
+
+namespace Mutation.Tests;
+
+public class SettingsSearchStatusTests
+{
+	[Theory]
+	[InlineData(null)]
+	[InlineData("")]
+	[InlineData("   ")]
+	public void Compose_EmptyQuery_ReturnsEmpty(string? query)
+	{
+		Assert.Equal(string.Empty, SettingsSearchStatus.Compose(query, 9, 9, 5));
+	}
+
+	[Fact]
+	public void Compose_NoCategoryMatches_SaysNoMatch()
+	{
+		Assert.Equal("No categories match.", SettingsSearchStatus.Compose("zzz", 0, 9, null));
+	}
+
+	[Fact]
+	public void Compose_NoPageLoaded_ReportsCategoriesOnly()
+	{
+		Assert.Equal("3 of 9 categories match.", SettingsSearchStatus.Compose("audio", 3, 9, null));
+	}
+
+	[Fact]
+	public void Compose_WithPageMatches_ReportsBothCounts()
+	{
+		Assert.Equal("3 of 9 categories match. 2 matching sections shown on this page.",
+			SettingsSearchStatus.Compose("audio", 3, 9, 2));
+	}
+
+	[Fact]
+	public void Compose_SingleSectionMatch_UsesSingular()
+	{
+		Assert.Equal("1 of 9 categories match. 1 matching section shown on this page.",
+			SettingsSearchStatus.Compose("mute", 1, 9, 1));
+	}
+
+	[Fact]
+	public void Compose_ZeroSectionsOnMatchingPage_ReportsZero()
+	{
+		Assert.Equal("2 of 9 categories match. 0 matching sections shown on this page.",
+			SettingsSearchStatus.Compose("key", 2, 9, 0));
+	}
+}

--- a/Mutation.Ui/Views/Settings/SettingsSearchHelper.cs
+++ b/Mutation.Ui/Views/Settings/SettingsSearchHelper.cs
@@ -7,16 +7,18 @@ using Microsoft.UI.Xaml.Media;
 namespace Mutation.Ui.Views.SettingsUi;
 
 // Walks the top-level children of a settings page's root Panel, gathers the
-// visible text underneath each child, and dims children whose text doesn't
-// contain the query. Empty query restores full opacity.
+// visible text underneath each child, and collapses children whose text doesn't
+// contain the query. Collapsing (rather than dimming) removes non-matching
+// sections from the tab order and the screen-reader tree, so search results are
+// perceivable without sight. Empty query restores all sections.
+// Returns the number of sections that match (all sections for an empty query).
 internal static class SettingsSearchHelper
 {
-	private const double DimmedOpacity = 0.35;
-
-	public static void ApplyFilter(Panel root, string query)
+	public static int ApplyFilter(Panel root, string query)
 	{
 		string q = (query ?? string.Empty).Trim().ToLowerInvariant();
 		bool noQuery = q.Length == 0;
+		int matches = 0;
 
 		foreach (UIElement child in root.Children)
 		{
@@ -25,13 +27,18 @@ internal static class SettingsSearchHelper
 
 			if (noQuery)
 			{
-				fe.Opacity = 1.0;
+				fe.Visibility = Visibility.Visible;
+				matches++;
 				continue;
 			}
 
-			string text = CollectText(fe).ToLowerInvariant();
-			fe.Opacity = text.Contains(q) ? 1.0 : DimmedOpacity;
+			bool isMatch = CollectText(fe).ToLowerInvariant().Contains(q);
+			fe.Visibility = isMatch ? Visibility.Visible : Visibility.Collapsed;
+			if (isMatch)
+				matches++;
 		}
+
+		return matches;
 	}
 
 	private static string CollectText(DependencyObject root)

--- a/Mutation.Ui/Views/Settings/SettingsSearchStatus.cs
+++ b/Mutation.Ui/Views/Settings/SettingsSearchStatus.cs
@@ -1,0 +1,35 @@
+namespace Mutation.Ui.Views.SettingsUi;
+
+// Composes the search-status text shown under the settings search box and
+// announced through its live region. Pure logic, no UI types, so it is
+// unit-testable in isolation (same pattern as StatusAnnouncement).
+public static class SettingsSearchStatus
+{
+	/// <summary>
+	/// Builds the status line for the current search state.
+	/// Returns an empty string when the query is empty (nothing to report).
+	/// </summary>
+	/// <param name="query">The raw search box text.</param>
+	/// <param name="matchingCategories">Categories whose keywords match the query.</param>
+	/// <param name="totalCategories">Total number of settings categories.</param>
+	/// <param name="matchingSections">Sections on the active page that match, or null when no page is loaded yet.</param>
+	public static string Compose(string? query, int matchingCategories, int totalCategories, int? matchingSections)
+	{
+		if (string.IsNullOrWhiteSpace(query))
+			return string.Empty;
+
+		if (matchingCategories == 0)
+			return "No categories match.";
+
+		string categories = $"{matchingCategories} of {totalCategories} categories match.";
+
+		if (matchingSections is null)
+			return categories;
+
+		string sections = matchingSections == 1
+			? "1 matching section shown on this page."
+			: $"{matchingSections} matching sections shown on this page.";
+
+		return $"{categories} {sections}";
+	}
+}

--- a/Mutation.Ui/Views/SettingsDialog.xaml
+++ b/Mutation.Ui/Views/SettingsDialog.xaml
@@ -42,14 +42,20 @@
 			<ColumnDefinition Width="*" />
 		</Grid.ColumnDefinitions>
 
-		<TextBox x:Name="SearchBox"
-				 Grid.Row="0" Grid.Column="0"
-				 PlaceholderText="Search settings..."
-				 TextChanged="SearchBox_TextChanged">
-			<TextBox.Resources>
-				<Style TargetType="TextBox" BasedOn="{StaticResource DefaultTextBoxStyle}" />
-			</TextBox.Resources>
-		</TextBox>
+		<StackPanel Grid.Row="0" Grid.Column="0" Spacing="4">
+			<TextBox x:Name="SearchBox"
+					 PlaceholderText="Search settings..."
+					 AutomationProperties.Name="Search settings"
+					 TextChanged="SearchBox_TextChanged">
+				<TextBox.Resources>
+					<Style TargetType="TextBox" BasedOn="{StaticResource DefaultTextBoxStyle}" />
+				</TextBox.Resources>
+			</TextBox>
+			<TextBlock x:Name="SearchStatusText"
+					   Style="{StaticResource CaptionTextBlockStyle}"
+					   AutomationProperties.LiveSetting="Polite"
+					   Visibility="Collapsed" />
+		</StackPanel>
 
 		<TextBlock x:Name="ActiveCategoryHeader"
 				   Grid.Row="0" Grid.Column="1"
@@ -109,6 +115,7 @@
 					HorizontalAlignment="Right"
 					VerticalAlignment="Center">
 			<ToggleSwitch x:Name="AdvancedToggle"
+						  AutomationProperties.Name="Advanced settings"
 						  OffContent="Advanced"
 						  OnContent="Advanced"
 						  Toggled="AdvancedToggle_Toggled" />

--- a/Mutation.Ui/Views/SettingsDialog.xaml.cs
+++ b/Mutation.Ui/Views/SettingsDialog.xaml.cs
@@ -171,13 +171,16 @@ public sealed partial class SettingsDialog : ContentDialog
 		PageHost.Content = _activePage;
 
 		// Re-apply any active search query against the freshly loaded page so a user
-		// who typed before switching tabs immediately sees matches highlighted on the new tab.
+		// who typed before switching tabs immediately sees matches on the new tab.
 		if (_activePage is UserControl uc && uc.Content is Panel rootPanel
 			&& !string.IsNullOrWhiteSpace(SearchBox?.Text))
 		{
 			// Defer until after the visual tree is populated — VisualTreeHelper requires a live tree.
 			DispatcherQueue.TryEnqueue(() =>
-				SettingsSearchHelper.ApplyFilter(rootPanel, SearchBox.Text));
+			{
+				int sectionMatches = SettingsSearchHelper.ApplyFilter(rootPanel, SearchBox.Text);
+				UpdateSearchStatus(sectionMatches);
+			});
 		}
 	}
 
@@ -197,13 +200,27 @@ public sealed partial class SettingsDialog : ContentDialog
 		ApplySearchFilter(SearchBox.Text);
 		if (FilteredCategories.Count > 0 && CategoryList.SelectedIndex < 0)
 			CategoryList.SelectedIndex = 0;
-		HighlightActivePage();
+		UpdateSearchStatus(FilterActivePage());
 	}
 
-	private void HighlightActivePage()
+	// Applies the current query to the active page, collapsing non-matching
+	// sections. Returns the section match count, or null when no page is loaded.
+	private int? FilterActivePage()
 	{
 		if (PageHost.Content is FrameworkElement page && page is UserControl uc && uc.Content is Panel rootPanel)
-			SettingsSearchHelper.ApplyFilter(rootPanel, SearchBox.Text ?? string.Empty);
+			return SettingsSearchHelper.ApplyFilter(rootPanel, SearchBox.Text ?? string.Empty);
+		return null;
+	}
+
+	// Reflects the current match state in the status line under the search box.
+	// The TextBlock is a polite live region, so updating its text announces the
+	// result to a screen reader without moving focus.
+	private void UpdateSearchStatus(int? sectionMatches)
+	{
+		string status = SettingsSearchStatus.Compose(
+			SearchBox.Text, FilteredCategories.Count, _allCategories.Count, sectionMatches);
+		SearchStatusText.Text = status;
+		SearchStatusText.Visibility = status.Length == 0 ? Visibility.Collapsed : Visibility.Visible;
 	}
 
 	private void AdvancedToggle_Toggled(object sender, RoutedEventArgs e)


### PR DESCRIPTION
## Summary

The settings dialog has a search box that filters a nine-category settings panel. Until now it signalled matches only by dimming non-matching sections to 35% opacity. Dimmed controls keep their tab stops and read identically to a screen reader, so search results were invisible to the app's primary user (a blind developer), and 35% opacity is poor contrast under ZoomText. Two pieces of dialog chrome were also unlabeled.

This change makes the search perceivable without sight:

- **Non-matching sections are now collapsed, not dimmed.** Collapsing removes them from the tab order and the screen-reader tree, so what remains after a search is exactly the set of matches — reachable by keyboard and announced by the screen reader. An empty query restores every section.
- **A status line under the search box announces the result.** It is a visible caption that doubles as a polite live region, so each search updates a message like "3 of 9 categories match. 2 matching sections shown on this page." without moving focus. A visible status (rather than a hidden one) matches the project preference for exposed controls.
- **The search box and the Advanced toggle now have accessible names** (`AutomationProperties.Name`), so they no longer read as unnamed controls.

The match-counting text is composed by a new pure helper (`SettingsSearchStatus`) with no UI dependencies, so it is unit-tested in isolation — the same pattern the codebase already uses for `StatusAnnouncement`.

## Test plan

- `dotnet test --configuration Release` — all 618 tests pass, including six new `SettingsSearchStatusTests` covering the empty query, no-match, categories-only, both-counts, singular/plural section wording, and zero-section cases.
- Manual (screen reader): open Settings, type a query, and confirm non-matching categories and sections disappear from tab navigation and the status line is announced; clear the query and confirm all sections return; confirm the search box and Advanced toggle announce their names.

Closes #166
