### PR TITLE
Queue dialogs requested while another is open instead of dropping them (#167)

### DIFF
--- a/Mutation.Tests/DialogQueueTests.cs
+++ b/Mutation.Tests/DialogQueueTests.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Mutation.Ui.Core;
+using Xunit;
+
+namespace Mutation.Tests;
+
+public class DialogQueueTests
+{
+	[Fact]
+	public async Task SingleDialog_ShowsImmediately_AndReturnsItsResult()
+	{
+		var queue = new DialogQueue<int>();
+
+		int result = await queue.EnqueueAsync(() => Task.FromResult(42));
+
+		Assert.Equal(42, result);
+		Assert.False(queue.IsBusy);
+		Assert.Equal(0, queue.PendingCount);
+	}
+
+	[Fact]
+	public async Task SecondDialog_IsQueuedAndShownWhenFirstCloses_InFifoOrder()
+	{
+		var queue = new DialogQueue<int>();
+		// Default TaskCompletionSource (inline continuations) so the queue's
+		// pump advances synchronously on this thread the moment a gate is
+		// completed — keeps the test deterministic and single-threaded, which
+		// mirrors the queue's UI-dispatcher affinity.
+		var gateA = new TaskCompletionSource<int>();
+		var gateB = new TaskCompletionSource<int>();
+		var shownOrder = new List<string>();
+
+		Task<int> first = queue.EnqueueAsync(() => { shownOrder.Add("A"); return gateA.Task; });
+		Task<int> second = queue.EnqueueAsync(() => { shownOrder.Add("B"); return gateB.Task; });
+
+		// A is on screen; B has not started and is waiting behind it.
+		Assert.Equal(new[] { "A" }, shownOrder);
+		Assert.True(queue.IsBusy);
+		Assert.Equal(1, queue.PendingCount);
+
+		// Closing A lets the queue show B next.
+		gateA.SetResult(1);
+		Assert.Equal(new[] { "A", "B" }, shownOrder);
+		Assert.Equal(0, queue.PendingCount);
+		Assert.True(queue.IsBusy);
+
+		// Closing B drains the queue.
+		gateB.SetResult(2);
+		Assert.False(queue.IsBusy);
+
+		Assert.Equal(1, await first);
+		Assert.Equal(2, await second);
+	}
+
+	[Fact]
+	public async Task FaultingShow_FaultsOnlyItsOwnTask_AndTheQueueKeepsDraining()
+	{
+		var queue = new DialogQueue<int>();
+		var boom = new InvalidOperationException("boom");
+
+		Task<int> failing = queue.EnqueueAsync(() => Task.FromException<int>(boom));
+		Task<int> following = queue.EnqueueAsync(() => Task.FromResult(7));
+
+		var thrown = await Assert.ThrowsAsync<InvalidOperationException>(() => failing);
+		Assert.Same(boom, thrown);
+		Assert.Equal(7, await following);
+		Assert.False(queue.IsBusy);
+		Assert.Equal(0, queue.PendingCount);
+	}
+
+	[Fact]
+	public void EnqueueAsync_NullShowOperation_Throws()
+	{
+		var queue = new DialogQueue<int>();
+
+		// The null guard throws synchronously before any task is created, so
+		// Assert.Throws is correct despite EnqueueAsync's Task return type; the
+		// analyzer cannot see that the throw is synchronous, so suppress it.
+#pragma warning disable xUnit2014
+		Assert.Throws<ArgumentNullException>(() =>
+		{
+			queue.EnqueueAsync(null!);
+		});
+#pragma warning restore xUnit2014
+	}
+}

--- a/Mutation.Ui/Core/DialogQueue.cs
+++ b/Mutation.Ui/Core/DialogQueue.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Mutation.Ui.Core;
+
+/// <summary>
+/// Serializes modal dialogs onto a single "one at a time" channel so a
+/// dialog requested while another is already open is queued and shown when
+/// the current one closes, instead of being silently dropped.
+///
+/// The queue is affine to the thread that drives it (the UI dispatcher in
+/// this app): every member must be called from that one thread. It holds no
+/// locks because that single-threaded contract removes the races a lock
+/// would guard; the awaited show operations still run asynchronously and
+/// yield the thread while a dialog is on screen.
+/// </summary>
+/// <typeparam name="TResult">The result each show operation produces (e.g.
+/// the button the user chose).</typeparam>
+public sealed class DialogQueue<TResult>
+{
+	private readonly Queue<PendingDialog> _pending = new();
+	private bool _isPumping;
+
+	/// <summary>True while a dialog is showing or waiting to show.</summary>
+	public bool IsBusy => _isPumping;
+
+	/// <summary>How many dialogs are waiting behind the one on screen.</summary>
+	public int PendingCount => _pending.Count;
+
+	/// <summary>
+	/// Queue a dialog-show operation. The returned task completes with the
+	/// operation's result once the dialog has actually been shown and closed,
+	/// so callers still <c>await</c> the real outcome whether it ran
+	/// immediately or waited its turn. A show operation that throws faults
+	/// only its own task; the queue keeps draining the rest.
+	/// </summary>
+	public Task<TResult> EnqueueAsync(Func<Task<TResult>> showAsync)
+	{
+		ArgumentNullException.ThrowIfNull(showAsync);
+
+		// RunContinuationsAsynchronously so an awaiting UI handler resumes on
+		// the dispatcher rather than nested inside the pump loop.
+		var completion = new TaskCompletionSource<TResult>(
+			TaskCreationOptions.RunContinuationsAsynchronously);
+		_pending.Enqueue(new PendingDialog(showAsync, completion));
+
+		if (!_isPumping)
+		{
+			_isPumping = true;
+			_ = PumpAsync();
+		}
+
+		return completion.Task;
+	}
+
+	private async Task PumpAsync()
+	{
+		while (_pending.Count > 0)
+		{
+			PendingDialog dialog = _pending.Dequeue();
+			try
+			{
+				dialog.Completion.TrySetResult(await dialog.ShowAsync());
+			}
+			catch (Exception ex)
+			{
+				dialog.Completion.TrySetException(ex);
+			}
+		}
+
+		_isPumping = false;
+	}
+
+	private readonly record struct PendingDialog(
+		Func<Task<TResult>> ShowAsync,
+		TaskCompletionSource<TResult> Completion);
+}

--- a/Mutation.Ui/MainWindow.xaml.cs
+++ b/Mutation.Ui/MainWindow.xaml.cs
@@ -56,7 +56,9 @@ public sealed partial class MainWindow : Window, IDisposable
 	private readonly CancellationTokenSource _shutdownCts = new();
 	private DictationInsertOption _insertOption = DictationInsertOption.Paste;
 	private readonly DispatcherTimer _statusDismissTimer;
-	private bool _isDialogOpen;
+	// Shows modal dialogs one at a time; a dialog requested while another
+	// is open is queued and shown when it closes, never dropped (issue #167).
+	private readonly DialogQueue<ContentDialogResult> _dialogQueue = new();
 	private bool _ttsControlsReady;
 	private bool _micLevelControlsReady;
 	private bool _playbackSpeedReady;
@@ -1884,18 +1886,27 @@ public sealed partial class MainWindow : Window, IDisposable
 		};
 		AutomationProperties.SetName(dialog, title);
 		AutomationProperties.SetHelpText(dialog, message);
+
+		// If a dialog is already open this error is queued behind it. Beep now
+		// so a screen-reader user hears the failure immediately rather than
+		// waiting in silence until the queued dialog surfaces (issue #167).
+		if (_dialogQueue.IsBusy)
+			BeepPlayer.Play(BeepType.Failure);
+
 		await ShowDialogAsync(dialog);
 	}
 
     private async Task<ContentDialogResult> ShowDialogAsync(ContentDialog dialog)
     {
-        if (_isDialogOpen)
-            return ContentDialogResult.None;
+        // A dialog requested while another is open is announced now and queued;
+        // the queue shows it when the current dialog closes rather than
+        // dropping it (issue #167).
+        if (_dialogQueue.IsBusy)
+            AnnouncePendingDialog(dialog);
 
-        _isDialogOpen = true;
         try
         {
-            return await dialog.ShowAsync();
+            return await _dialogQueue.EnqueueAsync(async () => await dialog.ShowAsync());
         }
         catch (Exception ex)
         {
@@ -1903,10 +1914,32 @@ public sealed partial class MainWindow : Window, IDisposable
             ShowStatus("Dialog Error", $"Failed to show dialog: {ex.Message}", InfoBarSeverity.Error);
             return ContentDialogResult.None;
         }
-        finally
-        {
-            _isDialogOpen = false;
-        }
+    }
+
+    /// <summary>
+    /// Raises a UIA notification for a dialog that is being queued behind an
+    /// already-open one, so a screen-reader user learns about it immediately
+    /// instead of only when it eventually appears. The dialog is not on screen
+    /// yet, so the notification is raised on the always-present status bar
+    /// (the same channel as <see cref="AnnounceStatus"/>).
+    /// </summary>
+    private void AnnouncePendingDialog(ContentDialog dialog)
+    {
+        string title = AutomationProperties.GetName(dialog);
+        if (string.IsNullOrWhiteSpace(title))
+            title = dialog.Title?.ToString() ?? string.Empty;
+        string message = AutomationProperties.GetHelpText(dialog);
+
+        string announcement = StatusAnnouncement.ComposeText(title, message);
+        if (announcement.Length == 0)
+            return;
+
+        var peer = Microsoft.UI.Xaml.Automation.Peers.FrameworkElementAutomationPeer.CreatePeerForElement(StatusInfoBar);
+        peer?.RaiseNotificationEvent(
+            Microsoft.UI.Xaml.Automation.Peers.AutomationNotificationKind.Other,
+            Microsoft.UI.Xaml.Automation.Peers.AutomationNotificationProcessing.ImportantMostRecent,
+            announcement,
+            StatusAnnouncement.ActivityId);
     }
 
 	private void CmbMicrophone_SelectionChanged(object sender, SelectionChangedEventArgs e)
@@ -2324,9 +2357,11 @@ public sealed partial class MainWindow : Window, IDisposable
         var result = await ShowDialogAsync(dialog);
         if (result != ContentDialogResult.Primary)
         {
-            // Covers an explicit Cancel and the guarded case where another
-            // dialog was already open (ShowDialogAsync returns None): nothing
+            // Covers an explicit Cancel or a dialog that failed to show: nothing
             // is deleted, and the outcome is announced for the screen reader.
+            // (A confirmation requested while another dialog is open is now
+            // queued and shown when that one closes, so deletion still requires
+            // an explicit Delete click.)
             ShowStatus(PromptDeletionMessages.ConfirmationTitle, PromptDeletionMessages.BuildCancelled(name), InfoBarSeverity.Informational);
             return;
         }


### PR DESCRIPTION
Closes #167

## What this fixes

`ShowDialogAsync` refused to show a dialog while another one was already
open: it returned immediately and the new dialog was never queued or shown.
Because every error dialog (`ShowErrorDialog`) and the audio-session error
handler funnel through this method, a background transcription or OCR
failure that fired while the Settings dialog — or any content dialog — was
open was discarded entirely. For the error paths that call `ShowErrorDialog`
directly (screenshot, OCR, speech-to-text, LLM), nothing was shown and
nothing was announced, so a blind user was left with the operation appearing
to have produced nothing.

## What changed

- **New `DialogQueue<TResult>`** (a small, dependency-free helper): a serial
  first-in-first-out queue that shows modal dialogs one at a time. A dialog
  requested while another is open is queued and shown when the current one
  closes — never dropped. Callers still `await` and receive the dialog's
  real result, whether it ran immediately or waited its turn. A show
  operation that throws faults only its own result; the queue keeps draining
  the rest.
- **`ShowDialogAsync`** now enqueues through this queue instead of dropping
  the dialog on a busy flag.
- **Immediate feedback on deferral.** When a dialog has to wait behind
  another, an accessibility notification is raised right away with its title
  and message, and error dialogs also play the failure beep. The user learns
  a dialog is pending immediately rather than sitting in silence until the
  blocking dialog closes.
- The delete-prompt confirmation previously relied on the old
  "another dialog open → treated as cancel" behavior; its comment is updated.
  A confirmation requested while busy is now queued and actually shown, and
  deletion still requires an explicit Delete click, so nothing is deleted
  without confirmation.

## How the issue's suggestion is addressed

The issue suggested either queueing pending dialogs or, at minimum, routing
the suppressed dialog's title and message through an accessibility
notification plus the failure beep. This does both: dialogs are queued (the
primary fix) **and** deferral is announced immediately with the failure beep
for errors.

## Test plan

- New unit tests in `DialogQueueTests` cover: a single dialog showing
  immediately and returning its result; a second dialog queued behind the
  first and shown in FIFO order only after the first closes; `IsBusy` /
  `PendingCount` transitions; result propagation; and a faulting show
  operation faulting only its own task while the queue keeps draining.
- `dotnet test --configuration Release` — all 614 tests pass.
- The dialog-showing itself (WinUI `ContentDialog.ShowAsync`) is UI-thread
  bound and not unit-testable in isolation; the queueing logic it depends on
  is fully covered.
