### PR TITLE
Guard recorder start and roll back a failed start (#178)

### DIFF
--- a/CognitiveSupport/AudioRecorder.cs
+++ b/CognitiveSupport/AudioRecorder.cs
@@ -6,7 +6,7 @@ using System.IO;
 
 namespace CognitiveSupport;
 
-public class AudioRecorder : IDisposable
+public class AudioRecorder : IAudioRecorder
 {
 	private WaveInEvent? _waveIn;
 	private OpusEncoder? _encoder;

--- a/CognitiveSupport/IAudioRecorder.cs
+++ b/CognitiveSupport/IAudioRecorder.cs
@@ -1,0 +1,29 @@
+using System;
+
+namespace CognitiveSupport;
+
+/// <summary>
+/// The recording contract <c>SpeechToTextManager</c> depends on. Extracting it
+/// from the concrete <see cref="AudioRecorder"/> (which drives real NAudio
+/// hardware) lets the manager be unit-tested in isolation with a recorder that
+/// can fail a start on demand.
+/// </summary>
+public interface IAudioRecorder : IDisposable
+{
+	/// <summary>
+	/// After <see cref="StopRecording"/>, the trimmed speech duration in seconds
+	/// when silence stripping was active; null when stripping was disabled.
+	/// </summary>
+	double? TrimmedSpeechSeconds { get; }
+
+	/// <summary>
+	/// First exception (if any) that occurred while encoding audio on the capture
+	/// thread, captured there rather than thrown so it does not terminate the
+	/// process. Callers surface it after <see cref="StopRecording"/>.
+	/// </summary>
+	Exception? CaptureException { get; }
+
+	void StartRecording(int captureDeviceIndex, string outputFile, SilenceTrimmerOptions? silenceOptions = null);
+
+	void StopRecording();
+}

--- a/Mutation.Tests/SpeechToTextManagerStartGuardTests.cs
+++ b/Mutation.Tests/SpeechToTextManagerStartGuardTests.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using CognitiveSupport;
+using Mutation.Ui;
+
+namespace Mutation.Tests;
+
+// Covers issue #178: a failed recorder start must not leave the app reporting
+// "recording" with no active capture, and a second start while a recorder is
+// already live must be rejected rather than orphaning the running capture.
+public class SpeechToTextManagerStartGuardTests : IDisposable
+{
+	private readonly string _tempDirectory;
+	private readonly Settings _settings;
+
+	public SpeechToTextManagerStartGuardTests()
+	{
+		_tempDirectory = Path.Combine(Path.GetTempPath(), "MutationTests_" + Guid.NewGuid().ToString("N"));
+		Directory.CreateDirectory(_tempDirectory);
+		_settings = new Settings
+		{
+			SpeechToTextSettings = new SpeechToTextSettings
+			{
+				TempDirectory = _tempDirectory
+			}
+		};
+	}
+
+	public void Dispose()
+	{
+		try
+		{
+			Directory.Delete(_tempDirectory, recursive: true);
+		}
+		catch (IOException)
+		{
+		}
+		catch (UnauthorizedAccessException)
+		{
+		}
+	}
+
+	[Fact]
+	public async Task StartRecording_WhenRecorderStartFails_LeavesManagerIdleWithNoOrphanSession()
+	{
+		var failing = new FakeAudioRecorder(startError: new InvalidOperationException("capture device unavailable"));
+		using var manager = new SpeechToTextManager(_settings, () => failing);
+
+		await Assert.ThrowsAsync<InvalidOperationException>(() => manager.StartRecordingAsync(0));
+
+		Assert.False(manager.Recording);
+		Assert.Null(manager.CurrentRecordingSession);
+		Assert.True(failing.Disposed);
+		// The empty session file created before the start must be cleaned up.
+		Assert.Empty(manager.GetSessions());
+	}
+
+	[Fact]
+	public async Task StartRecording_AfterFailedStart_CanStartAgain()
+	{
+		var recorders = new List<FakeAudioRecorder>();
+		using var manager = new SpeechToTextManager(_settings, () =>
+		{
+			// First recorder fails its start, the second succeeds.
+			var recorder = new FakeAudioRecorder(
+				startError: recorders.Count == 0 ? new InvalidOperationException("first start fails") : null);
+			recorders.Add(recorder);
+			return recorder;
+		});
+
+		await Assert.ThrowsAsync<InvalidOperationException>(() => manager.StartRecordingAsync(0));
+		Assert.False(manager.Recording);
+
+		var session = await manager.StartRecordingAsync(0);
+
+		Assert.True(manager.Recording);
+		Assert.Equal(session.FilePath, manager.CurrentRecordingSession?.FilePath);
+		Assert.Equal(2, recorders.Count);
+		Assert.True(recorders[1].Started);
+	}
+
+	[Fact]
+	public async Task StartRecording_WhileAlreadyRecording_ThrowsAndLeavesLiveRecorderUntouched()
+	{
+		var recorders = new List<FakeAudioRecorder>();
+		using var manager = new SpeechToTextManager(_settings, () =>
+		{
+			var recorder = new FakeAudioRecorder();
+			recorders.Add(recorder);
+			return recorder;
+		});
+
+		var session = await manager.StartRecordingAsync(0);
+		Assert.True(manager.Recording);
+		var live = Assert.Single(recorders);
+
+		var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => manager.StartRecordingAsync(0));
+
+		Assert.Contains("already in progress", ex.Message, StringComparison.OrdinalIgnoreCase);
+		// The guard runs before a new recorder is constructed, so the live capture
+		// is neither overwritten nor disposed.
+		Assert.Single(recorders);
+		Assert.False(live.Disposed);
+		Assert.True(manager.Recording);
+		Assert.Equal(session.FilePath, manager.CurrentRecordingSession?.FilePath);
+	}
+
+	private sealed class FakeAudioRecorder : IAudioRecorder
+	{
+		private readonly Exception? _startError;
+
+		public FakeAudioRecorder(Exception? startError = null)
+		{
+			_startError = startError;
+		}
+
+		public bool Started { get; private set; }
+		public bool Disposed { get; private set; }
+
+		public double? TrimmedSpeechSeconds => null;
+		public Exception? CaptureException => null;
+
+		public void StartRecording(int captureDeviceIndex, string outputFile, SilenceTrimmerOptions? silenceOptions = null)
+		{
+			if (_startError != null)
+				throw _startError;
+
+			Started = true;
+		}
+
+		public void StopRecording()
+		{
+		}
+
+		public void Dispose()
+		{
+			Disposed = true;
+		}
+	}
+}

--- a/Mutation.Ui/Core/SpeechToTextManager.cs
+++ b/Mutation.Ui/Core/SpeechToTextManager.cs
@@ -22,13 +22,22 @@ public class SpeechToTextManager : IDisposable
 
 	private readonly Settings _settings;
 	private readonly SpeechToTextState _state;
-	private CognitiveSupport.AudioRecorder? _audioRecorder;
+	private readonly Func<IAudioRecorder> _recorderFactory;
+	private IAudioRecorder? _audioRecorder;
 	private readonly object _sessionLock = new();
 	private SpeechSession? _currentRecordingSession;
 
 	public SpeechToTextManager(Settings settings)
+		: this(settings, () => new CognitiveSupport.AudioRecorder())
+	{
+	}
+
+	// Test seam: injects the recorder so a start can be made to fail on demand
+	// without real NAudio hardware.
+	internal SpeechToTextManager(Settings settings, Func<IAudioRecorder> recorderFactory)
 	{
 		_settings = settings ?? throw new ArgumentNullException(nameof(settings));
+		_recorderFactory = recorderFactory ?? throw new ArgumentNullException(nameof(recorderFactory));
 		_state = new SpeechToTextState(() => _audioRecorder);
 	}
 
@@ -150,6 +159,13 @@ public class SpeechToTextManager : IDisposable
 
 		try
 		{
+			// Reject a second start while a recorder is already live. Overwriting
+			// the field would orphan the running capture — its mic is never
+			// released and its .ogg never finalized. Guard before creating the
+			// session file so a rejected entry leaves nothing behind.
+			if (_audioRecorder != null)
+				throw new InvalidOperationException("A recording is already in progress.");
+
 			// Create the session file only after winning the lock so a busy
 			// timeout leaves no orphaned empty session in the history.
 			EnsureSessionsDirectory();
@@ -162,9 +178,26 @@ public class SpeechToTextManager : IDisposable
 				_currentRecordingSession = session;
 			}
 
-			_audioRecorder = new CognitiveSupport.AudioRecorder();
-			_audioRecorder.StartRecording(microphoneDeviceIndex, path, BuildSilenceOptions());
+			// Start into a local first; commit the field only once StartRecording
+			// succeeds. A failed start (device unplugged, NAudio error) must not
+			// leave the manager reporting "recording" with no active capture.
+			IAudioRecorder recorder = _recorderFactory();
+			try
+			{
+				recorder.StartRecording(microphoneDeviceIndex, path, BuildSilenceOptions());
+			}
+			catch
+			{
+				recorder.Dispose();
+				lock (_sessionLock)
+				{
+					_currentRecordingSession = null;
+				}
+				TryDeleteSessionFile(path);
+				throw;
+			}
 
+			_audioRecorder = recorder;
 			return session;
 		}
 		finally
@@ -466,6 +499,28 @@ public class SpeechToTextManager : IDisposable
 		}
 
 		throw new IOException("Failed to create a unique session file name.");
+	}
+
+	// Best-effort removal of a just-created session file whose recording never
+	// started, so a failed start leaves no empty session lingering in history.
+	private static void TryDeleteSessionFile(string path)
+	{
+		try
+		{
+			File.Delete(path);
+		}
+		catch (DirectoryNotFoundException)
+		{
+		}
+		catch (UnauthorizedAccessException)
+		{
+		}
+		catch (PathTooLongException)
+		{
+		}
+		catch (IOException)
+		{
+		}
 	}
 
 	private static async Task CopyFileAsync(string sourcePath, string destinationPath, CancellationToken token)

--- a/Mutation.Ui/Core/SpeechToTextState.cs
+++ b/Mutation.Ui/Core/SpeechToTextState.cs
@@ -11,7 +11,7 @@ internal class SpeechToTextState : IDisposable
 	private readonly object _ctsLock = new();
 	private CancellationTokenSource? _cts;
 
-	private Func<AudioRecorder?> GetAudioRecorder;
+	private Func<IAudioRecorder?> GetAudioRecorder;
 	internal bool RecordingAudio => GetAudioRecorder() != null;
 
 	internal bool TranscribingAudio
@@ -20,7 +20,7 @@ internal class SpeechToTextState : IDisposable
 	}
 
 	public SpeechToTextState(
-		Func<AudioRecorder?> getAudioRecorder)
+		Func<IAudioRecorder?> getAudioRecorder)
 	{
 		GetAudioRecorder = getAudioRecorder ?? throw new ArgumentNullException(nameof(getAudioRecorder));
 	}


### PR DESCRIPTION
## What this fixes

Closes #178

Starting a dictation recording could leave the app permanently stuck in the "recording" state. The manager that owns the recorder treats "a recorder object exists" as the definition of "we are recording", but it created that recorder object and assigned it to its field *before* actually starting the audio capture. If the capture failed to start — for example the microphone was unplugged, the audio backend threw an error, or the output file could not be opened — the manager was left holding a recorder object that was doing nothing, yet it kept reporting that a recording was in progress. The Stop button stayed active, and pressing it tried to transcribe a zero-byte file, producing a confusing error.

The same code also had no guard against being asked to start a second recording while one was already running. A second start would silently replace the live recorder without stopping it, leaving the microphone open and the in-progress audio file truncated and unrecoverable.

## What changed

- `SpeechToTextManager.StartRecordingAsync` now starts the recorder into a local variable and only commits it to the field once the start succeeds. If the start throws, it disposes the local recorder, clears the in-progress session, and deletes the empty session file it had just created — so the app returns to a clean idle state instead of a phantom "recording" state.
- Starting a recording while one is already live is now rejected with a clear error, before any session file is created, so a live capture is never overwritten or orphaned.
- To make these paths testable without real microphone hardware, the recorder contract the manager depends on was extracted into a new `IAudioRecorder` interface (implemented by the existing `AudioRecorder`), and the manager now obtains its recorder through an injectable factory. Production behaviour is unchanged; the default factory builds the same concrete recorder as before.

## Test plan

New unit tests in `Mutation.Tests/SpeechToTextManagerStartGuardTests.cs` cover the three cases, using a fake recorder injected through the new factory seam:

- A recorder whose start fails leaves the manager reporting *not* recording, with no current session and no leftover empty session file on disk.
- After a failed start, a subsequent start succeeds normally (the manager is not wedged).
- Starting while a recording is already live throws, and the live recorder is neither replaced nor disposed.

Full gate: `dotnet test --configuration Release` — 626 passed, 0 failed.
