### PR TITLE
Run the mic mute toggle off the UI thread (#171)

### DIFF
--- a/Mutation.Tests/MicrophoneMuteToggleCoordinatorTests.cs
+++ b/Mutation.Tests/MicrophoneMuteToggleCoordinatorTests.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Mutation.Ui.Core;
+using Xunit;
+
+namespace Mutation.Tests;
+
+public class MicrophoneMuteToggleCoordinatorTests
+{
+	[Fact]
+	public void Constructor_NullToggle_Throws()
+	{
+		Assert.Throws<ArgumentNullException>(() => new MicrophoneMuteToggleCoordinator(null!));
+	}
+
+	[Fact]
+	public async Task ToggleAsync_ReturnsToggleResult()
+	{
+		var expected = new MuteToggleResult(Success: true, IsMuted: true);
+		var coordinator = new MicrophoneMuteToggleCoordinator(() => expected);
+
+		var result = await coordinator.ToggleAsync();
+
+		Assert.Equal(expected, result);
+		Assert.False(coordinator.IsToggling);
+	}
+
+	[Fact]
+	public async Task ToggleAsync_RunsToggleOffTheCallingThread()
+	{
+		// The delegate signals when it starts and then blocks. If the toggle ran
+		// synchronously on this thread, ToggleAsync would block inside the delegate
+		// and never hand back a task — so simply reaching the asserts below, with
+		// "started" already signalled, proves the work runs on another thread.
+		var started = new ManualResetEventSlim(false);
+		var release = new ManualResetEventSlim(false);
+		var coordinator = new MicrophoneMuteToggleCoordinator(() =>
+		{
+			started.Set();
+			release.Wait();
+			return new MuteToggleResult(Success: true, IsMuted: true);
+		});
+
+		var toggle = coordinator.ToggleAsync();
+
+		Assert.True(started.Wait(TimeSpan.FromSeconds(5)), "toggle did not start on a background thread");
+		Assert.False(toggle.IsCompleted);
+		Assert.True(coordinator.IsToggling);
+
+		release.Set();
+		var result = await toggle;
+
+		Assert.Equal(new MuteToggleResult(Success: true, IsMuted: true), result);
+		Assert.False(coordinator.IsToggling);
+	}
+
+	[Fact]
+	public async Task ToggleAsync_CoalescesOverlappingRequests()
+	{
+		var release = new ManualResetEventSlim(false);
+		int calls = 0;
+		var coordinator = new MicrophoneMuteToggleCoordinator(() =>
+		{
+			Interlocked.Increment(ref calls);
+			release.Wait();
+			return new MuteToggleResult(Success: true, IsMuted: true);
+		});
+
+		// The first call claims the single in-flight slot synchronously (before
+		// awaiting), so the overlapping second call is dropped, not queued.
+		var first = coordinator.ToggleAsync();
+		var second = await coordinator.ToggleAsync();
+
+		Assert.Null(second);
+
+		release.Set();
+		var firstResult = await first;
+
+		Assert.NotNull(firstResult);
+		Assert.Equal(1, calls);
+		Assert.False(coordinator.IsToggling);
+	}
+
+	[Fact]
+	public async Task ToggleAsync_AllowsANewToggleAfterThePreviousCompletes()
+	{
+		int calls = 0;
+		var coordinator = new MicrophoneMuteToggleCoordinator(() =>
+		{
+			Interlocked.Increment(ref calls);
+			return new MuteToggleResult(Success: true, IsMuted: calls % 2 == 1);
+		});
+
+		var first = await coordinator.ToggleAsync();
+		var second = await coordinator.ToggleAsync();
+
+		Assert.NotNull(first);
+		Assert.NotNull(second);
+		Assert.Equal(2, calls);
+	}
+}

--- a/Mutation.Ui/Core/MicrophoneMuteToggleCoordinator.cs
+++ b/Mutation.Ui/Core/MicrophoneMuteToggleCoordinator.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Mutation.Ui.Core;
+
+/// <summary>
+/// Runs a mute toggle off the caller's thread so the COM writes, read-back
+/// verification, and any device re-enumeration in the underlying toggle never
+/// block the UI thread (and, with it, the screen reader). The toggle itself is
+/// injected as a delegate, keeping this coordinator unit-testable without audio
+/// hardware or a UI.
+///
+/// Overlapping presses are coalesced: while one toggle is in flight, a second
+/// request is dropped rather than queued, so a rapid double-press cannot stack
+/// two flips and leave the mute state where it started.
+/// </summary>
+public sealed class MicrophoneMuteToggleCoordinator
+{
+	private readonly Func<MuteToggleResult> _toggle;
+
+	// 0 = idle, 1 = a toggle is running. Flipped atomically so two threads
+	// racing on the hotkey cannot both start a toggle.
+	private int _inFlight;
+
+	public MicrophoneMuteToggleCoordinator(Func<MuteToggleResult> toggle)
+	{
+		_toggle = toggle ?? throw new ArgumentNullException(nameof(toggle));
+	}
+
+	/// <summary>
+	/// True while a toggle started by this coordinator has not yet completed.
+	/// </summary>
+	public bool IsToggling => Volatile.Read(ref _inFlight) != 0;
+
+	/// <summary>
+	/// Runs the injected toggle on a background thread and returns its confirmed
+	/// result. Returns <c>null</c> when a toggle is already in flight — the
+	/// request is coalesced, not queued. The continuation resumes on the caller's
+	/// synchronization context (the UI thread when called from a UI event), so
+	/// the caller can update the UI directly with the result.
+	/// </summary>
+	public async Task<MuteToggleResult?> ToggleAsync()
+	{
+		// Claim the single in-flight slot; bail out if another toggle holds it.
+		if (Interlocked.CompareExchange(ref _inFlight, 1, 0) != 0)
+			return null;
+
+		try
+		{
+			return await Task.Run(_toggle);
+		}
+		finally
+		{
+			Volatile.Write(ref _inFlight, 0);
+		}
+	}
+}

--- a/Mutation.Ui/MainWindow.xaml.cs
+++ b/Mutation.Ui/MainWindow.xaml.cs
@@ -39,6 +39,10 @@ public sealed partial class MainWindow : Window, IDisposable
 	private readonly ISpeechToTextService[] _speechServices;
 	private readonly Mutation.Ui.Core.AudioSessionManager _audioSessionManager;
 	private readonly Mutation.Ui.Core.MicrophoneLevelPinService _micLevelPinService;
+	// Runs the mute toggle's COM writes, read-back verification, and any device
+	// re-enumeration off the UI thread so a hotkey press during a device hot-plug
+	// never freezes the UI (and the screen reader).
+	private readonly Mutation.Ui.Core.MicrophoneMuteToggleCoordinator _muteToggleCoordinator;
 	private readonly TranscriptFormatter _transcriptFormatter;
 	private readonly ITextToSpeechService _textToSpeech;
 	private readonly IWavFileSpeechExporter _wavFileSpeechExporter;
@@ -129,6 +133,7 @@ public sealed partial class MainWindow : Window, IDisposable
 
         _audioSessionManager = audioSessionManager;
         _micLevelPinService = micLevelPinService;
+        _muteToggleCoordinator = new Mutation.Ui.Core.MicrophoneMuteToggleCoordinator(_audioDeviceManager.ToggleMute);
         _audioSessionManager.StateChanged += AudioSessionManager_StateChanged;
         _audioSessionManager.TranscriptReady += AudioSessionManager_TranscriptReady;
         _audioSessionManager.ErrorOccurred += AudioSessionManager_ErrorOccurred;
@@ -546,9 +551,16 @@ public sealed partial class MainWindow : Window, IDisposable
 		Dispose();
 	}
 
-	public void BtnToggleMic_Click(object? sender, RoutedEventArgs? e)
+	public async void BtnToggleMic_Click(object? sender, RoutedEventArgs? e)
 	{
-		var result = _audioDeviceManager.ToggleMute();
+		// The toggle runs on a background thread; a null result means another
+		// toggle was already in flight and this press was coalesced away — leave
+		// the UI as-is rather than reporting a stale state.
+		MuteToggleResult? toggled = await _muteToggleCoordinator.ToggleAsync();
+		if (toggled is not MuteToggleResult result)
+			return;
+
+		// Back on the UI thread (the await resumes on the captured context).
 		// Drives the graphic off the confirmed state, so a failed mute never
 		// shows the muted icon.
 		UpdateMicrophoneToggleVisuals();


### PR DESCRIPTION
## What this changes

The microphone mute-toggle hotkey used to do all of its work directly on the
UI thread: it writes the new mute state to every capture device over the
Windows audio COM API, reads each one back to confirm it took effect, and — if
any write fails — re-enumerates every audio device and retries. All of that ran
on the thread that also draws the window and drives the screen reader, and it
held the same lock the operating system uses to notify the app when a
microphone is plugged in or removed. So pressing the mute hotkey while a device
was being hot-plugged could freeze the UI for tens to hundreds of milliseconds
— worst exactly on the failure/retry path the verify-and-retry logic exists
for.

This moves that work off the UI thread. A new `MicrophoneMuteToggleCoordinator`
runs the toggle (writes, read-back verification, and any device
re-enumeration) on a background thread and hands only the confirmed result back
to the UI, where the icon, status message, and beep are updated as before. The
coordinator also coalesces overlapping presses: while one toggle is in flight,
a second press is dropped rather than queued, so a fast double-press can't stack
two flips and leave the mic where it started.

## Scope

The change targets the **mute toggle** specifically. The microphone-level
slider and the record-start path share the same "COM write on the UI thread"
pattern, but moving those off-thread safely needs a different, ordering-aware
design (each slider tick must not overtake a later one). That is filed as a
separate follow-up rather than bundled here.

## Behaviour notes

- The confirmed-state semantics are unchanged: the mute icon and status still
  reflect only a state that was written and read back successfully, so a failed
  mute never shows the muted icon.
- On the normal (healthy-device) path the extra background hop is imperceptible;
  the win is that the failure/retry path no longer blocks the UI or the screen
  reader.
- Accessibility: the status InfoBar announcement and the mute/unmute/failure
  beeps still fire, now from the resumed UI thread after the confirmed result
  comes back.

## Test plan

- `dotnet test --configuration Release` — all 628 tests pass (5 new).
- New `MicrophoneMuteToggleCoordinatorTests` cover: the toggle runs off the
  calling thread, its result is returned, overlapping requests are coalesced to
  `null`, a fresh toggle is allowed after the previous one completes, and a null
  toggle delegate is rejected.
- Existing `MuteStateControllerTests` continue to cover the write / verify /
  retry logic the coordinator drives.

Closes #171
