### PR TITLE
Debounce slider settings persistence to stop per-tick file churn (#172)

### DIFF
--- a/Mutation.Tests/DebouncerTests.cs
+++ b/Mutation.Tests/DebouncerTests.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Mutation.Ui.Core;
+
+namespace Mutation.Tests;
+
+public class DebouncerTests
+{
+	// A delay stand-in the test drives by hand: each call records a pending "gate"
+	// the test completes explicitly (as if the time elapsed), so the coalescing and
+	// cancellation behaviour is exercised deterministically with no real time passing.
+	private sealed class ManualDelay
+	{
+		private readonly List<(TaskCompletionSource Tcs, CancellationToken Token)> _pending = new();
+		private readonly object _lock = new();
+
+		public Func<TimeSpan, CancellationToken, Task> Func => (_, token) =>
+		{
+			var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+			lock (_lock)
+				_pending.Add((tcs, token));
+			token.Register(() => tcs.TrySetCanceled(token));
+			return tcs.Task;
+		};
+
+		public int Count
+		{
+			get { lock (_lock) return _pending.Count; }
+		}
+
+		// Complete the most recently scheduled delay as if its quiet period elapsed.
+		public void CompleteLast()
+		{
+			TaskCompletionSource tcs;
+			lock (_lock)
+				tcs = _pending[_pending.Count - 1].Tcs;
+			tcs.TrySetResult();
+		}
+	}
+
+	[Fact]
+	public void Trigger_RapidBurst_RunsActionOnce()
+	{
+		var clock = new ManualDelay();
+		int runs = 0;
+		using var ran = new ManualResetEventSlim(false);
+		using var debouncer = new Debouncer(
+			TimeSpan.FromMilliseconds(500),
+			() => { Interlocked.Increment(ref runs); ran.Set(); },
+			clock.Func);
+
+		debouncer.Trigger();
+		debouncer.Trigger();
+		debouncer.Trigger();
+
+		// Three triggers scheduled three delays; the first two were superseded and
+		// cancelled. Only completing the last one may run the action.
+		Assert.Equal(3, clock.Count);
+		clock.CompleteLast();
+
+		Assert.True(ran.Wait(TimeSpan.FromSeconds(5)), "Action should run after the last trigger settles.");
+		// Let any wrongly-scheduled run have a chance to fire; the count must stay at one.
+		Thread.Sleep(50);
+		Assert.Equal(1, Volatile.Read(ref runs));
+	}
+
+	[Fact]
+	public void Trigger_AfterPreviousRunCompleted_RunsAgain()
+	{
+		var clock = new ManualDelay();
+		int runs = 0;
+		using var ran = new AutoResetEvent(false);
+		using var debouncer = new Debouncer(
+			TimeSpan.FromMilliseconds(500),
+			() => { Interlocked.Increment(ref runs); ran.Set(); },
+			clock.Func);
+
+		debouncer.Trigger();
+		clock.CompleteLast();
+		Assert.True(ran.WaitOne(TimeSpan.FromSeconds(5)), "First run should fire.");
+
+		debouncer.Trigger();
+		clock.CompleteLast();
+		Assert.True(ran.WaitOne(TimeSpan.FromSeconds(5)), "A trigger after the first run settled should fire again.");
+
+		Assert.Equal(2, Volatile.Read(ref runs));
+	}
+
+	[Fact]
+	public void Dispose_WithPendingRun_DoesNotRunAction()
+	{
+		var clock = new ManualDelay();
+		int runs = 0;
+		var debouncer = new Debouncer(
+			TimeSpan.FromMilliseconds(500),
+			() => Interlocked.Increment(ref runs),
+			clock.Func);
+
+		debouncer.Trigger();
+		debouncer.Dispose();
+
+		// Even if the quiet period "elapses" after disposal, the pending run was cancelled.
+		clock.CompleteLast();
+		Thread.Sleep(50);
+		Assert.Equal(0, Volatile.Read(ref runs));
+	}
+
+	[Fact]
+	public void Trigger_AfterDispose_IsNoOp()
+	{
+		var clock = new ManualDelay();
+		int runs = 0;
+		var debouncer = new Debouncer(
+			TimeSpan.FromMilliseconds(500),
+			() => Interlocked.Increment(ref runs),
+			clock.Func);
+		debouncer.Dispose();
+
+		debouncer.Trigger();
+
+		Assert.Equal(0, clock.Count);
+		Assert.Equal(0, Volatile.Read(ref runs));
+	}
+
+	[Fact]
+	public void Constructor_NullAction_Throws() =>
+		Assert.Throws<ArgumentNullException>(() =>
+			new Debouncer(TimeSpan.FromMilliseconds(1), null!));
+
+	[Fact]
+	public void Constructor_NegativeDelay_Throws() =>
+		Assert.Throws<ArgumentOutOfRangeException>(() =>
+			new Debouncer(TimeSpan.FromMilliseconds(-1), () => { }));
+}

--- a/Mutation.Ui/Core/Debouncer.cs
+++ b/Mutation.Ui/Core/Debouncer.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Mutation.Ui.Core;
+
+/// <summary>
+/// Coalesces a burst of rapid triggers into a single deferred action. Each
+/// <see cref="Trigger"/> cancels any run that has not yet fired and schedules a
+/// new one after the configured delay, so the action runs only once the triggers
+/// stop for at least that delay. Used to keep a continuous UI stream — a slider
+/// drag or a held arrow key, which raise <c>ValueChanged</c> dozens of times per
+/// second — from running an expensive action (a full settings serialize plus an
+/// atomic file replace) on every tick.
+/// </summary>
+/// <remarks>
+/// The action runs on whatever synchronization context <see cref="Trigger"/> was
+/// called from (the UI thread, in this app), so the caller's action can safely
+/// touch UI-affine state exactly as an inline save would. The delay mechanism is
+/// injectable so the coalescing and cancellation behaviour can be unit-tested
+/// without real time passing.
+/// </remarks>
+public sealed class Debouncer : IDisposable
+{
+	private readonly TimeSpan _delay;
+	private readonly Action _action;
+	private readonly Func<TimeSpan, CancellationToken, Task> _delayAsync;
+	private readonly object _gate = new();
+	private CancellationTokenSource? _cts;
+	private bool _disposed;
+
+	/// <summary>
+	/// Creates a debouncer that runs <paramref name="action"/> once the triggers
+	/// have been quiet for <paramref name="delay"/>.
+	/// </summary>
+	/// <param name="delay">Quiet period that must elapse after the last trigger
+	/// before the action runs. Must not be negative.</param>
+	/// <param name="action">The work to run once per settled burst.</param>
+	/// <param name="delayAsync">The delay mechanism; defaults to
+	/// <see cref="Task.Delay(TimeSpan, CancellationToken)"/>. Injectable so tests
+	/// can drive the timing deterministically.</param>
+	public Debouncer(
+		TimeSpan delay,
+		Action action,
+		Func<TimeSpan, CancellationToken, Task>? delayAsync = null)
+	{
+		if (delay < TimeSpan.Zero)
+			throw new ArgumentOutOfRangeException(nameof(delay), "Delay must not be negative.");
+
+		_delay = delay;
+		_action = action ?? throw new ArgumentNullException(nameof(action));
+		_delayAsync = delayAsync ?? Task.Delay;
+	}
+
+	/// <summary>
+	/// Schedules the action to run after the delay, cancelling any earlier run
+	/// that has not yet fired. Rapid successive calls therefore collapse into a
+	/// single run once the calls stop. A no-op after <see cref="Dispose"/>.
+	/// </summary>
+	public void Trigger()
+	{
+		CancellationToken token;
+		lock (_gate)
+		{
+			if (_disposed)
+				return;
+
+			_cts?.Cancel();
+			_cts?.Dispose();
+			_cts = new CancellationTokenSource();
+			token = _cts.Token;
+		}
+
+		_ = RunAsync(token);
+	}
+
+	private async Task RunAsync(CancellationToken token)
+	{
+		try
+		{
+			await _delayAsync(_delay, token).ConfigureAwait(true);
+			if (!token.IsCancellationRequested)
+				_action();
+		}
+		catch (OperationCanceledException)
+		{
+			// A newer trigger (or Dispose) superseded this run — expected, drop it.
+		}
+	}
+
+	/// <summary>
+	/// Cancels any pending run and stops accepting further triggers. Does not
+	/// flush a pending action; a caller that must persist the latest value on
+	/// shutdown does so on its own path (e.g. the window's close handler saves
+	/// the already-mutated settings object).
+	/// </summary>
+	public void Dispose()
+	{
+		lock (_gate)
+		{
+			if (_disposed)
+				return;
+
+			_disposed = true;
+			_cts?.Cancel();
+			_cts?.Dispose();
+			_cts = null;
+		}
+	}
+}

--- a/Mutation.Ui/MainWindow.xaml.cs
+++ b/Mutation.Ui/MainWindow.xaml.cs
@@ -53,6 +53,17 @@ public sealed partial class MainWindow : Window, IDisposable
 	private ISpeechToTextService? _activeSpeechService;
 	private CancellationTokenSource _formatDebounceCts = new();
 	private CancellationTokenSource _promptDebounceCts = new();
+	// Slider settings persistence is coalesced to this quiet period after the last
+	// change, mirroring the existing prompt TextBox debounce.
+	private static readonly TimeSpan SettingsSaveDebounceDelay = TimeSpan.FromMilliseconds(500);
+	// Coalesces per-tick settings saves from the main-window sliders. A drag or a
+	// held arrow key raises ValueChanged dozens of times per second, and saving on
+	// every tick serialized the whole settings object and atomically replaced the
+	// file (plus its .bak) on the UI thread — audible slider stutter and disk churn
+	// (issue #172). Each handler applies its value to _settings immediately; only the
+	// file write is deferred. The close handler saves _settings unconditionally, so a
+	// pending write is never lost on shutdown.
+	private readonly Debouncer _settingsSaveDebouncer;
 	private readonly CancellationTokenSource _shutdownCts = new();
 	private DictationInsertOption _insertOption = DictationInsertOption.Paste;
 	private readonly DispatcherTimer _statusDismissTimer;
@@ -126,6 +137,10 @@ public sealed partial class MainWindow : Window, IDisposable
 		_wavFileSpeechExporter = wavFileSpeechExporter;
 		_transcriptFormatter = transcriptFormatter;
 		_settings = settings;
+
+        _settingsSaveDebouncer = new Debouncer(
+            SettingsSaveDebounceDelay,
+            () => _settingsManager.SaveSettingsToFile(_settings));
 
         _audioSessionManager = audioSessionManager;
         _micLevelPinService = micLevelPinService;
@@ -1330,7 +1345,9 @@ public sealed partial class MainWindow : Window, IDisposable
 			if (_settings.AudioSettings.PinnedCaptureLevel != level)
 			{
 				_settings.AudioSettings.PinnedCaptureLevel = level;
-				_settingsManager.SaveSettingsToFile(_settings);
+				// Keep the live COM level write per tick above; only coalesce the file
+				// write, so a drag or held arrow key persists once it settles (issue #172).
+				_settingsSaveDebouncer.Trigger();
 			}
 		}
 	}
@@ -1429,7 +1446,7 @@ public sealed partial class MainWindow : Window, IDisposable
 		if (_settings.TextToSpeechSettings.Rate == rate) return;
 
 		_settings.TextToSpeechSettings.Rate = rate;
-		_settingsManager.SaveSettingsToFile(_settings);
+		_settingsSaveDebouncer.Trigger();
 	}
 
 	private void SldTtsVolume_ValueChanged(object sender, RangeBaseValueChangedEventArgs e)
@@ -1441,7 +1458,7 @@ public sealed partial class MainWindow : Window, IDisposable
 		if (_settings.TextToSpeechSettings.Volume == volume) return;
 
 		_settings.TextToSpeechSettings.Volume = volume;
-		_settingsManager.SaveSettingsToFile(_settings);
+		_settingsSaveDebouncer.Trigger();
 	}
 
 	public async void BtnFormatTranscript_Click(object? sender, RoutedEventArgs? e)
@@ -2368,6 +2385,7 @@ public sealed partial class MainWindow : Window, IDisposable
 		_microphoneVisualization?.Dispose();
 		_formatDebounceCts?.Dispose();
 		_promptDebounceCts?.Dispose();
+		_settingsSaveDebouncer?.Dispose();
 		_shutdownCts.Dispose();
 		_statusDismissTimer?.Stop();
 	}


### PR DESCRIPTION
## What this changes

The three sliders in the main window — microphone level, text-to-speech
rate, and text-to-speech volume — each wrote the settings file on **every**
value change. A WinUI slider raises a change event for every intermediate
value during a pointer drag or a held arrow key (the main way a keyboard user
adjusts a slider), and each of those changes serialized the entire settings
object and atomically replaced the settings file — plus its `.bak` backup — on
the UI thread. Dragging or key-repeating a slider therefore triggered dozens
of full serializations and file replaces per second, causing audible stutter
in the slider feedback, disk churn, and needless backup rewrites.

This change defers (debounces) the file write. Each slider still updates the
in-memory settings immediately, but the write to disk now happens once, about
half a second after the last change, instead of on every tick. This mirrors a
pattern already used for the prompt text box.

## How it works

- A small, reusable `Debouncer` (in `Mutation.Ui/Core`) collapses a burst of
  rapid triggers into a single deferred action once the triggers stop for the
  configured quiet period. Its timing mechanism is injectable so its behaviour
  can be unit-tested without a running UI.
- Each of the three slider handlers now calls `Trigger()` instead of saving
  directly. The microphone slider keeps its live per-tick hardware level write,
  so there is no change to how quickly the mic responds — only the settings
  save is deferred.
- No data is lost on shutdown: the window's close handler already saves the
  settings unconditionally, and the in-memory value is up to date the instant
  the slider moves, so a still-pending debounced write is captured on close.

## Scope

Only the continuous slider streams are debounced. Discrete controls (toggles,
combo boxes) keep saving immediately. The two existing inline debounces
(prompt text, format) are left as-is.

## Test plan

- `dotnet test --configuration Release` — all 629 tests pass (6 new).
- New `DebouncerTests` cover: a rapid burst of triggers runs the action only
  once, a trigger after a completed run fires again, disposing while a run is
  pending cancels it, triggering after dispose is a no-op, and the constructor
  guards (null action, negative delay).

Manual (behavioural, unchanged persistence):
- Drag or hold an arrow key on the mic-level, TTS-rate, and TTS-volume sliders;
  confirm the value still persists across an app restart and that slider
  feedback is smooth.

Closes #172
