### PR TITLE
Defer transcription CTS disposal so cancel can't race retries (#179)

### DIFF
--- a/Mutation.Tests/TranscriptionCancellationTests.cs
+++ b/Mutation.Tests/TranscriptionCancellationTests.cs
@@ -1,0 +1,165 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using CognitiveSupport;
+using Mutation.Ui;
+
+namespace Mutation.Tests;
+
+// Covers issue #179: cancelling a transcription must not dispose the
+// CancellationTokenSource while background retries still link fresh tokens to
+// it. Disposal there surfaced an ObjectDisposedException as a raw error dialog
+// instead of a clean "Transcription cancelled".
+public class TranscriptionCancellationTests : IDisposable
+{
+	private readonly string _tempDirectory;
+	private readonly Settings _settings;
+
+	public TranscriptionCancellationTests()
+	{
+		_tempDirectory = Path.Combine(Path.GetTempPath(), "MutationTests_" + Guid.NewGuid().ToString("N"));
+		Directory.CreateDirectory(_tempDirectory);
+		_settings = new Settings
+		{
+			SpeechToTextSettings = new SpeechToTextSettings
+			{
+				TempDirectory = _tempDirectory
+			}
+		};
+	}
+
+	public void Dispose()
+	{
+		try
+		{
+			Directory.Delete(_tempDirectory, recursive: true);
+		}
+		catch (IOException)
+		{
+		}
+		catch (UnauthorizedAccessException)
+		{
+		}
+	}
+
+	[Fact]
+	public void CancelTranscription_SignalsCancellation_WithoutDisposingSource()
+	{
+		using var state = new SpeechToTextState(() => null);
+		var token = state.StartTranscription();
+
+		state.CancelTranscription();
+
+		Assert.True(token.IsCancellationRequested);
+
+		// A retry attempt links a fresh source to the token on every try. With the
+		// source only cancelled (not disposed) this must succeed and yield an
+		// already-cancelled token, never throw ObjectDisposedException.
+		using var thisTry = new CancellationTokenSource();
+		var ex = Record.Exception(() =>
+		{
+			using var linked = CancellationTokenSource.CreateLinkedTokenSource(token, thisTry.Token);
+			Assert.True(linked.IsCancellationRequested);
+		});
+		Assert.Null(ex);
+
+		// The transcription is still tearing down, so it remains reported as active
+		// until the owning task ends it.
+		Assert.True(state.TranscribingAudio);
+	}
+
+	[Fact]
+	public void EndTranscription_DisposesSource_AndClearsTranscribingFlag()
+	{
+		using var state = new SpeechToTextState(() => null);
+		state.StartTranscription();
+		Assert.True(state.TranscribingAudio);
+
+		state.EndTranscription();
+		Assert.False(state.TranscribingAudio);
+
+		// Idempotent: the owning task's finally and a later Dispose can both run.
+		state.EndTranscription();
+		Assert.False(state.TranscribingAudio);
+	}
+
+	[Fact]
+	public void StartTranscription_WhenPriorSourceLingers_CancelsPriorToken()
+	{
+		using var state = new SpeechToTextState(() => null);
+		var first = state.StartTranscription();
+		Assert.False(first.IsCancellationRequested);
+
+		// A second start without an intervening End must cancel the stale source
+		// before disposing it rather than abandoning an operation still tied to it.
+		var second = state.StartTranscription();
+
+		Assert.True(first.IsCancellationRequested);
+		Assert.False(second.IsCancellationRequested);
+	}
+
+	[Fact]
+	public async Task CancelTranscription_WhileServiceRetries_SurfacesOperationCanceled_NotObjectDisposed()
+	{
+		string sessionPath = Path.Combine(_tempDirectory, "session_2024-01-01_00-00-00.ogg");
+		await File.WriteAllTextAsync(sessionPath, "audio");
+		var session = new SpeechSession(sessionPath, new DateTime(2024, 1, 1));
+
+		var service = new RetryingCancellableService();
+		using var manager = new SpeechToTextManager(_settings, () => new NoopAudioRecorder());
+
+		var transcription = manager.TranscribeExistingRecordingAsync(service, session, "prompt", CancellationToken.None);
+
+		// Wait until the service is mid-call, then cancel while it is about to link
+		// a new token to the caller's source — the exact race the bug hit.
+		await service.Started;
+		manager.CancelTranscription();
+		service.Proceed();
+
+		await Assert.ThrowsAnyAsync<OperationCanceledException>(() => transcription);
+	}
+
+	// Mimics OpenAiSpeechToTextService's retry loop: it links a fresh source to
+	// the caller's token on each attempt. The test drives it to that point after
+	// a cancel to reproduce the dispose-during-retry race.
+	private sealed class RetryingCancellableService : ISpeechToTextService
+	{
+		private readonly TaskCompletionSource _started = new(TaskCreationOptions.RunContinuationsAsynchronously);
+		private readonly TaskCompletionSource _proceed = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+		public string ServiceName { get; init; } = "fake";
+
+		public Task Started => _started.Task;
+		public void Proceed() => _proceed.TrySetResult();
+
+		public async Task<string> ConvertAudioToText(string speechToTextPrompt, string audioffilePath, CancellationToken overallCancellationToken, int? timeoutSeconds = null)
+		{
+			_started.TrySetResult();
+			await _proceed.Task.ConfigureAwait(false);
+
+			using var thisTry = new CancellationTokenSource();
+			using var linked = CancellationTokenSource.CreateLinkedTokenSource(overallCancellationToken, thisTry.Token);
+			linked.Token.ThrowIfCancellationRequested();
+			return "unexpected-success";
+		}
+	}
+
+	private sealed class NoopAudioRecorder : IAudioRecorder
+	{
+		public double? TrimmedSpeechSeconds => null;
+		public Exception? CaptureException => null;
+
+		public void StartRecording(int captureDeviceIndex, string outputFile, SilenceTrimmerOptions? silenceOptions = null)
+		{
+		}
+
+		public void StopRecording()
+		{
+		}
+
+		public void Dispose()
+		{
+		}
+	}
+}

--- a/Mutation.Ui/Core/SpeechToTextManager.cs
+++ b/Mutation.Ui/Core/SpeechToTextManager.cs
@@ -248,7 +248,7 @@ public class SpeechToTextManager : IDisposable
 			}
 			finally
 			{
-				_state.StopTranscription();
+				_state.EndTranscription();
 			}
 		}
 		finally
@@ -287,7 +287,7 @@ public class SpeechToTextManager : IDisposable
 			}
 			finally
 			{
-				_state.StopTranscription();
+				_state.EndTranscription();
 			}
 
 			return text;
@@ -300,7 +300,7 @@ public class SpeechToTextManager : IDisposable
 
 	public void CancelTranscription()
 	{
-		_state.StopTranscription();
+		_state.CancelTranscription();
 	}
 
 	public async Task StopRecordingAsync()

--- a/Mutation.Ui/Core/SpeechToTextState.cs
+++ b/Mutation.Ui/Core/SpeechToTextState.cs
@@ -27,18 +27,43 @@ internal class SpeechToTextState : IDisposable
 
 	// Returns a token tied to BOTH the new internal CTS and `external`.
 	// Caller MUST use the returned token rather than re-reading state to avoid
-	// a race with StopTranscription on a different thread.
+	// a race with CancelTranscription on a different thread.
 	internal CancellationToken StartTranscription(CancellationToken external = default)
 	{
 		lock (_ctsLock)
 		{
-			_cts?.Dispose();
+			// A prior transcription should already have been ended, but if a stale
+			// source lingers, cancel it before disposing so any operation still tied
+			// to it unwinds as a cancellation rather than being abandoned mid-flight.
+			if (_cts is not null)
+			{
+				try { _cts.Cancel(); } catch (ObjectDisposedException) { }
+				_cts.Dispose();
+			}
 			_cts = CancellationTokenSource.CreateLinkedTokenSource(external);
 			return _cts.Token;
 		}
 	}
 
-	internal void StopTranscription()
+	// Signals cancellation WITHOUT disposing the source. Called from the UI
+	// cancel path, which can run while the owning transcription is still
+	// retrying — a retry attempt links a fresh token to this source on every
+	// try, so disposing here would surface ObjectDisposedException instead of a
+	// clean cancellation. Disposal is deferred to EndTranscription.
+	internal void CancelTranscription()
+	{
+		lock (_ctsLock)
+		{
+			if (_cts is null)
+				return;
+			try { _cts.Cancel(); } catch (ObjectDisposedException) { }
+		}
+	}
+
+	// Ends the current transcription and disposes its source. Called by the
+	// owning task once its awaited transcription (and every retry) has
+	// finished, so nothing can still link a token to the source. Idempotent.
+	internal void EndTranscription()
 	{
 		CancellationTokenSource? toDispose;
 		lock (_ctsLock)
@@ -54,7 +79,7 @@ internal class SpeechToTextState : IDisposable
 
 	public void Dispose()
 	{
-		StopTranscription();
+		EndTranscription();
 		AudioRecorderLock.Dispose();
 	}
 }


### PR DESCRIPTION
Closes #179

## What changed

Cancelling an in-progress transcription could surface a raw
`ObjectDisposedException` error dialog instead of a clean "Transcription
cancelled" message.

The cause: `SpeechToTextState.StopTranscription()` cancelled **and then
immediately disposed** the `CancellationTokenSource` that ties the
transcription to its cancellation. That method ran from two places — the UI
cancel path and the owning transcription task's cleanup. The OpenAI
speech-to-text service retries on failure, and each retry attempt links a
fresh cancellation token to that same source. When a user cancel landed
between two retry attempts, it disposed the source while the next attempt
was about to link to it, throwing `ObjectDisposedException`. That is not a
cancellation exception, so the layer that turns a cancel into a friendly
"Transcription cancelled" message did not recognise it and showed a raw
error dialog instead.

The fix splits the one "stop" operation into two, so cancelling never
disposes a source that retries might still use:

- **`CancelTranscription`** — signals cancellation only, no disposal. This
  is what the UI cancel path now calls. Retries still holding the token see
  the cancel and unwind cleanly as a cancellation.
- **`EndTranscription`** — cancels, disposes, and clears the source. Only
  the owning transcription task calls it, in its `finally`, once the awaited
  call and all of its retries have finished, so nothing can link to the
  source any more.

`StartTranscription` now also cancels a lingering prior source before
disposing it, rather than dropping it mid-flight.

One deliberate behaviour change: the app now reports a transcription as
"transcribing" from the moment of cancel until the task finishes tearing
down (a brief window) rather than flipping the state the instant cancel is
pressed. This is safer — the recorder lock is still held during teardown,
so the state now matches reality.

## Files

- `Mutation.Ui/Core/SpeechToTextState.cs` — split `StopTranscription` into
  `CancelTranscription` (signal only) and `EndTranscription` (dispose);
  cancel-before-dispose in `StartTranscription`.
- `Mutation.Ui/Core/SpeechToTextManager.cs` — the two transcription paths
  call `EndTranscription` in their `finally`; the public
  `CancelTranscription` delegates to the signal-only method.
- `Mutation.Tests/TranscriptionCancellationTests.cs` — new tests.

## Test plan

- `dotnet test --configuration Release` — all 645 tests pass, including 4
  new ones:
  - cancel signals cancellation without disposing the source (a fresh linked
    token can still be created and is already cancelled — no
    `ObjectDisposedException`);
  - end disposes the source and clears the transcribing flag, and is
    idempotent;
  - starting a new transcription cancels a lingering prior source;
  - end-to-end: a cancel while the service is mid-retry surfaces an
    `OperationCanceledException`, not an `ObjectDisposedException`.
