### PR TITLE
Lock mic selection paths and dispose superseded device wrappers

### DIFF
--- a/Mutation.Tests/AudioDeviceDisposalTests.cs
+++ b/Mutation.Tests/AudioDeviceDisposalTests.cs
@@ -1,0 +1,72 @@
+using System;
+using Mutation.Ui;
+
+namespace Mutation.Tests;
+
+/// <summary>
+/// Covers <see cref="AudioDeviceManager.DisposeSuperseded{T}"/> — the rule that
+/// releases the COM wrappers dropped on a hot-plug re-enumeration while keeping
+/// the currently selected microphone alive. Exercised through a fake disposable
+/// because real CoreAudio <c>MMDevice</c> instances need physical hardware.
+/// </summary>
+public class AudioDeviceDisposalTests
+{
+	private sealed class FakeDisposable : IDisposable
+	{
+		public int DisposeCount { get; private set; }
+		public bool ThrowOnDispose { get; init; }
+
+		public void Dispose()
+		{
+			DisposeCount++;
+			if (ThrowOnDispose)
+				throw new InvalidOperationException("boom");
+		}
+	}
+
+	[Fact]
+	public void Disposes_every_superseded_device_when_none_is_selected()
+	{
+		var a = new FakeDisposable();
+		var b = new FakeDisposable();
+
+		AudioDeviceManager.DisposeSuperseded(new[] { a, b }, selected: null);
+
+		Assert.Equal(1, a.DisposeCount);
+		Assert.Equal(1, b.DisposeCount);
+	}
+
+	[Fact]
+	public void Skips_the_currently_selected_device()
+	{
+		var selected = new FakeDisposable();
+		var other = new FakeDisposable();
+
+		AudioDeviceManager.DisposeSuperseded(new[] { selected, other }, selected);
+
+		Assert.Equal(0, selected.DisposeCount);
+		Assert.Equal(1, other.DisposeCount);
+	}
+
+	[Fact]
+	public void A_failing_dispose_does_not_strand_the_remaining_devices()
+	{
+		var bad = new FakeDisposable { ThrowOnDispose = true };
+		var good = new FakeDisposable();
+
+		AudioDeviceManager.DisposeSuperseded(new[] { bad, good }, selected: null);
+
+		Assert.Equal(1, bad.DisposeCount);
+		Assert.Equal(1, good.DisposeCount);
+	}
+
+	[Fact]
+	public void Null_entries_are_ignored()
+	{
+		var real = new FakeDisposable();
+
+		AudioDeviceManager.DisposeSuperseded(new FakeDisposable[] { null!, real }, selected: null);
+
+		Assert.Equal(1, real.DisposeCount);
+	}
+}

--- a/Mutation.Ui/Core/AudioDeviceManager.cs
+++ b/Mutation.Ui/Core/AudioDeviceManager.cs
@@ -54,9 +54,11 @@ public class AudioDeviceManager : IMuteEndpointProvider, ICaptureLevelEndpointPr
                 get { lock (_sync) return _captureDevices.ToList(); }
         }
 
-        public MMDevice? Microphone => _microphone;
+        // Read under _sync: a hot-plug on the notification thread can re-point
+        // _microphone / _microphoneDeviceIndex while a caller reads them.
+        public MMDevice? Microphone { get { lock (_sync) return _microphone; } }
 
-        public int MicrophoneDeviceIndex => _microphoneDeviceIndex;
+        public int MicrophoneDeviceIndex { get { lock (_sync) return _microphoneDeviceIndex; } }
 
         // Reflects the aggregate mute state that was actually written to the
         // capture devices and confirmed by read-back — not an optimistic guess
@@ -68,32 +70,53 @@ public class AudioDeviceManager : IMuteEndpointProvider, ICaptureLevelEndpointPr
                 var devices = _deviceEnumerator.EnumerateAudioEndPoints(DataFlow.Capture, DeviceState.Active);
                 lock (_sync)
                 {
+                        var superseded = _captureDevices;
                         _captureDevices = devices.ToList();
+                        // Dispose the COM wrappers from the previous enumeration so they do
+                        // not accumulate until finalization. The currently selected mic is
+                        // skipped: it stays live for recording and level/mute operations, and
+                        // RefreshActiveMicrophone swaps it for a fresh instance itself.
+                        DisposeSuperseded(superseded, _microphone);
                 }
         }
 
         public void SelectMicrophone(MMDevice device)
         {
-                _microphone = device ?? throw new ArgumentNullException(nameof(device));
-                SelectCaptureDeviceForNAudio();
+                if (device is null)
+                        throw new ArgumentNullException(nameof(device));
+
+                // Serialize with the device-change handler so a hot-plug re-enumeration
+                // cannot race the selection and leave _microphone and
+                // _microphoneDeviceIndex pointing at different devices.
+                lock (_sync)
+                {
+                        _microphone = device;
+                        SelectCaptureDeviceForNAudio();
+                }
         }
 
 	public void EnsureDefaultMicrophoneSelected()
 	{
-		if (_microphone != null)
-			return;
+		// The read of _microphone and the assignment that follows must be one
+		// atomic step relative to the device-change handler, so take the lock
+		// around the whole check-and-set rather than just the write.
+		lock (_sync)
+		{
+			if (_microphone != null)
+				return;
 
-                try
-                {
-                        var defaultMic = _deviceEnumerator.GetDefaultAudioEndpoint(DataFlow.Capture, Role.Console);
-                        if (defaultMic != null)
-                        {
-                                _microphone = defaultMic;
-                                SelectCaptureDeviceForNAudio();
-                        }
-                }
-                catch { }
-        }
+			try
+			{
+				var defaultMic = _deviceEnumerator.GetDefaultAudioEndpoint(DataFlow.Capture, Role.Console);
+				if (defaultMic != null)
+				{
+					_microphone = defaultMic;
+					SelectCaptureDeviceForNAudio();
+				}
+			}
+			catch { }
+		}
+	}
 
 	private void SelectCaptureDeviceForNAudio()
 	{
@@ -197,6 +220,9 @@ public class AudioDeviceManager : IMuteEndpointProvider, ICaptureLevelEndpointPr
                 try { id = _microphone.ID; }
                 catch { id = null; }
 
+                // RefreshCaptureDevices deliberately preserves the selected wrapper, so
+                // hold onto it here to dispose once a fresh instance replaces it below.
+                var previous = _microphone;
                 RefreshCaptureDevices();
 
                 if (id is null)
@@ -207,6 +233,10 @@ public class AudioDeviceManager : IMuteEndpointProvider, ICaptureLevelEndpointPr
                 {
                         _microphone = fresh;
                         SelectCaptureDeviceForNAudio();
+                        // The previous wrapper survived the re-enumeration; now that a fresh
+                        // instance is selected, dispose it so it does not leak.
+                        try { previous.Dispose(); }
+                        catch { }
                 }
         }
 
@@ -214,6 +244,23 @@ public class AudioDeviceManager : IMuteEndpointProvider, ICaptureLevelEndpointPr
         {
                 try { return device != null && string.Equals(device.ID, id, StringComparison.OrdinalIgnoreCase); }
                 catch { return false; }
+        }
+
+        // Disposes the COM wrappers from a superseded enumeration, skipping the one
+        // that is still the selected microphone (it stays live for the caller) and
+        // swallowing a per-device failure so one bad wrapper cannot strand the rest.
+        // Generic and static so the "skip the selected one" rule is unit-testable
+        // without real CoreAudio devices.
+        internal static void DisposeSuperseded<T>(IEnumerable<T> superseded, T? selected)
+                where T : class, IDisposable
+        {
+                foreach (var device in superseded)
+                {
+                        if (device is null || ReferenceEquals(device, selected))
+                                continue;
+                        try { device.Dispose(); }
+                        catch { }
+                }
         }
 
         // Callers hold _sync; the lock is reentrant so RefreshCaptureDevices'


### PR DESCRIPTION
## What this fixes

`AudioDeviceManager` keeps a lock (`_sync`) to stop the capture-device list and mute application from racing the background thread that OS device-change (hot-plug) notifications arrive on. The problem: the paths a user actually drives — selecting a microphone, falling back to the default mic, and reading the currently selected device/index — touched that same shared state **without** taking the lock.

As a result, plugging or unplugging a microphone at the same moment as a selection could leave the two pieces of "which mic" state out of step: `_microphone` (the device object) and `_microphoneDeviceIndex` (the recording index). The next recording could then capture from the wrong device or from index `-1` (no audio), and the pinned input-level adjustment could target a different device than the one recording.

A second, related problem: each re-enumeration replaced the device list but never released the old audio COM objects, so they accumulated in memory until the garbage collector finalised them.

## What changed

- Take `_sync` in `SelectMicrophone`, `EnsureDefaultMicrophoneSelected`, and the `Microphone` / `MicrophoneDeviceIndex` getters, so every read and write of the selected-microphone state is serialised with the hot-plug handler. The lock is reentrant, so the nested lock already inside `RefreshCaptureDevices` is harmless — this matches the pattern the mute path already uses.
- On re-enumeration, dispose the superseded device objects instead of dropping them. The currently selected microphone is deliberately kept alive (it is still in use); when the selected device is later refreshed to a fresh instance, the old one is disposed then.
- The "dispose the old ones but skip the selected one" rule is pulled out into a small generic helper so it can be unit-tested with a fake, since real audio devices need physical hardware.

## Test plan

- `dotnet test --configuration Release` — all 649 tests pass, including 4 new tests covering the disposal rule (disposes all superseded devices, skips the selected one, a failing dispose does not strand the rest, null entries ignored).
- The locking change has no automated coverage: `AudioDeviceManager` binds directly to CoreAudio's concrete device types, which cannot be instantiated without real hardware, so the class has no unit-test seam. The change is a defensive addition of an existing lock to sibling code paths and does not alter observable behaviour on the single-threaded path.

Closes #180
