### PR TITLE
Move mic-level slider and record-start COM writes off the UI thread (#197)

### DIFF
--- a/Mutation.Tests/MicrophoneLevelWriteCoordinatorTests.cs
+++ b/Mutation.Tests/MicrophoneLevelWriteCoordinatorTests.cs
@@ -1,0 +1,159 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Mutation.Ui.Core;
+using Xunit;
+
+namespace Mutation.Tests;
+
+public class MicrophoneLevelWriteCoordinatorTests
+{
+	[Fact]
+	public void Constructor_NullWrite_Throws()
+	{
+		Assert.Throws<ArgumentNullException>(() => new MicrophoneLevelWriteCoordinator(null!));
+	}
+
+	[Fact]
+	public async Task RequestLatestAsync_ReturnsTheWriteResult()
+	{
+		var coordinator = new MicrophoneLevelWriteCoordinator(
+			_ => new CaptureLevelResult(CaptureLevelOutcome.Failed));
+
+		var result = await coordinator.RequestLatestAsync(30);
+
+		Assert.Equal(new CaptureLevelResult(CaptureLevelOutcome.Failed), result);
+	}
+
+	[Fact]
+	public async Task RequestLatestAsync_RunsTheWriteOffTheCallingThread()
+	{
+		// The write signals it started, then blocks. If it ran synchronously on this
+		// thread, RequestLatestAsync would block inside it and never hand back a task —
+		// so reaching the asserts below, with "started" already signalled, proves the
+		// write runs on another thread.
+		var started = new ManualResetEventSlim(false);
+		var release = new ManualResetEventSlim(false);
+		var coordinator = new MicrophoneLevelWriteCoordinator(_ =>
+		{
+			started.Set();
+			release.Wait();
+			return new CaptureLevelResult(CaptureLevelOutcome.Applied);
+		});
+
+		var task = coordinator.RequestLatestAsync(50);
+
+		Assert.True(started.Wait(TimeSpan.FromSeconds(5)), "write did not start on a background thread");
+		Assert.False(task.IsCompleted);
+		Assert.True(coordinator.IsWriting);
+
+		release.Set();
+		var result = await task;
+
+		Assert.Equal(new CaptureLevelResult(CaptureLevelOutcome.Applied), result);
+		AssertEventually(() => !coordinator.IsWriting, "worker did not settle after the write");
+	}
+
+	[Fact]
+	public async Task RequestLatestAsync_CoalescesToLatest_AppliesFirstAndLast_DropsMiddle()
+	{
+		var started = new ManualResetEventSlim(false);
+		var release = new ManualResetEventSlim(false);
+		var applied = new List<int>();
+		bool firstCall = true;
+
+		CaptureLevelResult Write(int level)
+		{
+			bool isFirst;
+			lock (applied)
+			{
+				isFirst = firstCall;
+				firstCall = false;
+				applied.Add(level);
+			}
+
+			// Block only the first write, so the burst below queues behind it.
+			if (isFirst)
+			{
+				started.Set();
+				release.Wait();
+			}
+
+			return new CaptureLevelResult(CaptureLevelOutcome.Applied);
+		}
+
+		var coordinator = new MicrophoneLevelWriteCoordinator(Write);
+
+		var first = coordinator.RequestLatestAsync(10);
+		Assert.True(started.Wait(TimeSpan.FromSeconds(5)), "first write did not start");
+
+		// While the first write is blocked, three more requests queue. Each supersedes
+		// the previous still-queued one, so only the last survives to be written.
+		var superseded1 = coordinator.RequestLatestAsync(20);
+		var superseded2 = coordinator.RequestLatestAsync(30);
+		var latest = coordinator.RequestLatestAsync(40);
+
+		// The two middle requests were dropped before they ran.
+		Assert.Null(await superseded1);
+		Assert.Null(await superseded2);
+
+		release.Set();
+
+		Assert.NotNull(await first);
+		Assert.NotNull(await latest);
+
+		lock (applied)
+		{
+			// First and last reach the device, in order; the middle values never do.
+			Assert.Equal(new[] { 10, 40 }, applied);
+		}
+
+		AssertEventually(() => !coordinator.IsWriting, "worker did not settle");
+	}
+
+	[Fact]
+	public async Task RequestLatestAsync_TreatsAThrowingWriteAsFailed()
+	{
+		var coordinator = new MicrophoneLevelWriteCoordinator(
+			_ => throw new InvalidOperationException("device fault"));
+
+		var result = await coordinator.RequestLatestAsync(10);
+
+		Assert.Equal(new CaptureLevelResult(CaptureLevelOutcome.Failed), result);
+		AssertEventually(() => !coordinator.IsWriting, "worker did not settle after a throw");
+	}
+
+	[Fact]
+	public async Task RequestLatestAsync_AllowsANewWriteAfterThePreviousCompletes()
+	{
+		var applied = new List<int>();
+		var coordinator = new MicrophoneLevelWriteCoordinator(level =>
+		{
+			lock (applied) applied.Add(level);
+			return new CaptureLevelResult(CaptureLevelOutcome.Applied);
+		});
+
+		Assert.NotNull(await coordinator.RequestLatestAsync(10));
+		Assert.NotNull(await coordinator.RequestLatestAsync(20));
+
+		lock (applied) Assert.Equal(new[] { 10, 20 }, applied);
+		AssertEventually(() => !coordinator.IsWriting, "worker did not settle");
+	}
+
+	// Spins briefly for a condition the worker satisfies just after an awaited task
+	// completes (it clears its running flag on the loop pass after signalling the
+	// result), avoiding a race with a bare assertion.
+	private static void AssertEventually(Func<bool> condition, string message)
+	{
+		var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+		while (DateTime.UtcNow < deadline)
+		{
+			if (condition())
+				return;
+			Thread.Sleep(10);
+		}
+
+		Assert.True(condition(), message);
+	}
+}

--- a/Mutation.Ui/App.xaml.cs
+++ b/Mutation.Ui/App.xaml.cs
@@ -197,6 +197,12 @@ public partial class App : Application
 			builder.Services.AddSingleton<Mutation.Ui.Core.ICaptureLevelEndpointProvider>(sp =>
 				sp.GetRequiredService<AudioDeviceManager>());
 			builder.Services.AddSingleton<Mutation.Ui.Core.MicrophoneLevelPinService>();
+				// One shared instance serializes every capture-level write (slider, pin
+				// toggle, record-start re-assert) onto a single background worker, so the
+				// COM writes never run on the UI thread and never overlap each other.
+				builder.Services.AddSingleton<Mutation.Ui.Core.MicrophoneLevelWriteCoordinator>(sp =>
+					new Mutation.Ui.Core.MicrophoneLevelWriteCoordinator(
+						sp.GetRequiredService<Mutation.Ui.Core.MicrophoneLevelPinService>().ApplyLevel));
 			builder.Services.AddSingleton<IOcrService>(sp =>
 	 new OcrService(
 		  settings.AzureComputerVisionSettings?.ApiKey,

--- a/Mutation.Ui/Core/AudioSessionManager.cs
+++ b/Mutation.Ui/Core/AudioSessionManager.cs
@@ -24,7 +24,7 @@ public class AudioSessionManager : IDisposable
     private readonly AudioDeviceManager _audioDeviceManager;
     private readonly TranscriptFormatter _transcriptFormatter;
     private readonly Settings _settings;
-    private readonly MicrophoneLevelPinService _levelPinService;
+    private readonly MicrophoneLevelWriteCoordinator _levelWriteCoordinator;
     private readonly AudioPlayer _playbackPlayer;
     private SpeechSession? _playingSession;
     private SpeechSession? _selectedSession;
@@ -74,13 +74,13 @@ public class AudioSessionManager : IDisposable
         AudioDeviceManager audioDeviceManager,
         TranscriptFormatter transcriptFormatter,
         Settings settings,
-        MicrophoneLevelPinService levelPinService)
+        MicrophoneLevelWriteCoordinator levelWriteCoordinator)
     {
         _speechManager = speechManager;
         _audioDeviceManager = audioDeviceManager;
         _transcriptFormatter = transcriptFormatter;
         _settings = settings;
-        _levelPinService = levelPinService;
+        _levelWriteCoordinator = levelWriteCoordinator;
 
         _playbackPlayer = new AudioPlayer();
         _playbackPlayer.PlaybackEnded += PlaybackPlayer_PlaybackEnded;
@@ -162,12 +162,16 @@ public class AudioSessionManager : IDisposable
 
                 // Re-assert the pinned capture level right before recording so a level
                 // another app may have changed is corrected back to the user's choice.
+                // The write runs on the shared level-write worker, off the UI thread, so
+                // the failure path's device re-enumeration cannot freeze the UI (and the
+                // screen reader) — the same off-thread guarantee #171 gave the mute
+                // toggle. We await it so the level is settled before capture starts.
                 // If it cannot be applied and verified, tell the user rather than
                 // recording silently at the wrong gain — the recording still proceeds
                 // so no audio is lost, but the failure is signalled with a beep (played
                 // before capture starts, so it is not recorded) and a persistent status
                 // message that replaces the usual "Listening" line.
-                var levelResult = _levelPinService.ReassertPinnedLevel(_settings.AudioSettings?.PinnedCaptureLevel);
+                var levelResult = await ReassertPinnedLevelOffThreadAsync();
                 if (levelResult.Failed)
                     BeepPlayer.Play(BeepType.Failure);
 
@@ -220,6 +224,21 @@ public class AudioSessionManager : IDisposable
             ErrorOccurred?.Invoke(this, ex.Message);
             StateChanged?.Invoke(this, EventArgs.Empty);
         }
+    }
+
+    // Re-asserts the pinned capture level through the shared off-thread write worker.
+    // A null pin means pinning is disabled — nothing to write, so the level is
+    // Unchanged. A superseded write (the coordinator dropped this request because a
+    // newer level was requested and applied instead) is also Unchanged for signalling
+    // purposes: the device settled on the newer value, so there is nothing to warn the
+    // user about here.
+    private async Task<CaptureLevelResult> ReassertPinnedLevelOffThreadAsync()
+    {
+        if (_settings.AudioSettings?.PinnedCaptureLevel is not int pinned)
+            return new CaptureLevelResult(CaptureLevelOutcome.Unchanged);
+
+        return await _levelWriteCoordinator.RequestLatestAsync(pinned)
+            ?? new CaptureLevelResult(CaptureLevelOutcome.Unchanged);
     }
 
     public async Task RetryTranscriptionAsync(ISpeechToTextService activeService, string prompt, CancellationToken cancellationToken = default)

--- a/Mutation.Ui/Core/MicrophoneLevelWriteCoordinator.cs
+++ b/Mutation.Ui/Core/MicrophoneLevelWriteCoordinator.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Mutation.Ui.Core;
+
+/// <summary>
+/// Serializes microphone capture-level writes onto a single background worker so the
+/// COM write, its read-back verification, and any device re-enumeration in the
+/// underlying write never run on the UI thread (which would freeze the UI and, with
+/// it, the screen reader). The write itself is injected as a delegate, keeping this
+/// coordinator unit-testable without audio hardware or a UI.
+///
+/// Unlike <see cref="MicrophoneMuteToggleCoordinator"/>, which drops an overlapping
+/// toggle, this coalesces to the latest requested level. A slider drag or a held
+/// arrow key raises a burst of level requests, and only the most recent one needs to
+/// reach the device — writing every intermediate value would apply a backlog of
+/// stale levels and could settle on the wrong one. So a request that has not started
+/// yet when a newer one arrives is superseded and dropped; the device ends up at the
+/// value the user actually chose.
+///
+/// Because a single instance is shared by every level writer (the slider, the pin
+/// toggle, and the record-start re-assert), it is also the one serialization point
+/// for the level endpoint: two threads never write the same COM object at once.
+/// </summary>
+public sealed class MicrophoneLevelWriteCoordinator
+{
+	private readonly Func<int, CaptureLevelResult> _write;
+	private readonly object _gate = new();
+
+	// The most recent level requested but not yet being written, and the awaiter tied
+	// to it. Both are cleared the moment the worker picks the request up. Guarded by
+	// _gate.
+	private int? _pendingLevel;
+	private TaskCompletionSource<CaptureLevelResult?>? _pendingCompletion;
+
+	// True while the drain worker is alive (a write is in flight or a request is
+	// queued). Guarded by _gate.
+	private bool _workerRunning;
+
+	public MicrophoneLevelWriteCoordinator(Func<int, CaptureLevelResult> write)
+	{
+		_write = write ?? throw new ArgumentNullException(nameof(write));
+	}
+
+	/// <summary>
+	/// True while a level write started by this coordinator is in flight or a newer
+	/// request is queued behind it.
+	/// </summary>
+	public bool IsWriting
+	{
+		get { lock (_gate) return _workerRunning; }
+	}
+
+	/// <summary>
+	/// Requests that <paramref name="level"/> be written to the device, coalescing to
+	/// the latest request. The write runs on a background thread. The returned task
+	/// completes with the write's <see cref="CaptureLevelResult"/> when this request
+	/// is the one applied, or with <c>null</c> when a newer request superseded it
+	/// before it started. The continuation resumes on the caller's synchronization
+	/// context (the UI thread when awaited from a UI event), so the caller can update
+	/// the UI directly with the outcome.
+	/// </summary>
+	public Task<CaptureLevelResult?> RequestLatestAsync(int level)
+	{
+		TaskCompletionSource<CaptureLevelResult?>? superseded;
+		var mine = new TaskCompletionSource<CaptureLevelResult?>(
+			TaskCreationOptions.RunContinuationsAsynchronously);
+		bool startWorker = false;
+
+		lock (_gate)
+		{
+			// Any request still queued (not yet started) is now stale — this newer one
+			// replaces it.
+			superseded = _pendingCompletion;
+			_pendingLevel = level;
+			_pendingCompletion = mine;
+
+			if (!_workerRunning)
+			{
+				_workerRunning = true;
+				startWorker = true;
+			}
+		}
+
+		// A dropped request completes with null. Done outside the lock so a continuation
+		// cannot run while it is held.
+		superseded?.TrySetResult(null);
+
+		if (startWorker)
+			_ = Task.Run(Drain);
+
+		return mine.Task;
+	}
+
+	// Applies queued level requests one at a time until none remain. Only the request
+	// currently held in _pendingLevel is applied each pass, so a burst that arrives
+	// during a write collapses to its most recent value.
+	private void Drain()
+	{
+		while (true)
+		{
+			int level;
+			TaskCompletionSource<CaptureLevelResult?> completion;
+
+			lock (_gate)
+			{
+				if (_pendingLevel is not int pending)
+				{
+					_workerRunning = false;
+					return;
+				}
+
+				level = pending;
+				completion = _pendingCompletion!;
+				_pendingLevel = null;
+				_pendingCompletion = null;
+			}
+
+			CaptureLevelResult result;
+			try
+			{
+				result = _write(level);
+			}
+			catch
+			{
+				// The injected write already treats device faults as a failed write and
+				// returns Failed; this guard only keeps an unexpected throw from killing
+				// the worker or leaving the awaiter hanging.
+				result = new CaptureLevelResult(CaptureLevelOutcome.Failed);
+			}
+
+			completion.TrySetResult(result);
+		}
+	}
+}

--- a/Mutation.Ui/MainWindow.xaml.cs
+++ b/Mutation.Ui/MainWindow.xaml.cs
@@ -1330,47 +1330,68 @@ public sealed partial class MainWindow : Window, IDisposable
 	// Toggle pinning on/off. Turning it on captures the slider's current value as the
 	// pinned target and applies it immediately; turning it off stops re-asserting but
 	// leaves the live level where it is. Persists the change.
-	private void TglPinMicLevel_Toggled(object sender, RoutedEventArgs e)
+	private async void TglPinMicLevel_Toggled(object sender, RoutedEventArgs e)
 	{
 		if (!_micLevelControlsReady) return;
 
 		_settings.AudioSettings ??= new AudioSettings();
 
+		int? target = null;
 		if (TglPinMicLevel.IsOn)
 		{
-			int level = (int)Math.Round(SldMicLevel.Value);
-			_settings.AudioSettings.PinnedCaptureLevel = level;
-			ReportIfLevelWriteFailed(_micLevelPinService.ApplyLevel(level));
+			target = (int)Math.Round(SldMicLevel.Value);
+			_settings.AudioSettings.PinnedCaptureLevel = target;
 		}
 		else
 		{
 			_settings.AudioSettings.PinnedCaptureLevel = null;
 		}
 
+		// Persist the pin state synchronously; it must be saved regardless of the async
+		// write below.
 		_settingsManager.SaveSettingsToFile(_settings);
+
+		// Turning the pin on applies the current slider level through the shared
+		// off-thread worker, so it neither blocks the UI nor overlaps a trailing slider
+		// write on the same COM endpoint. Turning it off writes nothing.
+		if (target is int level)
+		{
+			var result = await _micLevelWriteCoordinator.RequestLatestAsync(level);
+			if (result is { } outcome)
+				ReportIfLevelWriteFailed(outcome);
+		}
 	}
 
 	// Dragging the slider sets the actual Windows capture level immediately (instant
 	// feedback, even when not recording). When pinning is enabled, the same value
 	// becomes the stored pinned target so it is re-asserted later.
-	private void SldMicLevel_ValueChanged(object sender, RangeBaseValueChangedEventArgs e)
+	private async void SldMicLevel_ValueChanged(object sender, RangeBaseValueChangedEventArgs e)
 	{
 		if (!_micLevelControlsReady) return;
 
 		int level = (int)Math.Round(e.NewValue);
-		ReportIfLevelWriteFailed(_micLevelPinService.ApplyLevel(level));
 
+		// Record the intent first, synchronously on the UI thread. The COM write below is
+		// coalesced, so a tick that gets superseded never reaches the device — but its
+		// value must still become the stored pin. Only the file write is debounced, so a
+		// drag or held arrow key persists once it settles (issue #172).
 		if (TglPinMicLevel.IsOn)
 		{
 			_settings.AudioSettings ??= new AudioSettings();
 			if (_settings.AudioSettings.PinnedCaptureLevel != level)
 			{
 				_settings.AudioSettings.PinnedCaptureLevel = level;
-				// Keep the live COM level write per tick above; only coalesce the file
-				// write, so a drag or held arrow key persists once it settles (issue #172).
 				_settingsSaveDebouncer.Trigger();
 			}
 		}
+
+		// Coalesce-to-latest off-thread write: a burst from a drag or held arrow key
+		// collapses to its most recent value, so the write (and its failure-path device
+		// re-enumeration) never runs on the UI thread. Superseded ticks return null and
+		// are dropped, so only the write that reaches the device can raise a failure beep.
+		var result = await _micLevelWriteCoordinator.RequestLatestAsync(level);
+		if (result is { } outcome)
+			ReportIfLevelWriteFailed(outcome);
 	}
 
 	// When a level write could not be applied and verified, warn the user with the

--- a/Mutation.Ui/MainWindow.xaml.cs
+++ b/Mutation.Ui/MainWindow.xaml.cs
@@ -43,6 +43,11 @@ public sealed partial class MainWindow : Window, IDisposable
 	// re-enumeration off the UI thread so a hotkey press during a device hot-plug
 	// never freezes the UI (and the screen reader).
 	private readonly Mutation.Ui.Core.MicrophoneMuteToggleCoordinator _muteToggleCoordinator;
+	// Serializes the mic-level slider and pin-toggle COM writes onto the shared
+	// background worker so a drag burst never runs the write (and its failure-path
+	// device re-enumeration) on the UI thread, and never overlaps the record-start
+	// re-assert on the same COM endpoint.
+	private readonly Mutation.Ui.Core.MicrophoneLevelWriteCoordinator _micLevelWriteCoordinator;
 	private readonly TranscriptFormatter _transcriptFormatter;
 	private readonly ITextToSpeechService _textToSpeech;
 	private readonly IWavFileSpeechExporter _wavFileSpeechExporter;
@@ -131,7 +136,8 @@ public sealed partial class MainWindow : Window, IDisposable
 		ISettingsManager settingsManager,
 		Settings settings,
 		Mutation.Ui.Core.AudioSessionManager audioSessionManager,
-		Mutation.Ui.Core.MicrophoneLevelPinService micLevelPinService)
+		Mutation.Ui.Core.MicrophoneLevelPinService micLevelPinService,
+		Mutation.Ui.Core.MicrophoneLevelWriteCoordinator micLevelWriteCoordinator)
 	{
 		_clipboard = clipboard;
 		_uiStateManager = uiStateManager;
@@ -150,6 +156,7 @@ public sealed partial class MainWindow : Window, IDisposable
 
         _audioSessionManager = audioSessionManager;
         _micLevelPinService = micLevelPinService;
+        _micLevelWriteCoordinator = micLevelWriteCoordinator;
         _muteToggleCoordinator = new Mutation.Ui.Core.MicrophoneMuteToggleCoordinator(_audioDeviceManager.ToggleMute);
         _audioSessionManager.StateChanged += AudioSessionManager_StateChanged;
         _audioSessionManager.TranscriptReady += AudioSessionManager_TranscriptReady;


### PR DESCRIPTION
Closes #197

## What this changes

Story #171 moved the microphone **mute toggle** off the UI thread. Two sibling paths that write the microphone **capture level** were left running synchronously on the UI thread because they needed a different, ordering-aware fix:

- the **input-level slider** (fires many times per drag or per held arrow key), and
- the **record-start** re-assert of the pinned level.

Both eventually call the pin service, which writes the level over the Windows audio COM API, reads it back to confirm, and — on failure — re-enumerates the audio device and retries. On the UI thread that failure path can briefly freeze the window and the screen reader, and the slider makes it worse by repeating rapidly.

This change moves those writes off the UI thread with a design that is safe for a burst of rapid requests.

## How it works

A new `MicrophoneLevelWriteCoordinator` (in `Mutation.Ui/Core`) owns a single background worker that serializes every capture-level write. Its behavior differs from the mute coordinator in one important way:

- The mute coordinator **drops** an overlapping toggle (a second press while one is running).
- This coordinator **coalesces to the latest**: while a write is in flight, newer requests replace the queued one, and only the most recent survives. A slider drag therefore applies its first and its final value and skips the stale in-between ones, so the device settles on exactly what the user chose without a backlog of out-of-order writes. Superseded requests complete as "dropped" and never touch the device, so a whole drag can raise at most one failure warning.

Because a **single shared instance** (registered in DI) is used by every writer — the slider, the pin toggle, and the record-start re-assert — it is also the one place the level COM endpoint is written, so two threads never write it at once.

Call sites updated:

- **Slider** (`SldMicLevel_ValueChanged`) and **pin toggle** (`TglPinMicLevel_Toggled`) in `MainWindow` now hand their write to the coordinator instead of calling the pin service on the UI thread. The pin value is still persisted synchronously, so a coalesced/dropped write never loses the user's choice; only the file write stays debounced (issue #172).
- **Record-start** (`AudioSessionManager`) now awaits the pinned-level re-assert on the shared worker before the recorder starts, so the level is settled before capture begins and the failure-path re-enumeration no longer runs on the UI thread. The failure signal (beep + status line) is unchanged.

The one-time startup / mic-change re-assert stays synchronous — it is a single, non-bursty write that runs before any slider interaction, so it carries no concurrent-write hazard. It can be moved later if that startup path ever needs it.

## Scope note

The first commit on this branch is a WIP snapshot: a concurrent session working a different story found this work uncommitted in a shared checkout and preserved it to this branch. The second commit completes it. The combined branch is the full feature.

## Test plan

- `dotnet test --configuration Release` — green (655 passed, 0 failed).
- New unit tests for `MicrophoneLevelWriteCoordinator`:
  - the write runs off the calling thread,
  - coalesce-to-latest applies the first and last requests and drops the middle ones, in order,
  - a throwing write is surfaced as `Failed` and the worker recovers,
  - a new write is accepted after the previous one completes.

### Manual (needs a machine with a controllable-level mic)

1. Drag the input-level slider quickly / hold an arrow key — the UI stays responsive and the device ends at the released value.
2. With the pin on, start recording — the pinned level is re-asserted and "Listening" appears; the UI does not stall even if the device is momentarily busy.
3. Toggle the pin on — the current slider level is applied without freezing the window.
