### PR TITLE
Redact all provider key formats and cap error-log growth (#160)

### DIFF
--- a/CognitiveSupport/ErrorLogger.cs
+++ b/CognitiveSupport/ErrorLogger.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 
@@ -21,6 +22,29 @@ namespace CognitiveSupport;
 public static class ErrorLogger
 {
 	private const string ErrorLogFileName = "Mutation_Errors.log";
+
+	// Rotate a log file once it exceeds this size, mirroring HotkeyManager's
+	// 100 KB cap, so neither log file can grow without bound.
+	private const long MaxLogFileSizeBytes = 100 * 1024;
+
+	// Configured key values shorter than this are ignored by the exact-match
+	// redactor — a very short "secret" would redact common substrings and do
+	// more harm than good. Real provider keys are far longer than this.
+	private const int MinRedactableSecretLength = 8;
+
+	// The placeholder the settings layer writes for an unconfigured key. It is
+	// not a real secret, so it must never be registered for redaction.
+	private const string SettingsPlaceholderValue = "<placeholder>";
+
+	// Snapshot of configured secret values to redact by exact match, ordered
+	// longest-first so an overlapping shorter value cannot mask a longer one.
+	// Replaced wholesale under the lock; readers take a local reference (array
+	// reference reads are atomic) so redaction never sees a torn update.
+	private static string[] s_secretValues = Array.Empty<string>();
+
+	// Serialises both the secret-snapshot swap and each file rotate+append so a
+	// concurrent writer cannot race the rotation move.
+	private static readonly object s_gate = new();
 
 	/// <summary>
 	/// The user-writable log path (<c>%LOCALAPPDATA%\Mutation\logs\Mutation_Errors.log</c>),
@@ -48,6 +72,43 @@ public static class ErrorLogger
 					return ErrorLogFileName;
 				}
 			}
+		}
+	}
+
+	/// <summary>
+	/// Registers the current set of configured provider key values so they are
+	/// redacted from every subsequent log entry by exact match, regardless of
+	/// their format. This catches keys (e.g. Deepgram/Azure) that no pattern
+	/// matches. Call it once after settings load and again whenever the keys
+	/// change (e.g. a settings save) — it replaces the previous snapshot, so a
+	/// removed key stops being tracked. Null/whitespace, the settings
+	/// placeholder, and values shorter than <see cref="MinRedactableSecretLength"/>
+	/// are ignored. Never throws.
+	/// </summary>
+	public static void RegisterSecretValues(IEnumerable<string?>? secrets)
+	{
+		string[] snapshot;
+		if (secrets is null)
+		{
+			snapshot = Array.Empty<string>();
+		}
+		else
+		{
+			snapshot = secrets
+				.Where(static s => !string.IsNullOrWhiteSpace(s))
+				.Select(static s => s!.Trim())
+				.Where(static s => s.Length >= MinRedactableSecretLength
+					&& !string.Equals(s, SettingsPlaceholderValue, StringComparison.Ordinal))
+				.Distinct(StringComparer.Ordinal)
+				// Longest first: redacting a longer key before a shorter one it
+				// contains prevents a partial, still-revealing replacement.
+				.OrderByDescending(static s => s.Length)
+				.ToArray();
+		}
+
+		lock (s_gate)
+		{
+			s_secretValues = snapshot;
 		}
 	}
 
@@ -80,7 +141,7 @@ public static class ErrorLogger
 			string logDir = Path.Combine(localAppData, "Mutation", "logs");
 			Directory.CreateDirectory(logDir);
 			string logPath = Path.Combine(logDir, ErrorLogFileName);
-			File.AppendAllText(logPath, entry, Encoding.UTF8);
+			AppendWithRotation(logPath, entry, MaxLogFileSizeBytes);
 		}
 		catch
 		{
@@ -92,11 +153,37 @@ public static class ErrorLogger
 		try
 		{
 			string logPath = Path.Combine(AppContext.BaseDirectory, ErrorLogFileName);
-			File.AppendAllText(logPath, entry, Encoding.UTF8);
+			AppendWithRotation(logPath, entry, MaxLogFileSizeBytes);
 		}
 		catch
 		{
 			// Never let logging throw — callers may already be in a failure path.
+		}
+	}
+
+	/// <summary>
+	/// Appends <paramref name="entry"/> to <paramref name="logPath"/>, first
+	/// rotating the file to <c>&lt;path&gt;.old</c> when it already exceeds
+	/// <paramref name="maxLogFileSizeBytes"/>, so the log cannot grow without
+	/// bound. Mirrors HotkeyManager's rotation. The rotate + append run under
+	/// the shared lock so two threads cannot both move the file at once.
+	/// </summary>
+	internal static void AppendWithRotation(string logPath, string entry, long maxLogFileSizeBytes)
+	{
+		lock (s_gate)
+		{
+			if (maxLogFileSizeBytes > 0 && File.Exists(logPath))
+			{
+				var fileInfo = new FileInfo(logPath);
+				if (fileInfo.Length > maxLogFileSizeBytes)
+				{
+					string backupPath = logPath + ".old";
+					if (File.Exists(backupPath))
+						File.Delete(backupPath);
+					File.Move(logPath, backupPath);
+				}
+			}
+			File.AppendAllText(logPath, entry, Encoding.UTF8);
 		}
 	}
 
@@ -117,7 +204,18 @@ public static class ErrorLogger
 			return text;
 		}
 
-		// Redact common secret patterns (API keys) so they never land in the log file.
+		// First, redact any registered key value by exact match. This is the
+		// reliable layer: it catches keys of any format (e.g. Deepgram's 40-char
+		// hex and Azure's 32-char hex) that the patterns below do not recognise,
+		// wherever they appear in the text.
+		string[] secrets = s_secretValues; // atomic reference read; snapshot is immutable
+		foreach (string secret in secrets)
+		{
+			text = text.Replace(secret, "***REDACTED***", StringComparison.Ordinal);
+		}
+
+		// Then redact common secret patterns (API keys) so a key that was never
+		// registered (e.g. logged before settings loaded) is still caught.
 		text = Regex.Replace(
 			text,
 			@"sk-[A-Za-z0-9_\-]{10,}",
@@ -127,6 +225,13 @@ public static class ErrorLogger
 			text,
 			@"Bearer\s+[A-Za-z0-9_\-\.]{10,}",
 			"Bearer ***REDACTED***");
+
+		// Deepgram keys are sent as `Authorization: Token <key>`; mirror the
+		// Bearer rule so the token never lands in the log even when unregistered.
+		text = Regex.Replace(
+			text,
+			@"Token\s+[A-Za-z0-9_\-\.]{10,}",
+			"Token ***REDACTED***");
 
 		return text;
 	}

--- a/Mutation.Tests/ErrorLoggerRedactionTests.cs
+++ b/Mutation.Tests/ErrorLoggerRedactionTests.cs
@@ -1,0 +1,133 @@
+using CognitiveSupport;
+using Xunit;
+
+namespace Mutation.Tests;
+
+// All tests in this class mutate ErrorLogger's static secret registry. xUnit
+// runs tests within a single class sequentially, so each test sets the registry
+// to a known state at the top and the tests stay order-independent.
+public class ErrorLoggerRedactionTests
+{
+	[Fact]
+	public void RedactSecrets_Null_ReturnsNull()
+	{
+		ErrorLogger.RegisterSecretValues(null);
+		Assert.Null(ErrorLogger.RedactSecrets(null!));
+	}
+
+	[Fact]
+	public void RedactSecrets_Empty_ReturnsEmpty()
+	{
+		ErrorLogger.RegisterSecretValues(null);
+		Assert.Equal(string.Empty, ErrorLogger.RedactSecrets(string.Empty));
+	}
+
+	[Fact]
+	public void RedactSecrets_OpenAiStyleKey_Redacted()
+	{
+		ErrorLogger.RegisterSecretValues(null);
+		string input = "auth failed with key sk-abcdEFGH1234567890 at call site";
+
+		string result = ErrorLogger.RedactSecrets(input);
+
+		Assert.DoesNotContain("sk-abcdEFGH1234567890", result);
+		Assert.Contains("sk-***REDACTED***", result);
+	}
+
+	[Fact]
+	public void RedactSecrets_BearerToken_Redacted()
+	{
+		ErrorLogger.RegisterSecretValues(null);
+		string input = "Authorization: Bearer eyJhbGciOiJ_secret-token.value";
+
+		string result = ErrorLogger.RedactSecrets(input);
+
+		Assert.DoesNotContain("eyJhbGciOiJ_secret-token.value", result);
+		Assert.Contains("Bearer ***REDACTED***", result);
+	}
+
+	[Fact]
+	public void RedactSecrets_DeepgramTokenHeader_RedactedByPattern()
+	{
+		// Deepgram is sent as `Authorization: Token <key>` — covered even when
+		// the key was never registered.
+		ErrorLogger.RegisterSecretValues(null);
+		string deepgramKey = "0123456789abcdef0123456789abcdef01234567"; // 40-char hex
+		string input = $"Authorization: Token {deepgramKey}";
+
+		string result = ErrorLogger.RedactSecrets(input);
+
+		Assert.DoesNotContain(deepgramKey, result);
+		Assert.Contains("Token ***REDACTED***", result);
+	}
+
+	[Fact]
+	public void RedactSecrets_RegisteredDeepgramKey_RedactedAnywhere()
+	{
+		// A bare 40-char hex Deepgram key with no header prefix matches no
+		// pattern; exact-match registration must still redact it.
+		string deepgramKey = "0123456789abcdef0123456789abcdef01234567";
+		ErrorLogger.RegisterSecretValues(new[] { deepgramKey });
+		string input = $"GET https://api.deepgram.com/v1/listen?key={deepgramKey} failed";
+
+		string result = ErrorLogger.RedactSecrets(input);
+
+		Assert.DoesNotContain(deepgramKey, result);
+		Assert.Contains("***REDACTED***", result);
+	}
+
+	[Fact]
+	public void RedactSecrets_RegisteredAzureKey_RedactedAnywhere()
+	{
+		// Azure Computer Vision keys are 32-char hex — no pattern matches them.
+		string azureKey = "0123456789abcdef0123456789abcdef"; // 32-char hex
+		ErrorLogger.RegisterSecretValues(new[] { azureKey });
+		string input = $"Ocp-Apim-Subscription-Key header carried {azureKey} in the failure";
+
+		string result = ErrorLogger.RedactSecrets(input);
+
+		Assert.DoesNotContain(azureKey, result);
+		Assert.Contains("***REDACTED***", result);
+	}
+
+	[Fact]
+	public void RegisterSecretValues_IgnoresBlankPlaceholderAndShortValues()
+	{
+		// None of these should be registered; a short token like "shortkey"
+		// must remain readable so real log text is not over-redacted.
+		ErrorLogger.RegisterSecretValues(new[] { null, "", "   ", "<placeholder>", "short" });
+		string input = "value <placeholder> and the word short appear here";
+
+		string result = ErrorLogger.RedactSecrets(input);
+
+		Assert.Equal(input, result);
+	}
+
+	[Fact]
+	public void RegisterSecretValues_ReplacesPreviousSnapshot()
+	{
+		string oldKey = "OLD-secret-key-value-1234567890";
+		string newKey = "NEW-secret-key-value-0987654321";
+
+		ErrorLogger.RegisterSecretValues(new[] { oldKey });
+		ErrorLogger.RegisterSecretValues(new[] { newKey });
+
+		string result = ErrorLogger.RedactSecrets($"{oldKey} then {newKey}");
+
+		// The old key is no longer tracked and appears verbatim; the new one is gone.
+		Assert.Contains(oldKey, result);
+		Assert.DoesNotContain(newKey, result);
+	}
+
+	[Fact]
+	public void RegisterSecretValues_Null_ClearsRegistry()
+	{
+		string key = "some-registered-secret-value-1234";
+		ErrorLogger.RegisterSecretValues(new[] { key });
+		ErrorLogger.RegisterSecretValues(null);
+
+		string result = ErrorLogger.RedactSecrets($"still has {key} in it");
+
+		Assert.Contains(key, result);
+	}
+}

--- a/Mutation.Tests/ErrorLoggerRotationTests.cs
+++ b/Mutation.Tests/ErrorLoggerRotationTests.cs
@@ -1,0 +1,75 @@
+using System;
+using System.IO;
+using CognitiveSupport;
+using Xunit;
+
+namespace Mutation.Tests;
+
+// Exercises ErrorLogger.AppendWithRotation against a real temp file so the
+// size-cap rotation is verified in isolation from the fixed OS log locations.
+public class ErrorLoggerRotationTests : IDisposable
+{
+	private readonly string _dir;
+	private readonly string _logPath;
+	private readonly string _backupPath;
+
+	public ErrorLoggerRotationTests()
+	{
+		_dir = Path.Combine(Path.GetTempPath(), "MutationErrorLoggerRotationTests_" + Guid.NewGuid().ToString("N"));
+		Directory.CreateDirectory(_dir);
+		_logPath = Path.Combine(_dir, "Mutation_Errors.log");
+		_backupPath = _logPath + ".old";
+	}
+
+	public void Dispose()
+	{
+		try { Directory.Delete(_dir, recursive: true); } catch { /* best-effort cleanup */ }
+	}
+
+	[Fact]
+	public void AppendWithRotation_CreatesFileWhenMissing()
+	{
+		ErrorLogger.AppendWithRotation(_logPath, "first entry\n", maxLogFileSizeBytes: 1024);
+
+		Assert.True(File.Exists(_logPath));
+		Assert.Equal("first entry\n", File.ReadAllText(_logPath));
+		Assert.False(File.Exists(_backupPath));
+	}
+
+	[Fact]
+	public void AppendWithRotation_UnderLimit_AppendsWithoutRotating()
+	{
+		ErrorLogger.AppendWithRotation(_logPath, "a\n", maxLogFileSizeBytes: 1024);
+		ErrorLogger.AppendWithRotation(_logPath, "b\n", maxLogFileSizeBytes: 1024);
+
+		Assert.Equal("a\nb\n", File.ReadAllText(_logPath));
+		Assert.False(File.Exists(_backupPath));
+	}
+
+	[Fact]
+	public void AppendWithRotation_OverLimit_RotatesToOldThenWritesFresh()
+	{
+		string bulk = new string('x', 200);
+		File.WriteAllText(_logPath, bulk);
+
+		ErrorLogger.AppendWithRotation(_logPath, "new entry\n", maxLogFileSizeBytes: 100);
+
+		// The oversized content moved to .old; the live file holds only the new entry.
+		Assert.True(File.Exists(_backupPath));
+		Assert.Equal(bulk, File.ReadAllText(_backupPath));
+		Assert.Equal("new entry\n", File.ReadAllText(_logPath));
+	}
+
+	[Fact]
+	public void AppendWithRotation_SecondRotation_OverwritesPreviousBackup()
+	{
+		File.WriteAllText(_backupPath, "stale backup");
+		File.WriteAllText(_logPath, new string('y', 200));
+
+		ErrorLogger.AppendWithRotation(_logPath, "latest\n", maxLogFileSizeBytes: 100);
+
+		// The pre-existing .old is replaced by the rotated content, not appended to.
+		Assert.Equal(new string('y', 200), File.ReadAllText(_backupPath));
+		Assert.Equal("latest\n", File.ReadAllText(_logPath));
+	}
+}

--- a/Mutation.Ui/Services/SettingsManager.cs
+++ b/Mutation.Ui/Services/SettingsManager.cs
@@ -994,6 +994,33 @@ End of summary.
 	{
 		string json = JsonConvert.SerializeObject(settings, Formatting.Indented, _jsonSerializerSettings);
 		AtomicWriteAllText(SettingsFilePath, json);
+
+		// Keep the error-log redactor current with the just-saved keys so a key
+		// entered via the Settings dialog is redacted without an app restart.
+		RegisterSecretsForRedaction(settings);
+	}
+
+	// Feeds every configured provider key into ErrorLogger's exact-match redactor
+	// so none of them can ever be written verbatim to the error log, regardless
+	// of the key's format. Placeholder/blank values are filtered by the redactor.
+	private static void RegisterSecretsForRedaction(Settings settings)
+	{
+		var secrets = new List<string?>
+		{
+			settings.ApiKeys?.OpenAiApiKey,
+			settings.ApiKeys?.AnthropicApiKey,
+			settings.ApiKeys?.DeepgramApiKey,
+			settings.AzureComputerVisionSettings?.ApiKey,
+		};
+
+		var services = settings.SpeechToTextSettings?.Services;
+		if (services is not null)
+		{
+			foreach (var service in services)
+				secrets.Add(service?.ApiKey);
+		}
+
+		ErrorLogger.RegisterSecretValues(secrets);
 	}
 
 	private static void AtomicWriteAllText(string targetPath, string contents)
@@ -1038,6 +1065,10 @@ End of summary.
                 SettingsDefaults.Speech.LegacyTempDirectory,
                 settings.SpeechToTextSettings!.TempDirectory!);
         }
+
+        // Register the loaded keys so any error logged during this run redacts
+        // them by exact match, covering formats no pattern recognises.
+        RegisterSecretsForRedaction(settings);
 
         return settings;
     }


### PR DESCRIPTION
## Summary

The shared error logger scrubs secrets before writing to disk, but its
redaction only recognised OpenAI-style `sk-` keys and `Bearer` tokens. Two
of the four configured providers slipped through: Deepgram keys (sent as
`Authorization: Token <40-char hex>`) and Azure Computer Vision keys
(32-char hex) matched no pattern and would be written verbatim if an
exception or breadcrumb ever contained one. Separately, both error-log
files grew forever — there was no size cap or rotation.

This change closes both gaps.

**Reliable redaction of every configured key.** The logger now keeps a
registry of the actual configured key values and removes them from every
log entry by exact match, so a key of *any* format is scrubbed wherever it
appears — this is what finally covers Deepgram and Azure. `SettingsManager`
feeds the keys in when settings load and again on every save, so a key
typed into the Settings dialog is protected without restarting the app.

**Pattern fallback for the header form.** A new `Token …` rule (mirroring
the existing `Bearer …` rule) catches a Deepgram key that is logged before
settings have loaded and registered it. The original `sk-` and `Bearer`
rules are unchanged.

**Bounded log growth.** Both log files now rotate to `<name>.old` once they
pass 100 KB, matching the existing cap in `HotkeyManager`. The
rotate-then-append runs under a lock so two threads can't race the rotation
move. The logger still writes to both the user-writable location and the
EXE-folder copy (the documented crash-log safety net), but that copy is now
bounded by rotation and scrubbed by the same redaction, which addresses the
size and leak concerns without dropping a fallback that exists so a
cold-start crash log always lands somewhere.

## Changes

- `CognitiveSupport/ErrorLogger.cs` — exact-match secret registry
  (`RegisterSecretValues`), the new `Token …` pattern, and size-based
  rotation (`AppendWithRotation`).
- `Mutation.Ui/Services/SettingsManager.cs` — registers the configured
  provider keys with the logger on load and on save.
- `Mutation.Tests/ErrorLoggerRedactionTests.cs`,
  `Mutation.Tests/ErrorLoggerRotationTests.cs` — new tests.

## Test plan

- `dotnet test --configuration Release` — all 663 tests pass (13 new).
- New tests cover: exact-match redaction of a Deepgram 40-hex key and an
  Azure 32-hex key anywhere in the text; the new `Token …` header pattern;
  the preserved `sk-` and `Bearer` rules; filtering of blank/placeholder/
  short values so ordinary log text is not over-redacted; snapshot
  replacement (a removed key stops being redacted); and the 100 KB rotation
  helper (create-when-missing, append-under-limit, rotate-over-limit,
  and overwrite of a stale `.old`).

Closes #160
