### PR TITLE
Skip idle microphone waveform redraws (#173)

### DIFF
--- a/Mutation.Tests/WaveformRenderGateTests.cs
+++ b/Mutation.Tests/WaveformRenderGateTests.cs
@@ -1,0 +1,63 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Mutation.Ui.Core;
+using Xunit;
+
+namespace Mutation.Tests;
+
+public class WaveformRenderGateTests
+{
+	[Fact]
+	public void ConsumeShouldRender_WithoutData_ReturnsFalse()
+	{
+		var gate = new WaveformRenderGate();
+
+		Assert.False(gate.ConsumeShouldRender());
+	}
+
+	[Fact]
+	public void ConsumeShouldRender_AfterDataArrived_ReturnsTrueThenFalse()
+	{
+		var gate = new WaveformRenderGate();
+		gate.MarkDataArrived();
+
+		Assert.True(gate.ConsumeShouldRender());
+		Assert.False(gate.ConsumeShouldRender());
+	}
+
+	[Fact]
+	public void ConsumeShouldRender_CoalescesMultipleArrivalsIntoOneRender()
+	{
+		var gate = new WaveformRenderGate();
+		gate.MarkDataArrived();
+		gate.MarkDataArrived();
+		gate.MarkDataArrived();
+
+		Assert.True(gate.ConsumeShouldRender());
+		Assert.False(gate.ConsumeShouldRender());
+	}
+
+	[Fact]
+	public void ConsumeShouldRender_ReRendersAfterEachNewArrival()
+	{
+		var gate = new WaveformRenderGate();
+
+		gate.MarkDataArrived();
+		Assert.True(gate.ConsumeShouldRender());
+		Assert.False(gate.ConsumeShouldRender());
+
+		gate.MarkDataArrived();
+		Assert.True(gate.ConsumeShouldRender());
+		Assert.False(gate.ConsumeShouldRender());
+	}
+
+	[Fact]
+	public async Task MarkDataArrived_FromAnotherThread_IsObservedByConsumer()
+	{
+		var gate = new WaveformRenderGate();
+
+		await Task.Run(gate.MarkDataArrived);
+
+		Assert.True(gate.ConsumeShouldRender());
+	}
+}

--- a/Mutation.Ui/Core/WaveformRenderGate.cs
+++ b/Mutation.Ui/Core/WaveformRenderGate.cs
@@ -1,0 +1,43 @@
+namespace Mutation.Ui.Core;
+
+/// <summary>
+/// Tracks whether the microphone waveform has new samples to draw since the last
+/// frame was rendered. The audio capture thread calls <see cref="MarkDataArrived"/>
+/// as buffers arrive; the UI render tick calls <see cref="ConsumeShouldRender"/> to
+/// decide whether to redraw. When nothing new has arrived, the plot, level meter, and
+/// pulse overlay are already showing the last rendered state, so the tick can skip its
+/// buffer copy, RMS scan, plot refresh, and meter writes entirely. This stops the
+/// ~30 FPS idle churn that otherwise ran for the app's lifetime whenever no capture
+/// was active (device not resolved, capture failed, or capture stopped).
+/// </summary>
+internal sealed class WaveformRenderGate
+{
+	private readonly object _gate = new();
+	private bool _dataArrived;
+
+	/// <summary>
+	/// Marks that new samples have been captured since the last render. Safe to call
+	/// from the capture thread; may be called many times between renders.
+	/// </summary>
+	public void MarkDataArrived()
+	{
+		lock (_gate)
+			_dataArrived = true;
+	}
+
+	/// <summary>
+	/// Returns whether a redraw is needed and clears the flag in one atomic step.
+	/// True on the first call after one or more <see cref="MarkDataArrived"/> calls,
+	/// then false until the next <see cref="MarkDataArrived"/>. Multiple arrivals
+	/// between renders coalesce into a single true.
+	/// </summary>
+	public bool ConsumeShouldRender()
+	{
+		lock (_gate)
+		{
+			bool shouldRender = _dataArrived;
+			_dataArrived = false;
+			return shouldRender;
+		}
+	}
+}

--- a/Mutation.Ui/Services/MicrophoneVisualizationController.cs
+++ b/Mutation.Ui/Services/MicrophoneVisualizationController.cs
@@ -30,6 +30,7 @@ internal sealed class MicrophoneVisualizationController : IDisposable
 	private readonly XamlRectangle? _pulseOverlay;
 	private readonly Action<string, string, InfoBarSeverity> _showStatus;
 
+	private readonly WaveformRenderGate _waveformRenderGate = new();
 	private WaveInEvent? _waveformCapture;
 	private DispatcherQueueTimer? _waveformTimer;
 	private Signal? _waveformSignal;
@@ -110,6 +111,9 @@ internal sealed class MicrophoneVisualizationController : IDisposable
 			_waveformBufferIndex = 0;
 			_waveformBufferFilled = false;
 		}
+
+		// Render the reset-to-flat state once even before the first samples arrive.
+		_waveformRenderGate.MarkDataArrived();
 
 		int deviceIndex = _audioDeviceManager.MicrophoneDeviceIndex;
 		if (deviceIndex < 0)
@@ -230,6 +234,16 @@ internal sealed class MicrophoneVisualizationController : IDisposable
 		if (_offLabel != null && _offLabel.Visibility == Visibility.Visible)
 			_offLabel.Visibility = Visibility.Collapsed;
 
+		// Nothing new has been captured since the last frame — the plot, meter, and
+		// pulse overlay are all still showing the last rendered state, so there is
+		// nothing to redraw. Skip the buffer copy, RMS scan, ScottPlot refresh, and
+		// meter writes. This is the idle path whenever no capture is running (device
+		// not resolved, capture failed, or capture stopped) and it keeps that
+		// per-frame work — and the DispatcherQueue it shares with hotkey dispatch —
+		// free instead of spinning at ~30 FPS for the app's lifetime.
+		if (!_waveformRenderGate.ConsumeShouldRender())
+			return;
+
 		int validSamples = PopulateWaveformRenderBuffer();
 
 		double peak = 0;
@@ -342,5 +356,8 @@ internal sealed class MicrophoneVisualizationController : IDisposable
 				}
 			}
 		}
+
+		// New samples are in the ring buffer — let the next render tick draw them.
+		_waveformRenderGate.MarkDataArrived();
 	}
 }


### PR DESCRIPTION
## What this changes

The microphone waveform visualization redrew itself on a 33 ms timer for the
application's entire lifetime. Every tick copied the capture buffer, scanned the
sample window to compute RMS and peak, ran a full ScottPlot refresh, and updated the
level bar and pulse overlay — and it did all of that even when no microphone was being
captured or the buffer had not changed since the previous frame. That was constant
~30-times-per-second work on the UI thread (with the CPU and battery cost that implies),
sharing the same dispatcher queue that also delivers hotkey presses.

This PR makes the redraw conditional on whether new audio has actually arrived since the
last frame.

## How it works

A small, thread-safe latch (`WaveformRenderGate`) sits between the audio capture callback
and the render tick:

- The capture callback marks the gate whenever new samples land in the ring buffer.
- The render tick asks the gate whether anything new arrived. If not, it returns
  immediately — skipping the buffer copy, the RMS/peak scan, the plot refresh, and the
  meter writes — leaving the plot, level bar, and pulse overlay showing their last state.

During active capture the audio backend delivers buffers faster than the tick fires
(roughly every 15 ms versus the 33 ms tick), so the gate is always marked and the visible
behavior is unchanged. The saving is in the idle state — no microphone resolved, capture
failed to start, or capture stopped — where each tick now costs a single flag read instead
of a full render.

The gate is its own class so the "should this frame redraw?" decision is unit-testable on
its own, matching the existing pattern of small focused helpers in `Mutation.Ui.Core`.

## Acceptance criteria addressed

- Skips the refresh and meter updates when no capture is active or the buffer is unchanged
  (the issue's suggested fix). The timer is intentionally left running and the tick simply
  early-returns, which removes the idle churn with the least behavioral risk.

## Test plan

- `dotnet test --configuration Release` — all 660 tests pass, including 5 new tests for the
  render gate (no data → no render; one render per data arrival; multiple arrivals coalesce
  into a single render; cross-thread marking is observed by the consumer).
- The gate logic is covered by unit tests; the controller wiring (capture callback marks the
  gate, tick consumes it) is verified by inspection since it depends on WinUI/NAudio runtime
  types that are not exercised in the headless test host.

## Notes

- The only visible difference is in the idle state: after capture stops, the pulse overlay
  now freezes at its last value rather than fading a few more sub-perceptible frames.
  Active-capture behavior is identical.

Closes #173
