### PR TITLE
Stream PCM into fixed frames without per-byte buffering (#174)

### DIFF
--- a/CognitiveSupport/AudioFileConverter.cs
+++ b/CognitiveSupport/AudioFileConverter.cs
@@ -72,11 +72,10 @@ public static class AudioFileConverter
 		byte[] buffer = new byte[outFormat.AverageBytesPerSecond];
 		int bytesRead;
 
-		// Buffer for accumulation to feed fixed frame sizes to Opus (960 samples = 1920 bytes)
-		// Opus requires 2.5, 5, 10, 20, 40, or 60ms frames. We use 20ms (960 samples).
+		// Split the decoded byte stream into fixed frame sizes for Opus (960 samples = 1920
+		// bytes). Opus requires 2.5, 5, 10, 20, 40, or 60ms frames. We use 20ms (960 samples).
 		int samplesPerFrame = 960;
-		int bytesPerFrame = samplesPerFrame * 2;
-		List<byte> accumulationBuffer = new List<byte>();
+		var splitter = new PcmFrameSplitter(samplesPerFrame);
 
 		var trimmer = silenceOptions is null
 			? null
@@ -92,40 +91,12 @@ public static class AudioFileConverter
 
 		while ((bytesRead = resampler.Read(buffer, 0, buffer.Length)) > 0)
 		{
-			for (int i = 0; i < bytesRead; i++)
-			{
-				accumulationBuffer.Add(buffer[i]);
-			}
-
-			while (accumulationBuffer.Count >= bytesPerFrame)
-			{
-				byte[] frameBytes = accumulationBuffer.GetRange(0, bytesPerFrame).ToArray();
-				accumulationBuffer.RemoveRange(0, bytesPerFrame);
-
-				// Convert byte[] to short[]
-				short[] pcmSamples = new short[samplesPerFrame];
-				Buffer.BlockCopy(frameBytes, 0, pcmSamples, 0, bytesPerFrame);
-
-				WriteFrame(pcmSamples);
-			}
+			splitter.Append(buffer, bytesRead, WriteFrame);
 		}
 
-		// Handle remaining bytes (pad with silence if needed, or just finish)
-		// For speech, we can probably drop the last partial frame if it's very short,
-		// or pad it.
-		if (accumulationBuffer.Count > 0)
-		{
-			// Padding with silence to reach frame size
-			while (accumulationBuffer.Count < bytesPerFrame)
-			{
-				accumulationBuffer.Add(0);
-			}
-
-			byte[] frameBytes = accumulationBuffer.ToArray();
-			short[] pcmSamples = new short[samplesPerFrame];
-			Buffer.BlockCopy(frameBytes, 0, pcmSamples, 0, bytesPerFrame);
-			WriteFrame(pcmSamples);
-		}
+		// Pad the final partial frame with silence and emit it, matching the previous
+		// behavior of never dropping trailing audio on file conversion.
+		splitter.Flush(WriteFrame, padWithSilence: true);
 
 		trimmer?.Flush(f => oggStream.WriteSamples(f, 0, f.Length));
 

--- a/CognitiveSupport/AudioRecorder.cs
+++ b/CognitiveSupport/AudioRecorder.cs
@@ -34,8 +34,9 @@ public class AudioRecorder : IAudioRecorder
 	private const int SamplesPerFrame = SampleRate * FrameSizeMs / 1000; // 960 samples
 	private const int Channels = 1;
 
-	// Buffer for incoming PCM data
-	private readonly List<short> _pcmBuffer = new();
+	// Splits incoming PCM bytes into fixed 960-sample frames. Created per recording in
+	// StartRecording so no partial-frame remainder bleeds from one recording into the next.
+	private PcmFrameSplitter? _pcmFrameSplitter;
 
 	public void StartRecording(int captureDeviceIndex, string outputFile, SilenceTrimmerOptions? silenceOptions = null)
 	{
@@ -44,6 +45,7 @@ public class AudioRecorder : IAudioRecorder
 			_silenceTrimmer = silenceOptions is null
 				? null
 				: new SilenceTrimmer(SampleRate, SamplesPerFrame, silenceOptions);
+			_pcmFrameSplitter = new PcmFrameSplitter(SamplesPerFrame);
 			TrimmedSpeechSeconds = null;
 			_captureException = null;
 
@@ -111,30 +113,12 @@ public class AudioRecorder : IAudioRecorder
 	{
 		lock (_writeLock)
 		{
-			if (_oggStream == null) return;
+			if (_oggStream == null || _pcmFrameSplitter is null) return;
 
 			try
 			{
-				// Convert bytes to shorts (16-bit PCM)
-				// e.BytesRecorded is count of bytes. 2 bytes per sample.
-				int incomingSamples = e.BytesRecorded / 2;
-				for (int i = 0; i < incomingSamples; i++)
-				{
-					short sample = (short)((e.Buffer[i * 2 + 1] << 8) | e.Buffer[i * 2]);
-					_pcmBuffer.Add(sample);
-				}
-
-				// Process complete frames
-				while (_pcmBuffer.Count >= SamplesPerFrame)
-				{
-					var frame = _pcmBuffer.GetRange(0, SamplesPerFrame).ToArray();
-					_pcmBuffer.RemoveRange(0, SamplesPerFrame);
-
-					if (_silenceTrimmer is null)
-						_oggStream.WriteSamples(frame, 0, SamplesPerFrame);
-					else
-						_silenceTrimmer.ProcessFrame(frame, WriteFrame);
-				}
+				// Split incoming 16-bit PCM bytes into whole 960-sample frames and write each.
+				_pcmFrameSplitter.Append(e.Buffer, e.BytesRecorded, EmitFrame);
 			}
 			catch (Exception ex)
 			{
@@ -142,10 +126,18 @@ public class AudioRecorder : IAudioRecorder
 				// unhandled exception that terminates the process. Capture the first
 				// failure and stop writing so StopRecording can surface it to the caller.
 				_captureException ??= ex;
-				_pcmBuffer.Clear();
+				_pcmFrameSplitter = null;
 				_oggStream = null;
 			}
 		}
+	}
+
+	private void EmitFrame(short[] frame)
+	{
+		if (_silenceTrimmer is null)
+			_oggStream?.WriteSamples(frame, 0, frame.Length);
+		else
+			_silenceTrimmer.ProcessFrame(frame, WriteFrame);
 	}
 
 	private void WriteFrame(short[] frame) => _oggStream?.WriteSamples(frame, 0, frame.Length);
@@ -182,6 +174,8 @@ public class AudioRecorder : IAudioRecorder
 				{
 					_oggStream = null;
 					_silenceTrimmer = null;
+					// Drop any buffered partial frame (< 20ms tail), as before.
+					_pcmFrameSplitter = null;
 				}
 			}
 		}

--- a/CognitiveSupport/PcmFrameSplitter.cs
+++ b/CognitiveSupport/PcmFrameSplitter.cs
@@ -1,0 +1,117 @@
+using System;
+
+namespace CognitiveSupport;
+
+/// <summary>
+/// Splits a stream of 16-bit little-endian PCM bytes into fixed-size sample frames
+/// without per-byte list growth or per-frame list shifts.
+///
+/// Feed raw capture/decoder bytes via <see cref="Append"/>; each completed frame is
+/// handed to the supplied callback as a freshly allocated <c>short[]</c>. Ownership of
+/// that array passes to the callback, so downstream code such as
+/// <see cref="SilenceTrimmer"/> — which retains frame references across calls — is safe.
+/// Call <see cref="Flush"/> once the stream ends to emit or drop the trailing partial
+/// frame.
+///
+/// Bytes that do not complete a frame are held in a single fixed carry buffer and
+/// combined with the next <see cref="Append"/>, so the class allocates only the frames
+/// it emits — no intermediate copies and no O(n) buffer shifts.
+///
+/// Not thread-safe; the caller must serialize access.
+/// </summary>
+public sealed class PcmFrameSplitter
+{
+	private const int BytesPerSample = 2; // 16-bit PCM
+
+	private readonly int _frameSamples;
+	private readonly int _frameBytes;
+
+	// Holds the bytes of an as-yet-incomplete frame between Append calls. Never handed
+	// to the callback directly; ToFrame copies out of it into a fresh array.
+	private readonly byte[] _carry;
+	private int _carryLength;
+
+	/// <param name="frameSamples">Samples per emitted frame (e.g. 960 for 20 ms at 48 kHz).</param>
+	public PcmFrameSplitter(int frameSamples)
+	{
+		if (frameSamples <= 0)
+			throw new ArgumentOutOfRangeException(nameof(frameSamples));
+
+		_frameSamples = frameSamples;
+		_frameBytes = frameSamples * BytesPerSample;
+		_carry = new byte[_frameBytes];
+	}
+
+	/// <summary>
+	/// Appends <paramref name="count"/> bytes from <paramref name="source"/>, emitting a
+	/// fresh <c>short[]</c> for every complete frame those bytes form (together with any
+	/// carried-over remainder). Leftover bytes are retained for the next call.
+	/// </summary>
+	public void Append(byte[] source, int count, Action<short[]> emit)
+	{
+		if (source is null) throw new ArgumentNullException(nameof(source));
+		if (emit is null) throw new ArgumentNullException(nameof(emit));
+		if (count < 0 || count > source.Length)
+			throw new ArgumentOutOfRangeException(nameof(count));
+
+		int offset = 0;
+
+		// Top up an in-progress carry frame first, then emit it once full.
+		if (_carryLength > 0)
+		{
+			int need = _frameBytes - _carryLength;
+			int take = Math.Min(need, count);
+			Buffer.BlockCopy(source, 0, _carry, _carryLength, take);
+			_carryLength += take;
+			offset += take;
+
+			if (_carryLength < _frameBytes)
+				return; // consumed everything, still short of a full frame
+
+			emit(ToFrame(_carry, 0));
+			_carryLength = 0;
+		}
+
+		// Emit whole frames straight from the source with no intermediate copy.
+		int remaining = count - offset;
+		while (remaining >= _frameBytes)
+		{
+			emit(ToFrame(source, offset));
+			offset += _frameBytes;
+			remaining -= _frameBytes;
+		}
+
+		// Stash the leftover tail (< one frame) for the next Append.
+		if (remaining > 0)
+		{
+			Buffer.BlockCopy(source, offset, _carry, 0, remaining);
+			_carryLength = remaining;
+		}
+	}
+
+	/// <summary>
+	/// Emits any buffered partial frame. When <paramref name="padWithSilence"/> is true a
+	/// non-empty remainder is zero-padded to a full frame and emitted; otherwise it is
+	/// dropped. The carry buffer is cleared either way.
+	/// </summary>
+	public void Flush(Action<short[]> emit, bool padWithSilence)
+	{
+		if (emit is null) throw new ArgumentNullException(nameof(emit));
+		if (_carryLength == 0) return;
+
+		if (padWithSilence)
+		{
+			Array.Clear(_carry, _carryLength, _frameBytes - _carryLength);
+			emit(ToFrame(_carry, 0));
+		}
+
+		_carryLength = 0;
+	}
+
+	private short[] ToFrame(byte[] source, int byteOffset)
+	{
+		var frame = new short[_frameSamples];
+		Buffer.BlockCopy(source, byteOffset, frame, 0, _frameBytes);
+		return frame;
+	}
+}

--- a/Mutation.Tests/PcmFrameSplitterTests.cs
+++ b/Mutation.Tests/PcmFrameSplitterTests.cs
@@ -1,0 +1,218 @@
+using System;
+using System.Collections.Generic;
+using CognitiveSupport;
+
+namespace Mutation.Tests;
+
+public class PcmFrameSplitterTests
+{
+	private const int FrameSamples = 4; // small frame keeps the test data readable
+	private const int FrameBytes = FrameSamples * 2;
+
+	// Little-endian 16-bit encoding of the given samples.
+	private static byte[] Bytes(params short[] samples)
+	{
+		var b = new byte[samples.Length * 2];
+		Buffer.BlockCopy(samples, 0, b, 0, b.Length);
+		return b;
+	}
+
+	private static List<short[]> Collect(Action<Action<short[]>> drive)
+	{
+		var frames = new List<short[]>();
+		drive(frames.Add);
+		return frames;
+	}
+
+	[Fact]
+	public void Append_WholeFrames_EmitsEachFrameWithCorrectSamples()
+	{
+		var splitter = new PcmFrameSplitter(FrameSamples);
+		var input = Bytes(1, 2, 3, 4, 5, 6, 7, 8); // exactly two frames
+
+		var frames = Collect(emit => splitter.Append(input, input.Length, emit));
+
+		Assert.Equal(2, frames.Count);
+		Assert.Equal(new short[] { 1, 2, 3, 4 }, frames[0]);
+		Assert.Equal(new short[] { 5, 6, 7, 8 }, frames[1]);
+	}
+
+	[Fact]
+	public void Append_PartialFrame_EmitsNothingUntilCompleted()
+	{
+		var splitter = new PcmFrameSplitter(FrameSamples);
+		var first = Bytes(1, 2);   // half a frame
+		var second = Bytes(3, 4);  // completes it
+
+		var frames = new List<short[]>();
+		splitter.Append(first, first.Length, frames.Add);
+		Assert.Empty(frames);
+
+		splitter.Append(second, second.Length, frames.Add);
+		Assert.Single(frames);
+		Assert.Equal(new short[] { 1, 2, 3, 4 }, frames[0]);
+	}
+
+	[Fact]
+	public void Append_CarriesRemainderAcrossCalls()
+	{
+		var splitter = new PcmFrameSplitter(FrameSamples);
+		// 1.5 frames, then another 1.5 frames -> 3 whole frames total.
+		var a = Bytes(1, 2, 3, 4, 5, 6);
+		var b = Bytes(7, 8, 9, 10, 11, 12);
+
+		var frames = new List<short[]>();
+		splitter.Append(a, a.Length, frames.Add);
+		Assert.Single(frames); // {1,2,3,4}; {5,6} carried
+
+		splitter.Append(b, b.Length, frames.Add);
+		Assert.Equal(3, frames.Count);
+		Assert.Equal(new short[] { 1, 2, 3, 4 }, frames[0]);
+		Assert.Equal(new short[] { 5, 6, 7, 8 }, frames[1]);
+		Assert.Equal(new short[] { 9, 10, 11, 12 }, frames[2]);
+	}
+
+	[Fact]
+	public void Append_ByteAtATime_ReconstructsFramesCorrectly()
+	{
+		var splitter = new PcmFrameSplitter(FrameSamples);
+		var input = Bytes(100, 200, 300, 400, 500, 600, 700, 800);
+
+		var frames = new List<short[]>();
+		var single = new byte[1];
+		foreach (var value in input)
+		{
+			single[0] = value;
+			splitter.Append(single, 1, frames.Add);
+		}
+
+		Assert.Equal(2, frames.Count);
+		Assert.Equal(new short[] { 100, 200, 300, 400 }, frames[0]);
+		Assert.Equal(new short[] { 500, 600, 700, 800 }, frames[1]);
+	}
+
+	[Fact]
+	public void Append_HonorsCountOverBufferLength()
+	{
+		var splitter = new PcmFrameSplitter(FrameSamples);
+		// Buffer is larger than the valid data; only the first frame's worth is real.
+		var buffer = Bytes(1, 2, 3, 4, 999, 999, 999, 999);
+
+		var frames = Collect(emit => splitter.Append(buffer, FrameBytes, emit));
+
+		Assert.Single(frames);
+		Assert.Equal(new short[] { 1, 2, 3, 4 }, frames[0]);
+	}
+
+	[Fact]
+	public void Flush_PadWithSilence_EmitsZeroPaddedRemainder()
+	{
+		var splitter = new PcmFrameSplitter(FrameSamples);
+		var input = Bytes(1, 2); // half a frame remains buffered
+
+		var frames = new List<short[]>();
+		splitter.Append(input, input.Length, frames.Add);
+		splitter.Flush(frames.Add, padWithSilence: true);
+
+		Assert.Single(frames);
+		Assert.Equal(new short[] { 1, 2, 0, 0 }, frames[0]);
+	}
+
+	[Fact]
+	public void Flush_WithoutPadding_DropsRemainder()
+	{
+		var splitter = new PcmFrameSplitter(FrameSamples);
+		var input = Bytes(1, 2);
+
+		var frames = new List<short[]>();
+		splitter.Append(input, input.Length, frames.Add);
+		splitter.Flush(frames.Add, padWithSilence: false);
+
+		Assert.Empty(frames);
+	}
+
+	[Fact]
+	public void Flush_WithNoRemainder_EmitsNothing()
+	{
+		var splitter = new PcmFrameSplitter(FrameSamples);
+		var input = Bytes(1, 2, 3, 4);
+
+		var frames = new List<short[]>();
+		splitter.Append(input, input.Length, frames.Add);
+		splitter.Flush(frames.Add, padWithSilence: true);
+
+		Assert.Single(frames); // only the whole frame; nothing extra from flush
+	}
+
+	[Fact]
+	public void Flush_ClearsRemainderSoSecondFlushIsNoOp()
+	{
+		var splitter = new PcmFrameSplitter(FrameSamples);
+		splitter.Append(Bytes(1, 2), FrameBytes / 2, (_) => { });
+
+		var frames = new List<short[]>();
+		splitter.Flush(frames.Add, padWithSilence: true);
+		splitter.Flush(frames.Add, padWithSilence: true);
+
+		Assert.Single(frames);
+	}
+
+	[Fact]
+	public void EmittedFrames_AreIndependentArrays()
+	{
+		var splitter = new PcmFrameSplitter(FrameSamples);
+		var input = Bytes(1, 2, 3, 4, 5, 6, 7, 8);
+
+		var frames = Collect(emit => splitter.Append(input, input.Length, emit));
+
+		// Mutating one emitted frame must not affect the other (required because
+		// SilenceTrimmer retains frame references).
+		frames[0][0] = -1;
+		Assert.Equal(new short[] { 5, 6, 7, 8 }, frames[1]);
+	}
+
+	[Fact]
+	public void Append_DecodesLittleEndian()
+	{
+		var splitter = new PcmFrameSplitter(1);
+		// 0x34, 0x12 little-endian -> 0x1234.
+		var input = new byte[] { 0x34, 0x12 };
+
+		var frames = Collect(emit => splitter.Append(input, input.Length, emit));
+
+		Assert.Single(frames);
+		Assert.Equal(0x1234, frames[0][0]);
+	}
+
+	[Fact]
+	public void Constructor_RejectsNonPositiveFrameSize()
+	{
+		Assert.Throws<ArgumentOutOfRangeException>(() => new PcmFrameSplitter(0));
+		Assert.Throws<ArgumentOutOfRangeException>(() => new PcmFrameSplitter(-1));
+	}
+
+	[Fact]
+	public void Append_RejectsNullArguments()
+	{
+		var splitter = new PcmFrameSplitter(FrameSamples);
+		Assert.Throws<ArgumentNullException>(() => splitter.Append(null!, 0, _ => { }));
+		Assert.Throws<ArgumentNullException>(() => splitter.Append(new byte[4], 4, null!));
+	}
+
+	[Theory]
+	[InlineData(-1)]
+	[InlineData(5)] // larger than the 4-byte source
+	public void Append_RejectsCountOutOfRange(int count)
+	{
+		var splitter = new PcmFrameSplitter(FrameSamples);
+		Assert.Throws<ArgumentOutOfRangeException>(
+			() => splitter.Append(new byte[4], count, _ => { }));
+	}
+
+	[Fact]
+	public void Flush_RejectsNullEmit()
+	{
+		var splitter = new PcmFrameSplitter(FrameSamples);
+		Assert.Throws<ArgumentNullException>(() => splitter.Flush(null!, padWithSilence: true));
+	}
+}


### PR DESCRIPTION
Closes #174

## What changed

Both audio paths that produce Opus frames — importing a file (`AudioFileConverter`) and live recording (`AudioRecorder`) — used to accumulate decoded 16-bit PCM one element at a time into a growing `List`, then pull each 20 ms (960-sample) frame out of the front with `GetRange(...).ToArray()` followed by `RemoveRange(...)`. `RemoveRange` shifts every remaining byte in the list forward on each frame, so the buffer (up to ~96 KB) was recopied once per frame. For a one-hour import that is on the order of hundreds of millions of single-element `Add` calls plus roughly 180,000 whole-buffer shift cycles, all of it running before transcription can even begin.

This replaces that with a small, reusable helper, `PcmFrameSplitter`, that turns a stream of little-endian PCM bytes into fixed-size `short[]` frames using one fixed carry buffer and `Buffer.BlockCopy`:

- Whole frames are copied straight out of the incoming buffer — no intermediate list, no per-byte adds, no per-frame buffer shifts.
- Bytes that do not complete a frame are held in a single carry buffer and combined with the next chunk.
- Each emitted frame is a freshly allocated array. This matters because `SilenceTrimmer` keeps references to frames it is handed; reusing one buffer would corrupt the trimmed output.

Both call sites keep their existing end-of-stream behavior:

- `AudioFileConverter` pads the final partial frame with silence and emits it (never drops trailing audio on import).
- `AudioRecorder` drops its trailing sub-20 ms tail, and now uses a fresh splitter per recording, which also stops a small partial-frame remainder from bleeding from one recording into the next.

Using little-endian `Buffer.BlockCopy` produces the same samples as the previous manual decode (`(short)((b[i*2+1] << 8) | b[i*2])`) on every platform this app supports (Windows x64/ARM64/ARM32, all little-endian), and `AudioFileConverter` already used `Buffer.BlockCopy`.

## Files

- `CognitiveSupport/PcmFrameSplitter.cs` — new helper (single responsibility, unit-tested in isolation).
- `CognitiveSupport/AudioFileConverter.cs` — use the splitter in place of the `List<byte>` accumulation loop.
- `CognitiveSupport/AudioRecorder.cs` — use a per-recording splitter in place of the `List<short>` buffer.
- `Mutation.Tests/PcmFrameSplitterTests.cs` — new tests.

## Test plan

- `dotnet test --configuration Release` — all 685 tests pass, including 16 new `PcmFrameSplitter` tests.
- New tests cover: whole-frame emission, partial frames completed across calls, carry-over remainder, byte-at-a-time feeding, honoring `count` over buffer length, flush with and without silence padding, empty flush, frame-array independence (the trimmer-retention guarantee), little-endian decode, and argument validation.
- The two call-site behaviors (pad-and-emit on import, drop-tail on record) are preserved; the existing recorder and speech-to-text tests continue to pass.
