### PR TITLE
Route startup/mic-change pinned-level reassert off the UI thread (#203)

### DIFF
--- a/Mutation.Ui/MainWindow.xaml.cs
+++ b/Mutation.Ui/MainWindow.xaml.cs
@@ -1319,8 +1319,31 @@ public sealed partial class MainWindow : Window, IDisposable
 		_micLevelInitialized = true;
 
 		// Re-assert now (app startup, or after a mic change): correct the level if
-		// another app changed it.
-		_micLevelPinService.ReassertPinnedLevel(pinned);
+		// another app changed it. Route it through the shared off-thread write worker
+		// rather than writing on the UI thread — the same guarantee the slider, pin
+		// toggle, and record-start paths already have. On the mic-change path this
+		// runs mid-session, where the write's failure path re-enumerates the device
+		// and would otherwise briefly freeze the window and the screen reader.
+		ReassertPinnedLevelOffThread(pinned);
+	}
+
+	// Nudges the pinned capture level back onto the active device through the shared
+	// off-thread write coordinator, without blocking the caller. Used by the startup
+	// and mic-change re-assert (InitializeMicrophoneLevelControls), where the write
+	// must not run on the UI thread — its failure path re-enumerates the device,
+	// which would freeze the UI and, with it, the screen reader. Routing through the
+	// coordinator also serializes this write with the slider and pin-toggle writes,
+	// so two threads never touch the same COM level endpoint at once, and a burst
+	// coalesces to the latest value. This is a fire-and-forget background correction:
+	// the re-assert only nudges the level back to the pinned value, so the outcome is
+	// not surfaced (matching the previous synchronous call, whose result was already
+	// discarded). A null pin means pinning is disabled — nothing to write.
+	private void ReassertPinnedLevelOffThread(int? pinnedLevel)
+	{
+		if (pinnedLevel is not int level)
+			return;
+
+		_ = _micLevelWriteCoordinator.RequestLatestAsync(level);
 	}
 
 	// Current Windows capture level as a 0–100 value, or a sensible default when it


### PR DESCRIPTION
## What this changes

The microphone "pin input level" feature keeps the Windows capture level at a
value the user chose, re-asserting it whenever the level might have drifted. That
re-assert involves a write over the Windows audio COM API, a read-back to confirm
it took, and — if the write fails — a fresh enumeration of the audio device before
one retry. Enumerating a device can be slow.

Most paths that trigger this re-assert (dragging the level slider, toggling the
pin, and re-asserting just before a recording starts) were already moved onto a
shared background worker so that slow work never runs on the UI thread. One path
was left behind: the re-assert that runs at **app startup** and **after the user
switches microphones**, in `InitializeMicrophoneLevelControls`. It still wrote
synchronously on the UI thread.

At startup that is low-risk (it runs before the user can interact). After a
microphone change it runs mid-session, so a failed write could briefly freeze the
window and, with it, the screen reader — the exact accessibility problem the
earlier work removed for the other paths. Because it also bypassed the shared
serialization point, it could overlap a following slider write on the same audio
endpoint.

## How

Route this re-assert through the same shared write coordinator the other paths
use, via a small fire-and-forget helper. The coordinator runs the write (and any
device re-enumeration) on a single background worker off the UI thread, serializes
it with the slider and pin-toggle writes so two threads never touch the same audio
endpoint at once, and collapses a burst of requests down to the most recent value.

The re-assert becomes a background correction rather than a blocking step, which
is acceptable — it only nudges the level back to the pinned value. When pinning is
off there is nothing to write, and the outcome is not surfaced to the user, which
matches the previous behavior (the old synchronous call already discarded its
result).

This completes the effort to move every capture-level write off the UI thread
(#171, #197 / #201).

## Test plan

- `dotnet test --configuration Release` — all 674 tests pass.
- The off-UI-thread and coalesce-to-latest guarantees this change relies on are
  already covered by `MicrophoneLevelWriteCoordinatorTests`
  (`RunsTheWriteOffTheCallingThread`, `CoalescesToLatest_AppliesFirstAndLast_DropsMiddle`).
- No new unit test: the change is WinUI code-behind wiring in `MainWindow`, which
  needs live XAML controls and is not unit-testable in isolation — the same reason
  the sibling slider and pin-toggle reroutes in #201 added no `MainWindow` tests.

## Manual verification (for a tester with a microphone)

1. Enable "Pin input level" and set a level.
2. Switch to a different microphone from the dropdown, then back.
3. Confirm the UI and screen reader stay responsive during the switch and the
   pinned level settles on the active device.

Closes #203
