### PR TITLE
Decode Ogg/Opus uploads in managed code instead of Media Foundation

### DIFF
--- a/CognitiveSupport/AudioFileConverter.cs
+++ b/CognitiveSupport/AudioFileConverter.cs
@@ -4,22 +4,28 @@ using Concentus.Structs;
 using NAudio.Wave;
 using System;
 using System.IO;
+using System.Runtime.InteropServices;
 
 namespace CognitiveSupport;
 
 public static class AudioFileConverter
 {
+	private const int OutputSampleRate = 48000;
+
+	// Opus requires 2.5, 5, 10, 20, 40, or 60ms frames. We use 20ms (960 samples at 48kHz).
+	private const int SamplesPerFrame = 960;
+
 	/// <summary>
 	/// Converts a video/audio file to OGG Opus format and saves to a temp file.
 	/// </summary>
-	/// <param name="inputPath">Path to the input file (MP4, AVI, etc.)</param>
+	/// <param name="inputPath">Path to the input file (MP4, MP3, OGG/Opus, etc.)</param>
 	/// <returns>Path to the temporary OGG file. Caller is responsible for cleanup.</returns>
-	public static string ConvertMp4ToOgg(string inputPath, SilenceTrimmerOptions? silenceOptions = null)
+	public static string ConvertToOgg(string inputPath, SilenceTrimmerOptions? silenceOptions = null)
 	{
 		string tempOggPath = Path.ChangeExtension(Path.GetTempFileName(), ".ogg");
 		try
 		{
-			ConvertMp4ToOgg(inputPath, tempOggPath, silenceOptions);
+			ConvertToOgg(inputPath, tempOggPath, silenceOptions);
 			return tempOggPath;
 		}
 		catch
@@ -35,9 +41,9 @@ public static class AudioFileConverter
 	/// <summary>
 	/// Converts a video/audio file to OGG Opus format and saves to the specified output path.
 	/// </summary>
-	/// <param name="inputPath">Path to the input file (MP4, AVI, etc.)</param>
+	/// <param name="inputPath">Path to the input file (MP4, MP3, OGG/Opus, etc.)</param>
 	/// <param name="outputOggPath">Path where the OGG file will be written.</param>
-	public static void ConvertMp4ToOgg(string inputPath, string outputOggPath, SilenceTrimmerOptions? silenceOptions = null)
+	public static void ConvertToOgg(string inputPath, string outputOggPath, SilenceTrimmerOptions? silenceOptions = null)
 	{
 		if (string.IsNullOrWhiteSpace(inputPath))
 			throw new ArgumentException("Input path cannot be empty", nameof(inputPath));
@@ -48,17 +54,9 @@ public static class AudioFileConverter
 		if (!File.Exists(inputPath))
 			throw new FileNotFoundException("Input file not found", inputPath);
 
-		using var reader = new MediaFoundationReader(inputPath);
-		
-		// Target format: 48kHz, Mono, 16-bit
-		var outFormat = new WaveFormat(48000, 16, 1);
-		
-		using var resampler = new MediaFoundationResampler(reader, outFormat);
-		resampler.ResamplerQuality = 60; // Reasonable quality
-
 		using var outStream = new FileStream(outputOggPath, FileMode.Create, FileAccess.Write, FileShare.None);
 #pragma warning disable CS0618 // Concentus.OggFile 1.0.6 still requires the concrete OpusEncoder type, not IOpusEncoder from OpusCodecFactory.
-		var encoder = new OpusEncoder(48000, 1, OpusApplication.OPUS_APPLICATION_VOIP)
+		var encoder = new OpusEncoder(OutputSampleRate, 1, OpusApplication.OPUS_APPLICATION_VOIP)
 		{
 			Bitrate = 24000,
 			UseVBR = true,
@@ -68,18 +66,11 @@ public static class AudioFileConverter
 		var tags = new OpusTags();
 		var oggStream = new OpusOggWriteStream(encoder, outStream, tags);
 
-		// Buffer for reading from resampler (1 second worth of audio)
-		byte[] buffer = new byte[outFormat.AverageBytesPerSecond];
-		int bytesRead;
-
-		// Split the decoded byte stream into fixed frame sizes for Opus (960 samples = 1920
-		// bytes). Opus requires 2.5, 5, 10, 20, 40, or 60ms frames. We use 20ms (960 samples).
-		int samplesPerFrame = 960;
-		var splitter = new PcmFrameSplitter(samplesPerFrame);
+		var splitter = new PcmFrameSplitter(SamplesPerFrame);
 
 		var trimmer = silenceOptions is null
 			? null
-			: new SilenceTrimmer(48000, samplesPerFrame, silenceOptions);
+			: new SilenceTrimmer(OutputSampleRate, SamplesPerFrame, silenceOptions);
 
 		void WriteFrame(short[] pcmSamples)
 		{
@@ -89,10 +80,12 @@ public static class AudioFileConverter
 				trimmer.ProcessFrame(pcmSamples, f => oggStream.WriteSamples(f, 0, f.Length));
 		}
 
-		while ((bytesRead = resampler.Read(buffer, 0, buffer.Length)) > 0)
-		{
-			splitter.Append(buffer, bytesRead, WriteFrame);
-		}
+		// Media Foundation cannot demux Ogg/Opus, so those files are decoded in managed code
+		// instead. Everything else goes through Media Foundation as before.
+		if (OggOpusPcmDecoder.IsOggOpus(inputPath))
+			DecodeOggOpus(inputPath, splitter, WriteFrame);
+		else
+			DecodeWithMediaFoundation(inputPath, splitter, WriteFrame);
 
 		// Pad the final partial frame with silence and emit it, matching the previous
 		// behavior of never dropping trailing audio on file conversion.
@@ -101,6 +94,52 @@ public static class AudioFileConverter
 		trimmer?.Flush(f => oggStream.WriteSamples(f, 0, f.Length));
 
 		oggStream.Finish();
+	}
+
+	private static void DecodeOggOpus(string inputPath, PcmFrameSplitter splitter, Action<short[]> writeFrame)
+	{
+		OggOpusPcmDecoder.DecodeToMonoPcm(inputPath, packet => splitter.AppendSamples(packet, packet.Length, writeFrame));
+	}
+
+	private static void DecodeWithMediaFoundation(string inputPath, PcmFrameSplitter splitter, Action<short[]> writeFrame)
+	{
+		using var reader = OpenMediaFoundationReader(inputPath);
+
+		// Target format: 48kHz, Mono, 16-bit
+		var outFormat = new WaveFormat(OutputSampleRate, 16, 1);
+
+		using var resampler = new MediaFoundationResampler(reader, outFormat);
+		resampler.ResamplerQuality = 60; // Reasonable quality
+
+		// Buffer for reading from resampler (1 second worth of audio)
+		byte[] buffer = new byte[outFormat.AverageBytesPerSecond];
+		int bytesRead;
+
+		while ((bytesRead = resampler.Read(buffer, 0, buffer.Length)) > 0)
+		{
+			splitter.Append(buffer, bytesRead, writeFrame);
+		}
+	}
+
+	/// <summary>
+	/// Opens the file with Media Foundation, translating its bare HRESULT failures (typically
+	/// MF_E_UNSUPPORTED_BYTESTREAM_TYPE, 0xC00D36C4, for formats Windows has no demuxer for
+	/// such as Ogg/Vorbis or some WebM) into a message that tells the user what to do next.
+	/// </summary>
+	private static MediaFoundationReader OpenMediaFoundationReader(string inputPath)
+	{
+		try
+		{
+			return new MediaFoundationReader(inputPath);
+		}
+		catch (COMException ex)
+		{
+			string extension = Path.GetExtension(inputPath);
+			string formatLabel = string.IsNullOrWhiteSpace(extension) ? "this format" : extension.ToLowerInvariant();
+			throw new InvalidOperationException(
+				$"Windows cannot decode '{Path.GetFileName(inputPath)}' ({formatLabel}). " +
+				"Convert it to WAV, MP3, MP4, or Ogg/Opus first.", ex);
+		}
 	}
 
 	public static bool IsVideoFile(string filePath)

--- a/CognitiveSupport/AudioPlayer.cs
+++ b/CognitiveSupport/AudioPlayer.cs
@@ -1,5 +1,3 @@
-using Concentus.Oggfile;
-using Concentus.Structs;
 using NAudio.Wave;
 using NAudio.Wave.SampleProviders;
 
@@ -18,7 +16,6 @@ namespace CognitiveSupport;
 public class AudioPlayer : IDisposable
 {
     private WaveOutEvent? _waveOut;
-    private OpusDecoder? _decoder;
     private MemoryStream? _pcmStream;
     private WaveStream? _sourceStream;
     private SoundTouchSampleProvider? _speedProvider;
@@ -88,26 +85,15 @@ public class AudioPlayer : IDisposable
     }
 
     /// <summary>
-    /// Plays an OGG/Opus file by decoding it with Concentus and playing via NAudio.
+    /// Plays an OGG/Opus file by decoding it with <see cref="OggOpusPcmDecoder"/> and playing
+    /// via NAudio. The decoder is shared with the import path so files this app did not record
+    /// itself — WhatsApp voice notes and the like — play back rather than hanging.
     /// </summary>
     private void PlayOgg(string filePath)
     {
         // Read and decode the entire OGG file to PCM
-        using var fileStream = File.OpenRead(filePath);
-#pragma warning disable CS0618 // Concentus.OggFile 1.0.6 still requires the concrete OpusDecoder type, not IOpusDecoder from OpusCodecFactory.
-        var oggReader = new OpusOggReadStream(_decoder = new OpusDecoder(SampleRate, Channels), fileStream);
-#pragma warning restore CS0618
-
-        // Collect all decoded samples
         var allSamples = new List<short>();
-        while (oggReader.HasNextPacket)
-        {
-            var samples = oggReader.DecodeNextPacket();
-            if (samples != null && samples.Length > 0)
-            {
-                allSamples.AddRange(samples);
-            }
-        }
+        OggOpusPcmDecoder.DecodeToMonoPcm(filePath, samples => allSamples.AddRange(samples));
 
         if (allSamples.Count == 0)
         {
@@ -197,8 +183,6 @@ public class AudioPlayer : IDisposable
 
                 _pcmStream?.Dispose();
                 _pcmStream = null;
-
-                _decoder = null;
             }
             catch
             {

--- a/CognitiveSupport/OggOpusPcmDecoder.cs
+++ b/CognitiveSupport/OggOpusPcmDecoder.cs
@@ -1,0 +1,288 @@
+using Concentus;
+using Concentus.Structs;
+using System;
+using System.IO;
+
+namespace CognitiveSupport;
+
+/// <summary>
+/// Decodes an Ogg/Opus file into 48 kHz mono 16-bit PCM.
+///
+/// Windows Media Foundation has no Ogg/Opus demuxer, so these files (WhatsApp voice notes,
+/// anything this app recorded itself) cannot be opened with <c>MediaFoundationReader</c> —
+/// it throws MF_E_UNSUPPORTED_BYTESTREAM_TYPE (0xC00D36C4). Decoding happens in managed
+/// code instead.
+///
+/// Two quirks of the bundled libraries are worked around here:
+/// <list type="bullet">
+/// <item>Concentus.Oggfile 1.0.6's reader is not used at all — on third-party files it stops
+/// yielding audio partway through and then loops forever. <see cref="OggPacketReader"/>
+/// demuxes instead.</item>
+/// <item>Concentus rejects a whole multi-frame packet when any frame inside it is
+/// zero-length (Opus DTX, which WhatsApp uses heavily). Packets are therefore split into
+/// their frames and decoded one at a time, with DTX frames concealed rather than dropped —
+/// otherwise roughly 7% of a typical voice note is lost and the timeline drifts.</item>
+/// </list>
+///
+/// Opus always decodes at 48 kHz, so the only normalisation needed is the downmix to mono,
+/// which matches the format <see cref="AudioFileConverter"/> encodes to.
+/// </summary>
+public static class OggOpusPcmDecoder
+{
+	public const int SampleRate = 48000;
+
+	private static readonly byte[] OggMagic = "OggS"u8.ToArray();
+	private static readonly byte[] OpusHeadMagic = "OpusHead"u8.ToArray();
+	private static readonly byte[] OpusTagsMagic = "OpusTags"u8.ToArray();
+
+	// The identification header lives in the first page of the logical stream, well within
+	// this. Reading a single small block keeps the format sniff cheap.
+	private const int HeaderScanBytes = 4096;
+
+	// 120ms at 48kHz — the longest frame Opus can carry.
+	private const int MaxFrameSamples = 5760;
+
+	/// <summary>
+	/// True when the file is an Ogg stream carrying Opus. Detection is by content rather than
+	/// extension so a mis-named file still decodes, and so Ogg/Vorbis — which Concentus cannot
+	/// decode — is correctly reported as not-Opus and left to the caller's fallback path.
+	/// </summary>
+	public static bool IsOggOpus(string filePath)
+	{
+		if (string.IsNullOrWhiteSpace(filePath) || !File.Exists(filePath))
+			return false;
+
+		try
+		{
+			using var stream = File.OpenRead(filePath);
+			return TryReadOpusHead(stream, out _, out _);
+		}
+		catch (IOException)
+		{
+			return false;
+		}
+	}
+
+	/// <summary>
+	/// Reads the channel count from the file's OpusHead identification header.
+	/// </summary>
+	/// <exception cref="InvalidDataException">The file is not an Ogg/Opus stream.</exception>
+	public static int ReadChannelCount(string filePath)
+	{
+		using var stream = File.OpenRead(filePath);
+		if (!TryReadOpusHead(stream, out int channels, out _))
+			throw new InvalidDataException($"'{Path.GetFileName(filePath)}' is not an Ogg/Opus stream.");
+
+		return channels;
+	}
+
+	/// <summary>
+	/// Streams the file's audio to <paramref name="onSamples"/> as 48 kHz mono 16-bit PCM,
+	/// one decoded frame at a time. Stereo sources are averaged down to mono. The array handed
+	/// to the callback is freshly allocated per frame, so the callback may retain it.
+	/// </summary>
+	/// <exception cref="InvalidDataException">The file is not an Ogg/Opus stream.</exception>
+	public static void DecodeToMonoPcm(string filePath, Action<short[]> onSamples)
+	{
+		if (string.IsNullOrWhiteSpace(filePath))
+			throw new ArgumentException("File path cannot be empty", nameof(filePath));
+		if (onSamples is null)
+			throw new ArgumentNullException(nameof(onSamples));
+
+		int channels;
+		int preSkipSamples;
+		using (var headerStream = File.OpenRead(filePath))
+		{
+			if (!TryReadOpusHead(headerStream, out channels, out preSkipSamples))
+				throw new InvalidDataException($"'{Path.GetFileName(filePath)}' is not an Ogg/Opus stream.");
+		}
+
+		var decoder = OpusCodecFactory.CreateDecoder(SampleRate, channels);
+		var buffer = new short[MaxFrameSamples * channels];
+		int remainingPreSkip = preSkipSamples;
+
+		using var stream = File.OpenRead(filePath);
+		foreach (byte[] packet in OggPacketReader.ReadPackets(stream))
+		{
+			if (IsHeaderPacket(packet))
+				continue;
+
+			DecodePacket(decoder, packet, channels, buffer, ref remainingPreSkip, onSamples);
+		}
+	}
+
+	/// <summary>
+	/// Decodes one Opus packet frame by frame. Splitting is what makes DTX-bearing packets
+	/// decodable: each frame is re-wrapped as a single-frame (code 0) packet, and a
+	/// zero-length frame is handed to the decoder as a loss so it emits concealment audio of
+	/// the right length instead of the packet failing outright.
+	/// </summary>
+	private static void DecodePacket(
+		IOpusDecoder decoder,
+		byte[] packet,
+		int channels,
+		short[] buffer,
+		ref int remainingPreSkip,
+		Action<short[]> onSamples)
+	{
+		// Concentus.Oggfile's writer terminates a stream with an empty packet, and its parser
+		// overflows rather than rejecting one, so drop empties before parsing.
+		if (packet.Length == 0)
+			return;
+
+		OpusPacketInfo info;
+		try
+		{
+			info = OpusPacketInfo.ParseOpusPacket(packet.AsSpan());
+		}
+		catch (Exception ex) when (ex is OpusException or OverflowException or ArgumentException)
+		{
+			return; // Unparseable packet — skip it rather than abandoning the rest of the file.
+		}
+
+		int frameSamples = info.NumSamplesPerFrame(SampleRate);
+		if (frameSamples <= 0 || frameSamples > MaxFrameSamples)
+			return;
+
+		byte singleFrameToc = (byte)(info.TOCByte & 0xFC); // clear the frame-count code
+		var singleFramePacket = new byte[1];
+
+		foreach (byte[] frame in info.Frames)
+		{
+			int decodedSamples;
+			try
+			{
+				if (frame.Length == 0)
+				{
+					// DTX: no data was transmitted for this frame. Ask for concealment so the
+					// output keeps the same duration as the source.
+					decodedSamples = decoder.Decode(ReadOnlySpan<byte>.Empty, buffer.AsSpan(0, frameSamples * channels), frameSamples, false);
+				}
+				else
+				{
+					if (singleFramePacket.Length != frame.Length + 1)
+						singleFramePacket = new byte[frame.Length + 1];
+
+					singleFramePacket[0] = singleFrameToc;
+					Buffer.BlockCopy(frame, 0, singleFramePacket, 1, frame.Length);
+					decodedSamples = decoder.Decode(singleFramePacket, buffer.AsSpan(0, frameSamples * channels), frameSamples, false);
+				}
+			}
+			catch (OpusException)
+			{
+				// A frame the decoder cannot handle becomes silence of the same length, so a
+				// single bad frame costs a few milliseconds instead of the whole recording.
+				Array.Clear(buffer, 0, frameSamples * channels);
+				decodedSamples = frameSamples;
+			}
+
+			if (decodedSamples <= 0)
+				continue;
+
+			EmitSamples(buffer, decodedSamples, channels, ref remainingPreSkip, onSamples);
+		}
+	}
+
+	/// <summary>
+	/// Downmixes to mono if needed, drops the encoder's pre-skip priming samples, and hands
+	/// the result to the caller.
+	/// </summary>
+	private static void EmitSamples(
+		short[] buffer,
+		int decodedSamples,
+		int channels,
+		ref int remainingPreSkip,
+		Action<short[]> onSamples)
+	{
+		int start = 0;
+		if (remainingPreSkip > 0)
+		{
+			int skipped = Math.Min(remainingPreSkip, decodedSamples);
+			remainingPreSkip -= skipped;
+			start = skipped;
+			if (start >= decodedSamples)
+				return;
+		}
+
+		int count = decodedSamples - start;
+		var mono = new short[count];
+
+		if (channels == 1)
+		{
+			Array.Copy(buffer, start, mono, 0, count);
+		}
+		else
+		{
+			// Averaging in int avoids the overflow a short-domain sum would hit on loud material.
+			for (int i = 0; i < count; i++)
+			{
+				int sum = 0;
+				int offset = (start + i) * channels;
+				for (int channel = 0; channel < channels; channel++)
+					sum += buffer[offset + channel];
+
+				mono[i] = (short)(sum / channels);
+			}
+		}
+
+		onSamples(mono);
+	}
+
+	private static bool IsHeaderPacket(byte[] packet) =>
+		MatchesAt(packet, 0, OpusHeadMagic) || MatchesAt(packet, 0, OpusTagsMagic);
+
+	/// <summary>
+	/// Locates the OpusHead identification header near the start of the stream and reads the
+	/// channel count (byte +9) and pre-skip sample count (bytes +10..11), per RFC 7845 §5.1.
+	/// </summary>
+	private static bool TryReadOpusHead(Stream stream, out int channels, out int preSkipSamples)
+	{
+		channels = 0;
+		preSkipSamples = 0;
+
+		var buffer = new byte[HeaderScanBytes];
+		int read = stream.ReadAtLeast(buffer, buffer.Length, throwOnEndOfStream: false);
+		if (read < OggMagic.Length || !MatchesAt(buffer, 0, OggMagic, read))
+			return false;
+
+		int headIndex = IndexOf(buffer, read, OpusHeadMagic);
+		if (headIndex < 0)
+			return false;
+
+		int channelIndex = headIndex + OpusHeadMagic.Length + 1; // skip the version byte
+		if (channelIndex + 2 >= read)
+			return false;
+
+		channels = buffer[channelIndex];
+		preSkipSamples = buffer[channelIndex + 1] | (buffer[channelIndex + 2] << 8);
+		return channels > 0;
+	}
+
+	private static int IndexOf(byte[] haystack, int length, byte[] needle)
+	{
+		for (int i = 0; i + needle.Length <= length; i++)
+		{
+			if (MatchesAt(haystack, i, needle))
+				return i;
+		}
+
+		return -1;
+	}
+
+	private static bool MatchesAt(byte[] haystack, int offset, byte[] needle) =>
+		MatchesAt(haystack, offset, needle, haystack.Length);
+
+	private static bool MatchesAt(byte[] haystack, int offset, byte[] needle, int length)
+	{
+		if (offset + needle.Length > length)
+			return false;
+
+		for (int i = 0; i < needle.Length; i++)
+		{
+			if (haystack[offset + i] != needle[i])
+				return false;
+		}
+
+		return true;
+	}
+}

--- a/CognitiveSupport/OggOpusPcmDecoder.cs
+++ b/CognitiveSupport/OggOpusPcmDecoder.cs
@@ -42,10 +42,17 @@ public static class OggOpusPcmDecoder
 	// 120ms at 48kHz — the longest frame Opus can carry.
 	private const int MaxFrameSamples = 5760;
 
+	// Concentus decodes mono and stereo only; it rejects anything else outright. Surround
+	// Opus (RFC 7845 channel mapping family 1) therefore cannot be handled here.
+	private const int MaxDecodableChannels = 2;
+
 	/// <summary>
-	/// True when the file is an Ogg stream carrying Opus. Detection is by content rather than
-	/// extension so a mis-named file still decodes, and so Ogg/Vorbis — which Concentus cannot
-	/// decode — is correctly reported as not-Opus and left to the caller's fallback path.
+	/// True when the file is an Ogg stream carrying Opus that this decoder can actually handle.
+	/// Detection is by content rather than extension so a mis-named file still decodes, and so
+	/// Ogg/Vorbis — which Concentus cannot decode — is correctly reported as not-Opus and left
+	/// to the caller's fallback path. Surround Opus is reported as not-decodable for the same
+	/// reason: better to fall through to the caller's fallback, which explains what to do, than
+	/// to fail deep inside the codec with a bare "Number of channels must be 1 or 2".
 	/// </summary>
 	public static bool IsOggOpus(string filePath)
 	{
@@ -55,9 +62,13 @@ public static class OggOpusPcmDecoder
 		try
 		{
 			using var stream = File.OpenRead(filePath);
-			return TryReadOpusHead(stream, out _, out _);
+			return TryReadOpusHead(stream, out int channels, out _) && channels <= MaxDecodableChannels;
 		}
 		catch (IOException)
+		{
+			return false;
+		}
+		catch (UnauthorizedAccessException)
 		{
 			return false;
 		}
@@ -82,6 +93,8 @@ public static class OggOpusPcmDecoder
 	/// to the callback is freshly allocated per frame, so the callback may retain it.
 	/// </summary>
 	/// <exception cref="InvalidDataException">The file is not an Ogg/Opus stream.</exception>
+	/// <exception cref="NotSupportedException">The file is surround Opus, which Concentus
+	/// cannot decode.</exception>
 	public static void DecodeToMonoPcm(string filePath, Action<short[]> onSamples)
 	{
 		if (string.IsNullOrWhiteSpace(filePath))
@@ -96,6 +109,13 @@ public static class OggOpusPcmDecoder
 			if (!TryReadOpusHead(headerStream, out channels, out preSkipSamples))
 				throw new InvalidDataException($"'{Path.GetFileName(filePath)}' is not an Ogg/Opus stream.");
 		}
+
+		// Say so plainly rather than letting Concentus surface a bare "Number of channels must
+		// be 1 or 2" from somewhere inside the codec.
+		if (channels > MaxDecodableChannels)
+			throw new NotSupportedException(
+				$"'{Path.GetFileName(filePath)}' is {channels}-channel Ogg/Opus, which cannot be decoded. " +
+				"Convert it to mono or stereo first.");
 
 		var decoder = OpusCodecFactory.CreateDecoder(SampleRate, channels);
 		var buffer = new short[MaxFrameSamples * channels];

--- a/CognitiveSupport/OggPacketReader.cs
+++ b/CognitiveSupport/OggPacketReader.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace CognitiveSupport;
+
+/// <summary>
+/// Minimal Ogg container demuxer: yields the logical bitstream's packets in order.
+///
+/// Concentus.Oggfile 1.0.6's own reader cannot be used for arbitrary third-party files —
+/// it stops producing audio partway through and then spins forever, because
+/// <c>HasNextPacket</c> stays true after the stream is exhausted while
+/// <c>DecodeNextPacket</c> returns null. Demuxing here (RFC 3533 §6) keeps the container
+/// concern separate from the codec and lets <see cref="OggOpusPcmDecoder"/> handle packets
+/// that the bundled reader chokes on.
+/// </summary>
+public static class OggPacketReader
+{
+	private const int PageHeaderBytes = 27;
+	private const int SegmentTableOffset = 26;
+	private const int ContinuedPacketFlag = 0x01;
+	private const int MaxSegmentLength = 255;
+
+	/// <summary>
+	/// Enumerates the packets of the stream, reassembling segments that a packet is split
+	/// across (including across page boundaries). Enumeration stops at the first page that
+	/// does not start with the "OggS" capture pattern, which is how a truncated or corrupt
+	/// tail is tolerated rather than throwing away everything decoded so far.
+	/// </summary>
+	public static IEnumerable<byte[]> ReadPackets(Stream stream)
+	{
+		if (stream is null) throw new ArgumentNullException(nameof(stream));
+
+		var header = new byte[PageHeaderBytes];
+		var packet = new List<byte>();
+
+		while (true)
+		{
+			if (stream.ReadAtLeast(header, header.Length, throwOnEndOfStream: false) < header.Length)
+				yield break;
+
+			if (header[0] != (byte)'O' || header[1] != (byte)'g' || header[2] != (byte)'g' || header[3] != (byte)'S')
+				yield break;
+
+			// A page whose continuation flag is clear starts a fresh packet; anything held over
+			// from a truncated previous page is then stale and must be dropped.
+			if ((header[5] & ContinuedPacketFlag) == 0)
+				packet.Clear();
+
+			int segmentCount = header[SegmentTableOffset];
+			var segmentTable = new byte[segmentCount];
+			if (stream.ReadAtLeast(segmentTable, segmentCount, throwOnEndOfStream: false) < segmentCount)
+				yield break;
+
+			bool truncated = false;
+			for (int i = 0; i < segmentCount; i++)
+			{
+				int length = segmentTable[i];
+				if (length > 0)
+				{
+					var segment = new byte[length];
+					if (stream.ReadAtLeast(segment, length, throwOnEndOfStream: false) < length)
+					{
+						truncated = true;
+						break;
+					}
+
+					packet.AddRange(segment);
+				}
+
+				// A segment shorter than 255 bytes terminates the packet; a full-length one
+				// means it continues in the next segment (possibly on the next page).
+				if (length < MaxSegmentLength)
+				{
+					yield return packet.ToArray();
+					packet.Clear();
+				}
+			}
+
+			if (truncated)
+				yield break;
+		}
+	}
+}

--- a/CognitiveSupport/PcmFrameSplitter.cs
+++ b/CognitiveSupport/PcmFrameSplitter.cs
@@ -90,6 +90,24 @@ public sealed class PcmFrameSplitter
 	}
 
 	/// <summary>
+	/// Appends already-decoded 16-bit samples, emitting a fresh <c>short[]</c> for every
+	/// complete frame. Used by decoders that hand back <c>short[]</c> directly (Opus) rather
+	/// than a raw byte stream; framing and carry-over behave exactly as in <see cref="Append"/>.
+	/// Kept as a distinct name rather than an overload so a <c>null</c> literal argument stays
+	/// unambiguous at the call site.
+	/// </summary>
+	public void AppendSamples(short[] source, int count, Action<short[]> emit)
+	{
+		if (source is null) throw new ArgumentNullException(nameof(source));
+		if (count < 0 || count > source.Length)
+			throw new ArgumentOutOfRangeException(nameof(count));
+
+		var bytes = new byte[count * BytesPerSample];
+		Buffer.BlockCopy(source, 0, bytes, 0, bytes.Length);
+		Append(bytes, bytes.Length, emit);
+	}
+
+	/// <summary>
 	/// Emits any buffered partial frame. When <paramref name="padWithSilence"/> is true a
 	/// non-empty remainder is zero-padded to a full frame and emitted; otherwise it is
 	/// dropped. The carry buffer is cleared either way.

--- a/Mutation.Tests/AudioFileConverterOggTests.cs
+++ b/Mutation.Tests/AudioFileConverterOggTests.cs
@@ -1,0 +1,161 @@
+using System;
+using System.IO;
+using CognitiveSupport;
+using Concentus.Enums;
+using Concentus.Oggfile;
+using Concentus.Structs;
+
+namespace Mutation.Tests;
+
+/// <summary>
+/// Covers the managed Ogg/Opus input path added because Media Foundation cannot demux
+/// Ogg/Opus (it throws 0xC00D36C4). Both ends of this round trip are pure Concentus, so
+/// these tests need no codec support from the host OS.
+/// </summary>
+public class AudioFileConverterOggTests : IDisposable
+{
+	private const int SampleRate = 48000;
+	private const int FrameSize = 960; // 20ms
+
+	private readonly string _workingDirectory = Directory.CreateTempSubdirectory("ogg-convert-tests").FullName;
+
+	public void Dispose()
+	{
+		try { Directory.Delete(_workingDirectory, recursive: true); } catch { }
+	}
+
+	private string PathFor(string fileName) => Path.Combine(_workingDirectory, fileName);
+
+	private static SilenceTrimmerOptions StripSilence() =>
+		new(SilenceThresholdDbFs: -40.0, MinSilenceSeconds: 0.2, GuardMilliseconds: 40.0);
+
+	/// <summary>
+	/// Writes an Ogg/Opus file of tone / silence / tone, one second each.
+	/// </summary>
+	private string WriteFixture(string fileName, int channels)
+	{
+		string path = PathFor(fileName);
+
+		using var outStream = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None);
+#pragma warning disable CS0618 // Concentus.OggFile 1.0.6 requires the concrete OpusEncoder type.
+		var encoder = new OpusEncoder(SampleRate, channels, OpusApplication.OPUS_APPLICATION_AUDIO)
+		{
+			Bitrate = 32000,
+			UseDTX = false
+		};
+#pragma warning restore CS0618
+		var oggStream = new OpusOggWriteStream(encoder, outStream, new OpusTags());
+
+		int framesPerSecond = SampleRate / FrameSize;
+		WriteSeconds(oggStream, channels, framesPerSecond, loud: true);
+		WriteSeconds(oggStream, channels, framesPerSecond, loud: false);
+		WriteSeconds(oggStream, channels, framesPerSecond, loud: true);
+
+		oggStream.Finish();
+		return path;
+	}
+
+	private static void WriteSeconds(OpusOggWriteStream oggStream, int channels, int frameCount, bool loud)
+	{
+		var frame = new short[FrameSize * channels];
+		if (loud)
+		{
+			// A 440Hz tone; a DC-constant signal would be trimmed as "silence" by nothing but
+			// is also unrealistic for a codec round trip.
+			for (int sample = 0; sample < FrameSize; sample++)
+			{
+				short value = (short)(12000 * Math.Sin(2 * Math.PI * 440 * sample / SampleRate));
+				for (int channel = 0; channel < channels; channel++)
+					frame[sample * channels + channel] = value;
+			}
+		}
+
+		for (int i = 0; i < frameCount; i++)
+			oggStream.WriteSamples(frame, 0, frame.Length);
+	}
+
+	private static int CountDecodedSamples(string oggPath)
+	{
+		int total = 0;
+		OggOpusPcmDecoder.DecodeToMonoPcm(oggPath, samples => total += samples.Length);
+		return total;
+	}
+
+	private static int CountNonZeroSamples(string oggPath)
+	{
+		int nonZero = 0;
+		OggOpusPcmDecoder.DecodeToMonoPcm(oggPath, samples =>
+		{
+			foreach (short sample in samples)
+			{
+				if (sample != 0) nonZero++;
+			}
+		});
+		return nonZero;
+	}
+
+	[Fact]
+	public void MonoOggOpus_WithoutSilenceStripping_KeepsFullDuration()
+	{
+		string input = WriteFixture("mono.ogg", channels: 1);
+		string output = PathFor("mono-out.ogg");
+
+		AudioFileConverter.ConvertToOgg(input, output, silenceOptions: null);
+
+		int decoded = CountDecodedSamples(output);
+		// ~3 seconds in, ~3 seconds out (allow a frame or two of codec padding either way).
+		Assert.InRange(decoded, SampleRate * 3 - FrameSize * 4, SampleRate * 3 + FrameSize * 4);
+		Assert.True(CountNonZeroSamples(output) > 0, "Converted audio should not be all zeros.");
+	}
+
+	[Fact]
+	public void MonoOggOpus_WithSilenceStripping_DropsTheSilentGap()
+	{
+		string input = WriteFixture("mono-gap.ogg", channels: 1);
+		string output = PathFor("mono-gap-out.ogg");
+
+		AudioFileConverter.ConvertToOgg(input, output, StripSilence());
+
+		int decoded = CountDecodedSamples(output);
+		// The one-second gap collapses to the 0.2s threshold, so well under three seconds.
+		Assert.True(decoded > 0, "Trimmed audio should still contain the speech.");
+		Assert.True(decoded < SampleRate * 3 - SampleRate / 2,
+			$"Expected the silent gap to be trimmed, but got {decoded} samples.");
+	}
+
+	[Fact]
+	public void StereoOggOpus_IsDownmixedToMono()
+	{
+		string input = WriteFixture("stereo.ogg", channels: 2);
+		string output = PathFor("stereo-out.ogg");
+
+		Assert.Equal(2, OggOpusPcmDecoder.ReadChannelCount(input));
+
+		AudioFileConverter.ConvertToOgg(input, output, silenceOptions: null);
+
+		Assert.Equal(1, OggOpusPcmDecoder.ReadChannelCount(output));
+		Assert.True(CountNonZeroSamples(output) > 0, "Downmixed audio should not be all zeros.");
+	}
+
+	[Fact]
+	public void IsOggOpus_DetectsOpusStreams()
+	{
+		string input = WriteFixture("detect.ogg", channels: 1);
+
+		Assert.True(OggOpusPcmDecoder.IsOggOpus(input));
+	}
+
+	[Fact]
+	public void IsOggOpus_RejectsNonOpusFiles()
+	{
+		string wavPath = PathFor("not-opus.wav");
+		File.WriteAllBytes(wavPath, "RIFF\0\0\0\0WAVEfmt "u8.ToArray());
+
+		string garbagePath = PathFor("garbage.bin");
+		File.WriteAllBytes(garbagePath, new byte[512]);
+
+		Assert.False(OggOpusPcmDecoder.IsOggOpus(wavPath));
+		Assert.False(OggOpusPcmDecoder.IsOggOpus(garbagePath));
+		Assert.False(OggOpusPcmDecoder.IsOggOpus(PathFor("missing.ogg")));
+	}
+}

--- a/Mutation.Tests/OggOpusPcmDecoderTests.cs
+++ b/Mutation.Tests/OggOpusPcmDecoderTests.cs
@@ -1,0 +1,137 @@
+using System;
+using System.IO;
+using CognitiveSupport;
+
+namespace Mutation.Tests;
+
+/// <summary>
+/// Container- and packet-level regressions for the Ogg/Opus decode path. The fixtures are
+/// hand-built because the bundled encoder cannot produce the packet shapes that broke
+/// importing real-world files (DTX frames, trailing empty packets).
+/// </summary>
+public class OggOpusPcmDecoderTests : IDisposable
+{
+	private const int SampleRate = 48000;
+
+	// Config 13 (hybrid, super-wideband, 20ms), mono, code 3 (arbitrary frame count).
+	private const byte HybridSwb20MsMonoCode3 = 0x6B;
+
+	// v=0 (CBR), p=0, M=6 frames. With no payload every frame is zero-length: pure DTX.
+	private const byte SixCbrFrames = 0x06;
+
+	private readonly string _workingDirectory = Directory.CreateTempSubdirectory("ogg-decoder-tests").FullName;
+
+	public void Dispose()
+	{
+		try { Directory.Delete(_workingDirectory, recursive: true); } catch { }
+	}
+
+	private string WriteFixture(string fileName, int channels, int preSkip, params byte[][] audioPackets)
+	{
+		string path = Path.Combine(_workingDirectory, fileName);
+
+		using var stream = File.Create(path);
+		OggStreamBuilder.WritePage(stream, new[] { OggStreamBuilder.OpusHead(channels, preSkip) });
+		OggStreamBuilder.WritePage(stream, new[] { OggStreamBuilder.OpusTags() }, pageSequence: 1);
+
+		int page = 2;
+		foreach (byte[] packet in audioPackets)
+			OggStreamBuilder.WritePage(stream, OggStreamBuilder.ToSegments(packet), pageSequence: page++);
+
+		return path;
+	}
+
+	private static int CountSamples(string path)
+	{
+		int total = 0;
+		OggOpusPcmDecoder.DecodeToMonoPcm(path, samples => total += samples.Length);
+		return total;
+	}
+
+	[Fact]
+	public void DtxFrames_AreConcealedRatherThanDroppingThePacket()
+	{
+		// A packet whose frames are all zero-length. Concentus rejects it as a whole packet,
+		// which is why real WhatsApp voice notes lost ~7% of their audio and drifted out of
+		// sync before the frame-by-frame path existed.
+		string path = WriteFixture("dtx.ogg", channels: 1, preSkip: 0,
+			new[] { HybridSwb20MsMonoCode3, SixCbrFrames });
+
+		// 6 frames x 20ms at 48kHz.
+		Assert.Equal(6 * 960, CountSamples(path));
+	}
+
+	[Fact]
+	public void PreSkipSamples_AreDropped()
+	{
+		const int preSkip = 312; // the usual encoder priming amount
+		string path = WriteFixture("preskip.ogg", channels: 1, preSkip: preSkip,
+			new[] { HybridSwb20MsMonoCode3, SixCbrFrames });
+
+		Assert.Equal(6 * 960 - preSkip, CountSamples(path));
+	}
+
+	[Fact]
+	public void TrailingEmptyPacket_IsIgnored()
+	{
+		// Concentus.Oggfile's writer ends every stream it produces with an empty packet, and
+		// its own packet parser overflows on one.
+		string path = Path.Combine(_workingDirectory, "empty-tail.ogg");
+		using (var stream = File.Create(path))
+		{
+			OggStreamBuilder.WritePage(stream, new[] { OggStreamBuilder.OpusHead(1) });
+			OggStreamBuilder.WritePage(stream, new[] { OggStreamBuilder.OpusTags() }, pageSequence: 1);
+			OggStreamBuilder.WritePage(stream, new[] { new[] { HybridSwb20MsMonoCode3, SixCbrFrames } }, pageSequence: 2);
+			OggStreamBuilder.WritePage(stream, new[] { Array.Empty<byte>() }, pageSequence: 3);
+		}
+
+		Assert.Equal(6 * 960, CountSamples(path));
+	}
+
+	[Fact]
+	public void StereoHeader_IsReportedAndDownmixed()
+	{
+		// Config 13 with the stereo bit set, code 3, six CBR frames.
+		const byte stereoToc = HybridSwb20MsMonoCode3 | 0x04;
+		string path = WriteFixture("stereo.ogg", channels: 2, preSkip: 0, new[] { stereoToc, SixCbrFrames });
+
+		Assert.Equal(2, OggOpusPcmDecoder.ReadChannelCount(path));
+		// Mono output: one sample per frame position, not two.
+		Assert.Equal(6 * 960, CountSamples(path));
+	}
+
+	[Fact]
+	public void IsOggOpus_DetectsOpusAndRejectsEverythingElse()
+	{
+		string opus = WriteFixture("detect.ogg", channels: 1, preSkip: 0,
+			new[] { HybridSwb20MsMonoCode3, SixCbrFrames });
+
+		string wav = Path.Combine(_workingDirectory, "not-opus.wav");
+		File.WriteAllBytes(wav, "RIFF\0\0\0\0WAVEfmt "u8.ToArray());
+
+		string vorbis = Path.Combine(_workingDirectory, "vorbis.ogg");
+		using (var stream = File.Create(vorbis))
+		{
+			// An Ogg page carrying Vorbis instead of Opus — Concentus cannot decode it, so it
+			// must fall through to the caller's Media Foundation path.
+			var identification = new byte[30];
+			identification[0] = 1;
+			"vorbis"u8.ToArray().CopyTo(identification, 1);
+			OggStreamBuilder.WritePage(stream, new[] { identification });
+		}
+
+		Assert.True(OggOpusPcmDecoder.IsOggOpus(opus));
+		Assert.False(OggOpusPcmDecoder.IsOggOpus(wav));
+		Assert.False(OggOpusPcmDecoder.IsOggOpus(vorbis));
+		Assert.False(OggOpusPcmDecoder.IsOggOpus(Path.Combine(_workingDirectory, "missing.ogg")));
+	}
+
+	[Fact]
+	public void NonOpusFile_ThrowsRatherThanReturningSilence()
+	{
+		string wav = Path.Combine(_workingDirectory, "throw.wav");
+		File.WriteAllBytes(wav, "RIFF\0\0\0\0WAVEfmt "u8.ToArray());
+
+		Assert.Throws<InvalidDataException>(() => OggOpusPcmDecoder.DecodeToMonoPcm(wav, _ => { }));
+	}
+}

--- a/Mutation.Tests/OggOpusPcmDecoderTests.cs
+++ b/Mutation.Tests/OggOpusPcmDecoderTests.cs
@@ -127,6 +127,21 @@ public class OggOpusPcmDecoderTests : IDisposable
 	}
 
 	[Fact]
+	public void SurroundOpus_IsNotClaimedAndFailsWithAReadableMessage()
+	{
+		// Concentus decodes mono and stereo only. A 6-channel file must not be claimed by this
+		// decoder, so the caller falls through to its own fallback rather than the codec
+		// throwing a bare "Number of channels must be 1 or 2" at the user.
+		string path = WriteFixture("surround.ogg", channels: 6, preSkip: 0,
+			new[] { HybridSwb20MsMonoCode3, SixCbrFrames });
+
+		Assert.False(OggOpusPcmDecoder.IsOggOpus(path));
+
+		var error = Assert.Throws<NotSupportedException>(() => OggOpusPcmDecoder.DecodeToMonoPcm(path, _ => { }));
+		Assert.Contains("6-channel", error.Message);
+	}
+
+	[Fact]
 	public void NonOpusFile_ThrowsRatherThanReturningSilence()
 	{
 		string wav = Path.Combine(_workingDirectory, "throw.wav");

--- a/Mutation.Tests/OggPacketReaderTests.cs
+++ b/Mutation.Tests/OggPacketReaderTests.cs
@@ -1,0 +1,109 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using CognitiveSupport;
+
+namespace Mutation.Tests;
+
+public class OggPacketReaderTests
+{
+	private static List<byte[]> Read(Stream stream) => OggPacketReader.ReadPackets(stream).ToList();
+
+	private static byte[] Filled(int length, byte value)
+	{
+		var data = new byte[length];
+		for (int i = 0; i < length; i++) data[i] = value;
+		return data;
+	}
+
+	[Fact]
+	public void ReadsMultiplePacketsFromOnePage()
+	{
+		using var stream = new MemoryStream();
+		OggStreamBuilder.WritePage(stream, new[] { Filled(10, 1), Filled(20, 2) });
+		stream.Position = 0;
+
+		var packets = Read(stream);
+
+		Assert.Equal(2, packets.Count);
+		Assert.Equal(10, packets[0].Length);
+		Assert.Equal(20, packets[1].Length);
+		Assert.All(packets[1], b => Assert.Equal(2, b));
+	}
+
+	[Fact]
+	public void ReassemblesPacketAcrossSegments()
+	{
+		var packet = Filled(600, 7); // 255 + 255 + 90
+		using var stream = new MemoryStream();
+		OggStreamBuilder.WritePage(stream, OggStreamBuilder.ToSegments(packet));
+		stream.Position = 0;
+
+		var packets = Read(stream);
+
+		Assert.Single(packets);
+		Assert.Equal(600, packets[0].Length);
+		Assert.All(packets[0], b => Assert.Equal(7, b));
+	}
+
+	[Fact]
+	public void PacketWhoseLengthIsAMultipleOf255_IsTerminatedByZeroSegment()
+	{
+		var packet = Filled(255, 3);
+		using var stream = new MemoryStream();
+		// ToSegments appends the required empty terminating segment.
+		OggStreamBuilder.WritePage(stream, OggStreamBuilder.ToSegments(packet));
+		stream.Position = 0;
+
+		var packets = Read(stream);
+
+		Assert.Single(packets);
+		Assert.Equal(255, packets[0].Length);
+	}
+
+	[Fact]
+	public void ReassemblesPacketSpanningTwoPages()
+	{
+		using var stream = new MemoryStream();
+		OggStreamBuilder.WritePage(stream, new[] { Filled(255, 4) }); // no terminator: continues
+		OggStreamBuilder.WritePage(stream, new[] { Filled(30, 5) }, continued: true, pageSequence: 1);
+		stream.Position = 0;
+
+		var packets = Read(stream);
+
+		Assert.Single(packets);
+		Assert.Equal(285, packets[0].Length);
+		Assert.Equal(4, packets[0][254]);
+		Assert.Equal(5, packets[0][255]);
+	}
+
+	[Fact]
+	public void StopsCleanlyOnATruncatedTail()
+	{
+		using var buffer = new MemoryStream();
+		OggStreamBuilder.WritePage(buffer, new[] { Filled(10, 1) });
+		byte[] complete = buffer.ToArray();
+
+		// Append a page header that promises more data than the file actually holds.
+		using var truncated = new MemoryStream();
+		truncated.Write(complete);
+		OggStreamBuilder.WritePage(truncated, new[] { Filled(40, 9) }, pageSequence: 1);
+		truncated.SetLength(truncated.Length - 20);
+		truncated.Position = 0;
+
+		var packets = Read(truncated);
+
+		Assert.Single(packets);
+		Assert.Equal(10, packets[0].Length);
+	}
+
+	[Fact]
+	public void StopsWhenTheCapturePatternIsMissing()
+	{
+		using var stream = new MemoryStream();
+		stream.Write("NotAnOggFileAtAllReallyNoPages"u8);
+		stream.Position = 0;
+
+		Assert.Empty(Read(stream));
+	}
+}

--- a/Mutation.Tests/OggStreamBuilder.cs
+++ b/Mutation.Tests/OggStreamBuilder.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Mutation.Tests;
+
+/// <summary>
+/// Builds Ogg pages by hand so container-level edge cases (multi-segment packets, packets
+/// spanning pages, DTX-bearing Opus packets) can be tested without depending on an encoder
+/// that can produce them.
+/// </summary>
+internal static class OggStreamBuilder
+{
+	/// <summary>
+	/// Writes one Ogg page containing the given segments verbatim. CRC is left zero — the
+	/// reader under test does not verify it, which is what lets tests hand-assemble pages.
+	/// </summary>
+	public static void WritePage(Stream stream, IEnumerable<byte[]> segments, bool continued = false, long granule = 0, int pageSequence = 0)
+	{
+		var segmentList = new List<byte[]>(segments);
+
+		var header = new byte[27];
+		header[0] = (byte)'O'; header[1] = (byte)'g'; header[2] = (byte)'g'; header[3] = (byte)'S';
+		header[4] = 0; // stream structure version
+		header[5] = (byte)(continued ? 0x01 : 0x00);
+		BitConverter.GetBytes(granule).CopyTo(header, 6);
+		BitConverter.GetBytes(1).CopyTo(header, 14); // serial
+		BitConverter.GetBytes(pageSequence).CopyTo(header, 18);
+		header[26] = (byte)segmentList.Count;
+
+		stream.Write(header, 0, header.Length);
+		foreach (var segment in segmentList)
+			stream.WriteByte((byte)segment.Length);
+		foreach (var segment in segmentList)
+			stream.Write(segment, 0, segment.Length);
+	}
+
+	/// <summary>
+	/// Splits a packet into the 255-byte lacing segments Ogg requires.
+	/// </summary>
+	public static List<byte[]> ToSegments(byte[] packet)
+	{
+		var segments = new List<byte[]>();
+		int offset = 0;
+		while (packet.Length - offset >= 255)
+		{
+			segments.Add(packet[offset..(offset + 255)]);
+			offset += 255;
+		}
+
+		segments.Add(packet[offset..]);
+		return segments;
+	}
+
+	/// <summary>
+	/// The 19-byte OpusHead identification header (RFC 7845 §5.1).
+	/// </summary>
+	public static byte[] OpusHead(int channels, int preSkip = 0)
+	{
+		var head = new byte[19];
+		"OpusHead"u8.ToArray().CopyTo(head, 0);
+		head[8] = 1; // version
+		head[9] = (byte)channels;
+		head[10] = (byte)(preSkip & 0xFF);
+		head[11] = (byte)((preSkip >> 8) & 0xFF);
+		BitConverter.GetBytes(48000).CopyTo(head, 12);
+		return head;
+	}
+
+	public static byte[] OpusTags()
+	{
+		using var buffer = new MemoryStream();
+		buffer.Write("OpusTags"u8);
+		buffer.Write(BitConverter.GetBytes(0)); // vendor string length
+		buffer.Write(BitConverter.GetBytes(0)); // comment count
+		return buffer.ToArray();
+	}
+}

--- a/Mutation.Ui/Core/SpeechToTextManager.cs
+++ b/Mutation.Ui/Core/SpeechToTextManager.cs
@@ -341,7 +341,7 @@ public class SpeechToTextManager : IDisposable
 		if (AudioFileConverter.IsVideoFile(sourcePath) || silenceOptions is not null)
 		{
 			string destinationPath = await CreateSessionFileAsync(".ogg").ConfigureAwait(false);
-			await Task.Run(() => AudioFileConverter.ConvertMp4ToOgg(sourcePath, destinationPath, silenceOptions), token).ConfigureAwait(false);
+			await Task.Run(() => AudioFileConverter.ConvertToOgg(sourcePath, destinationPath, silenceOptions), token).ConfigureAwait(false);
 
 			if (!TryCreateSession(destinationPath, out var convertedSession))
 				throw new InvalidOperationException($"Unable to parse converted session '{Path.GetFileName(destinationPath)}'.");


### PR DESCRIPTION
## What this fixes

Uploading a WhatsApp voice note (or any other Ogg/Opus audio file) failed
straight away with `The byte stream type of the given URL is unsupported.
(0xC00D36C4)`.

Silence stripping is on by default, so every upload went through the audio
converter, which opened files with Windows Media Foundation — and Windows
has no reader for the Ogg/Opus format. Two further problems turned up while
fixing that, both of which had to be solved for the file to actually work:

1. **The bundled Ogg reader could not be used as a fallback.** On files this
   app did not record itself it stops producing audio partway through and
   then loops forever. A straight swap to that reader would have replaced a
   clear error with a hang — including when playing back an imported voice
   note.
2. **The bundled Opus decoder rejects a whole packet of audio when any frame
   inside it carries no data.** That is a standard bandwidth-saving trick
   during silence, and WhatsApp uses it heavily. Rejecting those packets
   loses about 7% of a typical recording and pushes the rest out of sync.

Files the app records itself were never affected, because the recorder
disables that bandwidth-saving trick.

## What changed

- **`OggPacketReader`** — reads the audio file's container structure
  directly, replacing the library reader that hangs.
- **`OggOpusPcmDecoder`** — decodes audio one frame at a time instead of one
  packet at a time, so a single dataless frame no longer discards the audio
  around it. Frames with no data are filled with the decoder's own
  concealment audio, keeping the recording in sync. It also drops the few
  priming samples every encoder adds at the start and mixes stereo down to
  mono.
- **`AudioFileConverter`** — routes Ogg/Opus files to the new decoder and
  everything else to Media Foundation as before. Failures from Media
  Foundation now surface as "Windows cannot decode X — convert it to WAV,
  MP3, MP4, or Ogg/Opus first" instead of a raw error code, which also
  covers Ogg/Vorbis and WebM files. `ConvertMp4ToOgg` is renamed
  `ConvertToOgg`, since it is no longer specific to video.
- **`AudioPlayer`** — now shares the same decoder, so imported recordings
  play back instead of hanging.

## Test plan

Automated (707 tests pass, 12 new):

- Ogg/Opus files convert with and without silence stripping, and the silent
  gaps really are removed.
- Audio with dataless frames decodes to its full length rather than being
  discarded — the specific defect that lost 7% of the reported file.
- Priming samples are dropped; stereo is mixed down to mono.
- The container reader handles audio split across pages, truncated files,
  and files that are not Ogg at all.
- Ogg/Vorbis is correctly identified as *not* Opus, so it still falls
  through to the Windows decoder path.

Manual:

1. With silence stripping on (the default), upload the reported WhatsApp
   file — it should transcribe, with no error.
2. Play the resulting session back in the app.
3. Upload an MP3 and an MP4 to confirm the unchanged path still works.
4. Turn silence stripping off and upload the Ogg file again.

Verified against the reported file end to end: 86.45 seconds of audio
decoded — matching the timing recorded inside the file itself — and 73.60
seconds after silence stripping.

Closes #208
