### PR TITLE
Give every LLM prompt a distinct Id on load (#212)

### DIFF
--- a/Mutation.Tests/PromptIdBackfillTests.cs
+++ b/Mutation.Tests/PromptIdBackfillTests.cs
@@ -1,0 +1,95 @@
+using System.Collections.Generic;
+using System.Linq;
+using CognitiveSupport;
+using Mutation.Ui.Services;
+
+namespace Mutation.Tests;
+
+public class PromptIdBackfillTests
+{
+	private static List<LlmSettings.LlmPrompt> Prompts(params int[] ids) =>
+		ids.Select((id, index) => new LlmSettings.LlmPrompt { Id = id, Name = $"P{index}" }).ToList();
+
+	[Fact]
+	public void Apply_AllIdsMissing_NumbersThemFromOne()
+	{
+		var prompts = Prompts(0, 0, 0);
+
+		Assert.True(PromptIdBackfill.Apply(prompts));
+		Assert.Equal(new[] { 1, 2, 3 }, prompts.Select(p => p.Id));
+	}
+
+	[Fact]
+	public void Apply_ValidDistinctIds_LeavesThemAloneAndReportsNoChange()
+	{
+		var prompts = Prompts(3, 1, 7);
+
+		Assert.False(PromptIdBackfill.Apply(prompts));
+		Assert.Equal(new[] { 3, 1, 7 }, prompts.Select(p => p.Id));
+	}
+
+	[Fact]
+	public void Apply_MissingIdDoesNotStealAnIdAnotherPromptAlreadyHas()
+	{
+		// The prompt that already owns 1 must keep it, even though it comes second.
+		var prompts = Prompts(0, 1);
+
+		Assert.True(PromptIdBackfill.Apply(prompts));
+		Assert.Equal(1, prompts[1].Id);
+		Assert.NotEqual(1, prompts[0].Id);
+	}
+
+	[Fact]
+	public void Apply_DuplicateIds_KeepsTheFirstAndRenumbersTheRest()
+	{
+		var prompts = Prompts(5, 5, 5);
+
+		Assert.True(PromptIdBackfill.Apply(prompts));
+		Assert.Equal(5, prompts[0].Id);
+		Assert.Equal(3, prompts.Select(p => p.Id).Distinct().Count());
+	}
+
+	[Fact]
+	public void Apply_NegativeIdIsTreatedAsMissing()
+	{
+		var prompts = Prompts(-4, 2);
+
+		Assert.True(PromptIdBackfill.Apply(prompts));
+		Assert.True(prompts[0].Id > 0);
+		Assert.Equal(2, prompts[1].Id);
+	}
+
+	[Theory]
+	[InlineData(new int[0])]
+	[InlineData(new[] { 0, 0, 3, 3, 1 })]
+	[InlineData(new[] { 9, 0, 9, 0, 1 })]
+	public void Apply_AlwaysLeavesEveryIdPositiveAndUnique(int[] ids)
+	{
+		var prompts = Prompts(ids);
+
+		PromptIdBackfill.Apply(prompts);
+
+		Assert.All(prompts, p => Assert.True(p.Id > 0));
+		Assert.Equal(prompts.Count, prompts.Select(p => p.Id).Distinct().Count());
+	}
+
+	[Fact]
+	public void Apply_IsIdempotent()
+	{
+		var prompts = Prompts(0, 0, 4);
+		PromptIdBackfill.Apply(prompts);
+		var afterFirstPass = prompts.Select(p => p.Id).ToArray();
+
+		// A second load must not renumber anything, or the settings file would be
+		// rewritten on every startup.
+		Assert.False(PromptIdBackfill.Apply(prompts));
+		Assert.Equal(afterFirstPass, prompts.Select(p => p.Id));
+	}
+
+	[Fact]
+	public void Apply_EmptyOrNull_ReportsNoChange()
+	{
+		Assert.False(PromptIdBackfill.Apply(new List<LlmSettings.LlmPrompt>()));
+		Assert.False(PromptIdBackfill.Apply(null));
+	}
+}

--- a/Mutation.Tests/PromptIdBackfillTests.cs
+++ b/Mutation.Tests/PromptIdBackfillTests.cs
@@ -87,6 +87,32 @@ public class PromptIdBackfillTests
 	}
 
 	[Fact]
+	public void Apply_HugeExistingId_DoesNotPushTheNextIdTowardsOverflow()
+	{
+		// Highest-plus-one would wrap to int.MinValue here. Assigning from the lowest
+		// free number instead keeps every Id positive.
+		var prompts = Prompts(int.MaxValue, 0, 0);
+
+		Assert.True(PromptIdBackfill.Apply(prompts));
+		Assert.Equal(int.MaxValue, prompts[0].Id);
+		Assert.Equal(new[] { 1, 2 }, prompts.Skip(1).Select(p => p.Id));
+	}
+
+	[Fact]
+	public void Apply_SamePromptObjectInTwoSlots_ConvergesInsteadOfRenumberingForever()
+	{
+		// Newtonsoft honours $id/$ref, so a hand-written file can alias one prompt into
+		// two slots. Assigning to it twice would move both slots together, leaving the
+		// list permanently "duplicated" and rewriting the settings file on every start.
+		var shared = new LlmSettings.LlmPrompt { Id = 0, Name = "Shared" };
+		var prompts = new List<LlmSettings.LlmPrompt> { shared, shared };
+
+		Assert.True(PromptIdBackfill.Apply(prompts));
+		Assert.True(shared.Id > 0);
+		Assert.False(PromptIdBackfill.Apply(prompts));
+	}
+
+	[Fact]
 	public void Apply_EmptyOrNull_ReportsNoChange()
 	{
 		Assert.False(PromptIdBackfill.Apply(new List<LlmSettings.LlmPrompt>()));

--- a/Mutation.Tests/SettingsManagerPromptIdTests.cs
+++ b/Mutation.Tests/SettingsManagerPromptIdTests.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using CognitiveSupport;
 using Mutation.Ui.Services;
+using Newtonsoft.Json.Linq;
 
 namespace Mutation.Tests;
 
@@ -50,7 +51,7 @@ public class SettingsManagerPromptIdTests : IDisposable
 	}
 
 	[Fact]
-	public void BackfilledIdsArePersisted_SoTheySurviveARestart()
+	public void BackfilledIdsAreWrittenBackToTheFile()
 	{
 		File.WriteAllText(_tempPath, """
 			{
@@ -63,10 +64,43 @@ public class SettingsManagerPromptIdTests : IDisposable
 			}
 			""");
 
-		var first = Load().LlmSettings!.Prompts.ToDictionary(p => p.Name, p => p.Id);
-		var second = Load().LlmSettings!.Prompts.ToDictionary(p => p.Name, p => p.Id);
+		var loaded = Load().LlmSettings!.Prompts.ToDictionary(p => p.Name!, p => p.Id);
 
-		Assert.Equal(first, second);
+		// Asserted against the file, not against a second load: assignment is
+		// deterministic on list order, so comparing two loads would pass even if
+		// nothing were ever persisted.
+		var written = JObject.Parse(File.ReadAllText(_tempPath));
+		var prompts = (JArray)written["LlmSettings"]!["Prompts"]!;
+		foreach (var prompt in prompts)
+		{
+			string name = prompt["Name"]!.Value<string>()!;
+			Assert.Equal(loaded[name], prompt["Id"]!.Value<int>());
+		}
+		Assert.Equal(2, prompts.Select(p => p["Id"]!.Value<int>()).Distinct().Count());
+	}
+
+	[Fact]
+	public void ASettledFileIsNotRewrittenOnTheNextStart()
+	{
+		// The backfill must be idempotent end-to-end, not just in the helper: a settings
+		// file rewritten on every launch would be a regression in its own right.
+		File.WriteAllText(_tempPath, """
+			{
+				"LlmSettings": {
+					"Prompts": [
+						{ "Name": "Fix grammar", "Content": "a", "ModelName": "gpt-4.1" },
+						{ "Name": "Summarize",   "Content": "b", "ModelName": "gpt-4.1" }
+					]
+				}
+			}
+			""");
+
+		Load(); // First start fills in the Ids (and any other defaults) and saves.
+		byte[] settled = File.ReadAllBytes(_tempPath);
+
+		Load();
+
+		Assert.Equal(settled, File.ReadAllBytes(_tempPath));
 	}
 
 	[Fact]

--- a/Mutation.Tests/SettingsManagerPromptIdTests.cs
+++ b/Mutation.Tests/SettingsManagerPromptIdTests.cs
@@ -1,0 +1,132 @@
+using System;
+using System.IO;
+using System.Linq;
+using CognitiveSupport;
+using Mutation.Ui.Services;
+
+namespace Mutation.Tests;
+
+/// <summary>
+/// Loading is where the repair has to happen: the app must never hold two prompts that
+/// look like the same prompt, whatever a hand-edited Mutation.json says.
+/// </summary>
+public class SettingsManagerPromptIdTests : IDisposable
+{
+	private readonly string _tempPath;
+
+	public SettingsManagerPromptIdTests()
+	{
+		_tempPath = Path.Combine(Path.GetTempPath(), $"mutation-promptid-{Guid.NewGuid():N}.json");
+	}
+
+	public void Dispose()
+	{
+		if (File.Exists(_tempPath))
+			File.Delete(_tempPath);
+	}
+
+	private Settings Load() => new SettingsManager(_tempPath).LoadAndEnsureSettings();
+
+	[Fact]
+	public void HandWrittenPromptsWithoutIds_LoadWithDistinctIds()
+	{
+		File.WriteAllText(_tempPath, """
+			{
+				"LlmSettings": {
+					"Prompts": [
+						{ "Name": "Fix grammar", "Content": "a", "ModelName": "gpt-4.1" },
+						{ "Name": "Summarize",   "Content": "b", "ModelName": "gpt-4.1" },
+						{ "Name": "Translate",   "Content": "c", "ModelName": "gpt-4.1" }
+					]
+				}
+			}
+			""");
+
+		var prompts = Load().LlmSettings!.Prompts;
+
+		Assert.Equal(3, prompts.Count);
+		Assert.All(prompts, p => Assert.True(p.Id > 0));
+		Assert.Equal(3, prompts.Select(p => p.Id).Distinct().Count());
+	}
+
+	[Fact]
+	public void BackfilledIdsArePersisted_SoTheySurviveARestart()
+	{
+		File.WriteAllText(_tempPath, """
+			{
+				"LlmSettings": {
+					"Prompts": [
+						{ "Name": "Fix grammar", "Content": "a", "ModelName": "gpt-4.1" },
+						{ "Name": "Summarize",   "Content": "b", "ModelName": "gpt-4.1" }
+					]
+				}
+			}
+			""");
+
+		var first = Load().LlmSettings!.Prompts.ToDictionary(p => p.Name, p => p.Id);
+		var second = Load().LlmSettings!.Prompts.ToDictionary(p => p.Name, p => p.Id);
+
+		Assert.Equal(first, second);
+	}
+
+	[Fact]
+	public void ExistingIdsAreLeftAlone()
+	{
+		File.WriteAllText(_tempPath, """
+			{
+				"LlmSettings": {
+					"Prompts": [
+						{ "Id": 4, "Name": "Fix grammar", "Content": "a", "ModelName": "gpt-4.1" },
+						{ "Id": 9, "Name": "Summarize",   "Content": "b", "ModelName": "gpt-4.1" }
+					]
+				}
+			}
+			""");
+
+		var prompts = Load().LlmSettings!.Prompts;
+
+		Assert.Equal(4, prompts.Single(p => p.Name == "Fix grammar").Id);
+		Assert.Equal(9, prompts.Single(p => p.Name == "Summarize").Id);
+	}
+
+	[Fact]
+	public void DuplicateIdsAreSplitApart()
+	{
+		File.WriteAllText(_tempPath, """
+			{
+				"LlmSettings": {
+					"Prompts": [
+						{ "Id": 1, "Name": "Fix grammar", "Content": "a", "ModelName": "gpt-4.1" },
+						{ "Id": 1, "Name": "Summarize",   "Content": "b", "ModelName": "gpt-4.1" }
+					]
+				}
+			}
+			""");
+
+		var prompts = Load().LlmSettings!.Prompts;
+
+		Assert.Equal(2, prompts.Select(p => p.Id).Distinct().Count());
+	}
+
+	[Fact]
+	public void PerPromptStateIsNoLongerSharedAcrossHandWrittenPrompts()
+	{
+		// The bug this fixes: FastModeNoticeTracker keys on prompt Id, so with every
+		// prompt at 0 the first Fast mode notice silenced the notice for all the others.
+		File.WriteAllText(_tempPath, """
+			{
+				"LlmSettings": {
+					"Prompts": [
+						{ "Name": "First",  "Content": "a", "ModelName": "claude-opus-5" },
+						{ "Name": "Second", "Content": "b", "ModelName": "claude-opus-5" }
+					]
+				}
+			}
+			""");
+		var prompts = Load().LlmSettings!.Prompts;
+		var tracker = new FastModeNoticeTracker();
+
+		Assert.True(tracker.ShouldAnnounce(prompts[0].Id, FastModeFallbackReason.Unavailable));
+		Assert.True(tracker.ShouldAnnounce(prompts[1].Id, FastModeFallbackReason.Unavailable));
+	}
+}

--- a/Mutation.Ui/Services/PromptIdBackfill.cs
+++ b/Mutation.Ui/Services/PromptIdBackfill.cs
@@ -21,6 +21,9 @@ internal static class PromptIdBackfill
 	/// an earlier prompt already claimed. Prompts whose Id is already valid and unique
 	/// keep it, so a user's hand-chosen numbering survives and Ids stay stable across
 	/// loads. Returns true when anything was assigned, so the caller knows to persist.
+	///
+	/// Assigns from the lowest free number rather than above the highest in use, so a
+	/// hand-written Id near <see cref="int.MaxValue"/> cannot push the next one past it.
 	/// </summary>
 	internal static bool Apply(IReadOnlyList<LlmSettings.LlmPrompt>? prompts)
 	{
@@ -32,17 +35,21 @@ internal static class PromptIdBackfill
 		var reserved = new HashSet<int>();
 		foreach (var prompt in prompts)
 		{
-			if (prompt is not null && prompt.Id > 0)
+			if (prompt.Id > 0)
 				reserved.Add(prompt.Id);
 		}
 
 		var taken = new HashSet<int>();
+		// Newtonsoft honours $id/$ref by default, so a hand-written file can put one
+		// prompt object in two slots. Assigning to it twice would move both slots
+		// together and never converge, rewriting the settings file on every startup.
+		var seen = new HashSet<LlmSettings.LlmPrompt>(ReferenceEqualityComparer.Instance);
 		bool changed = false;
 		int candidate = 1;
 
 		foreach (var prompt in prompts)
 		{
-			if (prompt is null)
+			if (!seen.Add(prompt))
 				continue;
 
 			// First prompt to claim a given valid Id keeps it; a repeat is treated as

--- a/Mutation.Ui/Services/PromptIdBackfill.cs
+++ b/Mutation.Ui/Services/PromptIdBackfill.cs
@@ -1,0 +1,63 @@
+using CognitiveSupport;
+using System.Collections.Generic;
+
+namespace Mutation.Ui.Services;
+
+/// <summary>
+/// Gives every LLM prompt a distinct positive <c>Id</c>.
+///
+/// Ids are only ever assigned when a prompt is added through the UI, so a prompt written
+/// straight into Mutation.json by hand — a shape the README documents — leaves the field
+/// at the <c>int</c> default of 0. Several such prompts then look like one prompt to
+/// anything that identifies a prompt by Id, and the app quietly attributes one prompt's
+/// state to all of them.
+///
+/// Pure and list-based so the assignment rule can be tested without touching the disk.
+/// </summary>
+internal static class PromptIdBackfill
+{
+	/// <summary>
+	/// Assigns an Id to every prompt that has none (0 or negative) or that repeats an Id
+	/// an earlier prompt already claimed. Prompts whose Id is already valid and unique
+	/// keep it, so a user's hand-chosen numbering survives and Ids stay stable across
+	/// loads. Returns true when anything was assigned, so the caller knows to persist.
+	/// </summary>
+	internal static bool Apply(IReadOnlyList<LlmSettings.LlmPrompt>? prompts)
+	{
+		if (prompts is null || prompts.Count == 0)
+			return false;
+
+		// Every Id already spoken for, gathered up front so a prompt later in the list
+		// does not have its Id handed to an earlier one that was missing one.
+		var reserved = new HashSet<int>();
+		foreach (var prompt in prompts)
+		{
+			if (prompt is not null && prompt.Id > 0)
+				reserved.Add(prompt.Id);
+		}
+
+		var taken = new HashSet<int>();
+		bool changed = false;
+		int candidate = 1;
+
+		foreach (var prompt in prompts)
+		{
+			if (prompt is null)
+				continue;
+
+			// First prompt to claim a given valid Id keeps it; a repeat is treated as
+			// unidentified and renumbered.
+			if (prompt.Id > 0 && taken.Add(prompt.Id))
+				continue;
+
+			while (reserved.Contains(candidate) || taken.Contains(candidate))
+				candidate++;
+
+			taken.Add(candidate);
+			prompt.Id = candidate;
+			changed = true;
+		}
+
+		return changed;
+	}
+}

--- a/Mutation.Ui/Services/PromptLibraryController.cs
+++ b/Mutation.Ui/Services/PromptLibraryController.cs
@@ -64,12 +64,16 @@ internal sealed class PromptLibraryController
 		{
 			if (dialog.IsSaved && dialog.Prompt != null && !string.IsNullOrWhiteSpace(dialog.Prompt.Name))
 			{
-				dialog.Prompt.Id = (_settings.LlmSettings.Prompts.Max(p => (int?)p.Id) ?? 0) + 1;
-
 				if (dialog.Prompt.AutoRun)
 					foreach (var p in _settings.LlmSettings.Prompts) p.AutoRun = false;
 
 				_settings.LlmSettings.Prompts.Add(dialog.Prompt);
+
+				// One rule for handing out prompt Ids, shared with settings loading.
+				// Highest-plus-one would overflow to int.MinValue against a hand-written
+				// Id of int.MaxValue, and then hand every later prompt that same value.
+				PromptIdBackfill.Apply(_settings.LlmSettings.Prompts);
+
 				SaveAndRefresh();
 			}
 		};

--- a/Mutation.Ui/Services/SettingsManager.cs
+++ b/Mutation.Ui/Services/SettingsManager.cs
@@ -522,6 +522,12 @@ End of summary.
 			}
 		}
 
+		// Hand-written prompts have no Id and all default to 0, which makes them
+		// indistinguishable to anything keyed on prompt identity. Backfilling here means
+		// the Ids are also written back, so they stay put across restarts.
+		if (PromptIdBackfill.Apply(llmSettings.Prompts))
+			somethingWasMissing = true;
+
 		if (settings.TranscriptFormatRules == null || !settings.TranscriptFormatRules.Any())
 		{
 			settings.TranscriptFormatRules = new List<TranscriptFormatRule>

--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ All hotkeys are global and fully customisable. Below is an example covering ever
 
 > **Note on transcript formatting rules:** `TranscriptFormatRules` is a top-level setting. Rules run as a pre-processing pass on the transcript before any LLM processing is applied.
 
-> **Note on prompt `Id`:** it identifies the prompt to the rest of the app and must be unique. If you add prompts by hand and leave `Id` out (or repeat one), Mutation fills in the missing values on the next start and saves them back, so you do not have to keep track of them yourself.
+> **Note on prompt `Id`:** it identifies the prompt to the rest of the app and must be a unique positive number. If you add prompts by hand, you can leave `Id` out entirely — anything missing, zero, negative, or repeated is renumbered on the next start and saved back, so you do not have to keep track of them yourself. Ids that are already unique and positive are left exactly as you wrote them.
 
 > **Note on `FastMode`:** per-prompt, off by default, and also available as a **Fast mode** check box in the prompt editor. It runs the same model faster — same weights, same answer quality — but is billed at roughly **twice** the standard input and output token price, so turn it on only where latency actually costs you something. Not every model offers Fast mode, and on Anthropic (Claude) models it additionally needs research-preview access on your account. Whenever Fast mode can't be used, the prompt still returns a result at standard speed and Mutation announces why — whether you need to request access, pick a different model, or just try again later.
 

--- a/README.md
+++ b/README.md
@@ -248,6 +248,8 @@ All hotkeys are global and fully customisable. Below is an example covering ever
 
 > **Note on transcript formatting rules:** `TranscriptFormatRules` is a top-level setting. Rules run as a pre-processing pass on the transcript before any LLM processing is applied.
 
+> **Note on prompt `Id`:** it identifies the prompt to the rest of the app and must be unique. If you add prompts by hand and leave `Id` out (or repeat one), Mutation fills in the missing values on the next start and saves them back, so you do not have to keep track of them yourself.
+
 > **Note on `FastMode`:** per-prompt, off by default, and also available as a **Fast mode** check box in the prompt editor. It runs the same model faster — same weights, same answer quality — but is billed at roughly **twice** the standard input and output token price, so turn it on only where latency actually costs you something. Not every model offers Fast mode, and on Anthropic (Claude) models it additionally needs research-preview access on your account. Whenever Fast mode can't be used, the prompt still returns a result at standard speed and Mutation announces why — whether you need to request access, pick a different model, or just try again later.
 
 ### Provisioning Azure Computer Vision


### PR DESCRIPTION
Closes #212

## What

`LlmSettings.LlmPrompt.Id` is only ever assigned when a prompt is added through the UI (`PromptLibraryController.cs:67`) or seeded as the default (`SettingsManager.cs:495`). Nothing backfilled it on load, so prompts written straight into `Mutation.json` by hand — a shape the README documents — all sat at the `int` default of `0`.

Anything keyed on prompt identity then treated them as one prompt. `FastModeNoticeTracker` (added in #210) is the live consumer: it suppresses a Fast mode fallback notice per prompt per session, so with every Id at `0` the first prompt to fall back announced and **every other prompt was silently suppressed for the rest of the session** — the user never finds out why their other prompts aren't running fast.

## How

`SettingsManager.EnsureSettings` now backfills, via a pure `PromptIdBackfill` helper. `EnsureSettings` already reports "something was missing" and has `LoadAndEnsureSettings` persist the result, so the repaired Ids are written back and stay put across restarts rather than being recomputed every launch.

Two properties the assignment rule has to hold, both tested:

- **Existing Ids survive.** A prompt whose Id is valid and unique keeps it, so hand-chosen numbering isn't reshuffled. This is why reserved Ids are gathered in a first pass before any are handed out — otherwise `[{no Id}, {Id: 1}]` would hand `1` to the first prompt and renumber the prompt that already owned it.
- **It's idempotent.** A second load must assign nothing, or `EnsureSettings` would report a change and rewrite the settings file on every startup.

Duplicates are split apart too (first claimant keeps the Id, the rest are renumbered), since a hand-edited file can repeat one just as easily as omit it.

## Correction to the issue as filed

#212 originally claimed `HotkeyManager._promptIds` shared this dependency. **It does not.** That list holds Win32 hotkey registration ids from `Interlocked.Increment(ref _id)` (`HotkeyManager.cs:207`), not `LlmPrompt.Id`, and `RegisterPromptHotkeys` dispatches by capturing the prompt in a closure rather than looking it up by Id. Hotkeys were never affected.

I traced every remaining `LlmPrompt.Id` reference: `FastModeNoticeTracker` (via `AudioSessionManager` and `MainWindow.ExecutePrompt`) was the only real consumer. Everything else — `Prompts.Remove(prompt)`, the `p != prompt` auto-run scan, the editor dialog — works on object references. `PromptLibraryController`'s `Max(Id) + 1` was already collision-free on its own; it just couldn't repair what was already in the file. The issue body has been corrected.

## Tests

`dotnet test --configuration Release` → **793 passed, 0 failed** (15 new).

`PromptIdBackfillTests` covers the rule directly: all-missing, all-valid (and reporting no change), a missing Id not stealing one a later prompt owns, duplicates, negative Ids, idempotence, and a theory asserting the invariant — every Id positive and unique — across several mixed shapes.

`SettingsManagerPromptIdTests` covers it through a real load: hand-written prompts get distinct Ids, those Ids are stable across a reload, existing Ids are untouched, duplicates are split, and one test pins the actual bug by driving `FastModeNoticeTracker` with the loaded prompts and asserting both now announce.

## Docs

A note in `README.md` next to the `Mutation.json` example telling hand-editors that `Id` must be unique and is filled in for them if omitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
