### PR TITLE
Fix six accessibility and settings-persistence bugs (#214-#219)

### DIFF
--- a/CognitiveSupport/BeepPlayer.cs
+++ b/CognitiveSupport/BeepPlayer.cs
@@ -33,6 +33,9 @@ public static class BeepPlayer
 	private static SoundPlayer? _playerMute;
 	private static SoundPlayer? _playerUnmute;
 	private static SoundPlayer? _previewPlayer;
+	// Bumped whenever the per-type players are torn down, so an in-flight repeat loop
+	// can tell that the SoundPlayer it captured is no longer the live one.
+	private static int _playerGeneration;
 	private static readonly Dictionary<(BeepType Type, int RepeatCount), (SoundPlayer Player, MemoryStream Stream)> _defaultPlayers = new();
 	public static IReadOnlyList<string> LastInitializationIssues { get; private set; } = Array.Empty<string>();
 
@@ -143,19 +146,28 @@ public static class BeepPlayer
 			return true;
 		}
 
-		// PlaySync blocks, so it runs off the caller's thread; a shared SoundPlayer is
-		// only ever driven by one of these loops at a time in practice, and a torn
-		// repeat is preferable to blocking a transcription retry.
+		// PlaySync blocks, so the repeat runs off the caller's thread rather than
+		// stalling the transcription retry it is reporting on. That leaves the loop
+		// running while Initialize/DisposePlayers may replace these players (a Settings
+		// save, or shutdown), so it bails out the moment its generation is superseded
+		// instead of hammering a disposed SoundPlayer.
+		int generation = Volatile.Read(ref _playerGeneration);
 		Task.Run(() =>
 		{
-			try
+			for (var i = 0; i < repeatCount; i++)
 			{
-				for (var i = 0; i < repeatCount; i++)
+				if (Volatile.Read(ref _playerGeneration) != generation)
+					return;
+
+				try
+				{
 					player.PlaySync();
-			}
-			catch
-			{
-				// A failed beep must never take down the operation it is reporting on.
+				}
+				catch
+				{
+					// A failed beep must never take down the operation it reports on.
+					return;
+				}
 			}
 		});
 		return true;
@@ -246,6 +258,8 @@ public static class BeepPlayer
 
 	public static void DisposePlayers()
 	{
+		// Signal before disposing, so a repeat loop stops rather than racing the tear-down.
+		Interlocked.Increment(ref _playerGeneration);
 		_previewPlayer?.Dispose();
 		_previewPlayer = null;
 		_playerStart?.Dispose();

--- a/CognitiveSupport/BeepPlayer.cs
+++ b/CognitiveSupport/BeepPlayer.cs
@@ -19,6 +19,10 @@ public static class BeepPlayer
 	public const int DefaultUnmuteFrequency = 1300;
 	public const int DefaultUnmuteDuration = 50;
 
+	// Upper bound on how many times a beep is repeated in one PlayRepeated call. Keeps a
+	// runaway retry count from synthesizing a multi-second WAV the user has to sit through.
+	public const int MaxRepeatCount = 10;
+
 	private static readonly object SyncLock = new();
 	private static readonly TimeSpan DuplicateSuppressWindow = TimeSpan.FromMilliseconds(500);
 	private static readonly Dictionary<BeepType, DateTime> _lastPlayed = new();
@@ -29,7 +33,7 @@ public static class BeepPlayer
 	private static SoundPlayer? _playerMute;
 	private static SoundPlayer? _playerUnmute;
 	private static SoundPlayer? _previewPlayer;
-	private static readonly Dictionary<BeepType, (SoundPlayer Player, MemoryStream Stream)> _defaultPlayers = new();
+	private static readonly Dictionary<(BeepType Type, int RepeatCount), (SoundPlayer Player, MemoryStream Stream)> _defaultPlayers = new();
 	public static IReadOnlyList<string> LastInitializationIssues { get; private set; } = Array.Empty<string>();
 
 	public static void Initialize(Settings settings)
@@ -84,21 +88,82 @@ public static class BeepPlayer
 		}
 		if (TryPlayCustom(type))
 			return;
-		PlayDefault(type);
+		PlayDefault(type, repeatCount: 1);
+	}
+
+	// Plays <paramref name="repeatCount"/> copies of a beep as a single sound so the
+	// listener can actually count them. Playing Play() in a loop does not work: the
+	// duplicate-suppression window above swallows every call after the first (issue
+	// #216), and even without it SoundPlayer.Play restarts rather than queues. The
+	// default beeps are therefore synthesized as one N-tone WAV, and custom beep files
+	// are played back-to-back synchronously off the calling thread.
+	public static void PlayRepeated(BeepType type, int repeatCount)
+	{
+		repeatCount = ClampRepeatCount(repeatCount);
+
+		lock (SyncLock)
+		{
+			// Deliberately not consulting the suppression window: this call *is* the
+			// repeat, so it must never be collapsed. Still stamped so a stray single
+			// Play right behind it stays suppressed.
+			_lastPlayed[type] = DateTime.UtcNow;
+		}
+
+		if (TryPlayCustomRepeated(type, repeatCount))
+			return;
+		PlayDefault(type, repeatCount);
+	}
+
+	private static int ClampRepeatCount(int repeatCount) => Math.Clamp(repeatCount, 1, MaxRepeatCount);
+
+	// The tone sequence for a beep played <paramref name="repeatCount"/> times in a row.
+	// Exposed so the repeat behaviour is verifiable without an audio device.
+	public static IReadOnlyList<(int Frequency, int Duration)> GetRepeatedSequence(BeepType type, int repeatCount)
+	{
+		var single = GetDefaultSequence(type);
+		repeatCount = ClampRepeatCount(repeatCount);
+		if (repeatCount == 1)
+			return single;
+
+		var sequence = new List<(int Frequency, int Duration)>(single.Count * repeatCount);
+		for (var i = 0; i < repeatCount; i++)
+			sequence.AddRange(single);
+		return sequence;
+	}
+
+	private static bool TryPlayCustomRepeated(BeepType type, int repeatCount)
+	{
+		var player = GetCustomPlayer(type);
+		if (player is null)
+			return false;
+
+		if (repeatCount == 1)
+		{
+			player.Play();
+			return true;
+		}
+
+		// PlaySync blocks, so it runs off the caller's thread; a shared SoundPlayer is
+		// only ever driven by one of these loops at a time in practice, and a torn
+		// repeat is preferable to blocking a transcription retry.
+		Task.Run(() =>
+		{
+			try
+			{
+				for (var i = 0; i < repeatCount; i++)
+					player.PlaySync();
+			}
+			catch
+			{
+				// A failed beep must never take down the operation it is reporting on.
+			}
+		});
+		return true;
 	}
 
 	private static bool TryPlayCustom(BeepType type)
 	{
-		var player = type switch
-		{
-			BeepType.Start => _playerStart,
-			BeepType.Success => _playerSuccess,
-			BeepType.Failure => _playerFailure,
-			BeepType.End => _playerEnd,
-			BeepType.Mute => _playerMute,
-			BeepType.Unmute => _playerUnmute,
-			_ => null
-		};
+		var player = GetCustomPlayer(type);
 		if (player != null)
 		{
 			player.Play();
@@ -107,21 +172,33 @@ public static class BeepPlayer
 		return false;
 	}
 
+	private static SoundPlayer? GetCustomPlayer(BeepType type) => type switch
+	{
+		BeepType.Start => _playerStart,
+		BeepType.Success => _playerSuccess,
+		BeepType.Failure => _playerFailure,
+		BeepType.End => _playerEnd,
+		BeepType.Mute => _playerMute,
+		BeepType.Unmute => _playerUnmute,
+		_ => null
+	};
+
 	// Default beeps are synthesized once into in-memory WAVs and played through
 	// SoundPlayer.Play (asynchronous), so they never block the calling thread the
 	// way Console.Beep did (issue #169).
-	private static void PlayDefault(BeepType type)
+	private static void PlayDefault(BeepType type, int repeatCount)
 	{
 		SoundPlayer player;
+		var key = (type, ClampRepeatCount(repeatCount));
 		lock (SyncLock)
 		{
-			if (!_defaultPlayers.TryGetValue(type, out var cached))
+			if (!_defaultPlayers.TryGetValue(key, out var cached))
 			{
-				var wav = BeepToneSynthesizer.SynthesizeWav(GetDefaultSequence(type));
+				var wav = BeepToneSynthesizer.SynthesizeWav(GetRepeatedSequence(key.Item1, key.Item2));
 				var stream = new MemoryStream(wav, writable: false);
 				cached = (new SoundPlayer(stream), stream);
 				cached.Player.Load();
-				_defaultPlayers[type] = cached;
+				_defaultPlayers[key] = cached;
 			}
 			player = cached.Player;
 		}

--- a/CognitiveSupport/ComputerVision/OcrReadingOrderSorter.cs
+++ b/CognitiveSupport/ComputerVision/OcrReadingOrderSorter.cs
@@ -1,0 +1,103 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace CognitiveSupport;
+
+/// <summary>
+/// One OCR line with the axis-aligned bounds of its detected polygon, in image pixels.
+/// </summary>
+public readonly record struct OcrTextLine(string Text, double Left, double Top, double Right, double Bottom)
+{
+	public double Height => Bottom - Top;
+	public double VerticalCentre => (Top + Bottom) / 2.0;
+}
+
+/// <summary>
+/// Applies the requested <see cref="OcrReadingOrder"/> to already-recognised lines.
+///
+/// Azure Image Analysis 4.0 has no reading-order request option (unlike the retired
+/// Read 3.2 API), and returns lines grouped into blocks in its own natural,
+/// column-aware order. <see cref="OcrReadingOrder.TopToBottomColumnAware"/> therefore
+/// keeps that order as-is, while <see cref="OcrReadingOrder.LeftToRightTopToBottom"/>
+/// re-sorts every line onto visual rows that run straight across the page — which is
+/// what a table, spreadsheet, form, or invoice needs (issue #217).
+/// </summary>
+public static class OcrReadingOrderSorter
+{
+	// A line joins the row being built when its vertical span overlaps the row's by at
+	// least this fraction of the shorter of the two. Generous enough that cells whose
+	// baselines differ by a few pixels still share a row, strict enough that the next
+	// line of a paragraph — which merely abuts the previous one — starts a new row.
+	private const double RowOverlapFactor = 0.5;
+
+	public static IReadOnlyList<OcrTextLine> Sort(
+		IReadOnlyList<OcrTextLine> lines,
+		OcrReadingOrder readingOrder)
+	{
+		ArgumentNullException.ThrowIfNull(lines);
+
+		if (readingOrder != OcrReadingOrder.LeftToRightTopToBottom || lines.Count < 2)
+			return lines;
+
+		return GroupIntoRows(lines)
+			.SelectMany(row => row.OrderBy(line => line.Left).ThenBy(line => line.Top))
+			.ToList();
+	}
+
+	public static string ToText(IReadOnlyList<OcrTextLine> lines)
+	{
+		ArgumentNullException.ThrowIfNull(lines);
+
+		var sb = new StringBuilder();
+		foreach (var line in lines)
+			sb.AppendLine(line.Text);
+		return sb.ToString();
+	}
+
+	private static List<List<OcrTextLine>> GroupIntoRows(IReadOnlyList<OcrTextLine> lines)
+	{
+		// Ordering by vertical centre first means a row is always built from lines that
+		// are adjacent vertically, whatever order the API returned them in.
+		var byVerticalPosition = lines
+			.OrderBy(line => line.VerticalCentre)
+			.ThenBy(line => line.Left)
+			.ToList();
+
+		var rows = new List<List<OcrTextLine>>();
+		var current = new List<OcrTextLine> { byVerticalPosition[0] };
+		double rowTop = byVerticalPosition[0].Top;
+		double rowBottom = byVerticalPosition[0].Bottom;
+
+		foreach (var line in byVerticalPosition.Skip(1))
+		{
+			if (SharesRow(rowTop, rowBottom, line))
+			{
+				current.Add(line);
+				rowTop = Math.Min(rowTop, line.Top);
+				rowBottom = Math.Max(rowBottom, line.Bottom);
+				continue;
+			}
+
+			rows.Add(current);
+			current = new List<OcrTextLine> { line };
+			rowTop = line.Top;
+			rowBottom = line.Bottom;
+		}
+
+		rows.Add(current);
+		return rows;
+	}
+
+	private static bool SharesRow(double rowTop, double rowBottom, OcrTextLine line)
+	{
+		double overlap = Math.Min(rowBottom, line.Bottom) - Math.Max(rowTop, line.Top);
+		if (overlap <= 0)
+			return false;
+
+		// Degenerate zero-height bounds would otherwise make the threshold zero and
+		// collapse the whole page onto one row.
+		double shorter = Math.Max(1.0, Math.Min(rowBottom - rowTop, line.Height));
+		return overlap >= shorter * RowOverlapFactor;
+	}
+}

--- a/CognitiveSupport/ComputerVision/OcrReadingOrderSorter.cs
+++ b/CognitiveSupport/ComputerVision/OcrReadingOrderSorter.cs
@@ -66,6 +66,11 @@ public static class OcrReadingOrderSorter
 
 		var rows = new List<List<OcrTextLine>>();
 		var current = new List<OcrTextLine> { byVerticalPosition[0] };
+		// The band stays pinned to the line that opened the row and is deliberately
+		// never widened to the union of its members. Growing it let one abnormally tall
+		// line — a sidebar, a logo caption, a merged multi-line cell — dilate the band
+		// far enough to swallow several genuinely separate table rows, which then got
+		// re-sorted by Left into one interleaved line of nonsense.
 		double rowTop = byVerticalPosition[0].Top;
 		double rowBottom = byVerticalPosition[0].Bottom;
 
@@ -74,8 +79,6 @@ public static class OcrReadingOrderSorter
 			if (SharesRow(rowTop, rowBottom, line))
 			{
 				current.Add(line);
-				rowTop = Math.Min(rowTop, line.Top);
-				rowBottom = Math.Max(rowBottom, line.Bottom);
 				continue;
 			}
 

--- a/CognitiveSupport/DeepgramSpeechToTextService.cs
+++ b/CognitiveSupport/DeepgramSpeechToTextService.cs
@@ -67,8 +67,8 @@ public class DeepgramSpeechToTextService : ISpeechToTextService
 			using var thisTryCts = new CancellationTokenSource(TimeSpan.FromSeconds(timeout));
 			using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(overallToken, thisTryCts.Token);
 
-			if (attempt > 0)
-				this.Beep(attempt);
+			// Beep swallows the first, non-retry attempt itself; retries beep once per attempt.
+			this.Beep(attempt);
 
 			return await TranscribeViaDeepgram(keyterms, audioBytes, linkedCts).ConfigureAwait(false);
 		}, context, overallCancellationToken).ConfigureAwait(false);

--- a/CognitiveSupport/Extensions/ObjectExtensions.cs
+++ b/CognitiveSupport/Extensions/ObjectExtensions.cs
@@ -1,14 +1,23 @@
-﻿namespace CognitiveSupport.Extensions;
+namespace CognitiveSupport.Extensions;
 
 public static class ObjectExtensions
 {
+	/// <summary>
+	/// Signals retry progress audibly: one beep per attempt, so a third retry is
+	/// distinguishable from a first. <paramref name="attempt"/> is 1-based, and the
+	/// first (non-retry) attempt is silent — there is nothing to report yet.
+	/// </summary>
 	public static void Beep(
 			  this object caller,
 			  int attempt)
 	{
 #pragma warning disable CA1416 // Validate platform compatibility
-		for (int i = 0; i < attempt; i++)
-			BeepPlayer.Play(BeepType.End);
+		if (!RetryBeepPolicy.ShouldBeep(attempt))
+			return;
+
+		// One call, one sound. Looping BeepPlayer.Play here used to collapse to a
+		// single audible beep because of its duplicate-suppression window (issue #216).
+		BeepPlayer.PlayRepeated(BeepType.End, RetryBeepPolicy.RepeatCountFor(attempt));
 #pragma warning restore CA1416 // Validate platform compatibility
 	}
 

--- a/CognitiveSupport/OcrService.cs
+++ b/CognitiveSupport/OcrService.cs
@@ -81,7 +81,8 @@ public class OcrService : IOcrService, IDisposable
 		CancellationToken overallCancellationToken)
 	{
 		int attempt = (int)context["Attempt"];
-		if (attempt > 0) this.Beep(attempt);
+		// Beep swallows the first, non-retry attempt itself; retries beep once per attempt.
+		this.Beep(attempt);
 
 		imageStream.Seek(0, SeekOrigin.Begin);
 
@@ -190,12 +191,20 @@ public class OcrService : IOcrService, IDisposable
 			cancellationToken: requestCts.Token)
 			.ConfigureAwait(false);
 
-		return ExtractTextFromResults(result);
+		return ExtractTextFromResults(result, ocrReadingOrder);
 	}
 
-        private static string ExtractTextFromResults(ImageAnalysisResult result)
+        // Azure Image Analysis 4.0 exposes no reading-order request option, so the order is
+        // applied here to the recognised lines. See OcrReadingOrderSorter (issue #217).
+        private static string ExtractTextFromResults(ImageAnalysisResult result, OcrReadingOrder ocrReadingOrder)
         {
-                var sb = new StringBuilder();
+                var lines = FlattenLines(result);
+                return OcrReadingOrderSorter.ToText(OcrReadingOrderSorter.Sort(lines, ocrReadingOrder));
+        }
+
+        private static IReadOnlyList<OcrTextLine> FlattenLines(ImageAnalysisResult result)
+        {
+                var lines = new List<OcrTextLine>();
 
                 if (result.Read?.Blocks != null)
                 {
@@ -203,12 +212,25 @@ public class OcrService : IOcrService, IDisposable
                         {
                                 foreach (var line in block.Lines)
                                 {
-                                        sb.AppendLine(line.Text);
+                                        lines.Add(ToTextLine(line));
                                 }
                         }
                 }
 
-                return sb.ToString();
+                return lines;
+        }
+
+        private static OcrTextLine ToTextLine(DetectedTextLine line)
+        {
+                var polygon = line.BoundingPolygon;
+                if (polygon is null || polygon.Count == 0)
+                        return new OcrTextLine(line.Text, 0, 0, 0, 0);
+
+                double left = polygon.Min(p => (double)p.X);
+                double top = polygon.Min(p => (double)p.Y);
+                double right = polygon.Max(p => (double)p.X);
+                double bottom = polygon.Max(p => (double)p.Y);
+                return new OcrTextLine(line.Text, left, top, right, bottom);
         }
 
         public void Dispose()

--- a/CognitiveSupport/OpenAiSpeechToTextService.cs
+++ b/CognitiveSupport/OpenAiSpeechToTextService.cs
@@ -59,8 +59,8 @@ public class OpenAiSpeechToTextService : ISpeechToTextService
 			using var thisTryCts = new CancellationTokenSource(TimeSpan.FromSeconds(timeout));
 			using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(overallToken, thisTryCts.Token);
 
-			if (attempt > 0)
-				this.Beep(attempt);
+			// Beep swallows the first, non-retry attempt itself; retries beep once per attempt.
+			this.Beep(attempt);
 
 			return await TranscribeViaWhisper(speechToTextPrompt, audioffilePath, linkedCts.Token).ConfigureAwait(false);
 		}, context, overallCancellationToken).ConfigureAwait(false);

--- a/CognitiveSupport/RetryBeepPolicy.cs
+++ b/CognitiveSupport/RetryBeepPolicy.cs
@@ -1,0 +1,20 @@
+namespace CognitiveSupport;
+
+/// <summary>
+/// Decides how a retry attempt is signalled audibly. Kept separate from the playback
+/// call so the policy is verifiable without an audio device (issue #216).
+/// </summary>
+public static class RetryBeepPolicy
+{
+	/// <summary>
+	/// The first attempt is not a retry, so it stays silent — beeping there made a
+	/// first attempt indistinguishable from a first retry.
+	/// </summary>
+	public static bool ShouldBeep(int attempt) => attempt > 1;
+
+	/// <summary>
+	/// How many beeps announce this attempt: one per attempt, so the listener can count
+	/// how deep into the retries the operation is.
+	/// </summary>
+	public static int RepeatCountFor(int attempt) => ShouldBeep(attempt) ? attempt : 0;
+}

--- a/Mutation.Tests/HotkeyAccessibleTextTests.cs
+++ b/Mutation.Tests/HotkeyAccessibleTextTests.cs
@@ -1,0 +1,52 @@
+using Mutation.Ui.Core;
+
+namespace Mutation.Tests;
+
+// Issue #214: the accessible name was rebuilt from a cached, first-seen label, so a
+// button whose state changed kept announcing its startup name. The name must come from
+// the label for the button's *current* state.
+public class HotkeyAccessibleTextTests
+{
+	[Fact]
+	public void ComposeName_AppendsTheHotkey()
+	{
+		Assert.Equal("Record, SHIFT+ALT+U", HotkeyAccessibleText.ComposeName("Record", "SHIFT+ALT+U"));
+	}
+
+	[Theory]
+	[InlineData(null)]
+	[InlineData("")]
+	[InlineData("   ")]
+	public void ComposeName_OmitsAnAbsentHotkey(string? hotkey)
+	{
+		Assert.Equal("Record", HotkeyAccessibleText.ComposeName("Record", hotkey));
+	}
+
+	[Theory]
+	[InlineData("Mute microphone", "Unmute microphone", "ALT+Q")]
+	[InlineData("Record", "Stop", "SHIFT+ALT+U")]
+	[InlineData("Record and Format", "Stop and Format", "SHIFT+ALT+I")]
+	public void ComposeName_FollowsTheStateTransition(string before, string after, string hotkey)
+	{
+		// The regression: composing after a transition must never resurrect the old label.
+		string startupName = HotkeyAccessibleText.ComposeName(before, hotkey);
+		string afterTransition = HotkeyAccessibleText.ComposeName(after, hotkey);
+
+		Assert.Equal($"{after}, {hotkey}", afterTransition);
+		Assert.NotEqual(startupName, afterTransition);
+	}
+
+	[Fact]
+	public void ComposeTooltip_AppendsTheHotkeyInBrackets()
+	{
+		Assert.Equal("Stop (Hotkey: SHIFT+ALT+U)", HotkeyAccessibleText.ComposeTooltip("Stop", "SHIFT+ALT+U"));
+		Assert.Equal("Stop", HotkeyAccessibleText.ComposeTooltip("Stop", null));
+	}
+
+	[Fact]
+	public void ComposeHotkeyText_IsEmptyWithoutAHotkey()
+	{
+		Assert.Equal("Hotkey: ALT+Q", HotkeyAccessibleText.ComposeHotkeyText("ALT+Q"));
+		Assert.Equal(string.Empty, HotkeyAccessibleText.ComposeHotkeyText(null));
+	}
+}

--- a/Mutation.Tests/HotkeyAccessibleTextTests.cs
+++ b/Mutation.Tests/HotkeyAccessibleTextTests.cs
@@ -22,20 +22,6 @@ public class HotkeyAccessibleTextTests
 		Assert.Equal("Record", HotkeyAccessibleText.ComposeName("Record", hotkey));
 	}
 
-	[Theory]
-	[InlineData("Mute microphone", "Unmute microphone", "ALT+Q")]
-	[InlineData("Record", "Stop", "SHIFT+ALT+U")]
-	[InlineData("Record and Format", "Stop and Format", "SHIFT+ALT+I")]
-	public void ComposeName_FollowsTheStateTransition(string before, string after, string hotkey)
-	{
-		// The regression: composing after a transition must never resurrect the old label.
-		string startupName = HotkeyAccessibleText.ComposeName(before, hotkey);
-		string afterTransition = HotkeyAccessibleText.ComposeName(after, hotkey);
-
-		Assert.Equal($"{after}, {hotkey}", afterTransition);
-		Assert.NotEqual(startupName, afterTransition);
-	}
-
 	[Fact]
 	public void ComposeTooltip_AppendsTheHotkeyInBrackets()
 	{

--- a/Mutation.Tests/HotkeyButtonLabelCacheTests.cs
+++ b/Mutation.Tests/HotkeyButtonLabelCacheTests.cs
@@ -1,0 +1,107 @@
+using Mutation.Ui.Core;
+
+namespace Mutation.Tests;
+
+// Issue #214: the defect was the label cache, not the string composition. The old cache
+// stored the name it first read back off the button and re-derived from that value on
+// every later call, so a hotkey-only refresh resurrected the startup name and undid the
+// state transition. Composition was always correct, so these tests drive the cache.
+public class HotkeyButtonLabelCacheTests
+{
+	// Stands in for a Button; the cache keys on reference identity.
+	private sealed class FakeButton
+	{
+		public FakeButton(string nameFromMarkup) => NameFromMarkup = nameFromMarkup;
+		public string NameFromMarkup { get; }
+	}
+
+	private static string Refresh(HotkeyButtonLabelCache cache, FakeButton button, string? hotkey, string tooltip, string? stateLabel = null)
+	{
+		string label = cache.Resolve(button, button.NameFromMarkup, tooltip, stateLabel);
+		return HotkeyAccessibleText.ComposeName(label, hotkey);
+	}
+
+	[Fact]
+	public void AHotkeyOnlyRefreshAfterAStateTransition_KeepsTheNewState()
+	{
+		// The exact failure from the issue: startup seeds "Record", recording sets
+		// "Stop", and then a hotkey refresh must not put "Record" back.
+		var cache = new HotkeyButtonLabelCache();
+		var button = new FakeButton("Record");
+
+		Assert.Equal("Record, SHIFT+ALT+U", Refresh(cache, button, "SHIFT+ALT+U", "Start or stop speech capture"));
+
+		Assert.Equal("Stop, SHIFT+ALT+U", Refresh(cache, button, "SHIFT+ALT+U", "Stop", stateLabel: "Stop"));
+
+		// Settings saved mid-recording: ApplyLiveSettings re-runs the hotkey refresh.
+		Assert.Equal("Stop, SHIFT+ALT+U", Refresh(cache, button, "SHIFT+ALT+U", "Start or stop speech capture"));
+	}
+
+	[Fact]
+	public void TheMicrophoneToggle_AnnouncesTheStateItIsActuallyIn()
+	{
+		var cache = new HotkeyButtonLabelCache();
+		var button = new FakeButton("Mute microphone");
+
+		Refresh(cache, button, "ALT+Q", "Toggle microphone mute state");
+		Refresh(cache, button, "ALT+Q", "Unmute microphone", stateLabel: "Unmute microphone");
+
+		Assert.Equal("Unmute microphone, ALT+Q", Refresh(cache, button, "ALT+Q", "Toggle microphone mute state"));
+	}
+
+	[Fact]
+	public void AStateLabelRecordedWithoutAHotkeyRefresh_SurvivesTheNextRefresh()
+	{
+		// The disabled "Transcribing…" state sets a name without touching the hotkey.
+		var cache = new HotkeyButtonLabelCache();
+		var button = new FakeButton("Record");
+		Refresh(cache, button, "SHIFT+ALT+U", "Start or stop speech capture");
+
+		cache.Set(button, "Transcribing…");
+
+		Assert.Equal("Transcribing…, SHIFT+ALT+U", Refresh(cache, button, "SHIFT+ALT+U", "Start or stop speech capture"));
+	}
+
+	[Fact]
+	public void AChangedHotkeyIsPickedUpWithoutDisturbingTheLabel()
+	{
+		var cache = new HotkeyButtonLabelCache();
+		var button = new FakeButton("Record and Format");
+		Refresh(cache, button, "SHIFT+ALT+I", "Record and Format", stateLabel: "Stop and Format");
+
+		Assert.Equal("Stop and Format, CTRL+ALT+J", Refresh(cache, button, "CTRL+ALT+J", "Record and Format"));
+	}
+
+	[Fact]
+	public void TheMarkupNameOnlyEverSeedsTheCache()
+	{
+		var cache = new HotkeyButtonLabelCache();
+		var button = new FakeButton("Record");
+		Refresh(cache, button, null, "Start or stop speech capture", stateLabel: "Stop");
+
+		// Even asked again with the markup name available, the state label wins.
+		Assert.Equal("Stop", cache.Resolve(button, button.NameFromMarkup, "Start or stop speech capture", null));
+	}
+
+	[Fact]
+	public void AButtonWithNoMarkupName_FallsBackToTheTooltip()
+	{
+		var cache = new HotkeyButtonLabelCache();
+		var button = new FakeButton("");
+
+		Assert.Equal("Send transcript through the configured language model",
+			cache.Resolve(button, button.NameFromMarkup, "Send transcript through the configured language model", null));
+	}
+
+	[Fact]
+	public void ButtonsDoNotShareLabels()
+	{
+		var cache = new HotkeyButtonLabelCache();
+		var record = new FakeButton("Record");
+		var recordAndFormat = new FakeButton("Record and Format");
+
+		cache.Resolve(record, record.NameFromMarkup, "x", "Stop");
+
+		Assert.Equal("Record and Format", cache.Resolve(recordAndFormat, recordAndFormat.NameFromMarkup, "x", null));
+	}
+}

--- a/Mutation.Tests/KeyboardRegionSelectorTests.cs
+++ b/Mutation.Tests/KeyboardRegionSelectorTests.cs
@@ -1,0 +1,250 @@
+using Mutation.Ui.Core;
+
+namespace Mutation.Tests;
+
+// Issue #215: the screenshot region overlay was pointer-only, leaving four core hotkeys
+// with no completable path for a user who cannot see the crosshair.
+public class KeyboardRegionSelectorTests
+{
+	private static KeyboardRegionSelector NewSelector(double width = 1000, double height = 800)
+	{
+		var selector = new KeyboardRegionSelector();
+		selector.Reset(width, height, width / 2, height / 2);
+		return selector;
+	}
+
+	private static RegionKeyResult Press(KeyboardRegionSelector selector, RegionSelectionKey key, bool shift = false, bool control = false)
+		=> selector.HandleKey(key, shift, control);
+
+	[Fact]
+	public void ArrowKeys_MoveTheCaret()
+	{
+		var selector = NewSelector();
+		double startX = selector.CaretX;
+		double startY = selector.CaretY;
+
+		Press(selector, RegionSelectionKey.Right);
+		Press(selector, RegionSelectionKey.Down);
+
+		Assert.Equal(startX + KeyboardRegionSelector.NormalStep, selector.CaretX);
+		Assert.Equal(startY + KeyboardRegionSelector.NormalStep, selector.CaretY);
+	}
+
+	[Fact]
+	public void ModifiersChooseTheStepSize()
+	{
+		var selector = NewSelector();
+		double startX = selector.CaretX;
+
+		Press(selector, RegionSelectionKey.Right, control: true);
+		Assert.Equal(startX + KeyboardRegionSelector.FineStep, selector.CaretX);
+
+		Press(selector, RegionSelectionKey.Right, shift: true);
+		Assert.Equal(startX + KeyboardRegionSelector.FineStep + KeyboardRegionSelector.CoarseStep, selector.CaretX);
+	}
+
+	[Fact]
+	public void TheCaretStaysInsideTheOverlay()
+	{
+		var selector = NewSelector(width: 100, height: 100);
+
+		for (int i = 0; i < 50; i++)
+		{
+			Press(selector, RegionSelectionKey.Left, shift: true);
+			Press(selector, RegionSelectionKey.Up, shift: true);
+		}
+		Assert.Equal(0, selector.CaretX);
+		Assert.Equal(0, selector.CaretY);
+
+		for (int i = 0; i < 50; i++)
+		{
+			Press(selector, RegionSelectionKey.Right, shift: true);
+			Press(selector, RegionSelectionKey.Down, shift: true);
+		}
+		Assert.Equal(100, selector.CaretX);
+		Assert.Equal(100, selector.CaretY);
+	}
+
+	[Fact]
+	public void HomeEndAndPaging_JumpToTheEdges()
+	{
+		var selector = NewSelector(width: 640, height: 480);
+
+		Press(selector, RegionSelectionKey.Home);
+		Assert.Equal(0, selector.CaretX);
+
+		Press(selector, RegionSelectionKey.End);
+		Assert.Equal(640, selector.CaretX);
+
+		Press(selector, RegionSelectionKey.PageUp);
+		Assert.Equal(0, selector.CaretY);
+
+		Press(selector, RegionSelectionKey.PageDown);
+		Assert.Equal(480, selector.CaretY);
+	}
+
+	[Fact]
+	public void FirstCommitPinsTheAnchorAndSecondCommitCaptures()
+	{
+		var selector = NewSelector();
+		Press(selector, RegionSelectionKey.Home);
+		Press(selector, RegionSelectionKey.PageUp);
+
+		var anchor = Press(selector, RegionSelectionKey.Commit);
+		Assert.Equal(RegionKeyOutcome.AnchorSet, anchor.Outcome);
+		Assert.True(selector.HasAnchor);
+
+		for (int i = 0; i < 3; i++)
+		{
+			Press(selector, RegionSelectionKey.Right);
+			Press(selector, RegionSelectionKey.Down);
+		}
+
+		var committed = Press(selector, RegionSelectionKey.Commit);
+		Assert.Equal(RegionKeyOutcome.Committed, committed.Outcome);
+		Assert.Equal(3 * KeyboardRegionSelector.NormalStep, selector.SelectionWidth);
+		Assert.Equal(3 * KeyboardRegionSelector.NormalStep, selector.SelectionHeight);
+		Assert.Equal(0, selector.SelectionLeft);
+		Assert.Equal(0, selector.SelectionTop);
+	}
+
+	[Fact]
+	public void ASelectionDraggedUpAndLeftIsStillNormalised()
+	{
+		var selector = NewSelector();
+		Press(selector, RegionSelectionKey.End);
+		Press(selector, RegionSelectionKey.PageDown);
+		Press(selector, RegionSelectionKey.Commit);
+
+		Press(selector, RegionSelectionKey.Left, shift: true);
+		Press(selector, RegionSelectionKey.Up, shift: true);
+
+		Assert.Equal(1000 - KeyboardRegionSelector.CoarseStep, selector.SelectionLeft);
+		Assert.Equal(800 - KeyboardRegionSelector.CoarseStep, selector.SelectionTop);
+		Assert.Equal(KeyboardRegionSelector.CoarseStep, selector.SelectionWidth);
+		Assert.Equal(KeyboardRegionSelector.CoarseStep, selector.SelectionHeight);
+	}
+
+	[Fact]
+	public void ControlA_SelectsTheWholeScreenAsAKeyboardFallback()
+	{
+		var selector = NewSelector(width: 1920, height: 1080);
+
+		var result = Press(selector, RegionSelectionKey.SelectAll, control: true);
+
+		Assert.Equal(RegionKeyOutcome.SelectedWholeScreen, result.Outcome);
+		Assert.Equal(0, selector.SelectionLeft);
+		Assert.Equal(0, selector.SelectionTop);
+		Assert.Equal(1920, selector.SelectionWidth);
+		Assert.Equal(1080, selector.SelectionHeight);
+
+		// And Enter completes the capture — a whole-screen grab in two keystrokes.
+		Assert.Equal(RegionKeyOutcome.Committed, Press(selector, RegionSelectionKey.Commit).Outcome);
+	}
+
+	[Fact]
+	public void PlainA_IsNotSelectAll()
+	{
+		var selector = NewSelector();
+
+		Assert.Equal(RegionKeyOutcome.Ignored, Press(selector, RegionSelectionKey.SelectAll).Outcome);
+	}
+
+	[Fact]
+	public void CommittingAnEmptyRegionIsRefusedOutLoud()
+	{
+		// Two presses of Enter without moving used to produce a zero-sized rect that the
+		// capture pipeline discarded silently.
+		var selector = NewSelector();
+		Press(selector, RegionSelectionKey.Commit);
+
+		var result = Press(selector, RegionSelectionKey.Commit);
+
+		Assert.Equal(RegionKeyOutcome.Rejected, result.Outcome);
+		Assert.Contains("empty", result.Announcement, StringComparison.OrdinalIgnoreCase);
+	}
+
+	[Fact]
+	public void BackspaceClearsAPinnedCorner()
+	{
+		var selector = NewSelector();
+		Press(selector, RegionSelectionKey.Commit);
+		Assert.True(selector.HasAnchor);
+
+		var cleared = Press(selector, RegionSelectionKey.Back);
+
+		Assert.Equal(RegionKeyOutcome.AnchorCleared, cleared.Outcome);
+		Assert.False(selector.HasAnchor);
+		Assert.Equal(0, selector.SelectionWidth);
+	}
+
+	[Fact]
+	public void BackspaceWithoutAnAnchorIsIgnored()
+	{
+		var selector = NewSelector();
+
+		Assert.Equal(RegionKeyOutcome.Ignored, Press(selector, RegionSelectionKey.Back).Outcome);
+	}
+
+	[Fact]
+	public void EveryActedOnKeyAnnouncesSomething()
+	{
+		// A blind user gets no feedback from the crosshair, so each accepted key has to
+		// say what happened.
+		var selector = NewSelector();
+		RegionSelectionKey[] keys =
+		[
+			RegionSelectionKey.Left, RegionSelectionKey.Right, RegionSelectionKey.Up, RegionSelectionKey.Down,
+			RegionSelectionKey.Home, RegionSelectionKey.End, RegionSelectionKey.PageUp, RegionSelectionKey.PageDown,
+			RegionSelectionKey.Commit,
+		];
+
+		foreach (var key in keys)
+		{
+			var result = Press(selector, key);
+			Assert.NotEqual(RegionKeyOutcome.Ignored, result.Outcome);
+			Assert.False(string.IsNullOrWhiteSpace(result.Announcement), $"{key} announced nothing.");
+		}
+	}
+
+	[Fact]
+	public void ResizingKeepsTheSelectionInsideTheNewBounds()
+	{
+		var selector = NewSelector(width: 1000, height: 800);
+		Press(selector, RegionSelectionKey.End);
+		Press(selector, RegionSelectionKey.PageDown);
+
+		selector.Resize(400, 300);
+
+		Assert.Equal(400, selector.CaretX);
+		Assert.Equal(300, selector.CaretY);
+	}
+
+	[Fact]
+	public void SyncCaret_TracksThePointerAndClamps()
+	{
+		var selector = NewSelector(width: 500, height: 500);
+
+		selector.SyncCaret(123, 456);
+		Assert.Equal(123, selector.CaretX);
+		Assert.Equal(456, selector.CaretY);
+
+		selector.SyncCaret(9999, -20);
+		Assert.Equal(500, selector.CaretX);
+		Assert.Equal(0, selector.CaretY);
+	}
+
+	[Fact]
+	public void ResetStartsWithoutAnAnchorAtTheGivenCaret()
+	{
+		var selector = new KeyboardRegionSelector();
+
+		selector.Reset(800, 600, 42, 84);
+
+		Assert.False(selector.HasAnchor);
+		Assert.Equal(42, selector.CaretX);
+		Assert.Equal(84, selector.CaretY);
+		Assert.Equal(0, selector.SelectionWidth);
+		Assert.Equal(0, selector.SelectionHeight);
+	}
+}

--- a/Mutation.Tests/OcrReadingOrderSorterTests.cs
+++ b/Mutation.Tests/OcrReadingOrderSorterTests.cs
@@ -1,0 +1,138 @@
+using CognitiveSupport;
+
+namespace Mutation.Tests;
+
+// Issue #217: OcrReadingOrder was threaded all the way to the Azure call and then never
+// applied, so the "basic" and "natural" hotkeys produced byte-identical output.
+public class OcrReadingOrderSorterTests
+{
+	private static OcrTextLine Line(string text, double left, double top, double width = 100, double height = 20)
+		=> new(text, left, top, left + width, top + height);
+
+	private static string Sorted(IReadOnlyList<OcrTextLine> lines, OcrReadingOrder order)
+		=> OcrReadingOrderSorter.ToText(OcrReadingOrderSorter.Sort(lines, order));
+
+	// A two-column page: the API returns each column as a block, top to bottom.
+	private static readonly OcrTextLine[] TwoColumnPage =
+	[
+		Line("left one", left: 0, top: 0),
+		Line("left two", left: 0, top: 30),
+		Line("left three", left: 0, top: 60),
+		Line("right one", left: 200, top: 0),
+		Line("right two", left: 200, top: 30),
+		Line("right three", left: 200, top: 60),
+	];
+
+	// A 3x2 table, returned column-major the way a column-aware reader groups it.
+	private static readonly OcrTextLine[] Table =
+	[
+		Line("Item", left: 0, top: 0, width: 80),
+		Line("Widget", left: 0, top: 25, width: 80),
+		Line("Gadget", left: 0, top: 50, width: 80),
+		Line("Qty", left: 100, top: 0, width: 40),
+		Line("2", left: 100, top: 25, width: 40),
+		Line("7", left: 100, top: 50, width: 40),
+		Line("Price", left: 160, top: 0, width: 60),
+		Line("1.50", left: 160, top: 25, width: 60),
+		Line("9.99", left: 160, top: 50, width: 60),
+	];
+
+	[Fact]
+	public void LeftToRightTopToBottom_ReadsATwoColumnPageStraightAcross()
+	{
+		var text = Sorted(TwoColumnPage, OcrReadingOrder.LeftToRightTopToBottom);
+
+		var expected = new[] { "left one", "right one", "left two", "right two", "left three", "right three" };
+		Assert.Equal(string.Join(Environment.NewLine, expected) + Environment.NewLine, text);
+	}
+
+	[Fact]
+	public void TopToBottomColumnAware_KeepsTheApiColumnOrder()
+	{
+		var text = Sorted(TwoColumnPage, OcrReadingOrder.TopToBottomColumnAware);
+
+		Assert.Equal(
+			string.Join(Environment.NewLine, TwoColumnPage.Select(l => l.Text)) + Environment.NewLine,
+			text);
+	}
+
+	[Fact]
+	public void TheTwoReadingOrders_ProduceDifferentOutput()
+	{
+		// The whole point of issue #217: these two hotkeys must not be interchangeable.
+		Assert.NotEqual(
+			Sorted(TwoColumnPage, OcrReadingOrder.LeftToRightTopToBottom),
+			Sorted(TwoColumnPage, OcrReadingOrder.TopToBottomColumnAware));
+	}
+
+	[Fact]
+	public void LeftToRightTopToBottom_ReadsATableRowByRow()
+	{
+		var text = Sorted(Table, OcrReadingOrder.LeftToRightTopToBottom);
+
+		var expected = new[] { "Item", "Qty", "Price", "Widget", "2", "1.50", "Gadget", "7", "9.99" };
+		Assert.Equal(string.Join(Environment.NewLine, expected) + Environment.NewLine, text);
+	}
+
+	[Fact]
+	public void LeftToRightTopToBottom_KeepsSlightlyMisalignedCellsOnTheSameRow()
+	{
+		// Real OCR bounds for a table row vary by a few pixels between cells.
+		var lines = new[]
+		{
+			Line("b", left: 100, top: 3),
+			Line("a", left: 0, top: 0),
+			Line("c", left: 200, top: 2),
+		};
+
+		var text = Sorted(lines, OcrReadingOrder.LeftToRightTopToBottom);
+
+		Assert.Equal(string.Join(Environment.NewLine, "a", "b", "c") + Environment.NewLine, text);
+	}
+
+	[Fact]
+	public void LeftToRightTopToBottom_KeepsConsecutiveParagraphLinesOnSeparateRows()
+	{
+		// Tightly-set body text: each line abuts the previous one but is still its own row.
+		var lines = new[]
+		{
+			Line("first", left: 0, top: 0, height: 20),
+			Line("second", left: 0, top: 20, height: 20),
+			Line("third", left: 0, top: 40, height: 20),
+		};
+
+		var text = Sorted(lines, OcrReadingOrder.LeftToRightTopToBottom);
+
+		Assert.Equal(string.Join(Environment.NewLine, "first", "second", "third") + Environment.NewLine, text);
+	}
+
+	[Fact]
+	public void Sort_LeavesASingleLineAlone()
+	{
+		var lines = new[] { Line("only", left: 5, top: 5) };
+
+		Assert.Equal("only" + Environment.NewLine, Sorted(lines, OcrReadingOrder.LeftToRightTopToBottom));
+	}
+
+	[Fact]
+	public void Sort_HandlesAnEmptyResult()
+	{
+		Assert.Equal(string.Empty, Sorted(Array.Empty<OcrTextLine>(), OcrReadingOrder.LeftToRightTopToBottom));
+		Assert.Equal(string.Empty, Sorted(Array.Empty<OcrTextLine>(), OcrReadingOrder.TopToBottomColumnAware));
+	}
+
+	[Fact]
+	public void Sort_TolerantOfZeroSizedBounds()
+	{
+		// A degenerate polygon must not collapse the page onto one row.
+		var lines = new[]
+		{
+			new OcrTextLine("second", 0, 10, 0, 10),
+			new OcrTextLine("first", 0, 0, 0, 0),
+		};
+
+		var text = Sorted(lines, OcrReadingOrder.LeftToRightTopToBottom);
+
+		Assert.Equal(string.Join(Environment.NewLine, "first", "second") + Environment.NewLine, text);
+	}
+}

--- a/Mutation.Tests/OcrReadingOrderSorterTests.cs
+++ b/Mutation.Tests/OcrReadingOrderSorterTests.cs
@@ -107,6 +107,52 @@ public class OcrReadingOrderSorterTests
 	}
 
 	[Fact]
+	public void LeftToRightTopToBottom_ATallLineDoesNotSwallowTheRowsBesideIt()
+	{
+		// An invoice with a full-height sidebar, logo caption, or merged multi-line cell
+		// next to normal rows. A row band that grew to the union of its members let the
+		// tall line glue every row it touched into one interleaved line.
+		var lines = new[]
+		{
+			new OcrTextLine("sidebar", 0, 0, 40, 100),
+			Line("row one left", left: 60, top: 10, height: 10),
+			Line("row one right", left: 200, top: 10, height: 10),
+			Line("row two left", left: 60, top: 40, height: 10),
+			Line("row two right", left: 200, top: 40, height: 10),
+			Line("row three left", left: 60, top: 70, height: 10),
+			Line("row three right", left: 200, top: 70, height: 10),
+		};
+
+		var text = Sorted(lines, OcrReadingOrder.LeftToRightTopToBottom);
+		var rows = text.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+
+		// Each row's two cells must stay adjacent and in left-to-right order.
+		Assert.Equal("row one left", rows[Array.IndexOf(rows, "row one right") - 1]);
+		Assert.Equal("row two left", rows[Array.IndexOf(rows, "row two right") - 1]);
+		Assert.Equal("row three left", rows[Array.IndexOf(rows, "row three right") - 1]);
+
+		// And the rows must stay in top-to-bottom order relative to one another.
+		Assert.True(Array.IndexOf(rows, "row one left") < Array.IndexOf(rows, "row two left"));
+		Assert.True(Array.IndexOf(rows, "row two left") < Array.IndexOf(rows, "row three left"));
+	}
+
+	[Fact]
+	public void LeftToRightTopToBottom_ATallCellDoesNotMergeTheFollowingRow()
+	{
+		// A double-height cell in the first row must not pull the second row up into it.
+		var lines = new[]
+		{
+			Line("a", left: 0, top: 0, height: 20),
+			Line("tall b", left: 100, top: 0, height: 40),
+			Line("c", left: 0, top: 25, height: 20),
+		};
+
+		var text = Sorted(lines, OcrReadingOrder.LeftToRightTopToBottom);
+
+		Assert.Equal(string.Join(Environment.NewLine, "a", "tall b", "c") + Environment.NewLine, text);
+	}
+
+	[Fact]
 	public void Sort_LeavesASingleLineAlone()
 	{
 		var lines = new[] { Line("only", left: 5, top: 5) };

--- a/Mutation.Tests/RetryBeepTests.cs
+++ b/Mutation.Tests/RetryBeepTests.cs
@@ -1,0 +1,92 @@
+using CognitiveSupport;
+
+namespace Mutation.Tests;
+
+// Issue #216: retry progress used to be signalled by calling BeepPlayer.Play in a loop,
+// which the 500 ms duplicate-suppression window collapsed down to one audible beep. The
+// repeat now has to reach the synthesizer as a single multi-tone sequence.
+public class RetryBeepTests
+{
+	[Theory]
+	[InlineData(1)]
+	[InlineData(2)]
+	[InlineData(3)]
+	[InlineData(5)]
+	public void GetRepeatedSequence_ScalesWithRepeatCount(int repeatCount)
+	{
+		var single = BeepPlayer.GetDefaultSequence(BeepType.End);
+
+		var repeated = BeepPlayer.GetRepeatedSequence(BeepType.End, repeatCount);
+
+		Assert.Equal(single.Count * repeatCount, repeated.Count);
+	}
+
+	[Fact]
+	public void GetRepeatedSequence_RepeatsTheSameTones()
+	{
+		var single = BeepPlayer.GetDefaultSequence(BeepType.End);
+
+		var repeated = BeepPlayer.GetRepeatedSequence(BeepType.End, 3);
+
+		for (int i = 0; i < repeated.Count; i++)
+			Assert.Equal(single[i % single.Count], repeated[i]);
+	}
+
+	[Fact]
+	public void GetRepeatedSequence_ThreeRetriesAreLongerThanOne()
+	{
+		var once = BeepToneSynthesizer.SynthesizeWav(BeepPlayer.GetRepeatedSequence(BeepType.End, 1));
+		var thrice = BeepToneSynthesizer.SynthesizeWav(BeepPlayer.GetRepeatedSequence(BeepType.End, 3));
+
+		Assert.True(thrice.Length > once.Length,
+			"Three retries must be audibly distinguishable from one.");
+	}
+
+	[Fact]
+	public void GetRepeatedSequence_MultiToneBeepRepeatsWholeSequence()
+	{
+		var single = BeepPlayer.GetDefaultSequence(BeepType.Success);
+		Assert.True(single.Count > 1, "Success is a multi-tone beep; the fixture assumes so.");
+
+		var repeated = BeepPlayer.GetRepeatedSequence(BeepType.Success, 2);
+
+		Assert.Equal(single.Count * 2, repeated.Count);
+	}
+
+	[Theory]
+	[InlineData(0)]
+	[InlineData(-4)]
+	public void GetRepeatedSequence_NonPositiveCountFallsBackToASingleBeep(int repeatCount)
+	{
+		var repeated = BeepPlayer.GetRepeatedSequence(BeepType.End, repeatCount);
+
+		Assert.Equal(BeepPlayer.GetDefaultSequence(BeepType.End).Count, repeated.Count);
+	}
+
+	[Fact]
+	public void ShouldBeep_IsSilentOnTheFirstNonRetryAttempt()
+	{
+		Assert.False(RetryBeepPolicy.ShouldBeep(1));
+		Assert.Equal(0, RetryBeepPolicy.RepeatCountFor(1));
+	}
+
+	[Theory]
+	[InlineData(2, 2)]
+	[InlineData(3, 3)]
+	[InlineData(4, 4)]
+	public void RepeatCountFor_GivesOneBeepPerRetryAttempt(int attempt, int expectedBeeps)
+	{
+		Assert.True(RetryBeepPolicy.ShouldBeep(attempt));
+		Assert.Equal(expectedBeeps, RetryBeepPolicy.RepeatCountFor(attempt));
+	}
+
+	[Fact]
+	public void GetRepeatedSequence_ClampsRunawayRetryCounts()
+	{
+		var single = BeepPlayer.GetDefaultSequence(BeepType.End);
+
+		var repeated = BeepPlayer.GetRepeatedSequence(BeepType.End, BeepPlayer.MaxRepeatCount + 50);
+
+		Assert.Equal(single.Count * BeepPlayer.MaxRepeatCount, repeated.Count);
+	}
+}

--- a/Mutation.Tests/SettingsWorkingCopyCommitTests.cs
+++ b/Mutation.Tests/SettingsWorkingCopyCommitTests.cs
@@ -1,0 +1,320 @@
+using System.Collections;
+using System.Reflection;
+using CognitiveSupport;
+using Mutation.Ui.Views.SettingsUi;
+
+namespace Mutation.Tests;
+
+// Issues #218 and #219: Save committed the working copy through a hand-maintained field
+// list that had drifted away from the model twice, silently discarding the seven speech
+// preprocessing toggles and orphaning the prompt list.
+public class SettingsWorkingCopyCommitTests
+{
+	private static Settings BuildLiveSettings()
+	{
+		var settings = new Settings
+		{
+			AudioSettings = new AudioSettings("ALT+Q")
+			{
+				CustomBeepSettings = new AudioSettings.CustomBeepSettingsData(),
+			},
+			AzureComputerVisionSettings = new AzureComputerVisionSettings(),
+			SpeechToTextSettings = new SpeechToTextSettings(),
+			ApiKeys = new ApiKeys(),
+			LlmSettings = new LlmSettings(),
+			TextToSpeechSettings = new TextToSpeechSettings(),
+		};
+		settings.LlmSettings.Prompts.Add(new LlmSettings.LlmPrompt { Id = 1, Name = "Tidy", Content = "tidy this" });
+		settings.LlmSettings.Prompts.Add(new LlmSettings.LlmPrompt { Id = 2, Name = "Summarise", Content = "summarise this" });
+		settings.LlmSettings.Models.Add(new LlmModelConfig { Name = "gpt-4.1" });
+		settings.TranscriptFormatRules.Add(new TranscriptFormatRule("a", "b", false, TranscriptFormatRule.MatchTypeEnum.Plain));
+		return settings;
+	}
+
+	// --- Issue #218: the speech-preprocessing toggles ------------------------------
+
+	public static TheoryData<string> PreprocessingToggleNames() =>
+	[
+		nameof(TextToSpeechSettings.PreprocessRemoveCodeBlocks),
+		nameof(TextToSpeechSettings.PreprocessStripBoldItalicCode),
+		nameof(TextToSpeechSettings.PreprocessStripHeadingMarks),
+		nameof(TextToSpeechSettings.PreprocessShortenWebLinks),
+		nameof(TextToSpeechSettings.PreprocessStripBulletMarkers),
+		nameof(TextToSpeechSettings.PreprocessExpandAbbreviations),
+		nameof(TextToSpeechSettings.PreprocessNormaliseWhitespace),
+	];
+
+	[Theory]
+	[MemberData(nameof(PreprocessingToggleNames))]
+	public void CommitInto_TransfersEverySpeechPreprocessingToggle(string propertyName)
+	{
+		var live = BuildLiveSettings();
+		var working = SettingsWorkingCopy.Clone(live);
+		var property = typeof(TextToSpeechSettings).GetProperty(propertyName)!;
+
+		property.SetValue(working.TextToSpeechSettings, false);
+		SettingsWorkingCopy.CommitInto(live, working);
+
+		Assert.False((bool)property.GetValue(live.TextToSpeechSettings!)!, $"{propertyName} was discarded on Save.");
+	}
+
+	// --- Issue #219: prompt-list identity -----------------------------------------
+
+	[Fact]
+	public void CommitInto_KeepsTheLivePromptListInstance()
+	{
+		var live = BuildLiveSettings();
+		var originalList = live.LlmSettings!.Prompts;
+		var working = SettingsWorkingCopy.Clone(live);
+
+		SettingsWorkingCopy.CommitInto(live, working);
+
+		Assert.Same(originalList, live.LlmSettings.Prompts);
+	}
+
+	[Fact]
+	public void CommitInto_KeepsTheLivePromptInstances()
+	{
+		var live = BuildLiveSettings();
+		var originalPrompt = live.LlmSettings!.Prompts[0];
+		var working = SettingsWorkingCopy.Clone(live);
+
+		SettingsWorkingCopy.CommitInto(live, working);
+
+		Assert.Same(originalPrompt, live.LlmSettings.Prompts[0]);
+	}
+
+	[Fact]
+	public void EditingAPromptAfterASave_SurvivesTheNextWrite()
+	{
+		// The failure scenario from issue #219: open Settings, Save with no changes,
+		// then edit a prompt from the main window. The edit used to land on an object
+		// no longer in the live collection.
+		var live = BuildLiveSettings();
+		var working = SettingsWorkingCopy.Clone(live);
+		var promptTheUiIsBoundTo = live.LlmSettings!.Prompts[0];
+
+		SettingsWorkingCopy.CommitInto(live, working);
+		promptTheUiIsBoundTo.Content = "edited after save";
+
+		Assert.Equal("edited after save", live.LlmSettings.Prompts[0].Content);
+	}
+
+	[Fact]
+	public void DeletingAPromptAfterASave_ActuallyRemovesIt()
+	{
+		var live = BuildLiveSettings();
+		var working = SettingsWorkingCopy.Clone(live);
+		var promptTheUiIsBoundTo = live.LlmSettings!.Prompts[1];
+
+		SettingsWorkingCopy.CommitInto(live, working);
+
+		Assert.True(live.LlmSettings.Prompts.Remove(promptTheUiIsBoundTo));
+		Assert.Single(live.LlmSettings.Prompts);
+	}
+
+	[Fact]
+	public void CommitInto_AppliesPromptsAddedInTheWorkingCopy()
+	{
+		var live = BuildLiveSettings();
+		var working = SettingsWorkingCopy.Clone(live);
+		working.LlmSettings!.Prompts.Add(new LlmSettings.LlmPrompt { Id = 3, Name = "New" });
+
+		SettingsWorkingCopy.CommitInto(live, working);
+
+		Assert.Equal(3, live.LlmSettings!.Prompts.Count);
+		Assert.Equal("New", live.LlmSettings.Prompts[2].Name);
+	}
+
+	[Fact]
+	public void CommitInto_AppliesPromptsRemovedInTheWorkingCopy()
+	{
+		var live = BuildLiveSettings();
+		var working = SettingsWorkingCopy.Clone(live);
+		working.LlmSettings!.Prompts.RemoveAt(1);
+
+		SettingsWorkingCopy.CommitInto(live, working);
+
+		Assert.Single(live.LlmSettings!.Prompts);
+		Assert.Equal("Tidy", live.LlmSettings.Prompts[0].Name);
+	}
+
+	[Fact]
+	public void CommitInto_AppliesPromptContentChanges()
+	{
+		var live = BuildLiveSettings();
+		var working = SettingsWorkingCopy.Clone(live);
+		working.LlmSettings!.Prompts[0].Content = "changed in settings";
+
+		SettingsWorkingCopy.CommitInto(live, working);
+
+		Assert.Equal("changed in settings", live.LlmSettings!.Prompts[0].Content);
+	}
+
+	[Fact]
+	public void CommitInto_KeepsSubObjectAndListInstances()
+	{
+		var live = BuildLiveSettings();
+		var audio = live.AudioSettings!;
+		var tts = live.TextToSpeechSettings!;
+		var rules = live.TranscriptFormatRules;
+		var models = live.LlmSettings!.Models;
+		var working = SettingsWorkingCopy.Clone(live);
+
+		SettingsWorkingCopy.CommitInto(live, working);
+
+		Assert.Same(audio, live.AudioSettings);
+		Assert.Same(tts, live.TextToSpeechSettings);
+		Assert.Same(rules, live.TranscriptFormatRules);
+		Assert.Same(models, live.LlmSettings.Models);
+	}
+
+	// --- The drift guard: every settable property must round-trip -------------------
+
+	[Fact]
+	public void CommitInto_TransfersEverySettableProperty()
+	{
+		var live = BuildLiveSettings();
+		var working = SettingsWorkingCopy.Clone(live);
+
+		var mutated = new List<string>();
+		MutateEveryValueProperty(working, "Settings", mutated);
+		Assert.True(mutated.Count > 50, $"Expected the settings graph to expose many properties, saw {mutated.Count}.");
+
+		SettingsWorkingCopy.CommitInto(live, working);
+
+		var mismatches = new List<string>();
+		CompareEveryValueProperty(live, working, "Settings", mismatches);
+		Assert.True(mismatches.Count == 0,
+			"CommitInto dropped: " + string.Join(", ", mismatches));
+	}
+
+	// Walks the graph and gives every simple property a value distinct from its current
+	// one, so a property CommitInto forgets shows up as a mismatch afterwards.
+	private static void MutateEveryValueProperty(object target, string path, List<string> mutated)
+	{
+		foreach (var property in target.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance))
+		{
+			if (property.GetIndexParameters().Length > 0 || !property.CanRead)
+				continue;
+
+			object? value = property.GetValue(target);
+			string childPath = $"{path}.{property.Name}";
+
+			if (value is IList list)
+			{
+				foreach (var item in list)
+				{
+					if (item is not null && !IsSimple(item.GetType()))
+						MutateEveryValueProperty(item, childPath, mutated);
+				}
+				continue;
+			}
+
+			if (value is not null && !IsSimple(property.PropertyType))
+			{
+				MutateEveryValueProperty(value, childPath, mutated);
+				continue;
+			}
+
+			if (!property.CanWrite || property.SetMethod is null || !property.SetMethod.IsPublic)
+				continue;
+
+			object? mutatedValue = NextValue(property.PropertyType, value);
+			if (mutatedValue is null && value is null)
+				continue;
+
+			property.SetValue(target, mutatedValue);
+			mutated.Add(childPath);
+		}
+	}
+
+	private static void CompareEveryValueProperty(object actual, object expected, string path, List<string> mismatches)
+	{
+		foreach (var property in expected.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance))
+		{
+			if (property.GetIndexParameters().Length > 0 || !property.CanRead)
+				continue;
+
+			object? expectedValue = property.GetValue(expected);
+			object? actualValue = property.GetValue(actual);
+			string childPath = $"{path}.{property.Name}";
+
+			if (expectedValue is IList expectedList)
+			{
+				if (actualValue is not IList actualList || actualList.Count != expectedList.Count)
+				{
+					mismatches.Add(childPath);
+					continue;
+				}
+				for (int i = 0; i < expectedList.Count; i++)
+				{
+					var expectedItem = expectedList[i];
+					var actualItem = actualList[i];
+					if (expectedItem is null || IsSimple(expectedItem.GetType()))
+					{
+						if (!Equals(expectedItem, actualItem))
+							mismatches.Add($"{childPath}[{i}]");
+						continue;
+					}
+					if (actualItem is null)
+					{
+						mismatches.Add($"{childPath}[{i}]");
+						continue;
+					}
+					CompareEveryValueProperty(actualItem, expectedItem, $"{childPath}[{i}]", mismatches);
+				}
+				continue;
+			}
+
+			if (expectedValue is not null && !IsSimple(property.PropertyType))
+			{
+				if (actualValue is null)
+					mismatches.Add(childPath);
+				else
+					CompareEveryValueProperty(actualValue, expectedValue, childPath, mismatches);
+				continue;
+			}
+
+			if (!Equals(expectedValue, actualValue))
+				mismatches.Add(childPath);
+		}
+	}
+
+	private static bool IsSimple(Type type)
+	{
+		var underlying = Nullable.GetUnderlyingType(type) ?? type;
+		return underlying.IsValueType || underlying == typeof(string) || underlying.IsArray;
+	}
+
+	private static object? NextValue(Type type, object? current)
+	{
+		var underlying = Nullable.GetUnderlyingType(type) ?? type;
+
+		if (underlying == typeof(bool))
+			return !(current as bool? ?? false);
+		if (underlying == typeof(string))
+			return (current as string) + "-committed";
+		if (underlying == typeof(int))
+			return (current as int? ?? 0) + 7;
+		if (underlying == typeof(long))
+			return (current as long? ?? 0L) + 11L;
+		if (underlying == typeof(double))
+			return (current as double? ?? 0d) + 1.5d;
+		if (underlying == typeof(decimal))
+			return (current as decimal? ?? 0m) + 3m;
+		if (underlying.IsEnum)
+		{
+			var values = Enum.GetValues(underlying);
+			foreach (var candidate in values)
+			{
+				if (!Equals(candidate, current))
+					return candidate;
+			}
+			return current;
+		}
+		// Structs without a natural "next" (Point, Size) and arrays are left alone;
+		// the comparison pass still checks that they were carried over unchanged.
+		return current;
+	}
+}

--- a/Mutation.Tests/SettingsWorkingCopyCommitTests.cs
+++ b/Mutation.Tests/SettingsWorkingCopyCommitTests.cs
@@ -28,6 +28,25 @@ public class SettingsWorkingCopyCommitTests
 		settings.LlmSettings.Prompts.Add(new LlmSettings.LlmPrompt { Id = 2, Name = "Summarise", Content = "summarise this" });
 		settings.LlmSettings.Models.Add(new LlmModelConfig { Name = "gpt-4.1" });
 		settings.TranscriptFormatRules.Add(new TranscriptFormatRule("a", "b", false, TranscriptFormatRule.MatchTypeEnum.Plain));
+
+		// Every branch of the committer needs a populated example, or a dropped property
+		// compares empty-to-empty and the drift guard waves it through: an array-valued
+		// section, a list of objects behind a constructor-only type, and non-default
+		// struct values.
+		settings.SpeechToTextSettings.Services =
+		[
+			new SpeechToTextServiceSettings
+			{
+				Name = "Whisper",
+				Provider = SpeechToTextProviders.OpenAi,
+				ApiKey = "sk-fixture",
+				BaseDomain = "api.openai.com",
+				ModelId = "whisper-1",
+			},
+		];
+		settings.HotKeyRouterSettings.Mappings.Add(new HotKeyRouterSettings.HotKeyRouterMap("CTRL+1", "CTRL+2"));
+		settings.MainWindowUiSettings.WindowLocation = new System.Drawing.Point(120, 240);
+		settings.MainWindowUiSettings.WindowSize = new System.Drawing.Size(1024, 768);
 		return settings;
 	}
 
@@ -98,6 +117,11 @@ public class SettingsWorkingCopyCommitTests
 		promptTheUiIsBoundTo.Content = "edited after save";
 
 		Assert.Equal("edited after save", live.LlmSettings.Prompts[0].Content);
+
+		// And it has to still be there after the write-and-reload the app does next:
+		// the original bug only showed itself on restart.
+		var reloaded = SettingsWorkingCopy.Clone(live);
+		Assert.Equal("edited after save", reloaded.LlmSettings!.Prompts[0].Content);
 	}
 
 	[Fact]
@@ -178,8 +202,16 @@ public class SettingsWorkingCopyCommitTests
 		var working = SettingsWorkingCopy.Clone(live);
 
 		var mutated = new List<string>();
-		MutateEveryValueProperty(working, "Settings", mutated);
+		var skipped = new List<string>();
+		MutateEveryValueProperty(working, "Settings", mutated, skipped);
 		Assert.True(mutated.Count > 50, $"Expected the settings graph to expose many properties, saw {mutated.Count}.");
+
+		// A property the mutator cannot give a distinct value to is invisible to the
+		// comparison below — both sides would already be equal — so it would sail
+		// through even if CommitInto dropped it. Fail loudly instead of silently
+		// shrinking the guard as the settings model grows.
+		Assert.True(skipped.Count == 0,
+			"The drift guard could not mutate, and therefore does not cover: " + string.Join(", ", skipped));
 
 		SettingsWorkingCopy.CommitInto(live, working);
 
@@ -190,8 +222,10 @@ public class SettingsWorkingCopyCommitTests
 	}
 
 	// Walks the graph and gives every simple property a value distinct from its current
-	// one, so a property CommitInto forgets shows up as a mismatch afterwards.
-	private static void MutateEveryValueProperty(object target, string path, List<string> mutated)
+	// one, so a property CommitInto forgets shows up as a mismatch afterwards. Anything
+	// it cannot give a distinct value to is reported in <paramref name="skipped"/>,
+	// because such a property is outside the guard's reach.
+	private static void MutateEveryValueProperty(object target, string path, List<string> mutated, List<string> skipped)
 	{
 		foreach (var property in target.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance))
 		{
@@ -201,28 +235,42 @@ public class SettingsWorkingCopyCommitTests
 			object? value = property.GetValue(target);
 			string childPath = $"{path}.{property.Name}";
 
+			// Arrays are IList too, so this covers both the list and array branches of
+			// the committer.
 			if (value is IList list)
 			{
+				if (list.Count == 0)
+					skipped.Add($"{childPath} (empty collection)");
 				foreach (var item in list)
 				{
 					if (item is not null && !IsSimple(item.GetType()))
-						MutateEveryValueProperty(item, childPath, mutated);
+						MutateEveryValueProperty(item, childPath, mutated, skipped);
 				}
 				continue;
 			}
 
 			if (value is not null && !IsSimple(property.PropertyType))
 			{
-				MutateEveryValueProperty(value, childPath, mutated);
+				MutateEveryValueProperty(value, childPath, mutated, skipped);
 				continue;
 			}
 
 			if (!property.CanWrite || property.SetMethod is null || !property.SetMethod.IsPublic)
 				continue;
 
-			object? mutatedValue = NextValue(property.PropertyType, value);
-			if (mutatedValue is null && value is null)
+			if (value is null && !IsSimple(property.PropertyType))
+			{
+				// A null sub-object has nothing to compare, so nothing is guarded.
+				skipped.Add($"{childPath} (null)");
 				continue;
+			}
+
+			object? mutatedValue = NextValue(property.PropertyType, value);
+			if (Equals(mutatedValue, value))
+			{
+				skipped.Add($"{childPath} ({property.PropertyType.Name})");
+				continue;
+			}
 
 			property.SetValue(target, mutatedValue);
 			mutated.Add(childPath);
@@ -303,18 +351,27 @@ public class SettingsWorkingCopyCommitTests
 			return (current as double? ?? 0d) + 1.5d;
 		if (underlying == typeof(decimal))
 			return (current as decimal? ?? 0m) + 3m;
+		if (underlying == typeof(System.Drawing.Point))
+		{
+			var point = (System.Drawing.Point)(current ?? new System.Drawing.Point());
+			return new System.Drawing.Point(point.X + 3, point.Y + 5);
+		}
+		if (underlying == typeof(System.Drawing.Size))
+		{
+			var size = (System.Drawing.Size)(current ?? new System.Drawing.Size());
+			return new System.Drawing.Size(size.Width + 3, size.Height + 5);
+		}
 		if (underlying.IsEnum)
 		{
-			var values = Enum.GetValues(underlying);
-			foreach (var candidate in values)
+			foreach (var candidate in Enum.GetValues(underlying))
 			{
 				if (!Equals(candidate, current))
 					return candidate;
 			}
 			return current;
 		}
-		// Structs without a natural "next" (Point, Size) and arrays are left alone;
-		// the comparison pass still checks that they were carried over unchanged.
+		// Unchanged: the caller reports this property as outside the guard's reach
+		// rather than counting it as covered.
 		return current;
 	}
 }

--- a/Mutation.Ui/Core/HotkeyAccessibleText.cs
+++ b/Mutation.Ui/Core/HotkeyAccessibleText.cs
@@ -1,0 +1,22 @@
+namespace Mutation.Ui.Core;
+
+/// <summary>
+/// Builds the accessible name and tooltip for a hotkey-bound button.
+///
+/// The name is always composed from the label the caller passes for the button's
+/// *current* state. An earlier version cached the first name it ever saw and rebuilt
+/// from that cache, so a button whose state changed — Mute to Unmute, Record to Stop —
+/// kept announcing its startup name while the glyph and tooltip updated correctly
+/// (issue #214). Only the screen reader saw the stale value.
+/// </summary>
+internal static class HotkeyAccessibleText
+{
+	public static string ComposeName(string label, string? hotkey) =>
+		string.IsNullOrWhiteSpace(hotkey) ? label : $"{label}, {hotkey}";
+
+	public static string ComposeTooltip(string tooltip, string? hotkey) =>
+		string.IsNullOrWhiteSpace(hotkey) ? tooltip : $"{tooltip} (Hotkey: {hotkey})";
+
+	public static string ComposeHotkeyText(string? hotkey) =>
+		string.IsNullOrWhiteSpace(hotkey) ? string.Empty : $"Hotkey: {hotkey}";
+}

--- a/Mutation.Ui/Core/HotkeyButtonLabelCache.cs
+++ b/Mutation.Ui/Core/HotkeyButtonLabelCache.cs
@@ -1,0 +1,51 @@
+using System.Collections.Generic;
+
+namespace Mutation.Ui.Core;
+
+/// <summary>
+/// Remembers the accessible label each hotkey button currently carries, without the
+/// hotkey suffix.
+///
+/// This is the part that was broken in issue #214. The old cache stored the first name
+/// it ever read back off the button and re-derived from that value forever, so a
+/// hotkey-only refresh resurrected the button's startup name and undid whatever the
+/// last state transition had set — the mic button announced "Mute microphone" while
+/// muted, and the Stop button announced "Record". State transitions now push their
+/// label in here, and refreshes read the current one back.
+///
+/// Keyed on <see cref="object"/> by reference so it is exercisable without a XAML tree.
+/// </summary>
+internal sealed class HotkeyButtonLabelCache
+{
+	private readonly Dictionary<object, string> _labels = new(ReferenceEqualityComparer.Instance);
+
+	/// <param name="stateLabel">
+	/// The label for the button's current state, from a caller that knows the state.
+	/// Null or blank means "this is a hotkey-only refresh": keep the label the button
+	/// already has.
+	/// </param>
+	/// <param name="nameFromMarkup">The button's declared name, used only to seed the cache.</param>
+	/// <param name="fallback">Used when the markup carries no name either.</param>
+	public string Resolve(object button, string? nameFromMarkup, string fallback, string? stateLabel)
+	{
+		if (!string.IsNullOrWhiteSpace(stateLabel))
+		{
+			_labels[button] = stateLabel;
+			return stateLabel;
+		}
+
+		if (_labels.TryGetValue(button, out var known))
+			return known;
+
+		// First sight of this button: its declared name is still the bare label.
+		string seed = string.IsNullOrWhiteSpace(nameFromMarkup) ? fallback : nameFromMarkup;
+		_labels[button] = seed;
+		return seed;
+	}
+
+	/// <summary>
+	/// Records a state label for a button whose hotkey affordances are not being
+	/// touched, so a later refresh does not undo it.
+	/// </summary>
+	public void Set(object button, string label) => _labels[button] = label;
+}

--- a/Mutation.Ui/Core/KeyboardRegionSelector.cs
+++ b/Mutation.Ui/Core/KeyboardRegionSelector.cs
@@ -1,0 +1,243 @@
+using System;
+
+namespace Mutation.Ui.Core;
+
+/// <summary>
+/// What a keystroke did to the keyboard-driven region selection, so the caller knows
+/// what to redraw and what to announce.
+/// </summary>
+internal enum RegionKeyOutcome
+{
+	/// <summary>The key means nothing here; let it bubble.</summary>
+	Ignored,
+
+	/// <summary>The caret or the in-progress selection moved.</summary>
+	Moved,
+
+	/// <summary>The first corner was pinned; the caret now drags the opposite corner.</summary>
+	AnchorSet,
+
+	/// <summary>The whole screen was selected, ready to capture.</summary>
+	SelectedWholeScreen,
+
+	/// <summary>The selection is final and the capture should run.</summary>
+	Committed,
+
+	/// <summary>Selection was abandoned before an anchor was set.</summary>
+	AnchorCleared,
+
+	/// <summary>The key was understood but could not be honoured; say why.</summary>
+	Rejected,
+}
+
+internal readonly record struct RegionKeyResult(RegionKeyOutcome Outcome, string Announcement)
+{
+	public static readonly RegionKeyResult Ignored = new(RegionKeyOutcome.Ignored, string.Empty);
+}
+
+/// <summary>
+/// The keyboard half of the screenshot region overlay.
+///
+/// The overlay used to be pointer-only, which left four of the app's core hotkeys
+/// (screenshot, screenshot+OCR, and both reading-order variants) with no completable
+/// path for a user who cannot see the crosshair — Escape was the only key it handled
+/// (issue #215).
+///
+/// The model is a caret plus an optional anchor. Arrow keys move the caret; the first
+/// Enter/Space pins the anchor; the second commits the rectangle between them. Ctrl+A
+/// selects the whole screen so a capture can always be completed in two keystrokes.
+///
+/// Coordinates are overlay-space DIPs, matching the pointer path, and all state is
+/// plain numbers so the behaviour is testable without a window.
+/// </summary>
+internal sealed class KeyboardRegionSelector
+{
+	public const double FineStep = 1;
+	public const double NormalStep = 10;
+	public const double CoarseStep = 100;
+
+	// Anything smaller crops to nothing once mapped to bitmap pixels.
+	public const double MinimumSelectionSize = 1;
+
+	private double _width;
+	private double _height;
+
+	public double CaretX { get; private set; }
+	public double CaretY { get; private set; }
+
+	public bool HasAnchor { get; private set; }
+	public double AnchorX { get; private set; }
+	public double AnchorY { get; private set; }
+
+	/// <summary>Left edge of the rectangle currently described, in overlay DIPs.</summary>
+	public double SelectionLeft => HasAnchor ? Math.Min(AnchorX, CaretX) : CaretX;
+	public double SelectionTop => HasAnchor ? Math.Min(AnchorY, CaretY) : CaretY;
+	public double SelectionWidth => HasAnchor ? Math.Abs(CaretX - AnchorX) : 0;
+	public double SelectionHeight => HasAnchor ? Math.Abs(CaretY - AnchorY) : 0;
+
+	/// <summary>
+	/// (Re)starts a selection over an overlay of the given size, with the caret at the
+	/// supplied position — normally where the mouse already is, so switching between
+	/// mouse and keyboard mid-selection is not jarring.
+	/// </summary>
+	public void Reset(double width, double height, double caretX, double caretY)
+	{
+		_width = Math.Max(0, width);
+		_height = Math.Max(0, height);
+		HasAnchor = false;
+		AnchorX = 0;
+		AnchorY = 0;
+		CaretX = Clamp(caretX, _width);
+		CaretY = Clamp(caretY, _height);
+	}
+
+	public void Resize(double width, double height)
+	{
+		_width = Math.Max(0, width);
+		_height = Math.Max(0, height);
+		CaretX = Clamp(CaretX, _width);
+		CaretY = Clamp(CaretY, _height);
+		AnchorX = Clamp(AnchorX, _width);
+		AnchorY = Clamp(AnchorY, _height);
+	}
+
+	/// <summary>Moves the caret to where the pointer left it, so the two paths agree.</summary>
+	public void SyncCaret(double x, double y)
+	{
+		CaretX = Clamp(x, _width);
+		CaretY = Clamp(y, _height);
+	}
+
+	public RegionKeyResult HandleKey(RegionSelectionKey key, bool shift, bool control)
+	{
+		switch (key)
+		{
+			case RegionSelectionKey.Left:
+				return Move(-Step(shift, control), 0);
+			case RegionSelectionKey.Right:
+				return Move(Step(shift, control), 0);
+			case RegionSelectionKey.Up:
+				return Move(0, -Step(shift, control));
+			case RegionSelectionKey.Down:
+				return Move(0, Step(shift, control));
+			case RegionSelectionKey.Home:
+				return MoveTo(0, CaretY);
+			case RegionSelectionKey.End:
+				return MoveTo(_width, CaretY);
+			case RegionSelectionKey.PageUp:
+				return MoveTo(CaretX, 0);
+			case RegionSelectionKey.PageDown:
+				return MoveTo(CaretX, _height);
+			case RegionSelectionKey.SelectAll when control:
+				return SelectWholeScreen();
+			case RegionSelectionKey.Commit:
+				return Commit();
+			case RegionSelectionKey.Back:
+				return ClearAnchor();
+			default:
+				return RegionKeyResult.Ignored;
+		}
+	}
+
+	private static double Step(bool shift, bool control)
+	{
+		if (control)
+			return FineStep;
+		if (shift)
+			return CoarseStep;
+		return NormalStep;
+	}
+
+	private RegionKeyResult Move(double dx, double dy) => MoveTo(CaretX + dx, CaretY + dy);
+
+	private RegionKeyResult MoveTo(double x, double y)
+	{
+		CaretX = Clamp(x, _width);
+		CaretY = Clamp(y, _height);
+		return new RegionKeyResult(RegionKeyOutcome.Moved, DescribePosition());
+	}
+
+	private RegionKeyResult SelectWholeScreen()
+	{
+		HasAnchor = true;
+		AnchorX = 0;
+		AnchorY = 0;
+		CaretX = _width;
+		CaretY = _height;
+		return new RegionKeyResult(
+			RegionKeyOutcome.SelectedWholeScreen,
+			$"Whole screen selected, {Describe(_width)} by {Describe(_height)}. Press Enter to capture.");
+	}
+
+	private RegionKeyResult Commit()
+	{
+		if (!HasAnchor)
+		{
+			HasAnchor = true;
+			AnchorX = CaretX;
+			AnchorY = CaretY;
+			return new RegionKeyResult(
+				RegionKeyOutcome.AnchorSet,
+				$"Region corner set at {Describe(CaretX)}, {Describe(CaretY)}. Move with the arrow keys, then press Enter to capture.");
+		}
+
+		// A zero-width or zero-height region is discarded further down the capture
+		// pipeline without a word, which would leave two presses of Enter looking like
+		// the overlay had simply ignored them.
+		if (SelectionWidth < MinimumSelectionSize || SelectionHeight < MinimumSelectionSize)
+		{
+			return new RegionKeyResult(
+				RegionKeyOutcome.Rejected,
+				"Region is empty. Move with the arrow keys to size it, then press Enter to capture.");
+		}
+
+		return new RegionKeyResult(
+			RegionKeyOutcome.Committed,
+			$"Capturing {Describe(SelectionWidth)} by {Describe(SelectionHeight)} region.");
+	}
+
+	private RegionKeyResult ClearAnchor()
+	{
+		if (!HasAnchor)
+			return RegionKeyResult.Ignored;
+
+		HasAnchor = false;
+		AnchorX = 0;
+		AnchorY = 0;
+		return new RegionKeyResult(RegionKeyOutcome.AnchorCleared, "Region corner cleared.");
+	}
+
+	private string DescribePosition() => HasAnchor
+		? $"{Describe(SelectionWidth)} by {Describe(SelectionHeight)}"
+		: $"{Describe(CaretX)}, {Describe(CaretY)}";
+
+	private static string Describe(double value) =>
+		Math.Round(value).ToString(System.Globalization.CultureInfo.CurrentCulture);
+
+	private static double Clamp(double value, double max)
+	{
+		if (double.IsNaN(value))
+			return 0;
+		return Math.Clamp(value, 0, Math.Max(0, max));
+	}
+}
+
+/// <summary>
+/// The keys the overlay acts on, decoupled from <c>VirtualKey</c> so the selection
+/// model stays testable outside a XAML app.
+/// </summary>
+internal enum RegionSelectionKey
+{
+	None,
+	Left,
+	Right,
+	Up,
+	Down,
+	Home,
+	End,
+	PageUp,
+	PageDown,
+	Commit,
+	Back,
+	SelectAll,
+}

--- a/Mutation.Ui/Core/KeyboardRegionSelector.cs
+++ b/Mutation.Ui/Core/KeyboardRegionSelector.cs
@@ -191,9 +191,9 @@ internal sealed class KeyboardRegionSelector
 				"Region is empty. Move with the arrow keys to size it, then press Enter to capture.");
 		}
 
-		return new RegionKeyResult(
-			RegionKeyOutcome.Committed,
-			$"Capturing {Describe(SelectionWidth)} by {Describe(SelectionHeight)} region.");
+		// No announcement: only the caller knows the region's size in bitmap pixels, and
+		// it announces the capture for the mouse path too.
+		return new RegionKeyResult(RegionKeyOutcome.Committed, string.Empty);
 	}
 
 	private RegionKeyResult ClearAnchor()
@@ -207,8 +207,11 @@ internal sealed class KeyboardRegionSelector
 		return new RegionKeyResult(RegionKeyOutcome.AnchorCleared, "Region corner cleared.");
 	}
 
+	// Once a corner is pinned, size alone is not enough: without the origin there is no
+	// way to tell where on the screen the rectangle sits, and no way to recover it short
+	// of clearing the corner and starting again.
 	private string DescribePosition() => HasAnchor
-		? $"{Describe(SelectionWidth)} by {Describe(SelectionHeight)}"
+		? $"{Describe(SelectionWidth)} by {Describe(SelectionHeight)}, from {Describe(SelectionLeft)}, {Describe(SelectionTop)}"
 		: $"{Describe(CaretX)}, {Describe(CaretY)}";
 
 	private static string Describe(double value) =>

--- a/Mutation.Ui/MainWindow.xaml.cs
+++ b/Mutation.Ui/MainWindow.xaml.cs
@@ -1665,8 +1665,7 @@ public sealed partial class MainWindow : Window, IDisposable
 		string labelText = muted ? "Unmute microphone" : "Mute microphone";
 		BtnToggleMicIcon.Glyph = MicOnGlyph;
 		BtnToggleMicSlash.Visibility = muted ? Visibility.Visible : Visibility.Collapsed;
-		AutomationProperties.SetName(BtnToggleMic, labelText);
-		ConfigureButtonHotkey(BtnToggleMic, null, _settings.AudioSettings?.MicrophoneToggleMuteHotKey, labelText);
+		ConfigureButtonHotkey(BtnToggleMic, null, _settings.AudioSettings?.MicrophoneToggleMuteHotKey, labelText, labelText);
 		MicStatusIcon.Glyph = MicOnGlyph;
 		MicStatusIconSlash.Visibility = muted ? Visibility.Visible : Visibility.Collapsed;
 		MicStatusIcon.Foreground = ResolveBrush(muted ? "TextFillColorSecondaryBrush" : "TextFillColorPrimaryBrush");
@@ -1691,37 +1690,33 @@ public sealed partial class MainWindow : Window, IDisposable
 			// Idle state
 			BtnSpeechToTextIcon.Glyph = RecordGlyph;
 			BtnSpeechToText.IsEnabled = true;
-			AutomationProperties.SetName(BtnSpeechToText, "Record");
-			ConfigureButtonHotkey(BtnSpeechToText, null, _settings.SpeechToTextSettings?.SpeechToTextHotKey, "Record");
+			ConfigureButtonHotkey(BtnSpeechToText, null, _settings.SpeechToTextSettings?.SpeechToTextHotKey, "Record", "Record");
 
 			BtnSpeechToTextWithFormatIcon.Glyph = MagicGlyph;
 			BtnSpeechToTextWithFormat.IsEnabled = true;
-			AutomationProperties.SetName(BtnSpeechToTextWithFormat, "Record and Format");
-			ConfigureButtonHotkey(BtnSpeechToTextWithFormat, null, _settings.SpeechToTextSettings?.SpeechToTextWithLlmProcessingHotKey, "Record and Format");
+			ConfigureButtonHotkey(BtnSpeechToTextWithFormat, null, _settings.SpeechToTextSettings?.SpeechToTextWithLlmProcessingHotKey, "Record and Format", "Record and Format");
 		}
 		else if (label == "Stop")
 		{
 			// Recording state
 			BtnSpeechToTextIcon.Glyph = StopGlyph;
 			BtnSpeechToText.IsEnabled = true;
-			AutomationProperties.SetName(BtnSpeechToText, "Stop");
-			ConfigureButtonHotkey(BtnSpeechToText, null, _settings.SpeechToTextSettings?.SpeechToTextHotKey, "Stop");
+			ConfigureButtonHotkey(BtnSpeechToText, null, _settings.SpeechToTextSettings?.SpeechToTextHotKey, "Stop", "Stop");
 
 			BtnSpeechToTextWithFormatIcon.Glyph = StopGlyph;
 			BtnSpeechToTextWithFormat.IsEnabled = true;
-			AutomationProperties.SetName(BtnSpeechToTextWithFormat, "Stop and Format");
-			ConfigureButtonHotkey(BtnSpeechToTextWithFormat, null, _settings.SpeechToTextSettings?.SpeechToTextWithLlmProcessingHotKey, "Stop and Format");
+			ConfigureButtonHotkey(BtnSpeechToTextWithFormat, null, _settings.SpeechToTextSettings?.SpeechToTextWithLlmProcessingHotKey, "Stop and Format", "Stop and Format");
 		}
 		else
 		{
 			// Transcribing / Processing
 			BtnSpeechToTextIcon.Glyph = glyph;
 			BtnSpeechToText.IsEnabled = isEnabled;
-			AutomationProperties.SetName(BtnSpeechToText, label);
+			SetButtonAccessibleLabel(BtnSpeechToText, label);
 
 			BtnSpeechToTextWithFormatIcon.Glyph = glyph;
 			BtnSpeechToTextWithFormat.IsEnabled = isEnabled;
-			AutomationProperties.SetName(BtnSpeechToTextWithFormat, label);
+			SetButtonAccessibleLabel(BtnSpeechToTextWithFormat, label);
 		}
 	}
 
@@ -1903,28 +1898,56 @@ public sealed partial class MainWindow : Window, IDisposable
         });
     }
 
-	private readonly Dictionary<Button, string> _buttonBaseNames = new();
+	// The accessible label each hotkey button currently carries, without the hotkey
+	// suffix. State transitions push the new label in here; hotkey-only refreshes read
+	// it back so they re-compose from the current state rather than resurrecting the
+	// name the button had at startup (issue #214).
+	private readonly Dictionary<Button, string> _buttonAccessibleLabels = new();
 
-	private void ConfigureButtonHotkey(Button button, TextBlock? hotkeyTextBlock, string? hotkey, string baseTooltip)
+	/// <param name="accessibleLabel">
+	/// The button's label in its current state. Pass this from anywhere the button
+	/// changes state; omit it for a hotkey-only refresh, which then keeps whatever
+	/// label the button already has.
+	/// </param>
+	private void ConfigureButtonHotkey(Button button, TextBlock? hotkeyTextBlock, string? hotkey, string baseTooltip, string? accessibleLabel = null)
 	{
-		if (!_buttonBaseNames.TryGetValue(button, out var baseName))
-		{
-			baseName = AutomationProperties.GetName(button);
-			if (string.IsNullOrWhiteSpace(baseName))
-				baseName = baseTooltip;
-			_buttonBaseNames[button] = baseName;
-		}
+		string label = ResolveAccessibleLabel(button, baseTooltip, accessibleLabel);
 
-		string composedName = string.IsNullOrWhiteSpace(hotkey)
-			? baseName
-			: $"{baseName}, {hotkey}";
-		AutomationProperties.SetName(button, composedName);
+		AutomationProperties.SetName(button, HotkeyAccessibleText.ComposeName(label, hotkey));
 
-		string tooltip = ComposeTooltip(baseTooltip, hotkey);
+		string tooltip = HotkeyAccessibleText.ComposeTooltip(baseTooltip, hotkey);
 		ToolTipService.SetToolTip(button, tooltip);
 		AutomationProperties.SetHelpText(button, tooltip);
 		AutomationProperties.SetAcceleratorKey(button, string.IsNullOrWhiteSpace(hotkey) ? string.Empty : hotkey);
 		UpdateHotkeyText(hotkeyTextBlock, hotkey);
+	}
+
+	private string ResolveAccessibleLabel(Button button, string baseTooltip, string? accessibleLabel)
+	{
+		if (!string.IsNullOrWhiteSpace(accessibleLabel))
+		{
+			_buttonAccessibleLabels[button] = accessibleLabel;
+			return accessibleLabel;
+		}
+
+		if (_buttonAccessibleLabels.TryGetValue(button, out var known))
+			return known;
+
+		// First sight of this button: its XAML name is still the bare label.
+		var fromXaml = AutomationProperties.GetName(button);
+		if (string.IsNullOrWhiteSpace(fromXaml))
+			fromXaml = baseTooltip;
+		_buttonAccessibleLabels[button] = fromXaml;
+		return fromXaml;
+	}
+
+	// Sets a state label on a button whose hotkey affordances are not being touched
+	// (e.g. the disabled "Transcribing…" state), keeping the label cache in step so a
+	// later hotkey refresh does not undo it.
+	private void SetButtonAccessibleLabel(Button button, string label)
+	{
+		_buttonAccessibleLabels[button] = label;
+		AutomationProperties.SetName(button, label);
 	}
 
 	private static void UpdateHotkeyText(TextBlock? hotkeyTextBlock, string? hotkey)
@@ -1938,13 +1961,10 @@ public sealed partial class MainWindow : Window, IDisposable
 		}
 		else
 		{
-			hotkeyTextBlock.Text = $"Hotkey: {hotkey}";
+			hotkeyTextBlock.Text = HotkeyAccessibleText.ComposeHotkeyText(hotkey);
 			hotkeyTextBlock.Visibility = Visibility.Visible;
 		}
 	}
-
-        private static string ComposeTooltip(string baseTooltip, string? hotkey) =>
-                          string.IsNullOrWhiteSpace(hotkey) ? baseTooltip : $"{baseTooltip} (Hotkey: {hotkey})";
 
 
 
@@ -2380,6 +2400,17 @@ public sealed partial class MainWindow : Window, IDisposable
 		catch (Exception ex)
 		{
 			System.Diagnostics.Debug.WriteLine($"ApplyLiveSettings (tts) failed: {ex.Message}");
+		}
+
+		try
+		{
+			// A save rewrites the prompts in place; the ListView needs re-pointing at
+			// them or it keeps rendering pre-save content (issue #219).
+			_promptLibrary?.RebindPromptList();
+		}
+		catch (Exception ex)
+		{
+			System.Diagnostics.Debug.WriteLine($"ApplyLiveSettings (prompts) failed: {ex.Message}");
 		}
 
 		var hotkeyFailures = new List<HotkeyManager.HotkeyBindingFailure>();

--- a/Mutation.Ui/MainWindow.xaml.cs
+++ b/Mutation.Ui/MainWindow.xaml.cs
@@ -364,7 +364,15 @@ public sealed partial class MainWindow : Window, IDisposable
 		if (!string.IsNullOrWhiteSpace(ocr?.ScreenshotHotKey))
 			TryRegister(hk, failures, "Screenshot to clipboard", ocr.ScreenshotHotKey!, async () =>
 			{
-				try { await _ocrManager.TakeScreenshotToClipboardAsync(); }
+				// The hotkey path announced nothing at all, leaving only a beep to
+				// distinguish a captured region from a cancelled one.
+				try
+				{
+					if (await _ocrManager.TakeScreenshotToClipboardAsync())
+						ShowStatus("Screenshot", "Screenshot copied to the clipboard.", InfoBarSeverity.Success);
+					else
+						ShowStatus("Screenshot", "Screenshot cancelled. Nothing was copied to the clipboard.", InfoBarSeverity.Informational);
+				}
 				catch (Exception ex) { await ShowErrorDialog("Screenshot Error", ex); }
 			});
 
@@ -617,8 +625,11 @@ public sealed partial class MainWindow : Window, IDisposable
 	{
 		try
 		{
-			await _ocrManager.TakeScreenshotToClipboardAsync();
-			ShowStatus("Screenshot", "Screenshot copied to the clipboard.", InfoBarSeverity.Success);
+			// Cancelling the region overlay used to be announced as a success.
+			if (await _ocrManager.TakeScreenshotToClipboardAsync())
+				ShowStatus("Screenshot", "Screenshot copied to the clipboard.", InfoBarSeverity.Success);
+			else
+				ShowStatus("Screenshot", "Screenshot cancelled. Nothing was copied to the clipboard.", InfoBarSeverity.Informational);
 		}
 		catch (Exception ex)
 		{
@@ -1901,11 +1912,10 @@ public sealed partial class MainWindow : Window, IDisposable
         });
     }
 
-	// The accessible label each hotkey button currently carries, without the hotkey
-	// suffix. State transitions push the new label in here; hotkey-only refreshes read
-	// it back so they re-compose from the current state rather than resurrecting the
-	// name the button had at startup (issue #214).
-	private readonly Dictionary<Button, string> _buttonAccessibleLabels = new();
+	// State transitions push their label into this cache; hotkey-only refreshes read it
+	// back, so they re-compose from the current state rather than resurrecting the name
+	// the button had at startup (issue #214).
+	private readonly HotkeyButtonLabelCache _buttonAccessibleLabels = new();
 
 	/// <param name="accessibleLabel">
 	/// The button's label in its current state. Pass this from anywhere the button
@@ -1925,31 +1935,15 @@ public sealed partial class MainWindow : Window, IDisposable
 		UpdateHotkeyText(hotkeyTextBlock, hotkey);
 	}
 
-	private string ResolveAccessibleLabel(Button button, string baseTooltip, string? accessibleLabel)
-	{
-		if (!string.IsNullOrWhiteSpace(accessibleLabel))
-		{
-			_buttonAccessibleLabels[button] = accessibleLabel;
-			return accessibleLabel;
-		}
-
-		if (_buttonAccessibleLabels.TryGetValue(button, out var known))
-			return known;
-
-		// First sight of this button: its XAML name is still the bare label.
-		var fromXaml = AutomationProperties.GetName(button);
-		if (string.IsNullOrWhiteSpace(fromXaml))
-			fromXaml = baseTooltip;
-		_buttonAccessibleLabels[button] = fromXaml;
-		return fromXaml;
-	}
+	private string ResolveAccessibleLabel(Button button, string baseTooltip, string? accessibleLabel) =>
+		_buttonAccessibleLabels.Resolve(button, AutomationProperties.GetName(button), baseTooltip, accessibleLabel);
 
 	// Sets a state label on a button whose hotkey affordances are not being touched
 	// (e.g. the disabled "Transcribing…" state), keeping the label cache in step so a
 	// later hotkey refresh does not undo it.
 	private void SetButtonAccessibleLabel(Button button, string label)
 	{
-		_buttonAccessibleLabels[button] = label;
+		_buttonAccessibleLabels.Set(button, label);
 		AutomationProperties.SetName(button, label);
 	}
 

--- a/Mutation.Ui/MainWindow.xaml.cs
+++ b/Mutation.Ui/MainWindow.xaml.cs
@@ -531,6 +531,9 @@ public sealed partial class MainWindow : Window, IDisposable
 	{
 		ConfigureButtonHotkey(BtnToggleMic, null, _settings.AudioSettings?.MicrophoneToggleMuteHotKey, "Toggle microphone mute state");
 		ConfigureButtonHotkey(BtnSpeechToText, null, _settings.SpeechToTextSettings?.SpeechToTextHotKey, "Start or stop speech capture");
+		// Omitting this one left the button announcing the previous accelerator until the
+		// next record/stop transition, every time its hotkey was changed in Settings.
+		ConfigureButtonHotkey(BtnSpeechToTextWithFormat, null, _settings.SpeechToTextSettings?.SpeechToTextWithLlmProcessingHotKey, "Start or stop speech capture, then process the transcript with the LLM");
 		ConfigureButtonHotkey(BtnScreenshot, BtnScreenshotHotkey, _settings.AzureComputerVisionSettings?.ScreenshotHotKey, "Copy a screenshot directly to the clipboard");
 		ConfigureButtonHotkey(BtnOcrClipboard, BtnOcrClipboardHotkey, _settings.AzureComputerVisionSettings?.OcrHotKey, "Run OCR on an image stored in the clipboard");
 		ConfigureButtonHotkey(BtnOcrClipboardLrtb, BtnOcrClipboardLrtbHotkey, _settings.AzureComputerVisionSettings?.OcrLeftToRightTopToBottomHotKey, "Run OCR on an image stored in the clipboard using left-to-right reading order");

--- a/Mutation.Ui/Services/OcrManager.cs
+++ b/Mutation.Ui/Services/OcrManager.cs
@@ -60,12 +60,18 @@ public class OcrManager
         try { _cachedOverlay = new RegionSelectionWindow(); _cachedOverlay.PrepareWindowForReuse(); } catch { _cachedOverlay = null; }
     }
 
-    public async Task TakeScreenshotToClipboardAsync()
+    /// <summary>
+    /// Returns true when an image reached the clipboard; false when the user cancelled
+    /// the region overlay or no region was selected. Callers must not announce success
+    /// unconditionally — for a blind user, "Screenshot copied to the clipboard" after a
+    /// cancelled capture is worse than silence.
+    /// </summary>
+    public async Task<bool> TakeScreenshotToClipboardAsync()
     {
         if (Interlocked.CompareExchange(ref _captureInFlight, 1, 0) != 0)
         {
             try { _activeOverlay?.BringToFront(); } catch { }
-            return;
+            return false;
         }
         try
         {
@@ -74,11 +80,11 @@ public class OcrManager
             {
                 await _clipboard.SetImageAsync(bitmap);
                 await PlayBeepSafeAsync(BeepType.Success);
+                return true;
             }
-            else
-            {
-                await PlayBeepSafeAsync(BeepType.Failure);
-            }
+
+            await PlayBeepSafeAsync(BeepType.Failure);
+            return false;
         }
         finally
         {

--- a/Mutation.Ui/Services/PromptLibraryController.cs
+++ b/Mutation.Ui/Services/PromptLibraryController.cs
@@ -36,8 +36,22 @@ internal sealed class PromptLibraryController
 
 	public void Initialize()
 	{
-		if (_settings.LlmSettings != null)
-			_promptListView.ItemsSource = _settings.LlmSettings.Prompts;
+		RebindPromptList();
+	}
+
+	/// <summary>
+	/// Re-points the ListView at the current prompt collection. Needed after a Settings
+	/// save, which rewrites the prompts in place: a plain List raises no change
+	/// notifications, so the rows would otherwise keep rendering pre-save content
+	/// (issue #219).
+	/// </summary>
+	public void RebindPromptList()
+	{
+		if (_settings.LlmSettings == null)
+			return;
+
+		_promptListView.ItemsSource = null;
+		_promptListView.ItemsSource = _settings.LlmSettings.Prompts;
 	}
 
 	public IReadOnlyList<HotkeyManager.HotkeyBindingFailure> AttachHotkeyManager(HotkeyManager hotkeyManager)
@@ -133,8 +147,7 @@ internal sealed class PromptLibraryController
 
 		_settingsManager.SaveSettingsToFile(_settings);
 
-		_promptListView.ItemsSource = null;
-		_promptListView.ItemsSource = _settings.LlmSettings.Prompts;
+		RebindPromptList();
 
 		if (_hotkeyManager is null)
 			return;

--- a/Mutation.Ui/Views/RegionSelectionWindow.xaml
+++ b/Mutation.Ui/Views/RegionSelectionWindow.xaml
@@ -7,7 +7,9 @@
     mc:Ignorable="d"
     Title="Select Region">
     <Grid Background="Transparent" UseLayoutRounding="True">
-        <Image x:Name="Img" Stretch="Fill">
+        <Image x:Name="Img" Stretch="Fill"
+            AutomationProperties.AccessibilityView="Raw"
+            AutomationProperties.Name="Screen capture preview">
             <Image.CacheMode>
                 <BitmapCache />
             </Image.CacheMode>
@@ -15,6 +17,8 @@
 
         <Canvas x:Name="Overlay" Background="Transparent"
             IsTabStop="True"
+            AutomationProperties.Name="Select screen region"
+            AutomationProperties.HelpText="Move with the arrow keys. Press Enter to set the first corner, move, then Enter again to capture. Control plus A selects the whole screen. Backspace clears the corner. Escape cancels. Hold Control for fine steps or Shift for large steps."
             PointerPressed="Overlay_PointerPressed"
             PointerMoved="Overlay_PointerMoved"
             PointerReleased="Overlay_PointerReleased"

--- a/Mutation.Ui/Views/RegionSelectionWindow.xaml.cs
+++ b/Mutation.Ui/Views/RegionSelectionWindow.xaml.cs
@@ -1,9 +1,11 @@
 ﻿using Microsoft.UI.Dispatching;
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation.Peers;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media.Imaging;
+using Mutation.Ui.Core;
 using System;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
@@ -26,6 +28,11 @@ public sealed partial class RegionSelectionWindow : Window
 	private bool _initialLayoutDone;
 	private IntPtr _previousForeground;
 	private readonly DispatcherQueue? _dispatcherQueue;
+
+	// Keyboard path for the overlay, so the four screenshot/OCR hotkeys are completable
+	// without sight of the crosshair (issue #215).
+	private readonly KeyboardRegionSelector _keyboard = new();
+	private const string AnnouncementActivityId = "RegionSelection";
 
 	// Cache XAML elements to avoid reliance on generated fields
 	private Microsoft.UI.Xaml.Controls.Image? _img;
@@ -228,6 +235,12 @@ public sealed partial class RegionSelectionWindow : Window
 		int width = GetSystemMetrics(SM_CXVIRTUALSCREEN);
 		int height = GetSystemMetrics(SM_CYVIRTUALSCREEN);
 		SetWindowPos(_hwnd, HWND_TOPMOST, left, top, width, height, SWP_NOMOVE | SWP_NOSIZE);
+		ResetKeyboardSelection();
+		// The overlay is full-screen and topmost: without this the reader just lands on
+		// an unnamed canvas with no hint that anything is expected of it (issue #215).
+		Announce(
+			"Select screen region. Move with the arrow keys, press Enter to set the first corner, move, then Enter again to capture. Control plus A selects the whole screen. Escape cancels.",
+			AutomationNotificationKind.Other);
 		return _tcs.Task;
 	}
 
@@ -241,6 +254,7 @@ public sealed partial class RegionSelectionWindow : Window
 		{
 			_dragging = false;
 			_tcs?.TrySetResult(null);
+			Announce("Region selection cancelled.", AutomationNotificationKind.ActionAborted);
 			ResetSelection();
 			HideAndRestore();
 			return;
@@ -253,6 +267,8 @@ public sealed partial class RegionSelectionWindow : Window
 		_start = pp.Position;
 		_dragging = true;
 		_lastPointerPos = _start;
+		// A mouse drag supersedes any half-finished keyboard selection.
+		_keyboard.Reset(_overlay.ActualWidth, _overlay.ActualHeight, _start.X, _start.Y);
 		// Capture the pointer so we still get the release even if cursor leaves the window/screen edge
 		try { _overlay.CapturePointer(e.Pointer); } catch { }
 		if (_selection is not null)
@@ -273,6 +289,9 @@ public sealed partial class RegionSelectionWindow : Window
 		var pos = e.GetCurrentPoint(_overlay).Position;
 		_lastPointerPos = pos;
 		UpdateCrosshair(pos);
+		// Keep the keyboard caret under the pointer so switching to the keys mid-drag
+		// picks up where the mouse left off.
+		_keyboard.SyncCaret(pos.X, pos.Y);
 		if (!_dragging) { return; }
 		double x = Math.Min(pos.X, _start.X);
 		double y = Math.Min(pos.Y, _start.Y);
@@ -297,6 +316,7 @@ public sealed partial class RegionSelectionWindow : Window
 		{
 			_dragging = false;
 			_tcs?.TrySetResult(null);
+			Announce("Region selection cancelled.", AutomationNotificationKind.ActionAborted);
 			ResetSelection();
 			HideAndRestore();
 			return;
@@ -354,6 +374,9 @@ public sealed partial class RegionSelectionWindow : Window
 			Math.Max(0, x2 - x1),
 			Math.Max(0, y2 - y1)
 		);
+		Announce(
+			$"Region captured, {Math.Round(rectPx.Width)} by {Math.Round(rectPx.Height)} pixels.",
+			AutomationNotificationKind.ActionCompleted);
 		_tcs?.TrySetResult(rectPx);
 		ResetSelection();
 		HideAndRestore();
@@ -395,7 +418,155 @@ public sealed partial class RegionSelectionWindow : Window
 		{
 			_dragging = false;
 			_tcs?.TrySetResult(null);
+			Announce("Region selection cancelled.", AutomationNotificationKind.ActionAborted);
 			HideAndRestore();
+			e.Handled = true;
+			return;
+		}
+
+		var key = MapKey(e.Key);
+		if (key == RegionSelectionKey.None)
+			return;
+
+		bool shift = IsModifierDown(Windows.System.VirtualKey.Shift);
+		bool control = IsModifierDown(Windows.System.VirtualKey.Control);
+
+		var result = _keyboard.HandleKey(key, shift, control);
+		if (result.Outcome == RegionKeyOutcome.Ignored)
+			return;
+
+		e.Handled = true;
+
+		if (result.Outcome == RegionKeyOutcome.Committed)
+		{
+			// FinishSelection announces the commit, for the mouse path too.
+			CommitKeyboardSelection();
+			return;
+		}
+
+		RenderKeyboardSelection();
+		Announce(result.Announcement, AutomationNotificationKind.Other);
+	}
+
+	private static RegionSelectionKey MapKey(Windows.System.VirtualKey key) => key switch
+	{
+		Windows.System.VirtualKey.Left => RegionSelectionKey.Left,
+		Windows.System.VirtualKey.Right => RegionSelectionKey.Right,
+		Windows.System.VirtualKey.Up => RegionSelectionKey.Up,
+		Windows.System.VirtualKey.Down => RegionSelectionKey.Down,
+		Windows.System.VirtualKey.Home => RegionSelectionKey.Home,
+		Windows.System.VirtualKey.End => RegionSelectionKey.End,
+		Windows.System.VirtualKey.PageUp => RegionSelectionKey.PageUp,
+		Windows.System.VirtualKey.PageDown => RegionSelectionKey.PageDown,
+		Windows.System.VirtualKey.Enter => RegionSelectionKey.Commit,
+		Windows.System.VirtualKey.Space => RegionSelectionKey.Commit,
+		Windows.System.VirtualKey.Back => RegionSelectionKey.Back,
+		Windows.System.VirtualKey.A => RegionSelectionKey.SelectAll,
+		_ => RegionSelectionKey.None
+	};
+
+	private static bool IsModifierDown(Windows.System.VirtualKey key)
+	{
+		try
+		{
+			var state = Microsoft.UI.Input.InputKeyboardSource.GetKeyStateForCurrentThread(key);
+			return (state & Windows.UI.Core.CoreVirtualKeyStates.Down) == Windows.UI.Core.CoreVirtualKeyStates.Down;
+		}
+		catch
+		{
+			return false;
+		}
+	}
+
+	// Mirrors the keyboard model onto the same rectangle and crosshair the mouse path
+	// draws, so the overlay stays usable with either input and readable over someone's
+	// shoulder.
+	private void RenderKeyboardSelection()
+	{
+		EnsureElementRefs();
+		UpdateCrosshair(new Point(_keyboard.CaretX, _keyboard.CaretY));
+
+		if (_selection is null)
+			return;
+
+		if (!_keyboard.HasAnchor)
+		{
+			_selection.Visibility = Visibility.Collapsed;
+			return;
+		}
+
+		_selection.Visibility = Visibility.Visible;
+		Canvas.SetLeft(_selection, _keyboard.SelectionLeft);
+		Canvas.SetTop(_selection, _keyboard.SelectionTop);
+		_selection.Width = _keyboard.SelectionWidth;
+		_selection.Height = _keyboard.SelectionHeight;
+	}
+
+	private void CommitKeyboardSelection()
+	{
+		// FinishSelection maps overlay DIPs to bitmap pixels and clamps; feed it the
+		// anchor as the drag origin so both input paths crop identically.
+		_start = new Point(_keyboard.AnchorX, _keyboard.AnchorY);
+		FinishSelection(new Point(_keyboard.CaretX, _keyboard.CaretY));
+	}
+
+	private void ResetKeyboardSelection()
+	{
+		EnsureElementRefs();
+		double width = _overlay?.ActualWidth ?? 0;
+		double height = _overlay?.ActualHeight ?? 0;
+		// Start where the pointer already is so mouse and keyboard agree, and so the
+		// caret matches the crosshair the mouse path draws on open.
+		var caret = _lastPointerPos ?? CursorInOverlayCoordinates(width, height);
+		_keyboard.Reset(width, height, caret.X, caret.Y);
+	}
+
+	private Point CursorInOverlayCoordinates(double overlayWidth, double overlayHeight)
+	{
+		var fallback = new Point(overlayWidth / 2.0, overlayHeight / 2.0);
+		try
+		{
+			double scale = 1.0;
+			var dpi = GetDpiForWindow(_hwnd);
+			if (dpi > 0)
+				scale = dpi / 96.0;
+
+			if (!GetCursorPos(out POINT p))
+				return fallback;
+
+			int left = GetSystemMetrics(SM_XVIRTUALSCREEN);
+			int top = GetSystemMetrics(SM_YVIRTUALSCREEN);
+			return new Point((p.X - left) / scale, (p.Y - top) / scale);
+		}
+		catch
+		{
+			return fallback;
+		}
+	}
+
+	private void Announce(string message, AutomationNotificationKind kind)
+	{
+		if (string.IsNullOrWhiteSpace(message))
+			return;
+
+		try
+		{
+			EnsureElementRefs();
+			if (_overlay is null)
+				return;
+
+			// CreatePeerForElement rather than FromElement so the very first
+			// announcement fires even before a peer exists.
+			var peer = FrameworkElementAutomationPeer.CreatePeerForElement(_overlay);
+			peer?.RaiseNotificationEvent(
+				kind,
+				AutomationNotificationProcessing.MostRecent,
+				message,
+				AnnouncementActivityId);
+		}
+		catch
+		{
+			// An announcement that cannot be raised must not break the capture.
 		}
 	}
 
@@ -404,6 +575,7 @@ public sealed partial class RegionSelectionWindow : Window
 		// Keep crosshair stretched to current size and at last pointer position (or center)
 		var pos = _lastPointerPos ?? new Point(e.NewSize.Width / 2.0, e.NewSize.Height / 2.0);
 		UpdateCrosshair(pos);
+		_keyboard.Resize(e.NewSize.Width, e.NewSize.Height);
 	}
 
 	private void UpdateCrosshair(Point pos)
@@ -478,6 +650,7 @@ public sealed partial class RegionSelectionWindow : Window
 		var bounds = new System.Drawing.Rectangle(left, top, width, height);
 		
 		InitializeCrosshairAtCursor(bounds);
+		ResetKeyboardSelection();
 		TryFocusOverlay();
 	}
 
@@ -657,7 +830,11 @@ public sealed partial class RegionSelectionWindow : Window
 				_dragging = false;
 				_tcs?.TrySetResult(null);
 				// Use dispatcher to ensure UI operations happen on the correct thread
-				_dispatcherQueue?.TryEnqueue(() => HideAndRestore());
+				_dispatcherQueue?.TryEnqueue(() =>
+				{
+					Announce("Region selection cancelled.", AutomationNotificationKind.ActionAborted);
+					HideAndRestore();
+				});
 				return (IntPtr)1; // Suppress the key
 			}
 		}

--- a/Mutation.Ui/Views/Settings/SettingsGraphCommitter.cs
+++ b/Mutation.Ui/Views/Settings/SettingsGraphCommitter.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace Mutation.Ui.Views.SettingsUi;
+
+/// <summary>
+/// Copies an object graph onto an existing one property-by-property, reusing the
+/// destination's sub-objects and list instances instead of swapping references.
+///
+/// This replaces the hand-maintained field list the Settings dialog used to commit
+/// with. That list silently dropped every property nobody remembered to add to it —
+/// which is how the seven speech-preprocessing toggles (issue #218) and the prompt
+/// list (issue #219) both ended up being discarded on Save. Reflection cannot drift
+/// away from the model the way a hand-written list can.
+/// </summary>
+internal static class SettingsGraphCommitter
+{
+	public static void Commit(object destination, object source)
+	{
+		ArgumentNullException.ThrowIfNull(destination);
+		ArgumentNullException.ThrowIfNull(source);
+
+		CopyProperties(destination, source, new HashSet<object>(ReferenceEqualityComparer.Instance));
+	}
+
+	private static void CopyProperties(object destination, object source, HashSet<object> visited)
+	{
+		if (!visited.Add(source))
+			return; // Already committed on this walk; a cycle would otherwise recurse forever.
+
+		foreach (var property in destination.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance))
+		{
+			if (property.GetIndexParameters().Length > 0)
+				continue;
+			if (!property.CanRead || property.GetMethod is null || !property.GetMethod.IsPublic)
+				continue;
+
+			var sourceProperty = source.GetType().GetProperty(property.Name, BindingFlags.Public | BindingFlags.Instance);
+			if (sourceProperty is null || !sourceProperty.CanRead)
+				continue;
+
+			object? sourceValue = sourceProperty.GetValue(source);
+			object? destinationValue = property.GetValue(destination);
+
+			// A collection with no setter can still be committed by refilling it.
+			if (TryCommitList(destinationValue, sourceValue, visited))
+				continue;
+
+			if (!property.CanWrite || property.SetMethod is null || !property.SetMethod.IsPublic)
+				continue;
+
+			// Reuse the destination's instance when both sides hold the same concrete
+			// type, so references held elsewhere in the app keep pointing at live data.
+			if (sourceValue is not null
+				&& destinationValue is not null
+				&& !IsDirectlyAssignable(sourceValue.GetType())
+				&& destinationValue.GetType() == sourceValue.GetType())
+			{
+				CopyProperties(destinationValue, sourceValue, visited);
+				continue;
+			}
+
+			property.SetValue(destination, sourceValue);
+		}
+	}
+
+	/// <summary>
+	/// Refills <paramref name="destinationValue"/> in place when both sides are
+	/// non-array lists, preserving the list instance and — index by index — the element
+	/// instances. Returns false when the pair is not a list pair, leaving the caller to
+	/// assign normally.
+	/// </summary>
+	private static bool TryCommitList(object? destinationValue, object? sourceValue, HashSet<object> visited)
+	{
+		if (destinationValue is not IList destinationList || sourceValue is not IList sourceList)
+			return false;
+		if (destinationValue is Array || sourceValue is Array)
+			return false; // Arrays are fixed-size; the caller assigns the reference instead.
+		if (destinationList.IsReadOnly || destinationList.IsFixedSize)
+			return false;
+
+		for (int i = 0; i < sourceList.Count; i++)
+		{
+			object? sourceItem = sourceList[i];
+
+			if (i >= destinationList.Count)
+			{
+				destinationList.Add(sourceItem);
+				continue;
+			}
+
+			object? destinationItem = destinationList[i];
+			if (sourceItem is not null
+				&& destinationItem is not null
+				&& !IsDirectlyAssignable(sourceItem.GetType())
+				&& destinationItem.GetType() == sourceItem.GetType())
+			{
+				CopyProperties(destinationItem, sourceItem, visited);
+				continue;
+			}
+
+			destinationList[i] = sourceItem;
+		}
+
+		for (int i = destinationList.Count - 1; i >= sourceList.Count; i--)
+			destinationList.RemoveAt(i);
+
+		return true;
+	}
+
+	// Types whose value is copied wholesale rather than recursed into: anything without
+	// meaningful sub-object identity to preserve.
+	private static bool IsDirectlyAssignable(Type type)
+	{
+		var underlying = Nullable.GetUnderlyingType(type) ?? type;
+		return underlying.IsValueType
+			|| underlying == typeof(string)
+			|| underlying.IsArray;
+	}
+}

--- a/Mutation.Ui/Views/Settings/SettingsWorkingCopy.cs
+++ b/Mutation.Ui/Views/Settings/SettingsWorkingCopy.cs
@@ -1,6 +1,7 @@
 using CognitiveSupport;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
+using System;
 using System.Collections.Generic;
 
 namespace Mutation.Ui.Views.SettingsUi;
@@ -24,123 +25,42 @@ internal static class SettingsWorkingCopy
 
 	// Copy values from the working copy into the live Settings instance, preserving
 	// the existing top-level reference so other parts of the app keep observing the
-	// same object. Sub-object references are also preserved where possible.
+	// same object. Sub-object and list instances are preserved too, which is what keeps
+	// the prompt ListView bound to the same objects the app later edits (issue #219).
+	//
+	// The copy is reflective on purpose. The hand-maintained field list this replaced
+	// silently dropped whatever nobody remembered to add to it, and it had already
+	// drifted twice (issues #218 and #219).
 	public static void CommitInto(Settings live, Settings workingCopy)
 	{
-		live.AudioSettings ??= new AudioSettings();
-		if (workingCopy.AudioSettings is not null)
-		{
-			live.AudioSettings.ActiveCaptureDeviceFullName = workingCopy.AudioSettings.ActiveCaptureDeviceFullName;
-			live.AudioSettings.MicrophoneToggleMuteHotKey = workingCopy.AudioSettings.MicrophoneToggleMuteHotKey;
-			live.AudioSettings.EnableMicrophoneVisualization = workingCopy.AudioSettings.EnableMicrophoneVisualization;
-			live.AudioSettings.CustomBeepSettings = workingCopy.AudioSettings.CustomBeepSettings;
-		}
+		ArgumentNullException.ThrowIfNull(live);
+		ArgumentNullException.ThrowIfNull(workingCopy);
 
-		live.AzureComputerVisionSettings ??= new AzureComputerVisionSettings();
-		if (workingCopy.AzureComputerVisionSettings is not null)
-		{
-			var src = workingCopy.AzureComputerVisionSettings;
-			var dst = live.AzureComputerVisionSettings;
-			dst.InvertScreenshot = src.InvertScreenshot;
-			dst.ScreenshotHotKey = src.ScreenshotHotKey;
-			dst.ScreenshotOcrHotKey = src.ScreenshotOcrHotKey;
-			dst.ScreenshotLeftToRightTopToBottomOcrHotKey = src.ScreenshotLeftToRightTopToBottomOcrHotKey;
-			dst.OcrHotKey = src.OcrHotKey;
-			dst.OcrLeftToRightTopToBottomHotKey = src.OcrLeftToRightTopToBottomHotKey;
-			dst.SendHotkeyAfterOcrOperation = src.SendHotkeyAfterOcrOperation;
-			dst.ApiKey = src.ApiKey;
-			dst.Endpoint = src.Endpoint;
-			dst.TimeoutSeconds = src.TimeoutSeconds;
-			dst.UseFreeTier = src.UseFreeTier;
-			dst.FreeTierPageLimit = src.FreeTierPageLimit;
-			dst.MaxParallelDocuments = src.MaxParallelDocuments;
-			dst.MaxParallelRequests = src.MaxParallelRequests;
-			dst.MaxDocumentBytes = src.MaxDocumentBytes;
-		}
+		EnsureSections(live);
+		EnsureSections(workingCopy);
 
-		live.SpeechToTextSettings ??= new SpeechToTextSettings();
-		if (workingCopy.SpeechToTextSettings is not null)
-		{
-			var src = workingCopy.SpeechToTextSettings;
-			var dst = live.SpeechToTextSettings;
-			dst.TempDirectory = src.TempDirectory;
-			dst.SpeechToTextHotKey = src.SpeechToTextHotKey;
-			dst.SpeechToTextWithLlmProcessingHotKey = src.SpeechToTextWithLlmProcessingHotKey;
-			dst.SendHotkeyAfterTranscriptionOperation = src.SendHotkeyAfterTranscriptionOperation;
-			dst.Services = src.Services;
-			dst.ActiveSpeechToTextService = src.ActiveSpeechToTextService;
-			dst.FileTranscriptionTimeoutSeconds = src.FileTranscriptionTimeoutSeconds;
-			dst.MaxRetainedSessions = src.MaxRetainedSessions;
-			dst.EnableSilenceStripping = src.EnableSilenceStripping;
-			dst.SilenceThresholdDbFs = src.SilenceThresholdDbFs;
-			dst.MinSilenceSeconds = src.MinSilenceSeconds;
-			dst.SilenceGuardMilliseconds = src.SilenceGuardMilliseconds;
-		}
+		SettingsGraphCommitter.Commit(live, workingCopy);
+	}
 
-		live.ApiKeys ??= new ApiKeys();
-		if (workingCopy.ApiKeys is not null)
-		{
-			var src = workingCopy.ApiKeys;
-			var dst = live.ApiKeys;
-			dst.OpenAiApiKey = src.OpenAiApiKey;
-			dst.AnthropicApiKey = src.AnthropicApiKey;
-			dst.DeepgramApiKey = src.DeepgramApiKey;
-		}
+	// Both sides need every section present: the committer copies null over non-null,
+	// so a missing section on either side would otherwise leave the live graph with a
+	// null the rest of the app does not expect.
+	private static void EnsureSections(Settings settings)
+	{
+		settings.AudioSettings ??= new AudioSettings();
+		settings.AzureComputerVisionSettings ??= new AzureComputerVisionSettings();
+		settings.SpeechToTextSettings ??= new SpeechToTextSettings();
+		settings.ApiKeys ??= new ApiKeys();
+		settings.LlmSettings ??= new LlmSettings();
+		settings.TextToSpeechSettings ??= new TextToSpeechSettings();
+		settings.MainWindowUiSettings ??= new MainWindowUiSettings();
+		settings.HotKeyRouterSettings ??= new HotKeyRouterSettings();
+		settings.TranscriptFormatRules ??= new List<TranscriptFormatRule>();
 
-		live.LlmSettings ??= new LlmSettings();
-		if (workingCopy.LlmSettings is not null)
-		{
-			var src = workingCopy.LlmSettings;
-			var dst = live.LlmSettings;
-			dst.Models = src.Models;
-			dst.Prompts = src.Prompts;
-			dst.TimeoutSeconds = src.TimeoutSeconds;
-			dst.RetryCount = src.RetryCount;
-		}
-
-		live.TranscriptFormatRules = workingCopy.TranscriptFormatRules ?? new List<TranscriptFormatRule>();
-
-		live.TextToSpeechSettings ??= new TextToSpeechSettings();
-		if (workingCopy.TextToSpeechSettings is not null)
-		{
-			var src = workingCopy.TextToSpeechSettings;
-			var dst = live.TextToSpeechSettings;
-			dst.SpeakClipboard = src.SpeakClipboard;
-			dst.SpeakSelectionHotKey = src.SpeakSelectionHotKey;
-			dst.RestartFromBeginningHotKey = src.RestartFromBeginningHotKey;
-			dst.SkipSentenceBackwardHotKey = src.SkipSentenceBackwardHotKey;
-			dst.SkipSentenceForwardHotKey = src.SkipSentenceForwardHotKey;
-			dst.SpeakPositionHotKey = src.SpeakPositionHotKey;
-			dst.PauseResumeHotKey = src.PauseResumeHotKey;
-			dst.Rate = src.Rate;
-			dst.Volume = src.Volume;
-			dst.EnableSpeechPreprocessing = src.EnableSpeechPreprocessing;
-			dst.VoiceName = src.VoiceName;
-			dst.SkipSentenceGraceWindowMs = src.SkipSentenceGraceWindowMs;
-			dst.ResumeRewindWordCount = src.ResumeRewindWordCount;
-			dst.ResumeRewindAfterPauseSeconds = src.ResumeRewindAfterPauseSeconds;
-			dst.AnnounceReadingTimeAtStart = src.AnnounceReadingTimeAtStart;
-			dst.AnnounceReadingTimeMinimumMinutes = src.AnnounceReadingTimeMinimumMinutes;
-			dst.AnnounceProgressEnabled = src.AnnounceProgressEnabled;
-			dst.AnnounceProgressEveryPercent = src.AnnounceProgressEveryPercent;
-			dst.AnnounceProgressMinimumMinutes = src.AnnounceProgressMinimumMinutes;
-		}
-
-		live.MainWindowUiSettings ??= new MainWindowUiSettings();
-		if (workingCopy.MainWindowUiSettings is not null)
-		{
-			var src = workingCopy.MainWindowUiSettings;
-			var dst = live.MainWindowUiSettings;
-			dst.WindowLocation = src.WindowLocation;
-			dst.WindowSize = src.WindowSize;
-			dst.MaxTextBoxLineCount = src.MaxTextBoxLineCount;
-			dst.DictationInsertPreference = src.DictationInsertPreference;
-		}
-
-		live.HotKeyRouterSettings ??= new HotKeyRouterSettings();
-		if (workingCopy.HotKeyRouterSettings is not null)
-		{
-			live.HotKeyRouterSettings.Mappings = workingCopy.HotKeyRouterSettings.Mappings;
-		}
+		// A settings file with an explicit null for one of these lists deserializes to
+		// null, and the committer would then propagate that null onto the live graph.
+		settings.LlmSettings.Models ??= new List<LlmModelConfig>();
+		settings.LlmSettings.Prompts ??= new List<LlmSettings.LlmPrompt>();
+		settings.HotKeyRouterSettings.Mappings ??= new List<HotKeyRouterSettings.HotKeyRouterMap>();
 	}
 }

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Press one hotkey to mute or unmute every enabled microphone system-wide—indepe
 ### 2. Screen Capturing and OCR  
 Mutation supports two OCR reading orders via Azure **Computer Vision**:
 
-* **Natural layout** – reads top-to-bottom within each column, then left-to-right across columns. Best for newspapers, journals, brochures, or any multi-column PDF.  
-* **Basic layout** – reads strictly left-to-right, top-to-bottom. Best for tables, spreadsheets, forms, invoices, or any row-oriented content.
+* **Natural layout** – keeps the grouping Azure returns, which follows columns and sections rather than raw scan lines. Best for newspapers, journals, brochures, or any multi-column PDF.  
+* **Basic layout** – reads strictly left-to-right, top-to-bottom: recognised lines are regrouped onto visual rows that run straight across the page. Best for tables, spreadsheets, forms, invoices, or any row-oriented content.
 
 **Hotkeys:**
 
@@ -34,7 +34,7 @@ selection size, and the outcome as you go.
 
 | Key | Action |
 |-----|--------|
-| Arrow keys | Move the caret (hold **Ctrl** for 1-pixel steps, **Shift** for 100-pixel steps) |
+| Arrow keys | Move the caret (hold **Ctrl** for fine steps, **Shift** for large steps) |
 | **Home** / **End** | Jump the caret to the left / right edge |
 | **Page Up** / **Page Down** | Jump the caret to the top / bottom edge |
 | **Enter** or **Space** | First press pins one corner; second press captures the region |

--- a/README.md
+++ b/README.md
@@ -20,12 +20,27 @@ Mutation supports two OCR reading orders via Azure **Computer Vision**:
 
 | Hotkey | Description |
 |--------|-------------|
-| `ScreenshotHotKey` | Captures the full screen and lets you draw a rectangle with a crosshair cursor (press **Esc** to cancel); the selected region is copied to the clipboard. |
+| `ScreenshotHotKey` | Captures the full screen and lets you pick a rectangle with the mouse or the keyboard (see below; press **Esc** to cancel); the selected region is copied to the clipboard. |
 | `OcrHotKey` | OCR the clipboard image with **Natural** layout. |
 | `ScreenshotOcrHotKey` | Take a screenshot and OCR it with **Natural** layout in one step. |
 | `OcrLeftToRightTopToBottomHotKey` | OCR the clipboard image with **Basic** layout. |
 | `ScreenshotLeftToRightTopToBottomOcrHotKey` | Take a screenshot and OCR it with **Basic** layout in one step. |
 | `SendHotkeyAfterOcrOperation` | Sends a specified hotkey after OCR completes (e.g., to trigger screen reader). |
+
+**Selecting the region with the keyboard:**
+
+The region overlay is fully keyboard-driven, and announces the caret position, the
+selection size, and the outcome as you go.
+
+| Key | Action |
+|-----|--------|
+| Arrow keys | Move the caret (hold **Ctrl** for 1-pixel steps, **Shift** for 100-pixel steps) |
+| **Home** / **End** | Jump the caret to the left / right edge |
+| **Page Up** / **Page Down** | Jump the caret to the top / bottom edge |
+| **Enter** or **Space** | First press pins one corner; second press captures the region |
+| **Ctrl+A** | Select the whole screen — then **Enter** to capture it |
+| **Backspace** | Clear the pinned corner and start the selection again |
+| **Esc** | Cancel |
 
 **Additional Options:**
 - `InvertScreenshot` – inverts screenshot colours (useful for accessibility)


### PR DESCRIPTION
Fixes #214, #215, #216, #217, #218, #219.

Six bugs found in a codebase audit, all shipped together because #218 and #219 share a root cause and the rest are independent.

## #214 — Stale accessible names on the Stop and Unmute buttons

`ConfigureButtonHotkey` cached each button's automation name on first sight and re-derived from that cache on every later call, overwriting the name the state transition had just set. The glyph and tooltip updated correctly, so only the screen reader saw the stale value: the mic button announced "Mute microphone" while muted, and the Stop button announced "Record, SHIFT+ALT+U" while recording.

- Callers now pass the label for the button's **current** state; the cache tracks that label instead of the startup one.
- Name/tooltip composition extracted to [HotkeyAccessibleText](Mutation.Ui/Core/HotkeyAccessibleText.cs) so it is testable outside the window.
- The disabled "Transcribing…" state routes through `SetButtonAccessibleLabel`, which keeps the cache in step so a later hotkey refresh cannot undo it.

## #215 — Region selection overlay had no keyboard path and no accessible name

The overlay was pointer-only with Escape as the sole key, leaving four core hotkeys uncompletable without sight, and the reader landed on an unnamed `Canvas`.

- New [KeyboardRegionSelector](Mutation.Ui/Core/KeyboardRegionSelector.cs): caret plus optional anchor, all plain numbers so it is testable without a window.
- Arrows move (Ctrl = 1 px, Shift = 100 px), Home/End/PageUp/PageDown jump to edges, Enter or Space pins the first corner then captures, **Ctrl+A** selects the whole screen as a two-keystroke fallback, Backspace restarts the selection, Escape cancels.
- `AutomationProperties.Name`/`HelpText` on the overlay, and UIA notifications on open, on every accepted key, on commit (both input paths), and on cancel.
- Committing a zero-sized region is refused out loud rather than discarded silently downstream.
- Mouse and keyboard share one caret, so switching mid-selection is seamless.

## #216 — Retry-progress beeps collapsed to a single beep

`Beep(attempt)` looped `BeepPlayer.Play(BeepType.End)`, and the 500 ms duplicate-suppression window swallowed calls 2..N. Three retries sounded exactly like one.

- New `BeepPlayer.PlayRepeated` synthesizes an N-tone WAV in a single `Play`, bypassing the dedupe window; custom beep files are played back-to-back off the calling thread.
- The first, non-retry attempt is now silent — see [RetryBeepPolicy](CognitiveSupport/RetryBeepPolicy.cs).
- Runaway retry counts are clamped so a beep can never run for seconds.

## #217 — OCR reading order was ignored

`OcrReadingOrder` reached `ReadInternal` and was then dropped, so the Basic and Natural hotkeys produced byte-identical output.

Azure Image Analysis 4.0 exposes no reading-order request option (unlike the retired Read 3.2 API), so the order is applied to the recognised lines in [OcrReadingOrderSorter](CognitiveSupport/ComputerVision/OcrReadingOrderSorter.cs):

- **Natural** keeps the API's column-aware block order — newspapers, journals, multi-column PDFs.
- **Basic** groups lines onto visual rows by vertical overlap and reads each row left to right — tables, spreadsheets, forms, invoices.

This matches what the README already documented.

## #218 / #219 — Settings Save discarded toggles and orphaned the prompt list

Both come from the hand-maintained field list in `CommitInto`, which had already drifted from the model twice: it dropped all seven `Preprocess*` toggles (and, it turns out, `LiveTranscriptionTimeoutSeconds`), and it reference-swapped `Prompts` to freshly deserialized objects the prompt ListView was no longer bound to — so a later Edit was lost on restart and Delete announced "the prompt was no longer in the library".

- Replaced with [SettingsGraphCommitter](Mutation.Ui/Views/Settings/SettingsGraphCommitter.cs), a reflective commit that cannot drift from the model.
- It reuses the destination's sub-objects and refills lists in place, so the live prompt list and its elements keep their identity.
- `ApplyLiveSettings` re-binds the prompt ListView, since a plain `List` raises no change notifications.

## Tests

63 new tests; **859 pass, 0 fail** (`dotnet test --configuration Release`).

- `SettingsWorkingCopyCommitTests` includes a drift guard that walks the whole settings graph, mutates every settable property, commits, and asserts nothing was dropped — this is what stops #218 recurring.
- Plus per-issue coverage: prompt instance/list identity through a save-edit-delete cycle, two-column and table OCR fixtures asserting the two orders differ, beep sequence length scaling with attempt count, name composition across state transitions, and the full keyboard region-selection model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)