### PR TITLE
Add a plain-language user guide, built to HTML with pandoc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,7 @@ graphify-out/graph.html
 graphify-out/cost.json
 graphify-out/.graphify_python
 graphify-out/.graphify_root
+
+# pandoc is ~220MB, over GitHub's 100MB file limit - fetch it locally instead.
+# See Documentation/UserGuide/README.md
+Documentation/pandoc.exe

--- a/Documentation/Build-UserGuide.cmd
+++ b/Documentation/Build-UserGuide.cmd
@@ -1,0 +1,48 @@
+@echo off
+REM ===========================================================================
+REM  Build-UserGuide.cmd
+REM
+REM  Rebuilds the HTML version of the Mutation user guide from the Markdown
+REM  files in .\UserGuide\markdown, writing the result into .\UserGuide\html.
+REM
+REM  The Markdown is always the source of truth. Edit the .md files, run this,
+REM  and never edit the generated .html by hand.
+REM
+REM  Conversion is done by pandoc.exe, which is looked for in this folder first
+REM  and then on PATH.
+REM
+REM  Just double-click this file, or run it from a command prompt.
+REM ===========================================================================
+
+setlocal
+cd /d "%~dp0"
+
+REM Pause at the end only when double-clicked, so the window stays open long
+REM enough to read. When run from a prompt or a script, finish and return.
+set "INTERACTIVE="
+echo %CMDCMDLINE% | find /i "%~nx0" >nul 2>&1 && set "INTERACTIVE=1"
+
+echo.
+echo Building the Mutation user guide...
+echo.
+
+set "PS_EXE=powershell.exe"
+where pwsh.exe >nul 2>&1 && set "PS_EXE=pwsh.exe"
+
+"%PS_EXE%" -NoProfile -NoLogo -ExecutionPolicy Bypass -File "%~dp0Convert-UserGuide.ps1"
+set "RESULT=%ERRORLEVEL%"
+
+echo.
+if not "%RESULT%"=="0" (
+	echo Build FAILED. See the messages above.
+	echo.
+	if defined INTERACTIVE pause
+	endlocal
+	exit /b %RESULT%
+)
+
+echo Build finished successfully.
+echo.
+if defined INTERACTIVE pause
+endlocal
+exit /b 0

--- a/Documentation/Build-UserGuide.cmd
+++ b/Documentation/Build-UserGuide.cmd
@@ -19,8 +19,10 @@ cd /d "%~dp0"
 
 REM Pause at the end only when double-clicked, so the window stays open long
 REM enough to read. When run from a prompt or a script, finish and return.
+REM CMDCMDLINE is quoted before echoing: an unquoted path containing & or |
+REM would otherwise be parsed as a command separator.
 set "INTERACTIVE="
-echo %CMDCMDLINE% | find /i "%~nx0" >nul 2>&1 && set "INTERACTIVE=1"
+echo "%CMDCMDLINE%" | find /i "%~nx0" >nul 2>&1 && set "INTERACTIVE=1"
 
 echo.
 echo Building the Mutation user guide...

--- a/Documentation/Convert-UserGuide.ps1
+++ b/Documentation/Convert-UserGuide.ps1
@@ -1,0 +1,235 @@
+<#
+	Convert-UserGuide.ps1
+
+	Builds the HTML version of the Mutation user guide from the Markdown files
+	in .\UserGuide\markdown, writing the result into .\UserGuide\html.
+
+	The Markdown files are the source of truth. The HTML is generated output —
+	never edit the HTML by hand; edit the Markdown and re-run Build-UserGuide.cmd.
+
+	Conversion is done by pandoc. Supporting files, all in this folder:
+
+		userguide-template.html  page shell (skip link, nav slot, main landmark)
+		userguide.css            styling, inlined into each page at build time
+		userguide.lua            rewrites .md links to .html, adds table scope
+
+	pandoc is looked for in this folder first, then on PATH.
+#>
+
+[CmdletBinding()]
+param(
+	[string] $MarkdownPath,
+	[string] $HtmlPath,
+	[string] $Pandoc,
+	[string] $SiteTitle = 'Mutation User Guide'
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$root = Split-Path -Parent $MyInvocation.MyCommand.Path
+if (-not $MarkdownPath) { $MarkdownPath = Join-Path $root 'UserGuide\markdown' }
+if (-not $HtmlPath) { $HtmlPath = Join-Path $root 'UserGuide\html' }
+
+$template = Join-Path $root 'userguide-template.html'
+$css = Join-Path $root 'userguide.css'
+$filter = Join-Path $root 'userguide.lua'
+
+# The order chapters appear in the sidebar. Anything not listed is appended
+# alphabetically, so adding a new chapter never breaks the build.
+$chapterOrder = @(
+	'index',
+	'getting-started',
+	'main-window',
+	'microphone',
+	'dictation',
+	'screen-capture-and-ocr',
+	'read-aloud',
+	'ai-prompts',
+	'transcript-formatting',
+	'keyboard-shortcuts',
+	'settings',
+	'accessibility',
+	'troubleshooting'
+)
+
+# ----------------------------------------------------------------------------
+# Locate pandoc
+# ----------------------------------------------------------------------------
+
+function Resolve-Pandoc([string] $explicit, [string] $scriptRoot) {
+	if ($explicit) {
+		if (Test-Path $explicit) { return (Resolve-Path $explicit).Path }
+		throw "pandoc was not found at the path you gave: $explicit"
+	}
+
+	$local = Join-Path $scriptRoot 'pandoc.exe'
+	if (Test-Path $local) { return $local }
+
+	$onPath = Get-Command 'pandoc' -ErrorAction SilentlyContinue
+	if ($onPath) { return $onPath.Source }
+
+	throw @"
+pandoc was not found.
+
+Put pandoc.exe in this folder:
+    $scriptRoot
+
+or install it so that 'pandoc' works from a command prompt, or run this script
+with -Pandoc "C:\path\to\pandoc.exe".
+
+Download: https://pandoc.org/installing.html
+"@
+}
+
+# Setup problems are the ones a non-technical user is most likely to hit, so
+# report them as a plain sentence rather than a PowerShell stack trace.
+try {
+	$pandocExe = Resolve-Pandoc $Pandoc $root
+
+	foreach ($required in @($template, $css, $filter)) {
+		if (-not (Test-Path $required)) {
+			throw "A supporting file is missing: $required"
+		}
+	}
+	if (-not (Test-Path $MarkdownPath)) {
+		throw "Markdown folder not found: $MarkdownPath"
+	}
+	if (-not (Test-Path $HtmlPath)) {
+		New-Item -ItemType Directory -Path $HtmlPath | Out-Null
+	}
+}
+catch {
+	Write-Host ''
+	Write-Host $_.Exception.Message -ForegroundColor Red
+	Write-Host ''
+	exit 1
+}
+
+Write-Host "Using pandoc: $pandocExe"
+Write-Host ''
+
+# ----------------------------------------------------------------------------
+# Work out the chapter list and each chapter's title
+# ----------------------------------------------------------------------------
+
+$files = Get-ChildItem -Path $MarkdownPath -Filter '*.md' -File |
+	Where-Object { $_.Name -notlike '_*' }
+
+if (-not $files) { throw "No Markdown files found in $MarkdownPath" }
+
+$ordered = @()
+foreach ($name in $chapterOrder) {
+	$match = $files | Where-Object { $_.BaseName -eq $name }
+	if ($match) { $ordered += $match }
+}
+$ordered += ($files | Where-Object { $chapterOrder -notcontains $_.BaseName } | Sort-Object Name)
+
+# A chapter's title is its first level-1 heading, which every chapter starts with.
+$pages = foreach ($file in $ordered) {
+	$firstHeading = Select-String -Path $file.FullName -Pattern '^#\s+(.+?)\s*$' |
+		Select-Object -First 1
+
+	$title = if ($firstHeading) {
+		($firstHeading.Matches[0].Groups[1].Value -replace '\*\*', '' -replace '`', '').Trim()
+	}
+	else { $file.BaseName }
+
+	[pscustomobject]@{
+		Source = $file
+		File   = "$($file.BaseName).html"
+		Title  = $title
+	}
+}
+
+# ----------------------------------------------------------------------------
+# Build
+# ----------------------------------------------------------------------------
+
+# Clear out stale HTML so a renamed or deleted chapter leaves no orphan behind.
+Get-ChildItem -Path $HtmlPath -Filter '*.html' -File -ErrorAction SilentlyContinue |
+	Where-Object { $pages.File -notcontains $_.Name } |
+	ForEach-Object {
+		Write-Host "  removed stale $($_.Name)"
+		Remove-Item $_.FullName -Force
+	}
+
+$scratch = Join-Path ([System.IO.Path]::GetTempPath()) ("mutation-guide-" + [guid]::NewGuid().ToString('n'))
+New-Item -ItemType Directory -Path $scratch | Out-Null
+
+$stamp = (Get-Date).ToString('d MMMM yyyy')
+$failed = 0
+
+try {
+	foreach ($page in $pages) {
+		# The sidebar is rebuilt per page so the current chapter can carry
+		# aria-current, which is what tells a screen reader where it is.
+		$nav = New-Object System.Text.StringBuilder
+		$nav.AppendLine('<nav class="sidebar" aria-label="User guide contents">') | Out-Null
+		$nav.AppendLine("<h2>$([System.Net.WebUtility]::HtmlEncode($SiteTitle))</h2>") | Out-Null
+		$nav.AppendLine('<ol>') | Out-Null
+		foreach ($item in $pages) {
+			$current = if ($item.File -eq $page.File) { ' aria-current="page"' } else { '' }
+			$label = [System.Net.WebUtility]::HtmlEncode($item.Title)
+			$nav.AppendLine("<li><a href=""$($item.File)""$current>$label</a></li>") | Out-Null
+		}
+		$nav.AppendLine('</ol>') | Out-Null
+		$nav.AppendLine('</nav>') | Out-Null
+
+		$footer = @"
+<footer>
+<p><a href="index.html">Back to the contents page</a></p>
+<p>Generated from the Markdown source on $stamp. The Markdown files are the source of truth &ndash; do not edit these HTML pages by hand.</p>
+</footer>
+"@
+
+		$navFile = Join-Path $scratch 'nav.html'
+		$footFile = Join-Path $scratch 'footer.html'
+		$utf8 = New-Object System.Text.UTF8Encoding $false
+		[System.IO.File]::WriteAllText($navFile, $nav.ToString(), $utf8)
+		[System.IO.File]::WriteAllText($footFile, $footer, $utf8)
+
+		# The contents page is already named after the guide; don't say it twice.
+		$headTitle = if ($page.Title -like "*$SiteTitle*") { $page.Title } else { "$($page.Title) - $SiteTitle" }
+
+		$target = Join-Path $HtmlPath $page.File
+
+		$pandocArgs = @(
+			'--from=gfm'
+			'--to=html5'
+			'--standalone'
+			'--embed-resources'
+			"--template=$template"
+			"--css=$css"
+			"--lua-filter=$filter"
+			"--include-before-body=$navFile"
+			"--include-after-body=$footFile"
+			"--metadata=pagetitle:$headTitle"
+			'--metadata=lang:en'
+			'--output'
+			$target
+			$page.Source.FullName
+		)
+
+		& $pandocExe @pandocArgs
+		if ($LASTEXITCODE -ne 0) {
+			Write-Warning "pandoc failed on $($page.Source.Name) (exit $LASTEXITCODE)"
+			$failed++
+			continue
+		}
+
+		Write-Host "  $($page.Source.Name) -> $($page.File)"
+	}
+}
+finally {
+	Remove-Item $scratch -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+Write-Host ''
+if ($failed -gt 0) {
+	Write-Host "$failed page(s) FAILED to build." -ForegroundColor Red
+	exit 1
+}
+
+Write-Host "Done. $($pages.Count) page(s) written to $HtmlPath"
+Write-Host "Open $(Join-Path $HtmlPath 'index.html') to read the guide."

--- a/Documentation/UserGuide/README.md
+++ b/Documentation/UserGuide/README.md
@@ -1,0 +1,100 @@
+# User guide — how this folder works
+
+This folder holds the Mutation user guide.
+
+```
+Documentation/
+	Build-UserGuide.cmd        <- double-click this to rebuild the HTML
+	Convert-UserGuide.ps1      <- the build script it calls
+	userguide-template.html    <- page shell (skip link, nav slot, main landmark)
+	userguide.css              <- styling, inlined into every page at build time
+	userguide.lua              <- pandoc filter: .md links -> .html, table scope
+	pandoc.exe                 <- the converter (not in git, see below)
+	UserGuide/
+		markdown/              <- the source of truth. Edit these.
+		html/                  <- generated. Do not edit by hand.
+		README.md              <- this file (not part of the guide)
+```
+
+## The Markdown is authoritative
+
+`UserGuide/markdown/*.md` is the guide. The pages in `UserGuide/html/` are generated
+output, checked in so the app can open the guide locally without a build step. If you
+change the guide, change the Markdown and re-run the build — any hand edit to an HTML
+file is lost on the next run.
+
+## Rebuilding the HTML
+
+Double-click `Documentation\Build-UserGuide.cmd`, or run it from a prompt:
+
+```bash
+Documentation\Build-UserGuide.cmd
+```
+
+Commit the regenerated `UserGuide/html/` alongside your Markdown change so the two
+never drift.
+
+## You need pandoc
+
+Conversion is done by [pandoc](https://pandoc.org). The build looks for it in this
+order:
+
+1. `pandoc.exe` in the `Documentation` folder.
+2. `pandoc` on your PATH.
+3. Whatever you pass to `-Pandoc`, for example:
+
+```bash
+powershell -File Documentation\Convert-UserGuide.ps1 -Pandoc "C:\tools\pandoc.exe"
+```
+
+If none of those find it, the build stops with a message telling you where to put it.
+
+**`pandoc.exe` is deliberately not committed.** It is around 220 MB, which is over
+GitHub's 100 MB per-file limit, so a push containing it would be rejected outright.
+It is listed in `.gitignore`. Download it once from
+<https://pandoc.org/installing.html> and drop it in `Documentation\`, or install it
+normally so it is on your PATH.
+
+## Adding a chapter
+
+1. Add `UserGuide/markdown/your-chapter.md`, starting with a single `# Title` line.
+2. Link to it from `UserGuide/markdown/index.md` so readers can find it.
+3. Add its file name (without `.md`) to `$chapterOrder` near the top of
+   `Convert-UserGuide.ps1` so it lands in the right place in the sidebar. Chapters
+   that are not listed still build — they are just appended alphabetically.
+4. Run the build.
+
+Renaming or deleting a chapter is safe: the build removes orphaned HTML files.
+
+## Markdown flavour
+
+Pages are parsed as GitHub Flavored Markdown, so anything that renders on GitHub
+renders here: headings, lists, tables, fenced code, blockquotes, task lists,
+strikethrough, autolinks.
+
+Two project-specific rules the build applies on top:
+
+- Links to `something.md` are rewritten to `something.html`, so chapters can link to
+  each other and stay correct both on GitHub and in the built site.
+- Table header cells get `scope="col"` for screen readers.
+
+## The generated pages
+
+Each page is standalone — the CSS is inlined by pandoc, so there are no external
+files or network requests, and `UserGuide/html/index.html` opens correctly straight
+off disk.
+
+The output is built to be accessible, which matters for this project specifically:
+`lang` set, a skip-to-content link, a labelled `<nav>` landmark with `aria-current`
+on the current page, a `<main>` landmark, headings in document order, `scope="col"`
+on every table header, visible focus outlines, and a light/dark theme that follows
+the reader's Windows setting. There is also a print stylesheet that drops the
+navigation.
+
+To change how pages look, edit `userguide.css`. To change their structure, edit
+`userguide-template.html`. Neither needs the Markdown to be touched.
+
+## Linking the guide from the app
+
+The pages are self-contained, so opening `UserGuide/html/index.html` in the default
+browser is all that is needed. Nothing in the app depends on this folder yet.

--- a/Documentation/UserGuide/html/accessibility.html
+++ b/Documentation/UserGuide/html/accessibility.html
@@ -62,8 +62,8 @@ border-left:5px solid var(--quote-rule); border-radius:0 8px 8px 0;
 }
 blockquote p{margin:.3rem 0}
 
-table{border-collapse:collapse; width:100%; margin:1rem 0; display:block; overflow-x:auto}
-thead,tbody,tr{width:100%}
+.table-wrap{overflow-x:auto; margin:1rem 0}
+table{border-collapse:collapse; width:100%; min-width:26rem}
 th,td{border:1px solid var(--rule); padding:.5rem .65rem; vertical-align:top}
 th{background:var(--surface); font-weight:700; text-align:left}
 tbody tr:nth-child(even){background:var(--surface)}
@@ -71,9 +71,10 @@ hr{border:none; border-top:1px solid var(--rule); margin:2rem 0}
 kbd{background:var(--surface); border:1px solid var(--rule); border-bottom-width:2px; border-radius:5px; padding:.1em .4em}
 footer{margin-top:3rem; padding-top:1rem; border-top:1px solid var(--rule); color:var(--muted); font-size:.9rem}
 @media (max-width:860px){
-.layout{flex-direction:column; padding:1rem}
+
+.layout{flex-direction:column; align-items:stretch; padding:1rem}
 .sidebar{position:static; flex:1 1 auto; width:100%}
-main{max-width:none}
+main{max-width:none; width:100%; min-width:0}
 }
 @media print{
 .sidebar,.skip{display:none}

--- a/Documentation/UserGuide/html/accessibility.html
+++ b/Documentation/UserGuide/html/accessibility.html
@@ -1,0 +1,237 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Screen reader and accessibility notes - Mutation User
+Guide</title>
+<meta name="generator" content="pandoc 3.9.0.2" />
+<style type="text/css">
+:root{
+color-scheme: light dark;
+--bg:#ffffff; --fg:#1b1b1f; --muted:#5a5a66; --rule:#d9d9e0;
+--accent:#0b5fa5; --accent-fg:#ffffff; --surface:#f5f5f8; --code:#f0f0f4;
+--quote:#eef4fb; --quote-rule:#0b5fa5;
+}
+@media (prefers-color-scheme: dark){
+:root{
+--bg:#15151a; --fg:#eaeaf0; --muted:#a8a8b6; --rule:#3a3a45;
+--accent:#6fb3ff; --accent-fg:#10131a; --surface:#1e1e26; --code:#22222c;
+--quote:#1c2530; --quote-rule:#6fb3ff;
+}
+}
+*{box-sizing:border-box}
+html{font-size:106%}
+body{
+margin:0; background:var(--bg); color:var(--fg);
+font-family:"Segoe UI",system-ui,-apple-system,Arial,sans-serif;
+line-height:1.65;
+}
+.skip{
+position:absolute; left:-9999px; top:0; padding:.6rem 1rem; z-index:10;
+background:var(--accent); color:var(--accent-fg); font-weight:600;
+}
+.skip:focus{left:0}
+.layout{display:flex; align-items:flex-start; gap:2rem; max-width:1180px; margin:0 auto; padding:1.5rem}
+.sidebar{
+flex:0 0 16rem; position:sticky; top:1.5rem;
+background:var(--surface); border:1px solid var(--rule); border-radius:10px; padding:1rem 1.1rem;
+}
+.sidebar h2{font-size:1rem; margin:0 0 .6rem; text-transform:uppercase; letter-spacing:.04em; color:var(--muted)}
+.sidebar ol{list-style:none; margin:0; padding:0}
+.sidebar li{margin:.15rem 0}
+.sidebar a{display:block; padding:.3rem .45rem; border-radius:6px; text-decoration:none; color:var(--fg)}
+.sidebar a:hover{background:var(--bg); text-decoration:underline}
+.sidebar a[aria-current="page"]{background:var(--accent); color:var(--accent-fg); font-weight:600}
+main{flex:1 1 auto; min-width:0; max-width:52rem}
+h1{font-size:2.1rem; line-height:1.2; margin:.2rem 0 1rem; border-bottom:3px solid var(--accent); padding-bottom:.5rem}
+h2{font-size:1.5rem; margin:2.2rem 0 .7rem; border-bottom:1px solid var(--rule); padding-bottom:.3rem}
+h3{font-size:1.2rem; margin:1.7rem 0 .5rem}
+h4{font-size:1.05rem; margin:1.4rem 0 .4rem}
+p{margin:.7rem 0}
+a{color:var(--accent)}
+a:focus-visible,button:focus-visible,main:focus-visible{outline:3px solid var(--accent); outline-offset:2px}
+ul,ol{margin:.7rem 0; padding-left:1.6rem}
+li{margin:.3rem 0}
+code{background:var(--code); padding:.12em .38em; border-radius:4px; font-family:Consolas,"Cascadia Mono",monospace; font-size:.92em}
+pre{background:var(--code); border:1px solid var(--rule); border-radius:8px; padding:.9rem 1rem; overflow-x:auto}
+pre code{background:none; padding:0; font-size:.9em}
+blockquote{
+margin:1rem 0; padding:.7rem 1rem; background:var(--quote);
+border-left:5px solid var(--quote-rule); border-radius:0 8px 8px 0;
+}
+blockquote p{margin:.3rem 0}
+
+table{border-collapse:collapse; width:100%; margin:1rem 0; display:block; overflow-x:auto}
+thead,tbody,tr{width:100%}
+th,td{border:1px solid var(--rule); padding:.5rem .65rem; vertical-align:top}
+th{background:var(--surface); font-weight:700; text-align:left}
+tbody tr:nth-child(even){background:var(--surface)}
+hr{border:none; border-top:1px solid var(--rule); margin:2rem 0}
+kbd{background:var(--surface); border:1px solid var(--rule); border-bottom-width:2px; border-radius:5px; padding:.1em .4em}
+footer{margin-top:3rem; padding-top:1rem; border-top:1px solid var(--rule); color:var(--muted); font-size:.9rem}
+@media (max-width:860px){
+.layout{flex-direction:column; padding:1rem}
+.sidebar{position:static; flex:1 1 auto; width:100%}
+main{max-width:none}
+}
+@media print{
+.sidebar,.skip{display:none}
+body{background:#fff; color:#000}
+.layout{display:block; max-width:none; padding:0}
+a{color:#000}
+}
+</style>
+</head>
+<body>
+<a class="skip" href="#content">Skip to the main content</a>
+<div class="layout">
+<nav class="sidebar" aria-label="User guide contents">
+<h2>Mutation User Guide</h2>
+<ol>
+<li><a href="index.html">The Mutation User Guide</a></li>
+<li><a href="getting-started.html">Getting started</a></li>
+<li><a href="main-window.html">A tour of the main window</a></li>
+<li><a href="microphone.html">Muting your microphone</a></li>
+<li><a href="dictation.html">Dictation: turning speech into text</a></li>
+<li><a href="screen-capture-and-ocr.html">Screenshots and reading text from images</a></li>
+<li><a href="read-aloud.html">Having text read aloud</a></li>
+<li><a href="ai-prompts.html">Using AI prompts on your text</a></li>
+<li><a href="transcript-formatting.html">Automatic find-and-replace rules</a></li>
+<li><a href="keyboard-shortcuts.html">Keyboard shortcuts</a></li>
+<li><a href="settings.html">The Settings window</a></li>
+<li><a href="accessibility.html" aria-current="page">Screen reader and accessibility notes</a></li>
+<li><a href="troubleshooting.html">Troubleshooting</a></li>
+</ol>
+</nav>
+<main id="content" tabindex="-1">
+<h1 id="screen-reader-and-accessibility-notes">Screen reader and
+accessibility notes</h1>
+<p>Mutation was written by a developer who is nearly blind, for his own
+daily use. That shows up all through the app. This chapter gathers the
+things that matter most if you work with a screen reader, a magnifier,
+or both.</p>
+<h2 id="everything-works-from-the-keyboard">Everything works from the
+keyboard</h2>
+<p>There is no part of Mutation that needs a mouse. The global shortcuts
+do the real work, so most of the time you never open the app at all.
+When you do open the main window, you can Tab through every card, and
+every button, slider, list and text box can be reached and operated from
+the keyboard.</p>
+<p>Settings opens with <strong>Ctrl+Comma</strong> and is
+keyboard-driven too, including the search box at the top and the
+&quot;Advanced&quot; toggle.</p>
+<h2 id="controls-are-named-and-the-help-text-is-the-same-text-you-see">Controls
+are named, and the help text is the same text you see</h2>
+<p>Every control tells your screen reader what it is. Buttons that have
+a shortcut attached announce the shortcut as part of their name, so you
+hear something like &quot;Mute, Ctrl+Shift+M&quot;. When a button changes state,
+the announced name changes with it — a button that becomes Unmute
+announces itself as Unmute, not as the name it had at startup.</p>
+<p>The help text for settings is written once and used twice. The
+sentence your screen reader reads out for a setting is exactly the
+sentence that appears in the tooltip when you hover it with the mouse.
+There is no short visual label with a longer hidden explanation, or the
+other way around. What you hear is what is there.</p>
+<h2 id="sounds-tell-you-what-happened">Sounds tell you what
+happened</h2>
+<p>Mutation uses short beeps so you know an action landed without having
+to check the screen. There are distinct sounds for:</p>
+<ul>
+<li><strong>Start</strong> — a recording has begun.</li>
+<li><strong>End</strong> — a recording has stopped.</li>
+<li><strong>Success</strong> — a two-note rising chirp when something
+completed.</li>
+<li><strong>Failure</strong> — a low tone, repeated, when something went
+wrong.</li>
+<li><strong>Mute</strong> — a low tone when microphones are muted.</li>
+<li><strong>Unmute</strong> — a short high tone when they are live.</li>
+</ul>
+<p>You can replace all of them with your own sound files. Open
+<strong>Settings</strong> with <strong>Ctrl+Comma</strong>, go to the
+audio settings, turn on the option to play your own sound files instead
+of the built-in beeps, and pick a <code>.wav</code> file for each of the
+six cues. There is a preview button so you can hear a file before
+committing to it.</p>
+<h2 id="spoken-status-announcements">Spoken status announcements</h2>
+<p>The main window has a status area at the bottom, named &quot;Status
+notifications&quot; for your screen reader. Everything that appears there is
+also announced out loud, even when the status area was already open — so
+a run of updates like &quot;Recording…&quot; then &quot;Transcribing…&quot; then the final
+result all reach you.</p>
+<p>Errors and warnings interrupt whatever your screen reader is
+currently saying, because they need you now. Routine progress updates
+wait their turn politely. If several updates arrive quickly, you hear
+the most recent one rather than a backlog of stale messages.</p>
+<h2 id="the-screenshot-overlay-talks-you-through-it">The screenshot
+overlay talks you through it</h2>
+<p>Grabbing part of a screen you cannot see sounds impossible. It is
+not.</p>
+<p>When the screen-capture overlay opens, it announces itself and tells
+you the keys: move with the arrow keys, press <strong>Enter</strong> to
+set the first corner, move again, then <strong>Enter</strong> to
+capture. <strong>Ctrl+A</strong> selects the whole screen, which means
+any capture can be finished in two keystrokes.
+<strong>Backspace</strong> clears the corner you set.
+<strong>Escape</strong> cancels.</p>
+<p>As you move, it reads your position out. Before you set a corner you
+hear the caret position. After you set one you hear the size of the
+region and where its top-left corner sits, so you always know where on
+the screen you are. Hold <strong>Ctrl</strong> for one-pixel steps or
+<strong>Shift</strong> for big hundred-pixel jumps. When the capture
+finishes it tells you the size of what it grabbed, in pixels. If you
+press Enter twice without moving, it tells you the region is empty
+rather than silently doing nothing.</p>
+<h2 id="reading-aloud-is-a-first-class-feature">Reading aloud is a
+first-class feature</h2>
+<p>Mutation can read the clipboard out loud, with its own voice, rate
+and volume, and its own pause, skip and rewind controls. It can announce
+roughly how long a piece of text will take to read before it starts, and
+read your progress out at intervals — &quot;50%, about 3 minutes left&quot;. You
+can ask where you are at any moment and hear &quot;Sentence 4 of 22, about
+40% through, about 2 minutes left&quot;.</p>
+<p>See <a href="read-aloud.html">Having text read aloud</a> for the full
+picture.</p>
+<h2 id="handing-the-result-to-your-screen-reader-automatically">Handing
+the result to your screen reader automatically</h2>
+<p>This one is worth setting up. After an OCR run or a dictation
+finishes, Mutation can send a keystroke of your choosing to whatever app
+you were in.</p>
+<p>Say you dictate a note into an email. Mutation puts the transcript on
+the clipboard, then sends <strong>Ctrl+V</strong> to the email window
+for you, so the text lands where your cursor was without you touching
+anything. Or set it to your screen reader&#39;s own &quot;read from here&quot;
+shortcut, and the OCR result gets read to you the moment it is
+ready.</p>
+<p>You set it in <strong>Settings</strong>, under the shortcuts section:
+one box for &quot;after OCR&quot; and one for &quot;after transcription&quot;. Leave a box
+empty and nothing is sent.</p>
+<h2 id="alongside-a-screen-reader-and-zoomtext">Alongside a screen
+reader and ZoomText</h2>
+<p>Mutation is designed to sit next to your existing tools, not replace
+them. Its global shortcuts are registered with Windows, so they work
+whichever app has focus. If your screen reader or magnifier already owns
+a combination you want, Windows will refuse to give it to Mutation — you
+will get a message at startup listing the shortcuts that could not be
+registered and why, and you can pick different ones. See <a href="troubleshooting.html">Troubleshooting</a> if that happens.</p>
+<p>Every default shortcut in Mutation can be changed, so you can fit it
+around the shortcuts you already have in your fingers.</p>
+<h2 id="where-to-next">Where to next</h2>
+<ul>
+<li><a href="keyboard-shortcuts.html">Keyboard shortcuts</a> — the full
+list, and how to change them.</li>
+<li><a href="read-aloud.html">Having text read aloud</a> — voices,
+speed, and the reading controls.</li>
+<li><a href="screen-capture-and-ocr.html">Screenshots and reading text
+from images</a> — the capture overlay in context.</li>
+<li><a href="troubleshooting.html">Troubleshooting</a> — when something
+does not behave.</li>
+</ul>
+<footer>
+<p><a href="index.html">Back to the contents page</a></p>
+<p>Generated from the Markdown source on 4 August 2026. The Markdown files are the source of truth – do not edit these HTML pages by hand.</p>
+</footer>
+</main>
+</div>
+</body>
+</html>

--- a/Documentation/UserGuide/html/ai-prompts.html
+++ b/Documentation/UserGuide/html/ai-prompts.html
@@ -1,0 +1,286 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Using AI prompts on your text - Mutation User Guide</title>
+<meta name="generator" content="pandoc 3.9.0.2" />
+<style type="text/css">
+:root{
+color-scheme: light dark;
+--bg:#ffffff; --fg:#1b1b1f; --muted:#5a5a66; --rule:#d9d9e0;
+--accent:#0b5fa5; --accent-fg:#ffffff; --surface:#f5f5f8; --code:#f0f0f4;
+--quote:#eef4fb; --quote-rule:#0b5fa5;
+}
+@media (prefers-color-scheme: dark){
+:root{
+--bg:#15151a; --fg:#eaeaf0; --muted:#a8a8b6; --rule:#3a3a45;
+--accent:#6fb3ff; --accent-fg:#10131a; --surface:#1e1e26; --code:#22222c;
+--quote:#1c2530; --quote-rule:#6fb3ff;
+}
+}
+*{box-sizing:border-box}
+html{font-size:106%}
+body{
+margin:0; background:var(--bg); color:var(--fg);
+font-family:"Segoe UI",system-ui,-apple-system,Arial,sans-serif;
+line-height:1.65;
+}
+.skip{
+position:absolute; left:-9999px; top:0; padding:.6rem 1rem; z-index:10;
+background:var(--accent); color:var(--accent-fg); font-weight:600;
+}
+.skip:focus{left:0}
+.layout{display:flex; align-items:flex-start; gap:2rem; max-width:1180px; margin:0 auto; padding:1.5rem}
+.sidebar{
+flex:0 0 16rem; position:sticky; top:1.5rem;
+background:var(--surface); border:1px solid var(--rule); border-radius:10px; padding:1rem 1.1rem;
+}
+.sidebar h2{font-size:1rem; margin:0 0 .6rem; text-transform:uppercase; letter-spacing:.04em; color:var(--muted)}
+.sidebar ol{list-style:none; margin:0; padding:0}
+.sidebar li{margin:.15rem 0}
+.sidebar a{display:block; padding:.3rem .45rem; border-radius:6px; text-decoration:none; color:var(--fg)}
+.sidebar a:hover{background:var(--bg); text-decoration:underline}
+.sidebar a[aria-current="page"]{background:var(--accent); color:var(--accent-fg); font-weight:600}
+main{flex:1 1 auto; min-width:0; max-width:52rem}
+h1{font-size:2.1rem; line-height:1.2; margin:.2rem 0 1rem; border-bottom:3px solid var(--accent); padding-bottom:.5rem}
+h2{font-size:1.5rem; margin:2.2rem 0 .7rem; border-bottom:1px solid var(--rule); padding-bottom:.3rem}
+h3{font-size:1.2rem; margin:1.7rem 0 .5rem}
+h4{font-size:1.05rem; margin:1.4rem 0 .4rem}
+p{margin:.7rem 0}
+a{color:var(--accent)}
+a:focus-visible,button:focus-visible,main:focus-visible{outline:3px solid var(--accent); outline-offset:2px}
+ul,ol{margin:.7rem 0; padding-left:1.6rem}
+li{margin:.3rem 0}
+code{background:var(--code); padding:.12em .38em; border-radius:4px; font-family:Consolas,"Cascadia Mono",monospace; font-size:.92em}
+pre{background:var(--code); border:1px solid var(--rule); border-radius:8px; padding:.9rem 1rem; overflow-x:auto}
+pre code{background:none; padding:0; font-size:.9em}
+blockquote{
+margin:1rem 0; padding:.7rem 1rem; background:var(--quote);
+border-left:5px solid var(--quote-rule); border-radius:0 8px 8px 0;
+}
+blockquote p{margin:.3rem 0}
+
+table{border-collapse:collapse; width:100%; margin:1rem 0; display:block; overflow-x:auto}
+thead,tbody,tr{width:100%}
+th,td{border:1px solid var(--rule); padding:.5rem .65rem; vertical-align:top}
+th{background:var(--surface); font-weight:700; text-align:left}
+tbody tr:nth-child(even){background:var(--surface)}
+hr{border:none; border-top:1px solid var(--rule); margin:2rem 0}
+kbd{background:var(--surface); border:1px solid var(--rule); border-bottom-width:2px; border-radius:5px; padding:.1em .4em}
+footer{margin-top:3rem; padding-top:1rem; border-top:1px solid var(--rule); color:var(--muted); font-size:.9rem}
+@media (max-width:860px){
+.layout{flex-direction:column; padding:1rem}
+.sidebar{position:static; flex:1 1 auto; width:100%}
+main{max-width:none}
+}
+@media print{
+.sidebar,.skip{display:none}
+body{background:#fff; color:#000}
+.layout{display:block; max-width:none; padding:0}
+a{color:#000}
+}
+</style>
+</head>
+<body>
+<a class="skip" href="#content">Skip to the main content</a>
+<div class="layout">
+<nav class="sidebar" aria-label="User guide contents">
+<h2>Mutation User Guide</h2>
+<ol>
+<li><a href="index.html">The Mutation User Guide</a></li>
+<li><a href="getting-started.html">Getting started</a></li>
+<li><a href="main-window.html">A tour of the main window</a></li>
+<li><a href="microphone.html">Muting your microphone</a></li>
+<li><a href="dictation.html">Dictation: turning speech into text</a></li>
+<li><a href="screen-capture-and-ocr.html">Screenshots and reading text from images</a></li>
+<li><a href="read-aloud.html">Having text read aloud</a></li>
+<li><a href="ai-prompts.html" aria-current="page">Using AI prompts on your text</a></li>
+<li><a href="transcript-formatting.html">Automatic find-and-replace rules</a></li>
+<li><a href="keyboard-shortcuts.html">Keyboard shortcuts</a></li>
+<li><a href="settings.html">The Settings window</a></li>
+<li><a href="accessibility.html">Screen reader and accessibility notes</a></li>
+<li><a href="troubleshooting.html">Troubleshooting</a></li>
+</ol>
+</nav>
+<main id="content" tabindex="-1">
+<h1 id="using-ai-prompts-on-your-text">Using AI prompts on your
+text</h1>
+<p>A prompt is a saved instruction that you can run on any piece of
+text. You write the instruction once — &quot;fix the grammar&quot;, &quot;make this
+shorter&quot;, &quot;turn these rough notes into a polite email&quot; — give it a name,
+and from then on it is one click or one keyboard shortcut away.</p>
+<p>That is the whole idea. You are not chatting with anything. You hand
+Mutation some text, Mutation hands it to an AI along with your saved
+instruction, and you get the tidied-up version back.</p>
+<p>Here are four that earn their keep in an ordinary working day.</p>
+<table>
+<thead>
+<tr>
+<th scope="col">Name</th>
+<th scope="col">The instruction you would write</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Fix Grammar</td>
+<td>Fix the grammar, spelling and punctuation in the following text. Do
+not change the meaning or the tone.</td>
+</tr>
+<tr>
+<td>Shorten</td>
+<td>Rewrite the following text so it says the same thing in about half
+the words.</td>
+</tr>
+<tr>
+<td>Make It an Email</td>
+<td>Turn the following rough notes into a short, polite work email. Keep
+it plain and friendly.</td>
+</tr>
+<tr>
+<td>Key Points</td>
+<td>Summarise the following text as a short bullet list of the main
+points.</td>
+</tr>
+</tbody>
+</table>
+<hr />
+<h2 id="where-the-text-comes-from-and-where-the-answer-goes">Where the
+text comes from, and where the answer goes</h2>
+<p>When you run a prompt, Mutation uses <strong>whatever text is on your
+clipboard</strong>. So the normal routine is: select the text anywhere —
+in Word, in your browser, in an email — press <strong>Ctrl+C</strong>,
+then run the prompt.</p>
+<p>When the answer comes back, three things happen at once. The answer
+appears in the <strong>Formatted Transcript</strong> box on the main
+window, it is copied onto your clipboard, and Mutation puts it into the
+app you were working in. You hear a success beep when all of that
+worked. If the clipboard was busy and the text could not be delivered,
+you get a failure beep and a message telling you the result is still
+sitting safely in the Mutation window.</p>
+<hr />
+<h2 id="the-prompt-list">The prompt list</h2>
+<p>Your prompts live on the <strong>LLM Prompts</strong> card on the
+main window. Each row shows the prompt&#39;s name, its keyboard shortcut if
+it has one, the model it uses, and the word &quot;(Auto-Run)&quot; if it is the
+automatic one.</p>
+<p>Each row has three buttons.</p>
+<ul>
+<li><strong>Run</strong> — runs that prompt on the clipboard text, right
+now.</li>
+<li><strong>Edit</strong> — opens the prompt so you can change it.</li>
+<li><strong>Delete</strong> — removes it.</li>
+</ul>
+<p><strong>Add Prompt</strong>, at the top right of the card, creates a
+new one.</p>
+<hr />
+<h2 id="creating-a-prompt">Creating a prompt</h2>
+<p>Press <strong>Add Prompt</strong> and the <strong>Edit
+Prompt</strong> window opens. Two fields matter most.</p>
+<p><strong>Name</strong> is what you will see in the list. Keep it short
+— &quot;Fix Grammar&quot;, &quot;Shorten&quot;, &quot;Draft Reply&quot;.</p>
+<p><strong>Prompt Instructions</strong> is the instruction itself. This
+is the part that does the work.</p>
+<p>Three pointers for writing a good one:</p>
+<ul>
+<li>Say what you want done, plainly, as if you were asking a colleague.
+&quot;Fix the grammar and punctuation&quot; beats &quot;improve this&quot;.</li>
+<li>Say what you want back. Adding &quot;Reply with only the corrected text
+and nothing else&quot; stops the AI from adding a chatty preamble.</li>
+<li>Say what must not change. &quot;Keep my wording and tone&quot; is worth adding
+to any tidy-up prompt.</li>
+</ul>
+<p>There is a <strong>Test Run</strong> button at the bottom. It runs
+the prompt against your current clipboard content using the settings on
+screen, without saving anything. Use it to try an instruction before you
+commit to it.</p>
+<p>Then press <strong>Save</strong>, or <strong>Cancel</strong> to throw
+it away.</p>
+<hr />
+<h2 id="giving-a-prompt-its-own-shortcut">Giving a prompt its own
+shortcut</h2>
+<p>The <strong>Hotkey</strong> box in the prompt editor is optional.
+Fill it in and that key combination runs this prompt from anywhere — no
+need to switch to Mutation first. Copy some text in Outlook, press your
+shortcut, and the cleaned-up version lands back in Outlook.</p>
+<p>Pick combinations that nothing else is using.
+<strong>Ctrl+Alt</strong> plus a letter is usually safe. If a shortcut
+cannot be claimed because another program already has it, Mutation tells
+you.</p>
+<hr />
+<h2 id="the-auto-run-prompt">The Auto-Run prompt</h2>
+<p>One prompt in your list can be marked <strong>Run automatically after
+transcription</strong>. That prompt then runs on its own as soon as a
+recording has been turned into text, without you pressing anything.</p>
+<p>This is what the record-and-process dictation shortcut uses: you
+dictate, Mutation transcribes, and your Auto-Run prompt cleans the
+result up in the same breath. See <a href="dictation.html">Dictation:
+turning speech into text</a> for that shortcut.</p>
+<p>The <strong>Process with LLM</strong> button on the
+<strong>Transcripts</strong> card also reaches for the Auto-Run
+prompt.</p>
+<p>Only one prompt can hold this role. Marking a new one automatically
+clears it from the old one.</p>
+<hr />
+<h2 id="choosing-a-model">Choosing a model</h2>
+<p>A model is the particular AI that reads your text and writes the
+reply. Different models cost different amounts and are better at
+different jobs.</p>
+<p>The <strong>Model</strong> box in the prompt editor lets you pin a
+prompt to a specific one. <strong>If you leave it alone, that is
+completely fine</strong> — the prompt just uses the standard model. Only
+change it if you have a reason to.</p>
+<p>The list of available models is managed in <strong>Settings</strong>
+(<strong>Ctrl+Comma</strong>), under <strong>AI assistance</strong>.
+Each model belongs to one of two providers: <strong>OpenAI</strong> or
+<strong>Anthropic</strong> (whose models are called Claude). You need
+the matching key set up for the provider you choose — an OpenAI key for
+OpenAI models, an Anthropic key for Claude models. See <a href="getting-started.html">Getting started</a> for how to add them.</p>
+<hr />
+<h2 id="fast-mode">Fast mode</h2>
+<p><strong>Fast mode</strong> is a check box in the prompt editor. It
+runs the same model faster. The model, and the quality of its answers,
+are unchanged — only the speed and the price differ.</p>
+<p>The catch is the price. Fast mode is billed at roughly
+<strong>twice</strong> the standard rate, so turn it on only for prompts
+where waiting actually costs you something.</p>
+<p>Two more things to know. Not every model offers Fast mode. And on
+Anthropic (Claude) models it also needs research-preview access on your
+account, which you have to request.</p>
+<p>If Fast mode cannot be used for any reason, nothing breaks. The
+prompt still runs at normal speed, you still get your answer, and
+Mutation tells you why Fast mode was skipped — whether you need to
+request access, pick a different model, or simply try again later.</p>
+<hr />
+<h2 id="waiting-and-when-things-go-slowly">Waiting, and when things go
+slowly</h2>
+<p>Under <strong>AI assistance</strong> in <strong>Settings</strong>
+there are two knobs worth knowing about.</p>
+<p><strong>Request timeout</strong> is how long Mutation waits for the
+model to respond before giving up. If you regularly send long documents
+and see things time out, raise it.</p>
+<p><strong>Retries</strong> is how many times Mutation quietly tries
+again after a failed request, before telling you it did not work. The
+default of three is there for a good reason: it helps the very first
+request after you reboot succeed while your network is still warming
+up.</p>
+<hr />
+<h2 id="where-to-next">Where to next</h2>
+<ul>
+<li><a href="dictation.html">Dictation: turning speech into text</a> —
+the record-and-process shortcut that uses your Auto-Run prompt</li>
+<li><a href="transcript-formatting.html">Automatic find-and-replace
+rules</a> — fixing repeat offenders without involving an AI at all</li>
+<li><a href="getting-started.html">Getting started</a> — adding your
+OpenAI and Anthropic keys</li>
+<li><a href="keyboard-shortcuts.html">Keyboard shortcuts</a> — the full
+list, and how to change any of them</li>
+</ul>
+<footer>
+<p><a href="index.html">Back to the contents page</a></p>
+<p>Generated from the Markdown source on 4 August 2026. The Markdown files are the source of truth – do not edit these HTML pages by hand.</p>
+</footer>
+</main>
+</div>
+</body>
+</html>

--- a/Documentation/UserGuide/html/ai-prompts.html
+++ b/Documentation/UserGuide/html/ai-prompts.html
@@ -61,8 +61,8 @@ border-left:5px solid var(--quote-rule); border-radius:0 8px 8px 0;
 }
 blockquote p{margin:.3rem 0}
 
-table{border-collapse:collapse; width:100%; margin:1rem 0; display:block; overflow-x:auto}
-thead,tbody,tr{width:100%}
+.table-wrap{overflow-x:auto; margin:1rem 0}
+table{border-collapse:collapse; width:100%; min-width:26rem}
 th,td{border:1px solid var(--rule); padding:.5rem .65rem; vertical-align:top}
 th{background:var(--surface); font-weight:700; text-align:left}
 tbody tr:nth-child(even){background:var(--surface)}
@@ -70,9 +70,10 @@ hr{border:none; border-top:1px solid var(--rule); margin:2rem 0}
 kbd{background:var(--surface); border:1px solid var(--rule); border-bottom-width:2px; border-radius:5px; padding:.1em .4em}
 footer{margin-top:3rem; padding-top:1rem; border-top:1px solid var(--rule); color:var(--muted); font-size:.9rem}
 @media (max-width:860px){
-.layout{flex-direction:column; padding:1rem}
+
+.layout{flex-direction:column; align-items:stretch; padding:1rem}
 .sidebar{position:static; flex:1 1 auto; width:100%}
-main{max-width:none}
+main{max-width:none; width:100%; min-width:0}
 }
 @media print{
 .sidebar,.skip{display:none}
@@ -114,6 +115,7 @@ and from then on it is one click or one keyboard shortcut away.</p>
 Mutation some text, Mutation hands it to an AI along with your saved
 instruction, and you get the tidied-up version back.</p>
 <p>Here are four that earn their keep in an ordinary working day.</p>
+<div class="table-wrap">
 <table>
 <thead>
 <tr>
@@ -144,6 +146,7 @@ points.</td>
 </tr>
 </tbody>
 </table>
+</div>
 <hr />
 <h2 id="where-the-text-comes-from-and-where-the-answer-goes">Where the
 text comes from, and where the answer goes</h2>

--- a/Documentation/UserGuide/html/dictation.html
+++ b/Documentation/UserGuide/html/dictation.html
@@ -61,8 +61,8 @@ border-left:5px solid var(--quote-rule); border-radius:0 8px 8px 0;
 }
 blockquote p{margin:.3rem 0}
 
-table{border-collapse:collapse; width:100%; margin:1rem 0; display:block; overflow-x:auto}
-thead,tbody,tr{width:100%}
+.table-wrap{overflow-x:auto; margin:1rem 0}
+table{border-collapse:collapse; width:100%; min-width:26rem}
 th,td{border:1px solid var(--rule); padding:.5rem .65rem; vertical-align:top}
 th{background:var(--surface); font-weight:700; text-align:left}
 tbody tr:nth-child(even){background:var(--surface)}
@@ -70,9 +70,10 @@ hr{border:none; border-top:1px solid var(--rule); margin:2rem 0}
 kbd{background:var(--surface); border:1px solid var(--rule); border-bottom-width:2px; border-radius:5px; padding:.1em .4em}
 footer{margin-top:3rem; padding-top:1rem; border-top:1px solid var(--rule); color:var(--muted); font-size:.9rem}
 @media (max-width:860px){
-.layout{flex-direction:column; padding:1rem}
+
+.layout{flex-direction:column; align-items:stretch; padding:1rem}
 .sidebar{position:static; flex:1 1 auto; width:100%}
-main{max-width:none}
+main{max-width:none; width:100%; min-width:0}
 }
 @media print{
 .sidebar,.skip{display:none}
@@ -166,6 +167,7 @@ slowly.</p>
 <strong>Third-party interaction</strong>. It decides what Mutation does
 with your transcript <em>after</em> it has copied it to the clipboard.
 There are three choices:</p>
+<div class="table-wrap">
 <table>
 <thead>
 <tr>
@@ -191,6 +193,7 @@ and on the clipboard, and you paste it yourself.</td>
 </tr>
 </tbody>
 </table>
+</div>
 <blockquote>
 <p>The three choices are shown using their short internal names —
 <strong>Paste</strong>, <strong>SendKeys</strong> and

--- a/Documentation/UserGuide/html/dictation.html
+++ b/Documentation/UserGuide/html/dictation.html
@@ -1,0 +1,325 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Dictation: turning speech into text - Mutation User Guide</title>
+<meta name="generator" content="pandoc 3.9.0.2" />
+<style type="text/css">
+:root{
+color-scheme: light dark;
+--bg:#ffffff; --fg:#1b1b1f; --muted:#5a5a66; --rule:#d9d9e0;
+--accent:#0b5fa5; --accent-fg:#ffffff; --surface:#f5f5f8; --code:#f0f0f4;
+--quote:#eef4fb; --quote-rule:#0b5fa5;
+}
+@media (prefers-color-scheme: dark){
+:root{
+--bg:#15151a; --fg:#eaeaf0; --muted:#a8a8b6; --rule:#3a3a45;
+--accent:#6fb3ff; --accent-fg:#10131a; --surface:#1e1e26; --code:#22222c;
+--quote:#1c2530; --quote-rule:#6fb3ff;
+}
+}
+*{box-sizing:border-box}
+html{font-size:106%}
+body{
+margin:0; background:var(--bg); color:var(--fg);
+font-family:"Segoe UI",system-ui,-apple-system,Arial,sans-serif;
+line-height:1.65;
+}
+.skip{
+position:absolute; left:-9999px; top:0; padding:.6rem 1rem; z-index:10;
+background:var(--accent); color:var(--accent-fg); font-weight:600;
+}
+.skip:focus{left:0}
+.layout{display:flex; align-items:flex-start; gap:2rem; max-width:1180px; margin:0 auto; padding:1.5rem}
+.sidebar{
+flex:0 0 16rem; position:sticky; top:1.5rem;
+background:var(--surface); border:1px solid var(--rule); border-radius:10px; padding:1rem 1.1rem;
+}
+.sidebar h2{font-size:1rem; margin:0 0 .6rem; text-transform:uppercase; letter-spacing:.04em; color:var(--muted)}
+.sidebar ol{list-style:none; margin:0; padding:0}
+.sidebar li{margin:.15rem 0}
+.sidebar a{display:block; padding:.3rem .45rem; border-radius:6px; text-decoration:none; color:var(--fg)}
+.sidebar a:hover{background:var(--bg); text-decoration:underline}
+.sidebar a[aria-current="page"]{background:var(--accent); color:var(--accent-fg); font-weight:600}
+main{flex:1 1 auto; min-width:0; max-width:52rem}
+h1{font-size:2.1rem; line-height:1.2; margin:.2rem 0 1rem; border-bottom:3px solid var(--accent); padding-bottom:.5rem}
+h2{font-size:1.5rem; margin:2.2rem 0 .7rem; border-bottom:1px solid var(--rule); padding-bottom:.3rem}
+h3{font-size:1.2rem; margin:1.7rem 0 .5rem}
+h4{font-size:1.05rem; margin:1.4rem 0 .4rem}
+p{margin:.7rem 0}
+a{color:var(--accent)}
+a:focus-visible,button:focus-visible,main:focus-visible{outline:3px solid var(--accent); outline-offset:2px}
+ul,ol{margin:.7rem 0; padding-left:1.6rem}
+li{margin:.3rem 0}
+code{background:var(--code); padding:.12em .38em; border-radius:4px; font-family:Consolas,"Cascadia Mono",monospace; font-size:.92em}
+pre{background:var(--code); border:1px solid var(--rule); border-radius:8px; padding:.9rem 1rem; overflow-x:auto}
+pre code{background:none; padding:0; font-size:.9em}
+blockquote{
+margin:1rem 0; padding:.7rem 1rem; background:var(--quote);
+border-left:5px solid var(--quote-rule); border-radius:0 8px 8px 0;
+}
+blockquote p{margin:.3rem 0}
+
+table{border-collapse:collapse; width:100%; margin:1rem 0; display:block; overflow-x:auto}
+thead,tbody,tr{width:100%}
+th,td{border:1px solid var(--rule); padding:.5rem .65rem; vertical-align:top}
+th{background:var(--surface); font-weight:700; text-align:left}
+tbody tr:nth-child(even){background:var(--surface)}
+hr{border:none; border-top:1px solid var(--rule); margin:2rem 0}
+kbd{background:var(--surface); border:1px solid var(--rule); border-bottom-width:2px; border-radius:5px; padding:.1em .4em}
+footer{margin-top:3rem; padding-top:1rem; border-top:1px solid var(--rule); color:var(--muted); font-size:.9rem}
+@media (max-width:860px){
+.layout{flex-direction:column; padding:1rem}
+.sidebar{position:static; flex:1 1 auto; width:100%}
+main{max-width:none}
+}
+@media print{
+.sidebar,.skip{display:none}
+body{background:#fff; color:#000}
+.layout{display:block; max-width:none; padding:0}
+a{color:#000}
+}
+</style>
+</head>
+<body>
+<a class="skip" href="#content">Skip to the main content</a>
+<div class="layout">
+<nav class="sidebar" aria-label="User guide contents">
+<h2>Mutation User Guide</h2>
+<ol>
+<li><a href="index.html">The Mutation User Guide</a></li>
+<li><a href="getting-started.html">Getting started</a></li>
+<li><a href="main-window.html">A tour of the main window</a></li>
+<li><a href="microphone.html">Muting your microphone</a></li>
+<li><a href="dictation.html" aria-current="page">Dictation: turning speech into text</a></li>
+<li><a href="screen-capture-and-ocr.html">Screenshots and reading text from images</a></li>
+<li><a href="read-aloud.html">Having text read aloud</a></li>
+<li><a href="ai-prompts.html">Using AI prompts on your text</a></li>
+<li><a href="transcript-formatting.html">Automatic find-and-replace rules</a></li>
+<li><a href="keyboard-shortcuts.html">Keyboard shortcuts</a></li>
+<li><a href="settings.html">The Settings window</a></li>
+<li><a href="accessibility.html">Screen reader and accessibility notes</a></li>
+<li><a href="troubleshooting.html">Troubleshooting</a></li>
+</ol>
+</nav>
+<main id="content" tabindex="-1">
+<h1 id="dictation-turning-speech-into-text">Dictation: turning speech
+into text</h1>
+<p>Dictation is the feature most people end up using every day. You
+press a shortcut, talk, press it again, and a second or two later your
+words are sitting there as text — ready to paste into an email, a chat
+message, or a document.</p>
+<h2 id="the-basic-loop">The basic loop</h2>
+<ol type="1">
+<li>Press <strong>Shift+Alt+U</strong>. Mutation plays a short beep and
+starts recording.</li>
+<li>Say what you want to write. Take your time — pauses are fine.</li>
+<li>Press <strong>Shift+Alt+U</strong> again. The beep tells you
+recording has stopped.</li>
+<li>A moment later — usually one to three seconds for a few sentences —
+the text appears, and a success beep plays.</li>
+</ol>
+<p>That&#39;s it. The shortcut is global, so it works no matter which app
+you are in. You never have to switch to Mutation first.</p>
+<p>If you prefer clicking, the <strong>Speech to Text</strong> card on
+the main window has a <strong>Record</strong> button that does exactly
+the same thing.</p>
+<blockquote>
+<p><strong>Shift+Alt+U</strong> is just the default. Every shortcut in
+Mutation can be changed. Open <strong>Settings</strong> with
+<strong>Ctrl+Comma</strong> and look on the <strong>Hotkeys</strong>
+tab.</p>
+</blockquote>
+<h2 id="recording-and-cleaning-up-in-one-step">Recording and cleaning up
+in one step</h2>
+<p>There is a second shortcut, <strong>Shift+Alt+I</strong> by default,
+that records <em>and</em> then runs your chosen AI prompt on the result
+— all from the one press. So you can ramble a bit, and what comes back
+is already tidied into proper sentences.</p>
+<p>On the main window this is the <strong>Record and Format</strong>
+button, next to <strong>Record</strong>.</p>
+<p>Which prompt runs is up to you: it&#39;s the one you have marked as
+<strong>Auto-Run</strong>. See <a href="ai-prompts.html">Using AI
+prompts on your text</a> for how to set that up.</p>
+<h2 id="where-the-text-ends-up">Where the text ends up</h2>
+<p>Once a recording is transcribed, the text lands in three places at
+once:</p>
+<ul>
+<li>The <strong>Raw Transcript</strong> box on the main window — exactly
+what the transcription service heard.</li>
+<li>The <strong>Formatted Transcript</strong> box, just below it — the
+same text after your find-and-replace rules have been applied. If you
+haven&#39;t set any rules up, the two boxes will look the same. See <a href="transcript-formatting.html">Automatic find-and-replace
+rules</a>.</li>
+<li>Your <strong>clipboard</strong>. The formatted version is copied
+automatically, so you can paste it anywhere with
+<strong>Ctrl+V</strong>.</li>
+</ul>
+<p>Both boxes are ordinary text boxes. You can read them with your
+screen reader, edit them, or select and copy from them.</p>
+<h2 id="getting-the-text-into-the-app-you-were-using">Getting the text
+into the app you were using</h2>
+<p>This is the part that trips people up, so it&#39;s worth reading
+slowly.</p>
+<p>On the <strong>Automation</strong> card there is a dropdown called
+<strong>Third-party interaction</strong>. It decides what Mutation does
+with your transcript <em>after</em> it has copied it to the clipboard.
+There are three choices:</p>
+<table>
+<thead>
+<tr>
+<th scope="col">Choice in the list</th>
+<th scope="col">What happens</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>Paste</strong></td>
+<td>Mutation copies the text and then presses <strong>Ctrl+V</strong>
+for you, so it appears in whatever app was in front.</td>
+</tr>
+<tr>
+<td><strong>SendKeys</strong></td>
+<td>Mutation types the text out, one keystroke at a time, as if you had
+typed it yourself.</td>
+</tr>
+<tr>
+<td><strong>DoNotInsert</strong></td>
+<td>Mutation does nothing further. The text stays in the Mutation window
+and on the clipboard, and you paste it yourself.</td>
+</tr>
+</tbody>
+</table>
+<blockquote>
+<p>The three choices are shown using their short internal names —
+<strong>Paste</strong>, <strong>SendKeys</strong> and
+<strong>DoNotInsert</strong>. They are not the friendliest labels, but a
+line of explanation appears underneath the dropdown as soon as you pick
+one.</p>
+</blockquote>
+<p><strong>Which should you pick?</strong></p>
+<p>Start with <strong>Paste</strong>. It is the fastest and it handles
+long text without trouble.</p>
+<p>Switch to <strong>SendKeys</strong> when an app refuses to accept a
+paste, or mangles it. Some older apps, some remote-desktop sessions, and
+some web forms behave that way. Typing is slower and you will see the
+letters appear one by one, but it works almost everywhere.</p>
+<p>Choose <strong>DoNotInsert</strong> when you want to look at the text
+before it goes anywhere — or when you are dictating notes into Mutation
+itself and don&#39;t want stray text landing in another window.</p>
+<p>One thing worth knowing: if the Mutation window itself is the one in
+front, nothing is inserted anywhere. Mutation won&#39;t paste into
+itself.</p>
+<h3 id="sending-a-shortcut-afterwards">Sending a shortcut
+afterwards</h3>
+<p>In <strong>Settings</strong>, on the <strong>Speech to Text</strong>
+page, there is an optional box called <strong>Send hotkey after
+transcription</strong>. Whatever shortcut you put there is sent to the
+active app once the transcript has been delivered.</p>
+<p>It exists for apps that need one extra keypress to finish the job —
+for example sending <strong>Ctrl+V</strong> to paste, or a
+<strong>Tab</strong> or <strong>Enter</strong> to move on. Leave it
+blank if you don&#39;t need it.</p>
+<h2 id="choosing-a-transcription-service">Choosing a transcription
+service</h2>
+<p>At the top of the <strong>Speech to Text</strong> card is a dropdown
+listing your transcription services.</p>
+<p>A transcription service is simply an online service that receives
+your recording, listens to it, and sends the text back. Mutation doesn&#39;t
+do the listening itself — it hands the audio over and waits for the
+answer. Different services differ in how fast they are, how accurate
+they are, and what they charge, so it&#39;s worth trying a couple and
+settling on the one you like.</p>
+<p>Out of the box, Mutation knows about:</p>
+<ul>
+<li><strong>OpenAI gpt-4o-transcribe</strong> (and its smaller, cheaper
+sibling gpt-4o-mini-transcribe)</li>
+<li><strong>Groq Whisper 3</strong></li>
+<li><strong>Deepgram Nova3</strong></li>
+<li>Any other service that speaks the same language as OpenAI&#39;s
+Whisper</li>
+</ul>
+<p>Each service needs an API key — a long password that lets Mutation
+talk to the service on your behalf. See <a href="getting-started.html">Getting started</a> for where those go.</p>
+<blockquote>
+<p>Switching which service is <em>active</em> takes effect straight away
+— just pick a different one from the dropdown. But if you
+<strong>add</strong>, <strong>remove</strong>, or <strong>edit</strong>
+a service definition in Settings, you need to restart Mutation before
+the change takes hold.</p>
+</blockquote>
+<h2 id="the-prompt-box">The Prompt box</h2>
+<p>Under the session buttons there is a box simply labelled
+<strong>Prompt</strong>. It&#39;s optional and easy to overlook, but it can
+noticeably improve your results.</p>
+<p>Whatever you type here is sent along with each recording as a hint
+about what kind of words to expect. It is especially good at getting
+unusual spellings right.</p>
+<p>Say you work with a colleague called Siobhán, a product called
+Kestrel Nine, and you keep saying &quot;EBITDA&quot;. Type those into the Prompt
+box and the service will spell them properly instead of guessing:</p>
+<pre><code>Siobhán, Kestrel Nine, EBITDA, Bloemfontein, Anthropic</code></pre>
+<p>The Prompt box belongs to whichever service is currently selected, so
+you can keep a different list of terms for each one. It saves itself as
+you type.</p>
+<h2 id="working-with-past-recordings">Working with past recordings</h2>
+<p>Mutation keeps your recent recordings so you can go back to them.</p>
+<ul>
+<li>The <strong>older</strong> and <strong>newer</strong> arrow buttons
+step back and forward through your recent sessions.</li>
+<li><strong>Play selected session</strong> plays the one you&#39;ve landed
+on, so you can hear what you actually said.</li>
+<li>The <strong>Speed</strong> dropdown changes how fast it plays back,
+from half speed up to three times normal. Voices stay at their natural
+pitch at every speed — nobody turns into a chipmunk.</li>
+<li><strong>Retry transcription</strong> sends the selected recording
+off to be transcribed again. This is the useful one: if a transcript
+came back wrong, pick a different service or add some terms to the
+Prompt box, then press Retry.</li>
+</ul>
+<p>By default Mutation keeps the last <strong>10</strong> recordings,
+and quietly deletes the oldest ones beyond that. You can set this
+anywhere from 1 to 500 in <strong>Settings</strong>, under
+<strong>Recording sessions to keep</strong>. A recording that is still
+in progress is never deleted.</p>
+<h2 id="transcribing-a-file-you-already-have">Transcribing a file you
+already have</h2>
+<p>You don&#39;t have to record inside Mutation. If someone sends you a
+voice note, or you have a recording of a meeting, use the <strong>Upload
+audio for transcription</strong> button on the <strong>Speech to
+Text</strong> card. Pick the file and Mutation transcribes it the same
+way it would a live recording.</p>
+<p>It accepts audio files — MP3, WAV, M4A, AAC, FLAC, OGG, OPUS, WMA —
+and video files — WEBM, MP4, AVI, MKV, MOV, WMV, M4V. With a video,
+Mutation pulls out the soundtrack and transcribes that. Long files take
+longer, naturally; Mutation allows a much more generous wait for them
+than for a quick live recording.</p>
+<h2 id="trimming-the-quiet-bits">Trimming the quiet bits</h2>
+<p>Mutation trims long silent gaps out of your audio before sending it
+off. This means the pauses while you think don&#39;t make the recording
+bigger and slower than it needs to be. It applies to recordings you make
+and to files you upload, and it is on by default — leave it on unless
+you have a reason not to.</p>
+<p>If you want to fine-tune how aggressive the trimming is, the dials
+live in <a href="settings.html">The Settings window</a>.</p>
+<hr />
+<h2 id="where-to-next">Where to next</h2>
+<ul>
+<li><a href="ai-prompts.html">Using AI prompts on your text</a> — clean
+up, rewrite, or summarise what you dictated.</li>
+<li><a href="transcript-formatting.html">Automatic find-and-replace
+rules</a> — fix recurring mistakes automatically.</li>
+<li><a href="keyboard-shortcuts.html">Keyboard shortcuts</a> — the full
+list, and how to change them.</li>
+<li><a href="microphone.html">Muting your microphone</a> — choosing
+which microphone Mutation records from.</li>
+</ul>
+<footer>
+<p><a href="index.html">Back to the contents page</a></p>
+<p>Generated from the Markdown source on 4 August 2026. The Markdown files are the source of truth – do not edit these HTML pages by hand.</p>
+</footer>
+</main>
+</div>
+</body>
+</html>

--- a/Documentation/UserGuide/html/getting-started.html
+++ b/Documentation/UserGuide/html/getting-started.html
@@ -1,0 +1,268 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Getting started - Mutation User Guide</title>
+<meta name="generator" content="pandoc 3.9.0.2" />
+<style type="text/css">
+:root{
+color-scheme: light dark;
+--bg:#ffffff; --fg:#1b1b1f; --muted:#5a5a66; --rule:#d9d9e0;
+--accent:#0b5fa5; --accent-fg:#ffffff; --surface:#f5f5f8; --code:#f0f0f4;
+--quote:#eef4fb; --quote-rule:#0b5fa5;
+}
+@media (prefers-color-scheme: dark){
+:root{
+--bg:#15151a; --fg:#eaeaf0; --muted:#a8a8b6; --rule:#3a3a45;
+--accent:#6fb3ff; --accent-fg:#10131a; --surface:#1e1e26; --code:#22222c;
+--quote:#1c2530; --quote-rule:#6fb3ff;
+}
+}
+*{box-sizing:border-box}
+html{font-size:106%}
+body{
+margin:0; background:var(--bg); color:var(--fg);
+font-family:"Segoe UI",system-ui,-apple-system,Arial,sans-serif;
+line-height:1.65;
+}
+.skip{
+position:absolute; left:-9999px; top:0; padding:.6rem 1rem; z-index:10;
+background:var(--accent); color:var(--accent-fg); font-weight:600;
+}
+.skip:focus{left:0}
+.layout{display:flex; align-items:flex-start; gap:2rem; max-width:1180px; margin:0 auto; padding:1.5rem}
+.sidebar{
+flex:0 0 16rem; position:sticky; top:1.5rem;
+background:var(--surface); border:1px solid var(--rule); border-radius:10px; padding:1rem 1.1rem;
+}
+.sidebar h2{font-size:1rem; margin:0 0 .6rem; text-transform:uppercase; letter-spacing:.04em; color:var(--muted)}
+.sidebar ol{list-style:none; margin:0; padding:0}
+.sidebar li{margin:.15rem 0}
+.sidebar a{display:block; padding:.3rem .45rem; border-radius:6px; text-decoration:none; color:var(--fg)}
+.sidebar a:hover{background:var(--bg); text-decoration:underline}
+.sidebar a[aria-current="page"]{background:var(--accent); color:var(--accent-fg); font-weight:600}
+main{flex:1 1 auto; min-width:0; max-width:52rem}
+h1{font-size:2.1rem; line-height:1.2; margin:.2rem 0 1rem; border-bottom:3px solid var(--accent); padding-bottom:.5rem}
+h2{font-size:1.5rem; margin:2.2rem 0 .7rem; border-bottom:1px solid var(--rule); padding-bottom:.3rem}
+h3{font-size:1.2rem; margin:1.7rem 0 .5rem}
+h4{font-size:1.05rem; margin:1.4rem 0 .4rem}
+p{margin:.7rem 0}
+a{color:var(--accent)}
+a:focus-visible,button:focus-visible,main:focus-visible{outline:3px solid var(--accent); outline-offset:2px}
+ul,ol{margin:.7rem 0; padding-left:1.6rem}
+li{margin:.3rem 0}
+code{background:var(--code); padding:.12em .38em; border-radius:4px; font-family:Consolas,"Cascadia Mono",monospace; font-size:.92em}
+pre{background:var(--code); border:1px solid var(--rule); border-radius:8px; padding:.9rem 1rem; overflow-x:auto}
+pre code{background:none; padding:0; font-size:.9em}
+blockquote{
+margin:1rem 0; padding:.7rem 1rem; background:var(--quote);
+border-left:5px solid var(--quote-rule); border-radius:0 8px 8px 0;
+}
+blockquote p{margin:.3rem 0}
+
+table{border-collapse:collapse; width:100%; margin:1rem 0; display:block; overflow-x:auto}
+thead,tbody,tr{width:100%}
+th,td{border:1px solid var(--rule); padding:.5rem .65rem; vertical-align:top}
+th{background:var(--surface); font-weight:700; text-align:left}
+tbody tr:nth-child(even){background:var(--surface)}
+hr{border:none; border-top:1px solid var(--rule); margin:2rem 0}
+kbd{background:var(--surface); border:1px solid var(--rule); border-bottom-width:2px; border-radius:5px; padding:.1em .4em}
+footer{margin-top:3rem; padding-top:1rem; border-top:1px solid var(--rule); color:var(--muted); font-size:.9rem}
+@media (max-width:860px){
+.layout{flex-direction:column; padding:1rem}
+.sidebar{position:static; flex:1 1 auto; width:100%}
+main{max-width:none}
+}
+@media print{
+.sidebar,.skip{display:none}
+body{background:#fff; color:#000}
+.layout{display:block; max-width:none; padding:0}
+a{color:#000}
+}
+</style>
+</head>
+<body>
+<a class="skip" href="#content">Skip to the main content</a>
+<div class="layout">
+<nav class="sidebar" aria-label="User guide contents">
+<h2>Mutation User Guide</h2>
+<ol>
+<li><a href="index.html">The Mutation User Guide</a></li>
+<li><a href="getting-started.html" aria-current="page">Getting started</a></li>
+<li><a href="main-window.html">A tour of the main window</a></li>
+<li><a href="microphone.html">Muting your microphone</a></li>
+<li><a href="dictation.html">Dictation: turning speech into text</a></li>
+<li><a href="screen-capture-and-ocr.html">Screenshots and reading text from images</a></li>
+<li><a href="read-aloud.html">Having text read aloud</a></li>
+<li><a href="ai-prompts.html">Using AI prompts on your text</a></li>
+<li><a href="transcript-formatting.html">Automatic find-and-replace rules</a></li>
+<li><a href="keyboard-shortcuts.html">Keyboard shortcuts</a></li>
+<li><a href="settings.html">The Settings window</a></li>
+<li><a href="accessibility.html">Screen reader and accessibility notes</a></li>
+<li><a href="troubleshooting.html">Troubleshooting</a></li>
+</ol>
+</nav>
+<main id="content" tabindex="-1">
+<h1 id="getting-started">Getting started</h1>
+<p>Welcome. Mutation is a small Windows program that sits quietly in the
+background and gives your keyboard some extra powers. Press one key
+combination to mute every microphone on your PC at once. Press another
+to dictate a sentence instead of typing it. Press another to pull the
+text out of a screenshot, or to have whatever you copied read out
+loud.</p>
+<p>The clever part is that these shortcuts work everywhere. You do not
+have to switch to Mutation first. Whether you are in Outlook, Teams,
+Word or your browser, the same key combination does the same thing.
+Mutation was built by a developer who is almost blind, for his own daily
+work, so it is designed to be usable without hunting for tiny icons on
+screen.</p>
+<hr />
+<h2 id="what-you-need-before-you-start">What you need before you
+start</h2>
+<p><strong>Windows.</strong> Mutation is a Windows desktop app.</p>
+<p><strong>The .NET 10 runtime.</strong> This is a free piece of
+Microsoft plumbing that Mutation needs in order to run. Install it once,
+then start <strong>Mutation.exe</strong>. If you already have it,
+nothing more to do.</p>
+<p><strong>A key or two for the online services.</strong> Some of
+Mutation&#39;s features do their thinking on the internet rather than on
+your PC. Turning speech into text, or asking an AI to tidy up your
+writing, happens on someone else&#39;s servers. To use those servers you
+need an API key.</p>
+<p>An API key is simply a long password that lets Mutation talk to a
+service on your behalf. You create one on that company&#39;s website, copy
+it, and paste it into Mutation. Treat it exactly like a password: do not
+email it, do not paste it into a chat, and do not put it in a shared
+document. Anyone who has your key can spend money on your account.</p>
+<p>You only need the keys for the features you actually want. Here is
+what each one unlocks.</p>
+<table>
+<thead>
+<tr>
+<th scope="col">Key</th>
+<th scope="col">What it gives you</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>OpenAI</td>
+<td>Dictation (speech to text) and AI prompts</td>
+</tr>
+<tr>
+<td>Anthropic</td>
+<td>AI prompts using Claude models</td>
+</tr>
+<tr>
+<td>Deepgram</td>
+<td>An alternative dictation service, if you prefer it to OpenAI</td>
+</tr>
+<tr>
+<td>Azure Computer Vision (key <em>and</em> endpoint)</td>
+<td>Reading text out of screenshots and images</td>
+</tr>
+</tbody>
+</table>
+<p>If all you want is the microphone mute, you need no keys at all. That
+feature works straight away.</p>
+<blockquote>
+<p>The Azure Computer Vision service needs two things, not one: a key,
+and an &quot;endpoint&quot;, which is just the web address of your own Azure
+service. You get both from the same place when you set the service
+up.</p>
+</blockquote>
+<hr />
+<h2 id="your-very-first-launch">Your very first launch</h2>
+<p>The first time you run Mutation, it creates its settings file with
+sensible defaults, and every keyboard shortcut is already set up and
+ready to change later.</p>
+<p>If you have not yet added an OpenAI or Anthropic key, Mutation greets
+you with a short welcome message titled <strong>Welcome to
+Mutation</strong>. It explains that at least one key is needed, and
+lists which key does what. Press <strong>Continue</strong>.</p>
+<p>The <strong>Settings</strong> window then opens on its own, so you
+can paste your keys in right away. That is the whole of first-run setup.
+If you would rather do it later, just close Settings — you can reopen it
+at any time with <strong>Ctrl+Comma</strong>.</p>
+<p>One other message you might see later: if you have set up a dictation
+service but its key is missing, Mutation tells you which service it has
+switched off and opens Settings on the API keys page. Add the key, save,
+then restart Mutation so the service becomes available again.</p>
+<hr />
+<h2 id="entering-your-keys">Entering your keys</h2>
+<ol type="1">
+<li>Press <strong>Ctrl+Comma</strong> to open
+<strong>Settings</strong>.</li>
+<li>Choose <strong>API keys</strong> in the list on the left.</li>
+<li>Paste your key into the matching box: <strong>OpenAI API
+key</strong>, <strong>Anthropic API key</strong> or <strong>Deepgram API
+key</strong>.</li>
+<li>Save.</li>
+</ol>
+<p>The OpenAI key covers both AI prompts and OpenAI dictation, so one
+key does double duty there. The Deepgram key is only for Deepgram
+dictation.</p>
+<p>The Azure Computer Vision key lives somewhere else, because it
+belongs to the screenshot features. You will find it under
+<strong>Screen capture &amp; OCR</strong> in Settings, together with the
+<strong>Endpoint</strong> box.</p>
+<hr />
+<h2 id="where-your-settings-are-kept">Where your settings are kept</h2>
+<p>Everything you configure is stored in a single file called
+<strong>Mutation.json</strong>, which sits in the same folder as
+<strong>Mutation.exe</strong>.</p>
+<p>You do not need to open it. Everything in it can be changed from the
+Settings window. But it is worth knowing where it is for one reason: if
+you copy that file somewhere safe now and then, you have a backup of all
+your shortcuts, prompts and settings. Copy it back into the folder and
+Mutation picks up exactly where you left off.</p>
+<p>Because your API keys are stored in that file, keep any copies of it
+somewhere private.</p>
+<hr />
+<h2 id="try-it-in-five-minutes">Try it in five minutes</h2>
+<p>Give these a go, in any app you like. These are the shortcuts
+Mutation starts with — you can change every one of them later.</p>
+<ol type="1">
+<li><strong>Mute your microphone.</strong> Press <strong>Alt+Q</strong>.
+Every microphone on the PC mutes at once, and you hear a beep confirming
+which way it went. Press it again to unmute. See <a href="microphone.html">Muting your microphone</a>.</li>
+<li><strong>Dictate a sentence.</strong> Press
+<strong>Shift+Alt+U</strong>, say something, then press it again to
+stop. A few seconds later your words come back as text. See <a href="dictation.html">Dictation: turning speech into text</a>.</li>
+<li><strong>Have something read aloud.</strong> Copy any text, then
+press <strong>Ctrl+Shift+Alt+Q</strong> to hear it spoken. See <a href="read-aloud.html">Having text read aloud</a>.</li>
+<li><strong>Read text off the screen.</strong> Press
+<strong>Shift+Alt+J</strong>, drag a rectangle over some text in an
+image, and the text lands on your clipboard. This one needs the Azure
+key. See <a href="screen-capture-and-ocr.html">Screenshots and reading
+text from images</a>.</li>
+</ol>
+<p>That is the core of it. Everything else builds on those four
+ideas.</p>
+<hr />
+<h2 id="leave-it-running">Leave it running</h2>
+<p>Mutation does its job from the background. Once it is started you can
+minimise the main window and forget about it — the shortcuts keep
+working no matter which app you are using. Closing the window shuts the
+app down, and the shortcuts stop with it, so minimise rather than close
+if you want them to stay live.</p>
+<hr />
+<h2 id="where-to-next">Where to next</h2>
+<ul>
+<li><a href="main-window.html">A tour of the main window</a> — what each
+part of the screen does.</li>
+<li><a href="keyboard-shortcuts.html">Keyboard shortcuts</a> — the full
+list, and how to change any of them.</li>
+<li><a href="settings.html">The Settings window</a> — every option,
+explained.</li>
+<li><a href="troubleshooting.html">Troubleshooting</a> — if something is
+not behaving.</li>
+</ul>
+<footer>
+<p><a href="index.html">Back to the contents page</a></p>
+<p>Generated from the Markdown source on 4 August 2026. The Markdown files are the source of truth – do not edit these HTML pages by hand.</p>
+</footer>
+</main>
+</div>
+</body>
+</html>

--- a/Documentation/UserGuide/html/getting-started.html
+++ b/Documentation/UserGuide/html/getting-started.html
@@ -61,8 +61,8 @@ border-left:5px solid var(--quote-rule); border-radius:0 8px 8px 0;
 }
 blockquote p{margin:.3rem 0}
 
-table{border-collapse:collapse; width:100%; margin:1rem 0; display:block; overflow-x:auto}
-thead,tbody,tr{width:100%}
+.table-wrap{overflow-x:auto; margin:1rem 0}
+table{border-collapse:collapse; width:100%; min-width:26rem}
 th,td{border:1px solid var(--rule); padding:.5rem .65rem; vertical-align:top}
 th{background:var(--surface); font-weight:700; text-align:left}
 tbody tr:nth-child(even){background:var(--surface)}
@@ -70,9 +70,10 @@ hr{border:none; border-top:1px solid var(--rule); margin:2rem 0}
 kbd{background:var(--surface); border:1px solid var(--rule); border-bottom-width:2px; border-radius:5px; padding:.1em .4em}
 footer{margin-top:3rem; padding-top:1rem; border-top:1px solid var(--rule); color:var(--muted); font-size:.9rem}
 @media (max-width:860px){
-.layout{flex-direction:column; padding:1rem}
+
+.layout{flex-direction:column; align-items:stretch; padding:1rem}
 .sidebar{position:static; flex:1 1 auto; width:100%}
-main{max-width:none}
+main{max-width:none; width:100%; min-width:0}
 }
 @media print{
 .sidebar,.skip{display:none}
@@ -137,6 +138,7 @@ email it, do not paste it into a chat, and do not put it in a shared
 document. Anyone who has your key can spend money on your account.</p>
 <p>You only need the keys for the features you actually want. Here is
 what each one unlocks.</p>
+<div class="table-wrap">
 <table>
 <thead>
 <tr>
@@ -163,6 +165,7 @@ what each one unlocks.</p>
 </tr>
 </tbody>
 </table>
+</div>
 <p>If all you want is the microphone mute, you need no keys at all. That
 feature works straight away.</p>
 <blockquote>

--- a/Documentation/UserGuide/html/index.html
+++ b/Documentation/UserGuide/html/index.html
@@ -1,0 +1,282 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>The Mutation User Guide</title>
+<meta name="generator" content="pandoc 3.9.0.2" />
+<style type="text/css">
+:root{
+color-scheme: light dark;
+--bg:#ffffff; --fg:#1b1b1f; --muted:#5a5a66; --rule:#d9d9e0;
+--accent:#0b5fa5; --accent-fg:#ffffff; --surface:#f5f5f8; --code:#f0f0f4;
+--quote:#eef4fb; --quote-rule:#0b5fa5;
+}
+@media (prefers-color-scheme: dark){
+:root{
+--bg:#15151a; --fg:#eaeaf0; --muted:#a8a8b6; --rule:#3a3a45;
+--accent:#6fb3ff; --accent-fg:#10131a; --surface:#1e1e26; --code:#22222c;
+--quote:#1c2530; --quote-rule:#6fb3ff;
+}
+}
+*{box-sizing:border-box}
+html{font-size:106%}
+body{
+margin:0; background:var(--bg); color:var(--fg);
+font-family:"Segoe UI",system-ui,-apple-system,Arial,sans-serif;
+line-height:1.65;
+}
+.skip{
+position:absolute; left:-9999px; top:0; padding:.6rem 1rem; z-index:10;
+background:var(--accent); color:var(--accent-fg); font-weight:600;
+}
+.skip:focus{left:0}
+.layout{display:flex; align-items:flex-start; gap:2rem; max-width:1180px; margin:0 auto; padding:1.5rem}
+.sidebar{
+flex:0 0 16rem; position:sticky; top:1.5rem;
+background:var(--surface); border:1px solid var(--rule); border-radius:10px; padding:1rem 1.1rem;
+}
+.sidebar h2{font-size:1rem; margin:0 0 .6rem; text-transform:uppercase; letter-spacing:.04em; color:var(--muted)}
+.sidebar ol{list-style:none; margin:0; padding:0}
+.sidebar li{margin:.15rem 0}
+.sidebar a{display:block; padding:.3rem .45rem; border-radius:6px; text-decoration:none; color:var(--fg)}
+.sidebar a:hover{background:var(--bg); text-decoration:underline}
+.sidebar a[aria-current="page"]{background:var(--accent); color:var(--accent-fg); font-weight:600}
+main{flex:1 1 auto; min-width:0; max-width:52rem}
+h1{font-size:2.1rem; line-height:1.2; margin:.2rem 0 1rem; border-bottom:3px solid var(--accent); padding-bottom:.5rem}
+h2{font-size:1.5rem; margin:2.2rem 0 .7rem; border-bottom:1px solid var(--rule); padding-bottom:.3rem}
+h3{font-size:1.2rem; margin:1.7rem 0 .5rem}
+h4{font-size:1.05rem; margin:1.4rem 0 .4rem}
+p{margin:.7rem 0}
+a{color:var(--accent)}
+a:focus-visible,button:focus-visible,main:focus-visible{outline:3px solid var(--accent); outline-offset:2px}
+ul,ol{margin:.7rem 0; padding-left:1.6rem}
+li{margin:.3rem 0}
+code{background:var(--code); padding:.12em .38em; border-radius:4px; font-family:Consolas,"Cascadia Mono",monospace; font-size:.92em}
+pre{background:var(--code); border:1px solid var(--rule); border-radius:8px; padding:.9rem 1rem; overflow-x:auto}
+pre code{background:none; padding:0; font-size:.9em}
+blockquote{
+margin:1rem 0; padding:.7rem 1rem; background:var(--quote);
+border-left:5px solid var(--quote-rule); border-radius:0 8px 8px 0;
+}
+blockquote p{margin:.3rem 0}
+
+table{border-collapse:collapse; width:100%; margin:1rem 0; display:block; overflow-x:auto}
+thead,tbody,tr{width:100%}
+th,td{border:1px solid var(--rule); padding:.5rem .65rem; vertical-align:top}
+th{background:var(--surface); font-weight:700; text-align:left}
+tbody tr:nth-child(even){background:var(--surface)}
+hr{border:none; border-top:1px solid var(--rule); margin:2rem 0}
+kbd{background:var(--surface); border:1px solid var(--rule); border-bottom-width:2px; border-radius:5px; padding:.1em .4em}
+footer{margin-top:3rem; padding-top:1rem; border-top:1px solid var(--rule); color:var(--muted); font-size:.9rem}
+@media (max-width:860px){
+.layout{flex-direction:column; padding:1rem}
+.sidebar{position:static; flex:1 1 auto; width:100%}
+main{max-width:none}
+}
+@media print{
+.sidebar,.skip{display:none}
+body{background:#fff; color:#000}
+.layout{display:block; max-width:none; padding:0}
+a{color:#000}
+}
+</style>
+</head>
+<body>
+<a class="skip" href="#content">Skip to the main content</a>
+<div class="layout">
+<nav class="sidebar" aria-label="User guide contents">
+<h2>Mutation User Guide</h2>
+<ol>
+<li><a href="index.html" aria-current="page">The Mutation User Guide</a></li>
+<li><a href="getting-started.html">Getting started</a></li>
+<li><a href="main-window.html">A tour of the main window</a></li>
+<li><a href="microphone.html">Muting your microphone</a></li>
+<li><a href="dictation.html">Dictation: turning speech into text</a></li>
+<li><a href="screen-capture-and-ocr.html">Screenshots and reading text from images</a></li>
+<li><a href="read-aloud.html">Having text read aloud</a></li>
+<li><a href="ai-prompts.html">Using AI prompts on your text</a></li>
+<li><a href="transcript-formatting.html">Automatic find-and-replace rules</a></li>
+<li><a href="keyboard-shortcuts.html">Keyboard shortcuts</a></li>
+<li><a href="settings.html">The Settings window</a></li>
+<li><a href="accessibility.html">Screen reader and accessibility notes</a></li>
+<li><a href="troubleshooting.html">Troubleshooting</a></li>
+</ol>
+</nav>
+<main id="content" tabindex="-1">
+<h1 id="the-mutation-user-guide">The Mutation User Guide</h1>
+<p>Welcome. Mutation is a small Windows app that sits quietly in the
+background and gives you a set of keyboard shortcuts that work
+<em>everywhere</em> — in your email, in a meeting, in a spreadsheet, in
+your browser. You don&#39;t have to switch to Mutation to use it. You just
+press a key.</p>
+<p>It does six main jobs for you:</p>
+<ul>
+<li><strong>Mutes every microphone on your PC at once</strong>, so you
+always know for certain whether you are muted.</li>
+<li><strong>Grabs a piece of your screen and pulls the words out of
+it</strong>, so text trapped in a picture becomes text you can copy,
+search and paste.</li>
+<li><strong>Turns what you say into typed text</strong>, so you can
+dictate a message instead of typing it.</li>
+<li><strong>Runs your text past an AI assistant</strong> to fix the
+grammar, shorten it, or turn rough notes into a proper email.</li>
+<li><strong>Reads text out loud</strong>, with proper pause, resume and
+skip controls.</li>
+<li><strong>Turns one keyboard shortcut into another</strong>, so an
+awkward shortcut in some other app becomes an easy one.</li>
+</ul>
+<p>Mutation was built by a nearly-blind developer for his own daily
+work, so everything in it can be done from the keyboard, and everything
+it does it also tells you about out loud or with a sound.</p>
+<hr />
+<h2 id="where-to-start">Where to start</h2>
+<p>If you are brand new, read these two, in this order:</p>
+<ol type="1">
+<li><strong><a href="getting-started.html">Getting started</a></strong>
+— what you need, what happens the first time you run Mutation, and a
+five-minute first try.</li>
+<li><strong><a href="main-window.html">A tour of the main
+window</a></strong> — a quick map of what every part of the screen
+does.</li>
+</ol>
+<p>After that, dip into whichever chapter covers the job you want to
+do.</p>
+<hr />
+<h2 id="all-the-chapters">All the chapters</h2>
+<h3 id="getting-going">Getting going</h3>
+<table>
+<thead>
+<tr>
+<th scope="col">Chapter</th>
+<th scope="col">What&#39;s in it</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a href="getting-started.html">Getting started</a></td>
+<td>What you need before you begin, setting up your account keys, where
+your settings are kept, and a quick first try.</td>
+</tr>
+<tr>
+<td><a href="main-window.html">A tour of the main window</a></td>
+<td>Every section of the main screen, what each button does, and where
+to read more.</td>
+</tr>
+</tbody>
+</table>
+<h3 id="the-things-mutation-does">The things Mutation does</h3>
+<table>
+<thead>
+<tr>
+<th scope="col">Chapter</th>
+<th scope="col">What&#39;s in it</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a href="microphone.html">Muting your microphone</a></td>
+<td>One shortcut to mute and unmute every microphone at once, the
+confirmation beeps, the input level meter, and pinning your input
+level.</td>
+</tr>
+<tr>
+<td><a href="dictation.html">Dictation: turning speech into
+text</a></td>
+<td>Recording your voice and getting text back, choosing a transcription
+service, where the text is delivered, replaying past recordings, and
+transcribing files you already have.</td>
+</tr>
+<tr>
+<td><a href="screen-capture-and-ocr.html">Screenshots and reading text
+from images</a></td>
+<td>Capturing part of your screen with the mouse or the keyboard,
+pulling the text out of pictures and PDFs, and choosing the right
+reading order.</td>
+</tr>
+<tr>
+<td><a href="read-aloud.html">Having text read aloud</a></td>
+<td>Reading the clipboard or your selection out loud, pausing and
+resuming, skipping around sentence by sentence, and picking a voice,
+speed and volume.</td>
+</tr>
+<tr>
+<td><a href="ai-prompts.html">Using AI prompts on your text</a></td>
+<td>Saving your own instructions like &quot;fix the grammar&quot; or &quot;turn this
+into an email&quot;, giving each one a shortcut, and choosing which AI model
+runs it.</td>
+</tr>
+<tr>
+<td><a href="transcript-formatting.html">Automatic find-and-replace
+rules</a></td>
+<td>Teaching Mutation to fix the words it always gets wrong, and to
+strip out filler, automatically.</td>
+</tr>
+</tbody>
+</table>
+<h3 id="settings-and-reference">Settings and reference</h3>
+<table>
+<thead>
+<tr>
+<th scope="col">Chapter</th>
+<th scope="col">What&#39;s in it</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a href="keyboard-shortcuts.html">Keyboard shortcuts</a></td>
+<td>The full list of shortcuts and their defaults, how to change one,
+and how to make one shortcut stand in for another.</td>
+</tr>
+<tr>
+<td><a href="settings.html">The Settings window</a></td>
+<td>A guided walk through every settings page, what each option does,
+and how to put things back the way they were.</td>
+</tr>
+<tr>
+<td><a href="accessibility.html">Screen reader and accessibility
+notes</a></td>
+<td>How Mutation works with a screen reader and ZoomText, what it
+announces, and the sounds it uses to tell you what happened.</td>
+</tr>
+<tr>
+<td><a href="troubleshooting.html">Troubleshooting</a></td>
+<td>When something doesn&#39;t work: the usual causes, the quick fixes, and
+where the log file lives.</td>
+</tr>
+</tbody>
+</table>
+<hr />
+<h2 id="a-few-things-worth-knowing-up-front">A few things worth knowing
+up front</h2>
+<ul>
+<li><strong>Every shortcut in this guide can be changed.</strong> The
+ones printed here are just what Mutation starts with. If a combination
+clashes with something you already use, go to Settings and pick your own
+— see <a href="keyboard-shortcuts.html">Keyboard shortcuts</a>.</li>
+<li><strong>You only need to set up the parts you want.</strong>
+Mutation asks for account keys for the online services it uses, but they
+are separate. If you only want the microphone mute, you don&#39;t need any
+of them.</li>
+<li><strong>Settings open with Ctrl+Comma</strong> from anywhere in the
+app.</li>
+<li><strong>Most settings have hover help.</strong> If a setting isn&#39;t
+clear, rest your mouse on it, or tab to it with a screen reader — the
+same explanation is available both ways.</li>
+</ul>
+<hr />
+<h2 id="about-this-guide">About this guide</h2>
+<p>The chapters live as Markdown files in the <code>markdown</code>
+folder, and the matching web pages in the <code>html</code> folder are
+generated from them. The Markdown is always the authoritative version.
+To rebuild the web pages after an edit, run
+<code>Build-UserGuide.cmd</code> in the <code>Documentation</code>
+folder.</p>
+<footer>
+<p><a href="index.html">Back to the contents page</a></p>
+<p>Generated from the Markdown source on 4 August 2026. The Markdown files are the source of truth – do not edit these HTML pages by hand.</p>
+</footer>
+</main>
+</div>
+</body>
+</html>

--- a/Documentation/UserGuide/html/index.html
+++ b/Documentation/UserGuide/html/index.html
@@ -61,8 +61,8 @@ border-left:5px solid var(--quote-rule); border-radius:0 8px 8px 0;
 }
 blockquote p{margin:.3rem 0}
 
-table{border-collapse:collapse; width:100%; margin:1rem 0; display:block; overflow-x:auto}
-thead,tbody,tr{width:100%}
+.table-wrap{overflow-x:auto; margin:1rem 0}
+table{border-collapse:collapse; width:100%; min-width:26rem}
 th,td{border:1px solid var(--rule); padding:.5rem .65rem; vertical-align:top}
 th{background:var(--surface); font-weight:700; text-align:left}
 tbody tr:nth-child(even){background:var(--surface)}
@@ -70,9 +70,10 @@ hr{border:none; border-top:1px solid var(--rule); margin:2rem 0}
 kbd{background:var(--surface); border:1px solid var(--rule); border-bottom-width:2px; border-radius:5px; padding:.1em .4em}
 footer{margin-top:3rem; padding-top:1rem; border-top:1px solid var(--rule); color:var(--muted); font-size:.9rem}
 @media (max-width:860px){
-.layout{flex-direction:column; padding:1rem}
+
+.layout{flex-direction:column; align-items:stretch; padding:1rem}
 .sidebar{position:static; flex:1 1 auto; width:100%}
-main{max-width:none}
+main{max-width:none; width:100%; min-width:0}
 }
 @media print{
 .sidebar,.skip{display:none}
@@ -145,6 +146,7 @@ do.</p>
 <hr />
 <h2 id="all-the-chapters">All the chapters</h2>
 <h3 id="getting-going">Getting going</h3>
+<div class="table-wrap">
 <table>
 <thead>
 <tr>
@@ -165,7 +167,9 @@ to read more.</td>
 </tr>
 </tbody>
 </table>
+</div>
 <h3 id="the-things-mutation-does">The things Mutation does</h3>
+<div class="table-wrap">
 <table>
 <thead>
 <tr>
@@ -214,7 +218,9 @@ strip out filler, automatically.</td>
 </tr>
 </tbody>
 </table>
+</div>
 <h3 id="settings-and-reference">Settings and reference</h3>
+<div class="table-wrap">
 <table>
 <thead>
 <tr>
@@ -246,6 +252,7 @@ where the log file lives.</td>
 </tr>
 </tbody>
 </table>
+</div>
 <hr />
 <h2 id="a-few-things-worth-knowing-up-front">A few things worth knowing
 up front</h2>

--- a/Documentation/UserGuide/html/keyboard-shortcuts.html
+++ b/Documentation/UserGuide/html/keyboard-shortcuts.html
@@ -1,0 +1,431 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Keyboard shortcuts - Mutation User Guide</title>
+<meta name="generator" content="pandoc 3.9.0.2" />
+<style type="text/css">
+:root{
+color-scheme: light dark;
+--bg:#ffffff; --fg:#1b1b1f; --muted:#5a5a66; --rule:#d9d9e0;
+--accent:#0b5fa5; --accent-fg:#ffffff; --surface:#f5f5f8; --code:#f0f0f4;
+--quote:#eef4fb; --quote-rule:#0b5fa5;
+}
+@media (prefers-color-scheme: dark){
+:root{
+--bg:#15151a; --fg:#eaeaf0; --muted:#a8a8b6; --rule:#3a3a45;
+--accent:#6fb3ff; --accent-fg:#10131a; --surface:#1e1e26; --code:#22222c;
+--quote:#1c2530; --quote-rule:#6fb3ff;
+}
+}
+*{box-sizing:border-box}
+html{font-size:106%}
+body{
+margin:0; background:var(--bg); color:var(--fg);
+font-family:"Segoe UI",system-ui,-apple-system,Arial,sans-serif;
+line-height:1.65;
+}
+.skip{
+position:absolute; left:-9999px; top:0; padding:.6rem 1rem; z-index:10;
+background:var(--accent); color:var(--accent-fg); font-weight:600;
+}
+.skip:focus{left:0}
+.layout{display:flex; align-items:flex-start; gap:2rem; max-width:1180px; margin:0 auto; padding:1.5rem}
+.sidebar{
+flex:0 0 16rem; position:sticky; top:1.5rem;
+background:var(--surface); border:1px solid var(--rule); border-radius:10px; padding:1rem 1.1rem;
+}
+.sidebar h2{font-size:1rem; margin:0 0 .6rem; text-transform:uppercase; letter-spacing:.04em; color:var(--muted)}
+.sidebar ol{list-style:none; margin:0; padding:0}
+.sidebar li{margin:.15rem 0}
+.sidebar a{display:block; padding:.3rem .45rem; border-radius:6px; text-decoration:none; color:var(--fg)}
+.sidebar a:hover{background:var(--bg); text-decoration:underline}
+.sidebar a[aria-current="page"]{background:var(--accent); color:var(--accent-fg); font-weight:600}
+main{flex:1 1 auto; min-width:0; max-width:52rem}
+h1{font-size:2.1rem; line-height:1.2; margin:.2rem 0 1rem; border-bottom:3px solid var(--accent); padding-bottom:.5rem}
+h2{font-size:1.5rem; margin:2.2rem 0 .7rem; border-bottom:1px solid var(--rule); padding-bottom:.3rem}
+h3{font-size:1.2rem; margin:1.7rem 0 .5rem}
+h4{font-size:1.05rem; margin:1.4rem 0 .4rem}
+p{margin:.7rem 0}
+a{color:var(--accent)}
+a:focus-visible,button:focus-visible,main:focus-visible{outline:3px solid var(--accent); outline-offset:2px}
+ul,ol{margin:.7rem 0; padding-left:1.6rem}
+li{margin:.3rem 0}
+code{background:var(--code); padding:.12em .38em; border-radius:4px; font-family:Consolas,"Cascadia Mono",monospace; font-size:.92em}
+pre{background:var(--code); border:1px solid var(--rule); border-radius:8px; padding:.9rem 1rem; overflow-x:auto}
+pre code{background:none; padding:0; font-size:.9em}
+blockquote{
+margin:1rem 0; padding:.7rem 1rem; background:var(--quote);
+border-left:5px solid var(--quote-rule); border-radius:0 8px 8px 0;
+}
+blockquote p{margin:.3rem 0}
+
+table{border-collapse:collapse; width:100%; margin:1rem 0; display:block; overflow-x:auto}
+thead,tbody,tr{width:100%}
+th,td{border:1px solid var(--rule); padding:.5rem .65rem; vertical-align:top}
+th{background:var(--surface); font-weight:700; text-align:left}
+tbody tr:nth-child(even){background:var(--surface)}
+hr{border:none; border-top:1px solid var(--rule); margin:2rem 0}
+kbd{background:var(--surface); border:1px solid var(--rule); border-bottom-width:2px; border-radius:5px; padding:.1em .4em}
+footer{margin-top:3rem; padding-top:1rem; border-top:1px solid var(--rule); color:var(--muted); font-size:.9rem}
+@media (max-width:860px){
+.layout{flex-direction:column; padding:1rem}
+.sidebar{position:static; flex:1 1 auto; width:100%}
+main{max-width:none}
+}
+@media print{
+.sidebar,.skip{display:none}
+body{background:#fff; color:#000}
+.layout{display:block; max-width:none; padding:0}
+a{color:#000}
+}
+</style>
+</head>
+<body>
+<a class="skip" href="#content">Skip to the main content</a>
+<div class="layout">
+<nav class="sidebar" aria-label="User guide contents">
+<h2>Mutation User Guide</h2>
+<ol>
+<li><a href="index.html">The Mutation User Guide</a></li>
+<li><a href="getting-started.html">Getting started</a></li>
+<li><a href="main-window.html">A tour of the main window</a></li>
+<li><a href="microphone.html">Muting your microphone</a></li>
+<li><a href="dictation.html">Dictation: turning speech into text</a></li>
+<li><a href="screen-capture-and-ocr.html">Screenshots and reading text from images</a></li>
+<li><a href="read-aloud.html">Having text read aloud</a></li>
+<li><a href="ai-prompts.html">Using AI prompts on your text</a></li>
+<li><a href="transcript-formatting.html">Automatic find-and-replace rules</a></li>
+<li><a href="keyboard-shortcuts.html" aria-current="page">Keyboard shortcuts</a></li>
+<li><a href="settings.html">The Settings window</a></li>
+<li><a href="accessibility.html">Screen reader and accessibility notes</a></li>
+<li><a href="troubleshooting.html">Troubleshooting</a></li>
+</ol>
+</nav>
+<main id="content" tabindex="-1">
+<h1 id="keyboard-shortcuts">Keyboard shortcuts</h1>
+<p>Keyboard shortcuts are how you actually use Mutation day to day. This
+chapter lists every one of them, shows you how to change them, and
+explains what to do when a combination refuses to work.</p>
+<h2 id="what-global-means">What &quot;global&quot; means</h2>
+<p>Almost every Mutation shortcut is <strong>global</strong>. That means
+it works no matter which app you are in. You can be halfway through an
+email, a spreadsheet, or a video call, and the shortcut still fires.
+Mutation&#39;s own window does not need to be open, in front, or even
+visible. It just sits quietly in the background and listens.</p>
+<p>There is one exception, and it is noted in the tables below:
+<strong>Ctrl+Comma</strong> opens Settings, and that one only works when
+Mutation&#39;s own window is in front.</p>
+<p>Every default shortcut listed here can be changed. Nothing is
+fixed.</p>
+<h2 id="the-full-list">The full list</h2>
+<h3 id="microphone">Microphone</h3>
+<table>
+<thead>
+<tr>
+<th scope="col">What it does</th>
+<th scope="col">Default shortcut</th>
+<th scope="col">More about it</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Mute or unmute every microphone at once</td>
+<td><strong>Alt+Q</strong></td>
+<td><a href="microphone.html">Muting your microphone</a></td>
+</tr>
+</tbody>
+</table>
+<h3 id="dictation">Dictation</h3>
+<table>
+<thead>
+<tr>
+<th scope="col">What it does</th>
+<th scope="col">Default shortcut</th>
+<th scope="col">More about it</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Start or stop recording your voice, then turn it into text</td>
+<td><strong>Shift+Alt+U</strong></td>
+<td><a href="dictation.html">Dictation</a></td>
+</tr>
+<tr>
+<td>Same, then send the text straight through an AI prompt</td>
+<td><strong>Shift+Alt+I</strong></td>
+<td><a href="dictation.html">Dictation</a></td>
+</tr>
+<tr>
+<td>Send a key to the app you are in, after the text is delivered</td>
+<td>None — set your own</td>
+<td><a href="dictation.html">Dictation</a></td>
+</tr>
+</tbody>
+</table>
+<h3 id="screenshots-and-ocr">Screenshots and OCR</h3>
+<table>
+<thead>
+<tr>
+<th scope="col">What it does</th>
+<th scope="col">Default shortcut</th>
+<th scope="col">More about it</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Take a screenshot of part of the screen</td>
+<td><strong>Shift+Alt+K</strong></td>
+<td><a href="screen-capture-and-ocr.html">Screenshots and OCR</a></td>
+</tr>
+<tr>
+<td>Take a screenshot and pull the text out of it</td>
+<td><strong>Shift+Alt+J</strong></td>
+<td><a href="screen-capture-and-ocr.html">Screenshots and OCR</a></td>
+</tr>
+<tr>
+<td>Same, but read strictly left to right, top to bottom</td>
+<td><strong>Shift+Alt+E</strong></td>
+<td><a href="screen-capture-and-ocr.html">Screenshots and OCR</a></td>
+</tr>
+<tr>
+<td>Pull the text out of an image already on the clipboard</td>
+<td><strong>Alt+J</strong></td>
+<td><a href="screen-capture-and-ocr.html">Screenshots and OCR</a></td>
+</tr>
+<tr>
+<td>Same, but read strictly left to right, top to bottom</td>
+<td><strong>Alt+K</strong></td>
+<td><a href="screen-capture-and-ocr.html">Screenshots and OCR</a></td>
+</tr>
+<tr>
+<td>Send a key to the app you are in, after the text is delivered</td>
+<td>None — set your own</td>
+<td><a href="screen-capture-and-ocr.html">Screenshots and OCR</a></td>
+</tr>
+</tbody>
+</table>
+<h3 id="reading-aloud">Reading aloud</h3>
+<table>
+<thead>
+<tr>
+<th scope="col">What it does</th>
+<th scope="col">Default shortcut</th>
+<th scope="col">More about it</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Read whatever is on the clipboard</td>
+<td><strong>Ctrl+Shift+Alt+Q</strong></td>
+<td><a href="read-aloud.html">Having text read aloud</a></td>
+</tr>
+<tr>
+<td>Read the text you have selected</td>
+<td><strong>Ctrl+Shift+Q</strong></td>
+<td><a href="read-aloud.html">Having text read aloud</a></td>
+</tr>
+<tr>
+<td>Pause, or carry on from where you paused</td>
+<td><strong>Ctrl+Shift+Space</strong></td>
+<td><a href="read-aloud.html">Having text read aloud</a></td>
+</tr>
+<tr>
+<td>Start again from the beginning</td>
+<td><strong>Ctrl+Shift+B</strong></td>
+<td><a href="read-aloud.html">Having text read aloud</a></td>
+</tr>
+<tr>
+<td>Go back a sentence</td>
+<td><strong>Ctrl+Shift+J</strong></td>
+<td><a href="read-aloud.html">Having text read aloud</a></td>
+</tr>
+<tr>
+<td>Go forward a sentence</td>
+<td><strong>Ctrl+Shift+K</strong></td>
+<td><a href="read-aloud.html">Having text read aloud</a></td>
+</tr>
+<tr>
+<td>Say how far through the text you are</td>
+<td><strong>Ctrl+Shift+P</strong></td>
+<td><a href="read-aloud.html">Having text read aloud</a></td>
+</tr>
+<tr>
+<td>Save the spoken audio to a file</td>
+<td>None, and see the note below</td>
+<td><a href="read-aloud.html">Having text read aloud</a></td>
+</tr>
+</tbody>
+</table>
+<blockquote>
+<p><strong>Speak to file</strong> is the one action without a row on the
+Hotkeys page. Use the <strong>Speak to file</strong> button on the main
+window. If you really want a shortcut for it, it can only be added by
+editing the settings file by hand — see <a href="settings.html">The
+Settings window</a> for where that file lives.</p>
+</blockquote>
+<h3 id="ai-prompts">AI prompts</h3>
+<table>
+<thead>
+<tr>
+<th scope="col">What it does</th>
+<th scope="col">Default shortcut</th>
+<th scope="col">More about it</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Run one of your AI prompts</td>
+<td>None — set your own, one per prompt</td>
+<td><a href="ai-prompts.html">Using AI prompts</a></td>
+</tr>
+</tbody>
+</table>
+<p>Each prompt you create can have its own shortcut. You set it in the
+prompt editor on the main window, not on the Hotkeys page. None are
+filled in for you.</p>
+<h3 id="app">App</h3>
+<table>
+<thead>
+<tr>
+<th scope="col">What it does</th>
+<th scope="col">Default shortcut</th>
+<th scope="col">More about it</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Open Settings (only when Mutation&#39;s window is in front)</td>
+<td><strong>Ctrl+Comma</strong></td>
+<td><a href="settings.html">The Settings window</a></td>
+</tr>
+<tr>
+<td>Open Mutation&#39;s menu (only when Mutation&#39;s window is in front)</td>
+<td><strong>Alt</strong>, then <strong>H</strong></td>
+<td><a href="main-window.html">A tour of the main window</a></td>
+</tr>
+</tbody>
+</table>
+<h2 id="changing-a-shortcut">Changing a shortcut</h2>
+<p>Open <strong>Settings</strong> with <strong>Ctrl+Comma</strong>, then
+pick <strong>Hotkeys</strong> from the list on the left. Every shortcut
+in the tables above is on that one page, in roughly the same order — the
+only exception is <strong>Speak to file</strong>, noted above.</p>
+<p>Each row has the name of the action, a box holding the current
+combination, a <strong>Record</strong> button, a <strong>Clear</strong>
+button, and a small reset button. Hover over the reset button and it
+tells you what the default is, for example &quot;Reset to default
+(ALT+Q)&quot;.</p>
+<p>To record a new combination:</p>
+<ol type="1">
+<li>Press the <strong>Record</strong> button. Its label changes to
+&quot;Press keys...&quot;.</li>
+<li>Hold down the modifiers you want and press the final key. Holding
+Ctrl, Shift, Alt or the Windows key on their own does nothing — Mutation
+waits for a real key before it decides you are finished.</li>
+<li>The box fills in with what you pressed, in Mutation&#39;s own style,
+like <code>CTRL+ALT+J</code>. Recording stops on its own.</li>
+</ol>
+<p>Changed your mind mid-recording? Press <strong>Escape</strong> and
+nothing is captured.</p>
+<p>You can also just type into the box if you prefer. Write the keys
+separated by plus signs. Mutation tidies up the capitals for you when
+you move away from the box. The <strong>Clear</strong> button empties a
+box, which is what you want for the two optional &quot;send a key afterwards&quot;
+fields.</p>
+<p>Your changes are held until you press <strong>Save</strong> at the
+bottom of Settings. Press <strong>Cancel</strong> and nothing you
+changed is kept.</p>
+<h2 id="when-a-combination-is-taken-or-not-allowed">When a combination
+is taken or not allowed</h2>
+<p>Mutation checks as you go, and shows the problem in red just under
+the box. Screen readers announce it straight away.</p>
+<ul>
+<li><strong>Left blank when a shortcut is required</strong> — &quot;Enter a
+hotkey.&quot;</li>
+<li><strong>Only modifier keys</strong> — &quot;Hotkey must include a
+non-modifier key.&quot; Ctrl+Shift on its own is not a shortcut; it needs a
+letter, number, or other key on the end.</li>
+<li><strong>A key Mutation does not recognise</strong> — &quot;Unsupported
+key&quot;, followed by the key you typed.</li>
+<li><strong>The same combination used twice inside Mutation</strong> —
+an orange <strong>Duplicate hotkey</strong> note appears under both
+rows. Give one of them a different combination, otherwise only one of
+the two will ever fire.</li>
+<li><strong>Another app already owns it</strong> — Mutation cannot tell
+until it actually tries to claim the combination. When it fails, you get
+a beep and a message titled &quot;Some hotkeys could not be registered&quot;,
+listing each action, its combination, and the reason, usually &quot;The
+shortcut is already registered by another application.&quot; Go back to the
+Hotkeys page and pick something else.</li>
+</ul>
+<h2 id="choosing-combinations-that-wont-clash">Choosing combinations
+that won&#39;t clash</h2>
+<ol type="1">
+<li><strong>Use three modifiers.</strong> Combinations like
+<strong>Ctrl+Shift+Alt+Q</strong> are almost never claimed by anything
+else. That is exactly why Mutation uses one for reading the
+clipboard.</li>
+<li><strong>Stay away from the famous ones.</strong> Ctrl+C, Ctrl+V,
+Ctrl+S, Ctrl+Z, Ctrl+F, Alt+Tab and Alt+F4 are used everywhere. So are
+most combinations that include the Windows key, which Windows itself
+reserves.</li>
+<li><strong>Test it in the app you use most.</strong> Set the shortcut,
+switch to that app, and press it. If Mutation responds and the other app
+does not, you are fine. If nothing happens at all, something else
+grabbed it first — try another.</li>
+</ol>
+<h2 id="the-shortcut-router">The shortcut router</h2>
+<p>The router does one thing: you press one combination, and Mutation
+presses a different one for you. It never runs a Mutation feature. It
+just passes a different set of keys along to whatever app you are
+in.</p>
+<p>Two reasons people use it:</p>
+<ul>
+<li><strong>To make an awkward shortcut easy.</strong> Some other app
+has a shortcut that is a stretch for one hand. Give yourself a
+comfortable one instead.</li>
+<li><strong>To get around a clash.</strong> A combination you want is
+blocked or occupied, so you reach the same action a different way.</li>
+</ul>
+<p>Here is a worked example. Your video call app mutes with
+<strong>Ctrl+Shift+M</strong>, which is a fiddly reach while you are
+holding a coffee. Add a mapping with <strong>Ctrl+Alt+1</strong> in the
+&quot;From&quot; box and <strong>Ctrl+Shift+M</strong> in the &quot;To&quot; box. From then
+on, pressing <strong>Ctrl+Alt+1</strong> anywhere makes Mutation send
+<strong>Ctrl+Shift+M</strong> to whatever app you are in, and the call
+mutes.</p>
+<p>To set one up, go to <strong>Settings</strong>
+(<strong>Ctrl+Comma</strong>), pick <strong>Hotkeys</strong>, and scroll
+down to the <strong>Hotkey Router</strong> section. Press <strong>Add
+mapping</strong>, fill in the &quot;From&quot; and &quot;To&quot; boxes, and press
+<strong>Save</strong>. Each row shows a small status marker: a tick once
+the mapping is live, or an error marker with a message if something is
+wrong. Two mappings listening for the same &quot;From&quot; combination get a
+&quot;Duplicate &#39;From&#39; hotkey&quot; message. <strong>Delete</strong> removes a
+mapping.</p>
+<blockquote>
+<p>As the in-app help puts it: map one shortcut to another so a single
+key press can trigger a more complex shortcut. Changes apply when you
+save settings.</p>
+</blockquote>
+<h2 id="where-to-next">Where to next</h2>
+<ul>
+<li><a href="settings.html">The Settings window</a> — where the Hotkeys
+page lives, and everything else you can change.</li>
+<li><a href="main-window.html">A tour of the main window</a> — the
+buttons behind these shortcuts.</li>
+<li><a href="troubleshooting.html">Troubleshooting</a> — what to do when
+a shortcut stops responding.</li>
+<li><a href="accessibility.html">Screen reader and accessibility
+notes</a> — how Mutation announces what it is doing.</li>
+</ul>
+<footer>
+<p><a href="index.html">Back to the contents page</a></p>
+<p>Generated from the Markdown source on 4 August 2026. The Markdown files are the source of truth – do not edit these HTML pages by hand.</p>
+</footer>
+</main>
+</div>
+</body>
+</html>

--- a/Documentation/UserGuide/html/keyboard-shortcuts.html
+++ b/Documentation/UserGuide/html/keyboard-shortcuts.html
@@ -61,8 +61,8 @@ border-left:5px solid var(--quote-rule); border-radius:0 8px 8px 0;
 }
 blockquote p{margin:.3rem 0}
 
-table{border-collapse:collapse; width:100%; margin:1rem 0; display:block; overflow-x:auto}
-thead,tbody,tr{width:100%}
+.table-wrap{overflow-x:auto; margin:1rem 0}
+table{border-collapse:collapse; width:100%; min-width:26rem}
 th,td{border:1px solid var(--rule); padding:.5rem .65rem; vertical-align:top}
 th{background:var(--surface); font-weight:700; text-align:left}
 tbody tr:nth-child(even){background:var(--surface)}
@@ -70,9 +70,10 @@ hr{border:none; border-top:1px solid var(--rule); margin:2rem 0}
 kbd{background:var(--surface); border:1px solid var(--rule); border-bottom-width:2px; border-radius:5px; padding:.1em .4em}
 footer{margin-top:3rem; padding-top:1rem; border-top:1px solid var(--rule); color:var(--muted); font-size:.9rem}
 @media (max-width:860px){
-.layout{flex-direction:column; padding:1rem}
+
+.layout{flex-direction:column; align-items:stretch; padding:1rem}
 .sidebar{position:static; flex:1 1 auto; width:100%}
-main{max-width:none}
+main{max-width:none; width:100%; min-width:0}
 }
 @media print{
 .sidebar,.skip{display:none}
@@ -121,6 +122,7 @@ Mutation&#39;s own window is in front.</p>
 fixed.</p>
 <h2 id="the-full-list">The full list</h2>
 <h3 id="microphone">Microphone</h3>
+<div class="table-wrap">
 <table>
 <thead>
 <tr>
@@ -137,7 +139,9 @@ fixed.</p>
 </tr>
 </tbody>
 </table>
+</div>
 <h3 id="dictation">Dictation</h3>
+<div class="table-wrap">
 <table>
 <thead>
 <tr>
@@ -164,7 +168,9 @@ fixed.</p>
 </tr>
 </tbody>
 </table>
+</div>
 <h3 id="screenshots-and-ocr">Screenshots and OCR</h3>
+<div class="table-wrap">
 <table>
 <thead>
 <tr>
@@ -206,7 +212,9 @@ fixed.</p>
 </tr>
 </tbody>
 </table>
+</div>
 <h3 id="reading-aloud">Reading aloud</h3>
+<div class="table-wrap">
 <table>
 <thead>
 <tr>
@@ -258,6 +266,7 @@ fixed.</p>
 </tr>
 </tbody>
 </table>
+</div>
 <blockquote>
 <p><strong>Speak to file</strong> is the one action without a row on the
 Hotkeys page. Use the <strong>Speak to file</strong> button on the main
@@ -266,6 +275,7 @@ editing the settings file by hand — see <a href="settings.html">The
 Settings window</a> for where that file lives.</p>
 </blockquote>
 <h3 id="ai-prompts">AI prompts</h3>
+<div class="table-wrap">
 <table>
 <thead>
 <tr>
@@ -282,10 +292,12 @@ Settings window</a> for where that file lives.</p>
 </tr>
 </tbody>
 </table>
+</div>
 <p>Each prompt you create can have its own shortcut. You set it in the
 prompt editor on the main window, not on the Hotkeys page. None are
 filled in for you.</p>
 <h3 id="app">App</h3>
+<div class="table-wrap">
 <table>
 <thead>
 <tr>
@@ -307,6 +319,7 @@ filled in for you.</p>
 </tr>
 </tbody>
 </table>
+</div>
 <h2 id="changing-a-shortcut">Changing a shortcut</h2>
 <p>Open <strong>Settings</strong> with <strong>Ctrl+Comma</strong>, then
 pick <strong>Hotkeys</strong> from the list on the left. Every shortcut

--- a/Documentation/UserGuide/html/main-window.html
+++ b/Documentation/UserGuide/html/main-window.html
@@ -61,8 +61,8 @@ border-left:5px solid var(--quote-rule); border-radius:0 8px 8px 0;
 }
 blockquote p{margin:.3rem 0}
 
-table{border-collapse:collapse; width:100%; margin:1rem 0; display:block; overflow-x:auto}
-thead,tbody,tr{width:100%}
+.table-wrap{overflow-x:auto; margin:1rem 0}
+table{border-collapse:collapse; width:100%; min-width:26rem}
 th,td{border:1px solid var(--rule); padding:.5rem .65rem; vertical-align:top}
 th{background:var(--surface); font-weight:700; text-align:left}
 tbody tr:nth-child(even){background:var(--surface)}
@@ -70,9 +70,10 @@ hr{border:none; border-top:1px solid var(--rule); margin:2rem 0}
 kbd{background:var(--surface); border:1px solid var(--rule); border-bottom-width:2px; border-radius:5px; padding:.1em .4em}
 footer{margin-top:3rem; padding-top:1rem; border-top:1px solid var(--rule); color:var(--muted); font-size:.9rem}
 @media (max-width:860px){
-.layout{flex-direction:column; padding:1rem}
+
+.layout{flex-direction:column; align-items:stretch; padding:1rem}
 .sidebar{position:static; flex:1 1 auto; width:100%}
-main{max-width:none}
+main{max-width:none; width:100%; min-width:0}
 }
 @media print{
 .sidebar,.skip{display:none}
@@ -130,6 +131,7 @@ letter.</p>
 <p>Top left is a single <strong>Menu</strong> button (the three-line
 &quot;hamburger&quot; icon). Press <strong>Alt</strong> then <strong>H</strong> to
 open it, or just click it.</p>
+<div class="table-wrap">
 <table>
 <thead>
 <tr>
@@ -151,6 +153,7 @@ entirely.</td>
 </tr>
 </tbody>
 </table>
+</div>
 <p>See <a href="settings.html">The Settings window</a> for what is
 inside Settings.</p>
 <hr />
@@ -158,6 +161,7 @@ inside Settings.</p>
 <p>This is the mute switch. It turns every microphone on your PC on or
 off at once, so you never have to hunt for the mute button in whichever
 meeting app you happen to be in.</p>
+<div class="table-wrap">
 <table>
 <thead>
 <tr>
@@ -198,12 +202,14 @@ effect straight away, even when you are not recording.</td>
 </tr>
 </tbody>
 </table>
+</div>
 <p>Full details: <a href="microphone.html">Muting your
 microphone</a>.</p>
 <hr />
 <h2 id="the-speech-to-text-card">The Speech to Text card</h2>
 <p>This is dictation. You press record, you talk, you press stop, and a
 few seconds later your words appear as text.</p>
+<div class="table-wrap">
 <table>
 <thead>
 <tr>
@@ -256,6 +262,7 @@ service spell things the way you want.</td>
 </tr>
 </tbody>
 </table>
+</div>
 <p>Full details: <a href="dictation.html">Dictation: turning speech into
 text</a>.</p>
 <hr />
@@ -264,6 +271,7 @@ text</a>.</p>
 list of instructions for it — &quot;make this into a polite email&quot;,
 &quot;summarise this in three bullets&quot;, and so on. The card&#39;s own description
 says it plainly: configure multiple prompts for LLM processing.</p>
+<div class="table-wrap">
 <table>
 <thead>
 <tr>
@@ -303,6 +311,7 @@ shortcut.</td>
 </tr>
 </tbody>
 </table>
+</div>
 <p>Full details: <a href="ai-prompts.html">Using AI prompts on your
 text</a>.</p>
 <hr />
@@ -310,6 +319,7 @@ text</a>.</p>
 <p>This card has no heading of its own — just two labelled boxes stacked
 one above the other. It is where your dictated words land, and where the
 tidied-up version appears.</p>
+<div class="table-wrap">
 <table>
 <thead>
 <tr>
@@ -338,6 +348,7 @@ involved, so it is instant.</td>
 </tr>
 </tbody>
 </table>
+</div>
 <p>Full details: <a href="transcript-formatting.html">Automatic
 find-and-replace rules</a> and <a href="ai-prompts.html">Using AI
 prompts on your text</a>.</p>
@@ -346,6 +357,7 @@ prompts on your text</a>.</p>
 <p>One small but important setting: it controls where your finished
 transcripts are delivered. The card&#39;s own subtitle is &quot;Control where
 transcripts are delivered.&quot;</p>
+<div class="table-wrap">
 <table>
 <thead>
 <tr>
@@ -360,6 +372,7 @@ transcripts are delivered.&quot;</p>
 </tr>
 </tbody>
 </table>
+</div>
 <p>There are three choices, and the line of text underneath the dropdown
 explains whichever one you have picked:</p>
 <ul>
@@ -378,6 +391,7 @@ text</a>.</p>
 reading the words in an image so you can copy them as text.</p>
 <p>Each button in this card shows its current keyboard shortcut in small
 print underneath it, so you never have to go looking.</p>
+<div class="table-wrap">
 <table>
 <thead>
 <tr>
@@ -423,12 +437,14 @@ something to save.</td>
 </tr>
 </tbody>
 </table>
+</div>
 <p>Full details: <a href="screen-capture-and-ocr.html">Screenshots and
 reading text from images</a>.</p>
 <hr />
 <h2 id="the-voice--speech-card">The Voice &amp; Speech card</h2>
 <p>This is the read-aloud feature. Its subtitle says it well: speak the
 current clipboard contents and tune the voice.</p>
+<div class="table-wrap">
 <table>
 <thead>
 <tr>
@@ -487,6 +503,7 @@ left.</td>
 </tr>
 </tbody>
 </table>
+</div>
 <p>Full details: <a href="read-aloud.html">Having text read
 aloud</a>.</p>
 <hr />

--- a/Documentation/UserGuide/html/main-window.html
+++ b/Documentation/UserGuide/html/main-window.html
@@ -1,0 +1,532 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>A tour of the main window - Mutation User Guide</title>
+<meta name="generator" content="pandoc 3.9.0.2" />
+<style type="text/css">
+:root{
+color-scheme: light dark;
+--bg:#ffffff; --fg:#1b1b1f; --muted:#5a5a66; --rule:#d9d9e0;
+--accent:#0b5fa5; --accent-fg:#ffffff; --surface:#f5f5f8; --code:#f0f0f4;
+--quote:#eef4fb; --quote-rule:#0b5fa5;
+}
+@media (prefers-color-scheme: dark){
+:root{
+--bg:#15151a; --fg:#eaeaf0; --muted:#a8a8b6; --rule:#3a3a45;
+--accent:#6fb3ff; --accent-fg:#10131a; --surface:#1e1e26; --code:#22222c;
+--quote:#1c2530; --quote-rule:#6fb3ff;
+}
+}
+*{box-sizing:border-box}
+html{font-size:106%}
+body{
+margin:0; background:var(--bg); color:var(--fg);
+font-family:"Segoe UI",system-ui,-apple-system,Arial,sans-serif;
+line-height:1.65;
+}
+.skip{
+position:absolute; left:-9999px; top:0; padding:.6rem 1rem; z-index:10;
+background:var(--accent); color:var(--accent-fg); font-weight:600;
+}
+.skip:focus{left:0}
+.layout{display:flex; align-items:flex-start; gap:2rem; max-width:1180px; margin:0 auto; padding:1.5rem}
+.sidebar{
+flex:0 0 16rem; position:sticky; top:1.5rem;
+background:var(--surface); border:1px solid var(--rule); border-radius:10px; padding:1rem 1.1rem;
+}
+.sidebar h2{font-size:1rem; margin:0 0 .6rem; text-transform:uppercase; letter-spacing:.04em; color:var(--muted)}
+.sidebar ol{list-style:none; margin:0; padding:0}
+.sidebar li{margin:.15rem 0}
+.sidebar a{display:block; padding:.3rem .45rem; border-radius:6px; text-decoration:none; color:var(--fg)}
+.sidebar a:hover{background:var(--bg); text-decoration:underline}
+.sidebar a[aria-current="page"]{background:var(--accent); color:var(--accent-fg); font-weight:600}
+main{flex:1 1 auto; min-width:0; max-width:52rem}
+h1{font-size:2.1rem; line-height:1.2; margin:.2rem 0 1rem; border-bottom:3px solid var(--accent); padding-bottom:.5rem}
+h2{font-size:1.5rem; margin:2.2rem 0 .7rem; border-bottom:1px solid var(--rule); padding-bottom:.3rem}
+h3{font-size:1.2rem; margin:1.7rem 0 .5rem}
+h4{font-size:1.05rem; margin:1.4rem 0 .4rem}
+p{margin:.7rem 0}
+a{color:var(--accent)}
+a:focus-visible,button:focus-visible,main:focus-visible{outline:3px solid var(--accent); outline-offset:2px}
+ul,ol{margin:.7rem 0; padding-left:1.6rem}
+li{margin:.3rem 0}
+code{background:var(--code); padding:.12em .38em; border-radius:4px; font-family:Consolas,"Cascadia Mono",monospace; font-size:.92em}
+pre{background:var(--code); border:1px solid var(--rule); border-radius:8px; padding:.9rem 1rem; overflow-x:auto}
+pre code{background:none; padding:0; font-size:.9em}
+blockquote{
+margin:1rem 0; padding:.7rem 1rem; background:var(--quote);
+border-left:5px solid var(--quote-rule); border-radius:0 8px 8px 0;
+}
+blockquote p{margin:.3rem 0}
+
+table{border-collapse:collapse; width:100%; margin:1rem 0; display:block; overflow-x:auto}
+thead,tbody,tr{width:100%}
+th,td{border:1px solid var(--rule); padding:.5rem .65rem; vertical-align:top}
+th{background:var(--surface); font-weight:700; text-align:left}
+tbody tr:nth-child(even){background:var(--surface)}
+hr{border:none; border-top:1px solid var(--rule); margin:2rem 0}
+kbd{background:var(--surface); border:1px solid var(--rule); border-bottom-width:2px; border-radius:5px; padding:.1em .4em}
+footer{margin-top:3rem; padding-top:1rem; border-top:1px solid var(--rule); color:var(--muted); font-size:.9rem}
+@media (max-width:860px){
+.layout{flex-direction:column; padding:1rem}
+.sidebar{position:static; flex:1 1 auto; width:100%}
+main{max-width:none}
+}
+@media print{
+.sidebar,.skip{display:none}
+body{background:#fff; color:#000}
+.layout{display:block; max-width:none; padding:0}
+a{color:#000}
+}
+</style>
+</head>
+<body>
+<a class="skip" href="#content">Skip to the main content</a>
+<div class="layout">
+<nav class="sidebar" aria-label="User guide contents">
+<h2>Mutation User Guide</h2>
+<ol>
+<li><a href="index.html">The Mutation User Guide</a></li>
+<li><a href="getting-started.html">Getting started</a></li>
+<li><a href="main-window.html" aria-current="page">A tour of the main window</a></li>
+<li><a href="microphone.html">Muting your microphone</a></li>
+<li><a href="dictation.html">Dictation: turning speech into text</a></li>
+<li><a href="screen-capture-and-ocr.html">Screenshots and reading text from images</a></li>
+<li><a href="read-aloud.html">Having text read aloud</a></li>
+<li><a href="ai-prompts.html">Using AI prompts on your text</a></li>
+<li><a href="transcript-formatting.html">Automatic find-and-replace rules</a></li>
+<li><a href="keyboard-shortcuts.html">Keyboard shortcuts</a></li>
+<li><a href="settings.html">The Settings window</a></li>
+<li><a href="accessibility.html">Screen reader and accessibility notes</a></li>
+<li><a href="troubleshooting.html">Troubleshooting</a></li>
+</ol>
+</nav>
+<main id="content" tabindex="-1">
+<h1 id="a-tour-of-the-main-window">A tour of the main window</h1>
+<p>Most of the time you will not look at Mutation at all. You press a
+keyboard shortcut in whatever app you are using, and Mutation does its
+job in the background. But there is a main window, and it is worth
+knowing your way around it.</p>
+<p>The window is titled <strong>Mutation Workspace</strong>. Think of it
+as the control panel. Everything on it is also available as a keyboard
+shortcut that works from any other app, so the window is where you go to
+change a setting, check a result, or run something once without
+remembering a shortcut.</p>
+<p>The window is laid out as a set of cards, one per feature. On a wide
+window the cards sit two to a row. Narrow the window and they stack into
+a single column, so nothing is ever hidden off to the side.</p>
+<blockquote>
+<p>Everything here is reachable from the keyboard. <strong>Tab</strong>
+moves forward through the controls, <strong>Shift+Tab</strong> moves
+back, <strong>Space</strong> or <strong>Enter</strong> presses a button,
+and the arrow keys open and move through dropdowns. Many buttons also
+have an access key: hold <strong>Alt</strong> and the underlined
+letter.</p>
+</blockquote>
+<hr />
+<h2 id="the-menu-at-the-top">The menu at the top</h2>
+<p>Top left is a single <strong>Menu</strong> button (the three-line
+&quot;hamburger&quot; icon). Press <strong>Alt</strong> then <strong>H</strong> to
+open it, or just click it.</p>
+<table>
+<thead>
+<tr>
+<th scope="col">Item</th>
+<th scope="col">What it does</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>Settings</strong></td>
+<td>Opens the Settings window. Same as pressing
+<strong>Ctrl+Comma</strong> from anywhere in Mutation.</td>
+</tr>
+<tr>
+<td><strong>Debug</strong></td>
+<td>A submenu with three &quot;Simulate ... Crash&quot; items. These exist so the
+developer can test error handling. Ordinary users can ignore them
+entirely.</td>
+</tr>
+</tbody>
+</table>
+<p>See <a href="settings.html">The Settings window</a> for what is
+inside Settings.</p>
+<hr />
+<h2 id="the-microphone-card">The Microphone card</h2>
+<p>This is the mute switch. It turns every microphone on your PC on or
+off at once, so you never have to hunt for the mute button in whichever
+meeting app you happen to be in.</p>
+<table>
+<thead>
+<tr>
+<th scope="col">Control</th>
+<th scope="col">What it does</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>Microphone selection</strong> (dropdown)</td>
+<td>Chooses the input microphone.</td>
+</tr>
+<tr>
+<td><strong>Toggle microphone</strong> (button)</td>
+<td>Mutes or unmutes. The icon shows a line through the microphone when
+you are muted.</td>
+</tr>
+<tr>
+<td><strong>Toggle microphone visualization</strong></td>
+<td>The big waveform panel is itself a button. Press it to turn the live
+waveform drawing on or off. When it is off it simply reads &quot;Off&quot;.</td>
+</tr>
+<tr>
+<td>Level meter</td>
+<td>The thin bar beside the waveform. It rises and falls with how loud
+you are. Nothing to press.</td>
+</tr>
+<tr>
+<td><strong>Pin input level</strong> (on/off switch)</td>
+<td>Keeps the Windows recording level fixed at the value you choose.
+Mutation re-applies it every time you record, change microphone, or
+start the app.</td>
+</tr>
+<tr>
+<td><strong>Input level</strong> (slider)</td>
+<td>Sets the Windows recording level from 0 to 100. The change takes
+effect straight away, even when you are not recording.</td>
+</tr>
+</tbody>
+</table>
+<p>Full details: <a href="microphone.html">Muting your
+microphone</a>.</p>
+<hr />
+<h2 id="the-speech-to-text-card">The Speech to Text card</h2>
+<p>This is dictation. You press record, you talk, you press stop, and a
+few seconds later your words appear as text.</p>
+<table>
+<thead>
+<tr>
+<th scope="col">Control</th>
+<th scope="col">What it does</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>Speech-to-text service selection</strong> (dropdown)</td>
+<td>Picks which transcription service does the listening.</td>
+</tr>
+<tr>
+<td><strong>Record</strong> (button)</td>
+<td>Starts or stops speech capture. The transcript appears in the
+<strong>Raw Transcript</strong> box.</td>
+</tr>
+<tr>
+<td><strong>Record and Format</strong> (button)</td>
+<td>Starts or stops speech capture, then automatically sends the
+transcript to the AI model for tidying up.</td>
+</tr>
+<tr>
+<td><strong>Play selected session</strong></td>
+<td>Plays back the recording you currently have selected.</td>
+</tr>
+<tr>
+<td><strong>Go to older session</strong> / <strong>Go to newer
+session</strong></td>
+<td>Step backwards and forwards through your recent recordings.</td>
+</tr>
+<tr>
+<td><strong>Retry transcription</strong></td>
+<td>Transcribes the selected recording again. Useful if the first
+attempt failed.</td>
+</tr>
+<tr>
+<td><strong>Upload audio for transcription</strong></td>
+<td>Pick an audio file from your PC and have it transcribed.</td>
+</tr>
+<tr>
+<td><strong>Speed</strong> (dropdown)</td>
+<td>How fast recordings play back. Voices stay at their natural pitch at
+every speed.</td>
+</tr>
+<tr>
+<td><strong>Prompt</strong> (text box)</td>
+<td>Optional. A few words of context or a list of names, to help the
+service spell things the way you want.</td>
+</tr>
+</tbody>
+</table>
+<p>Full details: <a href="dictation.html">Dictation: turning speech into
+text</a>.</p>
+<hr />
+<h2 id="the-llm-prompts-card">The LLM Prompts card</h2>
+<p>An LLM is an AI writing assistant. This card is where you keep your
+list of instructions for it — &quot;make this into a polite email&quot;,
+&quot;summarise this in three bullets&quot;, and so on. The card&#39;s own description
+says it plainly: configure multiple prompts for LLM processing.</p>
+<table>
+<thead>
+<tr>
+<th scope="col">Control</th>
+<th scope="col">What it does</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>Add Prompt</strong> (button)</td>
+<td>Creates a new prompt.</td>
+</tr>
+<tr>
+<td>The list</td>
+<td>One row per prompt. Each row shows the prompt&#39;s name, its shortcut,
+its model, and the words <strong>(Auto-Run)</strong> if it is set to run
+by itself.</td>
+</tr>
+<tr>
+<td><strong>(Auto-Run)</strong> label</td>
+<td>Means that prompt runs automatically after a recording finishes,
+instead of waiting for you to trigger it.</td>
+</tr>
+<tr>
+<td><strong>Run</strong></td>
+<td>Runs that prompt now, on the text in the <strong>Raw
+Transcript</strong> box.</td>
+</tr>
+<tr>
+<td><strong>Edit</strong></td>
+<td>Opens the prompt so you can change its wording, model or
+shortcut.</td>
+</tr>
+<tr>
+<td><strong>Delete</strong></td>
+<td>Removes the prompt.</td>
+</tr>
+</tbody>
+</table>
+<p>Full details: <a href="ai-prompts.html">Using AI prompts on your
+text</a>.</p>
+<hr />
+<h2 id="the-transcript-boxes">The transcript boxes</h2>
+<p>This card has no heading of its own — just two labelled boxes stacked
+one above the other. It is where your dictated words land, and where the
+tidied-up version appears.</p>
+<table>
+<thead>
+<tr>
+<th scope="col">Control</th>
+<th scope="col">What it does</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>Raw Transcript</strong> (text box)</td>
+<td>Exactly what came back from the transcription service. You can edit
+it by hand.</td>
+</tr>
+<tr>
+<td><strong>Format with rules</strong> (button)</td>
+<td>Applies your own find-and-replace rules to the raw transcript. No AI
+involved, so it is instant.</td>
+</tr>
+<tr>
+<td><strong>Process with LLM</strong> (button)</td>
+<td>Sends the raw transcript to the AI model for formatting.</td>
+</tr>
+<tr>
+<td><strong>Formatted Transcript</strong> (text box)</td>
+<td>The result, ready to copy or share.</td>
+</tr>
+</tbody>
+</table>
+<p>Full details: <a href="transcript-formatting.html">Automatic
+find-and-replace rules</a> and <a href="ai-prompts.html">Using AI
+prompts on your text</a>.</p>
+<hr />
+<h2 id="the-automation-card">The Automation card</h2>
+<p>One small but important setting: it controls where your finished
+transcripts are delivered. The card&#39;s own subtitle is &quot;Control where
+transcripts are delivered.&quot;</p>
+<table>
+<thead>
+<tr>
+<th scope="col">Control</th>
+<th scope="col">What it does</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>Third-party interaction mode</strong> (dropdown)</td>
+<td>Chooses how the text reaches the app you were working in.</td>
+</tr>
+</tbody>
+</table>
+<p>There are three choices, and the line of text underneath the dropdown
+explains whichever one you have picked:</p>
+<ul>
+<li><strong>Paste</strong> — copies the transcript and pastes it into
+the active application.</li>
+<li><strong>SendKeys</strong> — types the transcript into the active app
+as if you entered it yourself.</li>
+<li><strong>DoNotInsert</strong> — keeps the transcript inside Mutation
+without sending it anywhere.</li>
+</ul>
+<p>Full details: <a href="dictation.html">Dictation: turning speech into
+text</a>.</p>
+<hr />
+<h2 id="the-visual-capture-card">The Visual Capture card</h2>
+<p>Screenshots, and pulling the text out of pictures. OCR simply means
+reading the words in an image so you can copy them as text.</p>
+<p>Each button in this card shows its current keyboard shortcut in small
+print underneath it, so you never have to go looking.</p>
+<table>
+<thead>
+<tr>
+<th scope="col">Control</th>
+<th scope="col">What it does</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>Screenshot to clipboard</strong></td>
+<td>Grab part of the screen and put the picture on the clipboard.</td>
+</tr>
+<tr>
+<td><strong>OCR clipboard</strong></td>
+<td>Read the text out of whatever image is on the clipboard.</td>
+</tr>
+<tr>
+<td><strong>OCR clipboard (L→R)</strong></td>
+<td>The same, but reading strictly left to right and top to bottom. Use
+this when the normal order jumbles columns or tables.</td>
+</tr>
+<tr>
+<td><strong>Screenshot &amp; OCR</strong></td>
+<td>Grab part of the screen and read its text, in one step.</td>
+</tr>
+<tr>
+<td><strong>Screenshot &amp; OCR (L→R)</strong></td>
+<td>The same, in strict left-to-right, top-to-bottom order.</td>
+</tr>
+<tr>
+<td><strong>OCR documents</strong></td>
+<td>Pick several PDFs or images and read them all into one result. A
+progress bar appears while it works.</td>
+</tr>
+<tr>
+<td><strong>OCR result</strong> (text box)</td>
+<td>Where the extracted text appears.</td>
+</tr>
+<tr>
+<td><strong>Download OCR result</strong></td>
+<td>Saves that text to a document. Stays greyed out until there is
+something to save.</td>
+</tr>
+</tbody>
+</table>
+<p>Full details: <a href="screen-capture-and-ocr.html">Screenshots and
+reading text from images</a>.</p>
+<hr />
+<h2 id="the-voice--speech-card">The Voice &amp; Speech card</h2>
+<p>This is the read-aloud feature. Its subtitle says it well: speak the
+current clipboard contents and tune the voice.</p>
+<table>
+<thead>
+<tr>
+<th scope="col">Control</th>
+<th scope="col">What it does</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>Voice</strong> (dropdown)</td>
+<td>Which voice reads to you.</td>
+</tr>
+<tr>
+<td><strong>Rate</strong> (slider)</td>
+<td>How fast it speaks.</td>
+</tr>
+<tr>
+<td><strong>Volume</strong> (slider)</td>
+<td>How loud, independent of your system volume.</td>
+</tr>
+<tr>
+<td><strong>Announce reading time at start</strong> (on/off)</td>
+<td>Speaks an estimate of how long the text will take before it starts
+reading.</td>
+</tr>
+<tr>
+<td><strong>Announce progress while reading</strong> (on/off)</td>
+<td>Speaks your progress at regular points through a long text.</td>
+</tr>
+<tr>
+<td><strong>Speak clipboard</strong></td>
+<td>Reads whatever you last copied.</td>
+</tr>
+<tr>
+<td><strong>Speak selection</strong></td>
+<td>Copies whatever is highlighted in the app you were in, and reads
+that.</td>
+</tr>
+<tr>
+<td><strong>Restart</strong></td>
+<td>Starts again from the beginning, ignoring the saved position.</td>
+</tr>
+<tr>
+<td><strong>Skip sentence backward</strong> / <strong>Skip sentence
+forward</strong></td>
+<td>Jump one sentence back or forward.</td>
+</tr>
+<tr>
+<td><strong>Position</strong></td>
+<td>Speaks where you are: the sentence, the percentage, and the time
+left.</td>
+</tr>
+<tr>
+<td><strong>Speak to file</strong></td>
+<td>Saves the spoken version as a WAV audio file.</td>
+</tr>
+</tbody>
+</table>
+<p>Full details: <a href="read-aloud.html">Having text read
+aloud</a>.</p>
+<hr />
+<h2 id="status-messages">Status messages</h2>
+<p>Mutation tells you what it is doing through a status bar that appears
+in the <strong>top right</strong> of the window, not at the bottom. It
+stays out of the way until there is something to say — &quot;Transcribing&quot;,
+&quot;OCR complete&quot;, an error — then slides into view. It is announced to
+screen readers politely, so it will not interrupt you mid-sentence.
+Close it with its own close button, or leave it; it goes away on its
+own.</p>
+<hr />
+<h2 id="two-useful-habits">Two useful habits</h2>
+<p><strong>You rarely need this window.</strong> Every button here has
+an equivalent shortcut that works from any app. The window is for
+setting things up and checking results. See <a href="keyboard-shortcuts.html">Keyboard shortcuts</a> for the full list,
+and remember that every shortcut can be changed in Settings.</p>
+<p><strong>The window remembers itself.</strong> Mutation saves the
+window&#39;s position and size when you close it, and puts it back exactly
+there next time. The very first time you run it, with no saved size yet,
+it opens at three-quarters of your screen, centred. If you later unplug
+a monitor, Mutation nudges the window back onto a screen you can
+actually see.</p>
+<hr />
+<h2 id="where-to-next">Where to next</h2>
+<ul>
+<li><a href="getting-started.html">Getting started</a> — set up your
+keys and take Mutation for its first run.</li>
+<li><a href="keyboard-shortcuts.html">Keyboard shortcuts</a> — the
+shortcuts behind every button on this window.</li>
+<li><a href="settings.html">The Settings window</a> — everything the
+main window does not show.</li>
+<li><a href="accessibility.html">Screen reader and accessibility
+notes</a> — navigating Mutation without looking at it.</li>
+</ul>
+<footer>
+<p><a href="index.html">Back to the contents page</a></p>
+<p>Generated from the Markdown source on 4 August 2026. The Markdown files are the source of truth – do not edit these HTML pages by hand.</p>
+</footer>
+</main>
+</div>
+</body>
+</html>

--- a/Documentation/UserGuide/html/microphone.html
+++ b/Documentation/UserGuide/html/microphone.html
@@ -1,0 +1,243 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Muting your microphone - Mutation User Guide</title>
+<meta name="generator" content="pandoc 3.9.0.2" />
+<style type="text/css">
+:root{
+color-scheme: light dark;
+--bg:#ffffff; --fg:#1b1b1f; --muted:#5a5a66; --rule:#d9d9e0;
+--accent:#0b5fa5; --accent-fg:#ffffff; --surface:#f5f5f8; --code:#f0f0f4;
+--quote:#eef4fb; --quote-rule:#0b5fa5;
+}
+@media (prefers-color-scheme: dark){
+:root{
+--bg:#15151a; --fg:#eaeaf0; --muted:#a8a8b6; --rule:#3a3a45;
+--accent:#6fb3ff; --accent-fg:#10131a; --surface:#1e1e26; --code:#22222c;
+--quote:#1c2530; --quote-rule:#6fb3ff;
+}
+}
+*{box-sizing:border-box}
+html{font-size:106%}
+body{
+margin:0; background:var(--bg); color:var(--fg);
+font-family:"Segoe UI",system-ui,-apple-system,Arial,sans-serif;
+line-height:1.65;
+}
+.skip{
+position:absolute; left:-9999px; top:0; padding:.6rem 1rem; z-index:10;
+background:var(--accent); color:var(--accent-fg); font-weight:600;
+}
+.skip:focus{left:0}
+.layout{display:flex; align-items:flex-start; gap:2rem; max-width:1180px; margin:0 auto; padding:1.5rem}
+.sidebar{
+flex:0 0 16rem; position:sticky; top:1.5rem;
+background:var(--surface); border:1px solid var(--rule); border-radius:10px; padding:1rem 1.1rem;
+}
+.sidebar h2{font-size:1rem; margin:0 0 .6rem; text-transform:uppercase; letter-spacing:.04em; color:var(--muted)}
+.sidebar ol{list-style:none; margin:0; padding:0}
+.sidebar li{margin:.15rem 0}
+.sidebar a{display:block; padding:.3rem .45rem; border-radius:6px; text-decoration:none; color:var(--fg)}
+.sidebar a:hover{background:var(--bg); text-decoration:underline}
+.sidebar a[aria-current="page"]{background:var(--accent); color:var(--accent-fg); font-weight:600}
+main{flex:1 1 auto; min-width:0; max-width:52rem}
+h1{font-size:2.1rem; line-height:1.2; margin:.2rem 0 1rem; border-bottom:3px solid var(--accent); padding-bottom:.5rem}
+h2{font-size:1.5rem; margin:2.2rem 0 .7rem; border-bottom:1px solid var(--rule); padding-bottom:.3rem}
+h3{font-size:1.2rem; margin:1.7rem 0 .5rem}
+h4{font-size:1.05rem; margin:1.4rem 0 .4rem}
+p{margin:.7rem 0}
+a{color:var(--accent)}
+a:focus-visible,button:focus-visible,main:focus-visible{outline:3px solid var(--accent); outline-offset:2px}
+ul,ol{margin:.7rem 0; padding-left:1.6rem}
+li{margin:.3rem 0}
+code{background:var(--code); padding:.12em .38em; border-radius:4px; font-family:Consolas,"Cascadia Mono",monospace; font-size:.92em}
+pre{background:var(--code); border:1px solid var(--rule); border-radius:8px; padding:.9rem 1rem; overflow-x:auto}
+pre code{background:none; padding:0; font-size:.9em}
+blockquote{
+margin:1rem 0; padding:.7rem 1rem; background:var(--quote);
+border-left:5px solid var(--quote-rule); border-radius:0 8px 8px 0;
+}
+blockquote p{margin:.3rem 0}
+
+table{border-collapse:collapse; width:100%; margin:1rem 0; display:block; overflow-x:auto}
+thead,tbody,tr{width:100%}
+th,td{border:1px solid var(--rule); padding:.5rem .65rem; vertical-align:top}
+th{background:var(--surface); font-weight:700; text-align:left}
+tbody tr:nth-child(even){background:var(--surface)}
+hr{border:none; border-top:1px solid var(--rule); margin:2rem 0}
+kbd{background:var(--surface); border:1px solid var(--rule); border-bottom-width:2px; border-radius:5px; padding:.1em .4em}
+footer{margin-top:3rem; padding-top:1rem; border-top:1px solid var(--rule); color:var(--muted); font-size:.9rem}
+@media (max-width:860px){
+.layout{flex-direction:column; padding:1rem}
+.sidebar{position:static; flex:1 1 auto; width:100%}
+main{max-width:none}
+}
+@media print{
+.sidebar,.skip{display:none}
+body{background:#fff; color:#000}
+.layout{display:block; max-width:none; padding:0}
+a{color:#000}
+}
+</style>
+</head>
+<body>
+<a class="skip" href="#content">Skip to the main content</a>
+<div class="layout">
+<nav class="sidebar" aria-label="User guide contents">
+<h2>Mutation User Guide</h2>
+<ol>
+<li><a href="index.html">The Mutation User Guide</a></li>
+<li><a href="getting-started.html">Getting started</a></li>
+<li><a href="main-window.html">A tour of the main window</a></li>
+<li><a href="microphone.html" aria-current="page">Muting your microphone</a></li>
+<li><a href="dictation.html">Dictation: turning speech into text</a></li>
+<li><a href="screen-capture-and-ocr.html">Screenshots and reading text from images</a></li>
+<li><a href="read-aloud.html">Having text read aloud</a></li>
+<li><a href="ai-prompts.html">Using AI prompts on your text</a></li>
+<li><a href="transcript-formatting.html">Automatic find-and-replace rules</a></li>
+<li><a href="keyboard-shortcuts.html">Keyboard shortcuts</a></li>
+<li><a href="settings.html">The Settings window</a></li>
+<li><a href="accessibility.html">Screen reader and accessibility notes</a></li>
+<li><a href="troubleshooting.html">Troubleshooting</a></li>
+</ol>
+</nav>
+<main id="content" tabindex="-1">
+<h1 id="muting-your-microphone">Muting your microphone</h1>
+<p>This is the feature Mutation was built for in the first place, and it
+is still the one most people use every day.</p>
+<p>Press one shortcut and every microphone on your PC goes quiet. Press
+it again and they all come back. It works no matter which app you are in
+— you do not have to find the meeting window first, and you do not have
+to learn a different mute shortcut for Teams, Zoom, Slack and everything
+else.</p>
+<h2 id="why-it-mutes-every-microphone">Why it mutes <em>every</em>
+microphone</h2>
+<p>Most PCs have more than one microphone. There is the one in your
+headset, maybe one in your webcam, and maybe one built into the laptop
+lid. Meeting apps do not always pick the one you expect, and they can
+quietly switch to a different one.</p>
+<p>That is the trap. You mute what you think is &quot;the&quot; microphone, carry
+on talking to someone in the room, and the call has been listening
+through a different mic the whole time.</p>
+<p>Mutation avoids that by muting all of them together. When it says
+muted, every microphone on the machine is muted.</p>
+<h2 id="the-shortcut">The shortcut</h2>
+<p>The default shortcut is <strong>Alt+Q</strong>.</p>
+<p>You can change it. Open <strong>Settings</strong> with
+<strong>Ctrl+Comma</strong>, go to the <strong>Audio</strong> page, and
+set a new shortcut in the &quot;Toggle microphone mute&quot; box. Every shortcut
+in Mutation can be changed this way.</p>
+<p>You can also click the microphone button on the
+<strong>Microphone</strong> card on the main window. It does exactly the
+same thing as the shortcut.</p>
+<h2 id="how-you-know-it-worked">How you know it worked</h2>
+<p>Two things tell you the new state.</p>
+<ul>
+<li><strong>A beep.</strong> One sound for muted, a different one for
+unmuted.</li>
+<li><strong>A message</strong> on the main window: &quot;Microphone muted.&quot;
+or &quot;Microphone is live.&quot;</li>
+</ul>
+<p>If the change could not be confirmed, you get the failure beep
+instead and a message saying the microphone may still be live. That is
+deliberate. Mutation will never tell you that you are muted unless it
+has checked each microphone and confirmed it.</p>
+<blockquote>
+<p>Tip: tapping the shortcut twice very quickly is safe. The second
+press is ignored while the first is still working, so you cannot
+accidentally end up back where you started.</p>
+</blockquote>
+<h3 id="using-your-own-sounds">Using your own sounds</h3>
+<p>If you do not like the built-in beeps, you can swap in your own sound
+files — one for mute, one for unmute, and for Mutation&#39;s other status
+sounds too. Turn on &quot;Custom beeps&quot; on the <strong>Audio</strong> page in
+<strong>Settings</strong>, then browse for a sound file for each one.
+There is a play button next to each so you can hear it before you
+commit. See <a href="settings.html">The Settings window</a> for the full
+walkthrough.</p>
+<h2 id="choosing-the-active-microphone">Choosing the active
+microphone</h2>
+<p>The <strong>Microphone</strong> card has a dropdown listing the
+microphones Mutation can see. The one you pick is the <em>active</em>
+microphone — the one Mutation records from for dictation, and the one
+the level meter and the level controls apply to.</p>
+<p>This choice does not affect muting. Muting always covers every
+microphone, whichever one is selected. Your choice is remembered the
+next time you start Mutation.</p>
+<h2 id="the-live-level-display">The live level display</h2>
+<p>Underneath the dropdown is a live picture of what your microphone is
+hearing: a waveform that moves as you speak, and a vertical bar next to
+it that rises and falls with how loud you are. It is a quick way to
+check that the mic is actually picking you up before you start
+talking.</p>
+<p>To turn it off, click on the waveform itself — it is a toggle. Click
+it again to turn it back on. When it is off it simply shows the word
+&quot;Off&quot;.</p>
+<p>It is reachable from the keyboard too: tab to &quot;Toggle microphone
+visualization&quot; and press Space or Enter. There is also a &quot;Microphone
+visualization&quot; switch on the <strong>Audio</strong> page in
+<strong>Settings</strong> if you prefer to set it there. Either way, the
+setting is remembered.</p>
+<h2 id="pin-input-level">Pin input level</h2>
+<p>Windows lets any app change your microphone&#39;s input volume, and some
+of them do it without telling you. You set your mic to a comfortable
+level, join a call a few days later, and suddenly nobody can hear
+you.</p>
+<p>&quot;Pin input level&quot; stops that. It works like this:</p>
+<ol type="1">
+<li>Use the <strong>Input level</strong> slider to set the volume you
+want, from 0 to 100. The change applies to Windows straight away, even
+when you are not recording.</li>
+<li>Turn <strong>Pin input level</strong> on. Mutation remembers that
+number as your target.</li>
+</ol>
+<p>From then on, Mutation puts the level back to your number whenever it
+matters: when you start recording, when you switch microphones, and when
+the app starts up. If something moved it in the meantime, it gets moved
+back.</p>
+<p>Turning the pin off stops the re-checking. It does not change the
+level you are currently on — it just stops Mutation from correcting
+it.</p>
+<p>Some microphones have a fixed input level that software cannot change
+at all. On those, the switch and the slider are greyed out, and Mutation
+tells you why.</p>
+<h2 id="plugging-microphones-in-and-out">Plugging microphones in and
+out</h2>
+<p>You can plug in a headset or unplug one while Mutation is running. It
+notices and updates the list on its own.</p>
+<ul>
+<li><strong>A mic appears or disappears somewhere else in the
+list</strong> — your selected microphone is untouched, and Mutation
+stays quiet about it. Nothing about your audio changed, so there is
+nothing to interrupt you with.</li>
+<li><strong>Your selected microphone is unplugged</strong> — Mutation
+switches to the first microphone in the list and tells you: &quot;The
+selected microphone was disconnected. Now using ...&quot;.</li>
+<li><strong>No microphones at all</strong> — you get a message saying
+none are available.</li>
+</ul>
+<p>There is one more nicety. If you are muted and then plug in a new
+microphone, the new one comes up muted too. Connecting a headset
+mid-call will not quietly put you back on air.</p>
+<h2 id="where-to-next">Where to next</h2>
+<ul>
+<li><a href="main-window.html">A tour of the main window</a> — where the
+<strong>Microphone</strong> card sits and what else shares the screen
+with it.</li>
+<li><a href="settings.html">The Settings window</a> — changing the
+shortcut, and using your own sound files instead of the beeps.</li>
+<li><a href="dictation.html">Dictation: turning speech into text</a> —
+the other half of what your microphone does in Mutation.</li>
+<li><a href="troubleshooting.html">Troubleshooting</a> — what to try
+when a mute does not take or a mic goes missing.</li>
+</ul>
+<footer>
+<p><a href="index.html">Back to the contents page</a></p>
+<p>Generated from the Markdown source on 4 August 2026. The Markdown files are the source of truth – do not edit these HTML pages by hand.</p>
+</footer>
+</main>
+</div>
+</body>
+</html>

--- a/Documentation/UserGuide/html/microphone.html
+++ b/Documentation/UserGuide/html/microphone.html
@@ -61,8 +61,8 @@ border-left:5px solid var(--quote-rule); border-radius:0 8px 8px 0;
 }
 blockquote p{margin:.3rem 0}
 
-table{border-collapse:collapse; width:100%; margin:1rem 0; display:block; overflow-x:auto}
-thead,tbody,tr{width:100%}
+.table-wrap{overflow-x:auto; margin:1rem 0}
+table{border-collapse:collapse; width:100%; min-width:26rem}
 th,td{border:1px solid var(--rule); padding:.5rem .65rem; vertical-align:top}
 th{background:var(--surface); font-weight:700; text-align:left}
 tbody tr:nth-child(even){background:var(--surface)}
@@ -70,9 +70,10 @@ hr{border:none; border-top:1px solid var(--rule); margin:2rem 0}
 kbd{background:var(--surface); border:1px solid var(--rule); border-bottom-width:2px; border-radius:5px; padding:.1em .4em}
 footer{margin-top:3rem; padding-top:1rem; border-top:1px solid var(--rule); color:var(--muted); font-size:.9rem}
 @media (max-width:860px){
-.layout{flex-direction:column; padding:1rem}
+
+.layout{flex-direction:column; align-items:stretch; padding:1rem}
 .sidebar{position:static; flex:1 1 auto; width:100%}
-main{max-width:none}
+main{max-width:none; width:100%; min-width:0}
 }
 @media print{
 .sidebar,.skip{display:none}

--- a/Documentation/UserGuide/html/read-aloud.html
+++ b/Documentation/UserGuide/html/read-aloud.html
@@ -1,0 +1,317 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Having text read aloud - Mutation User Guide</title>
+<meta name="generator" content="pandoc 3.9.0.2" />
+<style type="text/css">
+:root{
+color-scheme: light dark;
+--bg:#ffffff; --fg:#1b1b1f; --muted:#5a5a66; --rule:#d9d9e0;
+--accent:#0b5fa5; --accent-fg:#ffffff; --surface:#f5f5f8; --code:#f0f0f4;
+--quote:#eef4fb; --quote-rule:#0b5fa5;
+}
+@media (prefers-color-scheme: dark){
+:root{
+--bg:#15151a; --fg:#eaeaf0; --muted:#a8a8b6; --rule:#3a3a45;
+--accent:#6fb3ff; --accent-fg:#10131a; --surface:#1e1e26; --code:#22222c;
+--quote:#1c2530; --quote-rule:#6fb3ff;
+}
+}
+*{box-sizing:border-box}
+html{font-size:106%}
+body{
+margin:0; background:var(--bg); color:var(--fg);
+font-family:"Segoe UI",system-ui,-apple-system,Arial,sans-serif;
+line-height:1.65;
+}
+.skip{
+position:absolute; left:-9999px; top:0; padding:.6rem 1rem; z-index:10;
+background:var(--accent); color:var(--accent-fg); font-weight:600;
+}
+.skip:focus{left:0}
+.layout{display:flex; align-items:flex-start; gap:2rem; max-width:1180px; margin:0 auto; padding:1.5rem}
+.sidebar{
+flex:0 0 16rem; position:sticky; top:1.5rem;
+background:var(--surface); border:1px solid var(--rule); border-radius:10px; padding:1rem 1.1rem;
+}
+.sidebar h2{font-size:1rem; margin:0 0 .6rem; text-transform:uppercase; letter-spacing:.04em; color:var(--muted)}
+.sidebar ol{list-style:none; margin:0; padding:0}
+.sidebar li{margin:.15rem 0}
+.sidebar a{display:block; padding:.3rem .45rem; border-radius:6px; text-decoration:none; color:var(--fg)}
+.sidebar a:hover{background:var(--bg); text-decoration:underline}
+.sidebar a[aria-current="page"]{background:var(--accent); color:var(--accent-fg); font-weight:600}
+main{flex:1 1 auto; min-width:0; max-width:52rem}
+h1{font-size:2.1rem; line-height:1.2; margin:.2rem 0 1rem; border-bottom:3px solid var(--accent); padding-bottom:.5rem}
+h2{font-size:1.5rem; margin:2.2rem 0 .7rem; border-bottom:1px solid var(--rule); padding-bottom:.3rem}
+h3{font-size:1.2rem; margin:1.7rem 0 .5rem}
+h4{font-size:1.05rem; margin:1.4rem 0 .4rem}
+p{margin:.7rem 0}
+a{color:var(--accent)}
+a:focus-visible,button:focus-visible,main:focus-visible{outline:3px solid var(--accent); outline-offset:2px}
+ul,ol{margin:.7rem 0; padding-left:1.6rem}
+li{margin:.3rem 0}
+code{background:var(--code); padding:.12em .38em; border-radius:4px; font-family:Consolas,"Cascadia Mono",monospace; font-size:.92em}
+pre{background:var(--code); border:1px solid var(--rule); border-radius:8px; padding:.9rem 1rem; overflow-x:auto}
+pre code{background:none; padding:0; font-size:.9em}
+blockquote{
+margin:1rem 0; padding:.7rem 1rem; background:var(--quote);
+border-left:5px solid var(--quote-rule); border-radius:0 8px 8px 0;
+}
+blockquote p{margin:.3rem 0}
+
+table{border-collapse:collapse; width:100%; margin:1rem 0; display:block; overflow-x:auto}
+thead,tbody,tr{width:100%}
+th,td{border:1px solid var(--rule); padding:.5rem .65rem; vertical-align:top}
+th{background:var(--surface); font-weight:700; text-align:left}
+tbody tr:nth-child(even){background:var(--surface)}
+hr{border:none; border-top:1px solid var(--rule); margin:2rem 0}
+kbd{background:var(--surface); border:1px solid var(--rule); border-bottom-width:2px; border-radius:5px; padding:.1em .4em}
+footer{margin-top:3rem; padding-top:1rem; border-top:1px solid var(--rule); color:var(--muted); font-size:.9rem}
+@media (max-width:860px){
+.layout{flex-direction:column; padding:1rem}
+.sidebar{position:static; flex:1 1 auto; width:100%}
+main{max-width:none}
+}
+@media print{
+.sidebar,.skip{display:none}
+body{background:#fff; color:#000}
+.layout{display:block; max-width:none; padding:0}
+a{color:#000}
+}
+</style>
+</head>
+<body>
+<a class="skip" href="#content">Skip to the main content</a>
+<div class="layout">
+<nav class="sidebar" aria-label="User guide contents">
+<h2>Mutation User Guide</h2>
+<ol>
+<li><a href="index.html">The Mutation User Guide</a></li>
+<li><a href="getting-started.html">Getting started</a></li>
+<li><a href="main-window.html">A tour of the main window</a></li>
+<li><a href="microphone.html">Muting your microphone</a></li>
+<li><a href="dictation.html">Dictation: turning speech into text</a></li>
+<li><a href="screen-capture-and-ocr.html">Screenshots and reading text from images</a></li>
+<li><a href="read-aloud.html" aria-current="page">Having text read aloud</a></li>
+<li><a href="ai-prompts.html">Using AI prompts on your text</a></li>
+<li><a href="transcript-formatting.html">Automatic find-and-replace rules</a></li>
+<li><a href="keyboard-shortcuts.html">Keyboard shortcuts</a></li>
+<li><a href="settings.html">The Settings window</a></li>
+<li><a href="accessibility.html">Screen reader and accessibility notes</a></li>
+<li><a href="troubleshooting.html">Troubleshooting</a></li>
+</ol>
+</nav>
+<main id="content" tabindex="-1">
+<h1 id="having-text-read-aloud">Having text read aloud</h1>
+<p>Mutation can read text out loud to you. Copy an email, a report, a
+long article — then press a shortcut and listen while you do something
+else.</p>
+<p>Once you know a handful of shortcuts you can drive it like a music
+player: play, pause, skip ahead, jump back.</p>
+<h2 id="starting-a-reading">Starting a reading</h2>
+<p>There are two ways to get text into Mutation&#39;s ears.</p>
+<p><strong>Read the clipboard.</strong> Copy some text anywhere (the
+usual <strong>Ctrl+C</strong>), then press
+<strong>Ctrl+Shift+Alt+Q</strong>. Mutation starts reading it.</p>
+<p><strong>Read what you have selected.</strong> Highlight text in any
+app and press <strong>Ctrl+Shift+Q</strong>. Mutation grabs the
+selection for you, so you don&#39;t need to copy first.</p>
+<p>Both shortcuts are global. That means they work no matter which app
+is in front — you never have to switch back to Mutation. All of these
+shortcuts are just defaults, and you can change any of them in
+<strong>Settings</strong> (<strong>Ctrl+Comma</strong>) on the
+<strong>Hotkeys</strong> tab.</p>
+<p>If you prefer buttons, the <strong>Voice &amp; Speech</strong> card
+on the main window has <strong>Speak clipboard</strong> and
+<strong>Speak selection</strong> buttons that do the same thing.</p>
+<h2 id="pausing-and-picking-up-again">Pausing and picking up again</h2>
+<p>There are two ways to interrupt a reading, and they behave slightly
+differently.</p>
+<p><strong>Pause properly: Ctrl+Shift+Space.</strong> This is the real
+pause button. Press it while Mutation is reading and it says &quot;Paused.&quot;
+Press it again and it says &quot;Resuming.&quot; and carries on. If nothing is
+being read, it tells you &quot;Nothing to resume.&quot;</p>
+<p>When it resumes, it rewinds a few words first — five by default — so
+you get your bearings instead of being dropped mid-sentence. That rewind
+only happens if your pause was long enough to lose the thread. A quick
+pause of a few seconds picks up from exactly where it stopped. By
+default, &quot;long enough&quot; means more than 10 seconds.</p>
+<p>Both of those numbers are yours to set, on the <strong>Text to
+Speech</strong> tab in <strong>Settings</strong>: &quot;Rewind on resume
+(words)&quot; (0 to 20, where 0 means no rewind at all) and &quot;Rewind on resume
+after (seconds)&quot; (set it to 0 to always rewind, however brief the
+pause).</p>
+<p><strong>Stop with the same key you started with:
+Ctrl+Shift+Alt+Q.</strong> Pressing the speak shortcut again while it is
+reading stops it, and Mutation says &quot;Stopped.&quot; Press it once more and it
+picks the same text up again from where it left off — so in everyday use
+it works like a play/stop button on the one key.</p>
+<p>One handy detail: if you copy something new before pressing it again,
+Mutation notices and reads the <em>new</em> clipboard text instead of
+carrying on with the old one. It tells you so: &quot;Speaking new clipboard
+text.&quot;</p>
+<h2 id="moving-around-the-text">Moving around the text</h2>
+<p>You can move through the text sentence by sentence, the way you skip
+tracks on a music player.</p>
+<table>
+<thead>
+<tr>
+<th scope="col">What you want</th>
+<th scope="col">Shortcut</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Pause, then carry on again</td>
+<td><strong>Ctrl+Shift+Space</strong></td>
+</tr>
+<tr>
+<td>Skip forward one sentence</td>
+<td><strong>Ctrl+Shift+K</strong></td>
+</tr>
+<tr>
+<td>Skip back one sentence</td>
+<td><strong>Ctrl+Shift+J</strong></td>
+</tr>
+<tr>
+<td>Start again from the very beginning</td>
+<td><strong>Ctrl+Shift+B</strong></td>
+</tr>
+<tr>
+<td>Tell me where I am</td>
+<td><strong>Ctrl+Shift+P</strong></td>
+</tr>
+</tbody>
+</table>
+<p>Skipping back is a little cleverer than it looks. If you have only
+just landed on a sentence, pressing back jumps to the previous one —
+because you probably missed that one. If you have been listening to the
+current sentence for a moment, pressing back restarts the current
+sentence instead — because you probably want to hear that bit again.</p>
+<p>The dividing line is a short grace window, 1.5 seconds by default.
+You can adjust it under &quot;Skip-back grace window (milliseconds)&quot; on the
+<strong>Text to Speech</strong> tab. A larger value makes stepping back
+to the previous sentence easier; a smaller value favours re-reading the
+sentence you are on.</p>
+<p>If you skip past the end, Mutation says &quot;End of text.&quot; If you skip
+back before the start, it says &quot;Beginning of text.&quot;</p>
+<p>The <strong>Position</strong> button on the <strong>Voice &amp;
+Speech</strong> card (or <strong>Ctrl+Shift+P</strong>) tells you where
+you are in the text. You hear something like &quot;Sentence 4 of 22, about
+40% through, about 2 minutes left.&quot; If nothing is being read, it simply
+says &quot;Not currently reading.&quot;</p>
+<h2 id="choosing-a-voice-speed-and-volume">Choosing a voice, speed, and
+volume</h2>
+<p>The <strong>Voice &amp; Speech</strong> card on the main window holds
+three controls.</p>
+<ul>
+<li><strong>Voice</strong> — a list of every voice installed on Windows,
+plus &quot;(System default)&quot;. Pick one and Mutation immediately speaks a
+short sample in that voice, so you can hear it before committing.</li>
+<li><strong>Rate</strong> — how fast it reads, from -10 (slow) to +10
+(fast). The default is 8, which is brisk. Slide it down if that is too
+quick.</li>
+<li><strong>Volume</strong> — 0 to 100%, separate from your Windows
+volume.</li>
+</ul>
+<p>Your choices are saved automatically. There is no Save button to
+press.</p>
+<p>Want more voices? Install them through Windows&#39; own speech settings,
+and they turn up in Mutation&#39;s Voice list next time.</p>
+<h2 id="being-told-how-long-it-will-take">Being told how long it will
+take</h2>
+<p>Two switches on the <strong>Voice &amp; Speech</strong> card keep you
+informed while you listen.</p>
+<p><strong>Announce reading time at start</strong> speaks a short
+estimate before it begins, such as &quot;Reading approximately 3 minutes of
+text.&quot;</p>
+<p><strong>Announce progress while reading</strong> speaks your progress
+at regular points along the way, such as &quot;50%, about 3 minutes
+left.&quot;</p>
+<p>Short texts stay quiet. On the <strong>Text to Speech</strong> tab in
+<strong>Settings</strong> you can set a minimum length for each
+announcement: &quot;Announce reading time only above (minutes)&quot; and &quot;Announce
+progress only above (minutes)&quot;. Set either to 0 to hear it for any
+length of text. You can also set how often progress is spoken with
+&quot;Announce progress every (percent)&quot; — 25 gives you 25%, 50%, and
+75%.</p>
+<h2 id="tidier-reading">Tidier reading</h2>
+<p>Text copied from the web or from notes is often littered with symbols
+that sound awful when read out. So before speaking, Mutation quietly
+cleans the text up. This is on by default.</p>
+<p>Here is what it tidies:</p>
+<ul>
+<li><strong>Remove code blocks</strong> — drops chunks of code (text
+between triple backticks) rather than reading them out.</li>
+<li><strong>Strip bold, italic, and inline-code symbols</strong> —
+removes asterisks, underscores, and backticks, keeping the words between
+them.</li>
+<li><strong>Strip heading marks</strong> — removes leading
+<code>#</code> symbols so headings read as plain text.</li>
+<li><strong>Shorten web links</strong> — reads &quot;link to example.com&quot;
+instead of the full address.</li>
+<li><strong>Strip bullet markers</strong> — removes the <code>-</code>,
+<code>*</code>, or <code>+</code> at the start of list items.</li>
+<li><strong>Expand abbreviations</strong> — &quot;e.g.&quot; becomes &quot;for
+example&quot;, &quot;i.e.&quot; becomes &quot;that is&quot;, &quot;etc.&quot; becomes &quot;et cetera&quot;, and
+&quot;vs.&quot; becomes &quot;versus&quot;.</li>
+<li><strong>Normalise paragraph breaks and whitespace</strong> —
+collapses blank lines and runs of spaces so you don&#39;t sit through long
+silent gaps.</li>
+</ul>
+<p>Each of those is its own switch on the <strong>Text to
+Speech</strong> tab in <strong>Settings</strong>, so you can keep the
+ones you like and turn off the ones you don&#39;t. Above them is a master
+switch, &quot;Enable speech preprocessing&quot;. Turn that off and you hear the
+text exactly as written, symbols and all.</p>
+<blockquote>
+<p>Every setting on the page has a small reset button next to it that
+puts it back to the default, so experimenting is safe.</p>
+</blockquote>
+<h2 id="saving-a-reading-as-an-audio-file">Saving a reading as an audio
+file</h2>
+<p>The <strong>Speak to file</strong> button on the <strong>Voice &amp;
+Speech</strong> card takes whatever text is on your clipboard and saves
+it as a spoken audio file (a <code>.wav</code> file) instead of playing
+it. Mutation suggests a name with the date and time in it, and you
+choose where to put it.</p>
+<p>This is useful when you want to listen later — on your phone during a
+commute, for instance — or when you want to keep a spoken copy of a
+document.</p>
+<h2 id="when-mutation-cant-read-something">When Mutation can&#39;t read
+something</h2>
+<p>If there is nothing to read, Mutation tells you out loud rather than
+sitting silently. You will hear one of these:</p>
+<ul>
+<li>&quot;No text on the clipboard.&quot; — nothing has been copied yet.</li>
+<li>&quot;The clipboard contains an image, not text. Use OCR to extract text
+first.&quot; — see <a href="screen-capture-and-ocr.html">Screenshots and
+reading text from images</a> for how to pull the words out of a
+picture.</li>
+<li>&quot;The clipboard is in use by another application. Try again in a
+moment.&quot; — just press the shortcut again.</li>
+</ul>
+<p>Each of these also appears as a message on the main window, and plays
+the failure beep.</p>
+<h2 id="where-to-next">Where to next</h2>
+<ul>
+<li><a href="screen-capture-and-ocr.html">Screenshots and reading text
+from images</a> — get text out of a picture so it can be read
+aloud.</li>
+<li><a href="settings.html">The Settings window</a> — where the
+<strong>Text to Speech</strong> tab lives.</li>
+<li><a href="keyboard-shortcuts.html">Keyboard shortcuts</a> — the full
+list, and how to change them.</li>
+<li><a href="main-window.html">A tour of the main window</a> — where the
+<strong>Voice &amp; Speech</strong> card sits.</li>
+</ul>
+<footer>
+<p><a href="index.html">Back to the contents page</a></p>
+<p>Generated from the Markdown source on 4 August 2026. The Markdown files are the source of truth – do not edit these HTML pages by hand.</p>
+</footer>
+</main>
+</div>
+</body>
+</html>

--- a/Documentation/UserGuide/html/read-aloud.html
+++ b/Documentation/UserGuide/html/read-aloud.html
@@ -61,8 +61,8 @@ border-left:5px solid var(--quote-rule); border-radius:0 8px 8px 0;
 }
 blockquote p{margin:.3rem 0}
 
-table{border-collapse:collapse; width:100%; margin:1rem 0; display:block; overflow-x:auto}
-thead,tbody,tr{width:100%}
+.table-wrap{overflow-x:auto; margin:1rem 0}
+table{border-collapse:collapse; width:100%; min-width:26rem}
 th,td{border:1px solid var(--rule); padding:.5rem .65rem; vertical-align:top}
 th{background:var(--surface); font-weight:700; text-align:left}
 tbody tr:nth-child(even){background:var(--surface)}
@@ -70,9 +70,10 @@ hr{border:none; border-top:1px solid var(--rule); margin:2rem 0}
 kbd{background:var(--surface); border:1px solid var(--rule); border-bottom-width:2px; border-radius:5px; padding:.1em .4em}
 footer{margin-top:3rem; padding-top:1rem; border-top:1px solid var(--rule); color:var(--muted); font-size:.9rem}
 @media (max-width:860px){
-.layout{flex-direction:column; padding:1rem}
+
+.layout{flex-direction:column; align-items:stretch; padding:1rem}
 .sidebar{position:static; flex:1 1 auto; width:100%}
-main{max-width:none}
+main{max-width:none; width:100%; min-width:0}
 }
 @media print{
 .sidebar,.skip{display:none}
@@ -155,6 +156,7 @@ text.&quot;</p>
 <h2 id="moving-around-the-text">Moving around the text</h2>
 <p>You can move through the text sentence by sentence, the way you skip
 tracks on a music player.</p>
+<div class="table-wrap">
 <table>
 <thead>
 <tr>
@@ -185,6 +187,7 @@ tracks on a music player.</p>
 </tr>
 </tbody>
 </table>
+</div>
 <p>Skipping back is a little cleverer than it looks. If you have only
 just landed on a sentence, pressing back jumps to the previous one —
 because you probably missed that one. If you have been listening to the

--- a/Documentation/UserGuide/html/screen-capture-and-ocr.html
+++ b/Documentation/UserGuide/html/screen-capture-and-ocr.html
@@ -62,8 +62,8 @@ border-left:5px solid var(--quote-rule); border-radius:0 8px 8px 0;
 }
 blockquote p{margin:.3rem 0}
 
-table{border-collapse:collapse; width:100%; margin:1rem 0; display:block; overflow-x:auto}
-thead,tbody,tr{width:100%}
+.table-wrap{overflow-x:auto; margin:1rem 0}
+table{border-collapse:collapse; width:100%; min-width:26rem}
 th,td{border:1px solid var(--rule); padding:.5rem .65rem; vertical-align:top}
 th{background:var(--surface); font-weight:700; text-align:left}
 tbody tr:nth-child(even){background:var(--surface)}
@@ -71,9 +71,10 @@ hr{border:none; border-top:1px solid var(--rule); margin:2rem 0}
 kbd{background:var(--surface); border:1px solid var(--rule); border-bottom-width:2px; border-radius:5px; padding:.1em .4em}
 footer{margin-top:3rem; padding-top:1rem; border-top:1px solid var(--rule); color:var(--muted); font-size:.9rem}
 @media (max-width:860px){
-.layout{flex-direction:column; padding:1rem}
+
+.layout{flex-direction:column; align-items:stretch; padding:1rem}
 .sidebar{position:static; flex:1 1 auto; width:100%}
-main{max-width:none}
+main{max-width:none; width:100%; min-width:0}
 }
 @media print{
 .sidebar,.skip{display:none}
@@ -144,6 +145,7 @@ move it announces the position you are at, the size of the rectangle you
 have built so far, and finally the size of what was captured.</p>
 <p>Think of it as a moving pointer that you park at one corner, pin
 down, and then drag to the other corner.</p>
+<div class="table-wrap">
 <table>
 <thead>
 <tr>
@@ -184,6 +186,7 @@ it</td>
 </tr>
 </tbody>
 </table>
+</div>
 <p>So the quickest possible capture is <strong>Ctrl+A</strong> then
 <strong>Enter</strong>: the whole screen, in two keystrokes.</p>
 <h2 id="the-two-reading-orders">The two reading orders</h2>
@@ -203,6 +206,7 @@ Natural. If it has <em>rows</em>, use Basic.</p>
 same image.</p>
 <h2 id="the-buttons-and-their-shortcuts">The buttons and their
 shortcuts</h2>
+<div class="table-wrap">
 <table>
 <thead>
 <tr>
@@ -242,6 +246,7 @@ step.</td>
 </tr>
 </tbody>
 </table>
+</div>
 <p>Every one of these shortcuts can be changed in
 <strong>Settings</strong> (<strong>Ctrl+Comma</strong>).</p>
 <p>In all four OCR cases the text lands on your clipboard, ready to

--- a/Documentation/UserGuide/html/screen-capture-and-ocr.html
+++ b/Documentation/UserGuide/html/screen-capture-and-ocr.html
@@ -1,0 +1,305 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Screenshots and reading text from images - Mutation User
+Guide</title>
+<meta name="generator" content="pandoc 3.9.0.2" />
+<style type="text/css">
+:root{
+color-scheme: light dark;
+--bg:#ffffff; --fg:#1b1b1f; --muted:#5a5a66; --rule:#d9d9e0;
+--accent:#0b5fa5; --accent-fg:#ffffff; --surface:#f5f5f8; --code:#f0f0f4;
+--quote:#eef4fb; --quote-rule:#0b5fa5;
+}
+@media (prefers-color-scheme: dark){
+:root{
+--bg:#15151a; --fg:#eaeaf0; --muted:#a8a8b6; --rule:#3a3a45;
+--accent:#6fb3ff; --accent-fg:#10131a; --surface:#1e1e26; --code:#22222c;
+--quote:#1c2530; --quote-rule:#6fb3ff;
+}
+}
+*{box-sizing:border-box}
+html{font-size:106%}
+body{
+margin:0; background:var(--bg); color:var(--fg);
+font-family:"Segoe UI",system-ui,-apple-system,Arial,sans-serif;
+line-height:1.65;
+}
+.skip{
+position:absolute; left:-9999px; top:0; padding:.6rem 1rem; z-index:10;
+background:var(--accent); color:var(--accent-fg); font-weight:600;
+}
+.skip:focus{left:0}
+.layout{display:flex; align-items:flex-start; gap:2rem; max-width:1180px; margin:0 auto; padding:1.5rem}
+.sidebar{
+flex:0 0 16rem; position:sticky; top:1.5rem;
+background:var(--surface); border:1px solid var(--rule); border-radius:10px; padding:1rem 1.1rem;
+}
+.sidebar h2{font-size:1rem; margin:0 0 .6rem; text-transform:uppercase; letter-spacing:.04em; color:var(--muted)}
+.sidebar ol{list-style:none; margin:0; padding:0}
+.sidebar li{margin:.15rem 0}
+.sidebar a{display:block; padding:.3rem .45rem; border-radius:6px; text-decoration:none; color:var(--fg)}
+.sidebar a:hover{background:var(--bg); text-decoration:underline}
+.sidebar a[aria-current="page"]{background:var(--accent); color:var(--accent-fg); font-weight:600}
+main{flex:1 1 auto; min-width:0; max-width:52rem}
+h1{font-size:2.1rem; line-height:1.2; margin:.2rem 0 1rem; border-bottom:3px solid var(--accent); padding-bottom:.5rem}
+h2{font-size:1.5rem; margin:2.2rem 0 .7rem; border-bottom:1px solid var(--rule); padding-bottom:.3rem}
+h3{font-size:1.2rem; margin:1.7rem 0 .5rem}
+h4{font-size:1.05rem; margin:1.4rem 0 .4rem}
+p{margin:.7rem 0}
+a{color:var(--accent)}
+a:focus-visible,button:focus-visible,main:focus-visible{outline:3px solid var(--accent); outline-offset:2px}
+ul,ol{margin:.7rem 0; padding-left:1.6rem}
+li{margin:.3rem 0}
+code{background:var(--code); padding:.12em .38em; border-radius:4px; font-family:Consolas,"Cascadia Mono",monospace; font-size:.92em}
+pre{background:var(--code); border:1px solid var(--rule); border-radius:8px; padding:.9rem 1rem; overflow-x:auto}
+pre code{background:none; padding:0; font-size:.9em}
+blockquote{
+margin:1rem 0; padding:.7rem 1rem; background:var(--quote);
+border-left:5px solid var(--quote-rule); border-radius:0 8px 8px 0;
+}
+blockquote p{margin:.3rem 0}
+
+table{border-collapse:collapse; width:100%; margin:1rem 0; display:block; overflow-x:auto}
+thead,tbody,tr{width:100%}
+th,td{border:1px solid var(--rule); padding:.5rem .65rem; vertical-align:top}
+th{background:var(--surface); font-weight:700; text-align:left}
+tbody tr:nth-child(even){background:var(--surface)}
+hr{border:none; border-top:1px solid var(--rule); margin:2rem 0}
+kbd{background:var(--surface); border:1px solid var(--rule); border-bottom-width:2px; border-radius:5px; padding:.1em .4em}
+footer{margin-top:3rem; padding-top:1rem; border-top:1px solid var(--rule); color:var(--muted); font-size:.9rem}
+@media (max-width:860px){
+.layout{flex-direction:column; padding:1rem}
+.sidebar{position:static; flex:1 1 auto; width:100%}
+main{max-width:none}
+}
+@media print{
+.sidebar,.skip{display:none}
+body{background:#fff; color:#000}
+.layout{display:block; max-width:none; padding:0}
+a{color:#000}
+}
+</style>
+</head>
+<body>
+<a class="skip" href="#content">Skip to the main content</a>
+<div class="layout">
+<nav class="sidebar" aria-label="User guide contents">
+<h2>Mutation User Guide</h2>
+<ol>
+<li><a href="index.html">The Mutation User Guide</a></li>
+<li><a href="getting-started.html">Getting started</a></li>
+<li><a href="main-window.html">A tour of the main window</a></li>
+<li><a href="microphone.html">Muting your microphone</a></li>
+<li><a href="dictation.html">Dictation: turning speech into text</a></li>
+<li><a href="screen-capture-and-ocr.html" aria-current="page">Screenshots and reading text from images</a></li>
+<li><a href="read-aloud.html">Having text read aloud</a></li>
+<li><a href="ai-prompts.html">Using AI prompts on your text</a></li>
+<li><a href="transcript-formatting.html">Automatic find-and-replace rules</a></li>
+<li><a href="keyboard-shortcuts.html">Keyboard shortcuts</a></li>
+<li><a href="settings.html">The Settings window</a></li>
+<li><a href="accessibility.html">Screen reader and accessibility notes</a></li>
+<li><a href="troubleshooting.html">Troubleshooting</a></li>
+</ol>
+</nav>
+<main id="content" tabindex="-1">
+<h1 id="screenshots-and-reading-text-from-images">Screenshots and
+reading text from images</h1>
+<p>Sometimes the words you need are trapped inside a picture. A
+screenshot a colleague sent you. A scanned invoice. A PDF that will not
+let you select anything.</p>
+<p>OCR is the answer to that. It stands for optical character
+recognition, and it simply means reading the words out of a picture so
+you can copy, search, or paste them. Mutation does this for you, and
+puts the resulting text straight onto your clipboard.</p>
+<p>Everything in this chapter lives in the <strong>Visual
+Capture</strong> card on the main window.</p>
+<blockquote>
+<p>Before any of the OCR buttons will work, Mutation needs an Azure
+Computer Vision key (a long password that lets Mutation send your image
+to Microsoft&#39;s text-reading service and get the words back). See <a href="getting-started.html">Getting started</a> for how to set that
+up.</p>
+</blockquote>
+<h2 id="taking-a-screenshot-of-part-of-the-screen">Taking a screenshot
+of part of the screen</h2>
+<p>Press the screenshot shortcut — <strong>Shift+Alt+K</strong> by
+default. The screen freezes, and an overlay appears over everything. You
+then pick a rectangle. As soon as you finish picking, that rectangle is
+copied to your clipboard as an image, and you are back where you
+were.</p>
+<p>Press <strong>Esc</strong> at any point to cancel. Nothing is copied,
+and Mutation tells you so.</p>
+<h3 id="picking-the-rectangle-with-the-mouse">Picking the rectangle with
+the mouse</h3>
+<p>Hold the left mouse button down at one corner of the area you want,
+drag to the opposite corner, and let go. That is it. A right-click
+cancels instead.</p>
+<h3 id="picking-the-rectangle-with-the-keyboard">Picking the rectangle
+with the keyboard</h3>
+<p>You never need to see the screen to do this. The overlay talks you
+through it. When it opens it says what it wants from you, then as you
+move it announces the position you are at, the size of the rectangle you
+have built so far, and finally the size of what was captured.</p>
+<p>Think of it as a moving pointer that you park at one corner, pin
+down, and then drag to the other corner.</p>
+<table>
+<thead>
+<tr>
+<th scope="col">Key</th>
+<th scope="col">Action</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Arrow keys</td>
+<td>Move the pointer (hold <strong>Ctrl</strong> for fine steps,
+<strong>Shift</strong> for large steps)</td>
+</tr>
+<tr>
+<td><strong>Home</strong> / <strong>End</strong></td>
+<td>Jump the pointer to the left / right edge</td>
+</tr>
+<tr>
+<td><strong>Page Up</strong> / <strong>Page Down</strong></td>
+<td>Jump the pointer to the top / bottom edge</td>
+</tr>
+<tr>
+<td><strong>Enter</strong> or <strong>Space</strong></td>
+<td>First press pins one corner; second press captures the region</td>
+</tr>
+<tr>
+<td><strong>Ctrl+A</strong></td>
+<td>Select the whole screen — then <strong>Enter</strong> to capture
+it</td>
+</tr>
+<tr>
+<td><strong>Backspace</strong></td>
+<td>Clear the pinned corner and start the selection again</td>
+</tr>
+<tr>
+<td><strong>Esc</strong></td>
+<td>Cancel</td>
+</tr>
+</tbody>
+</table>
+<p>So the quickest possible capture is <strong>Ctrl+A</strong> then
+<strong>Enter</strong>: the whole screen, in two keystrokes.</p>
+<h2 id="the-two-reading-orders">The two reading orders</h2>
+<p>A page of text can be read in two sensible ways, and Mutation offers
+both.</p>
+<ul>
+<li><strong>Natural</strong> follows the shape of the page. It reads
+down one column, then down the next, keeping sections together. Choose
+it for newspapers, magazines, brochures, and multi-column PDFs.</li>
+<li><strong>Basic</strong> reads straight across each row, left to
+right, all the way down. The app labels this one <strong>(L→R)</strong>.
+Choose it for tables, spreadsheets, forms, and invoices.</li>
+</ul>
+<p>Rule of thumb: if the thing you are reading has <em>columns</em>, use
+Natural. If it has <em>rows</em>, use Basic.</p>
+<p>If one order gives you a jumbled result, just try the other on the
+same image.</p>
+<h2 id="the-buttons-and-their-shortcuts">The buttons and their
+shortcuts</h2>
+<table>
+<thead>
+<tr>
+<th scope="col">Button</th>
+<th scope="col">Default shortcut</th>
+<th scope="col">What it does</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Screenshot to clipboard</td>
+<td><strong>Shift+Alt+K</strong></td>
+<td>Picks a rectangle and copies it to the clipboard as an image. No
+text reading.</td>
+</tr>
+<tr>
+<td>OCR clipboard</td>
+<td><strong>Alt+J</strong></td>
+<td>Reads the text out of whatever image is already on your clipboard,
+in Natural order.</td>
+</tr>
+<tr>
+<td>OCR clipboard (L→R)</td>
+<td><strong>Alt+K</strong></td>
+<td>The same, but in Basic left-to-right order.</td>
+</tr>
+<tr>
+<td>Screenshot &amp; OCR</td>
+<td><strong>Shift+Alt+J</strong></td>
+<td>Picks a rectangle <em>and</em> reads its text, in Natural order. One
+step.</td>
+</tr>
+<tr>
+<td>Screenshot &amp; OCR (L→R)</td>
+<td><strong>Shift+Alt+E</strong></td>
+<td>The same, in Basic left-to-right order.</td>
+</tr>
+</tbody>
+</table>
+<p>Every one of these shortcuts can be changed in
+<strong>Settings</strong> (<strong>Ctrl+Comma</strong>).</p>
+<p>In all four OCR cases the text lands on your clipboard, ready to
+paste, and also appears in the <strong>OCR result</strong> box at the
+bottom of the card so you can read it in place.</p>
+<h2 id="reading-a-batch-of-files-at-once">Reading a batch of files at
+once</h2>
+<p>The <strong>OCR documents</strong> button handles whole files rather
+than screenshots. Click it, pick one or more files, and Mutation reads
+them all.</p>
+<p>It accepts PDFs and image files: <code>.pdf</code>,
+<code>.png</code>, <code>.jpg</code>, <code>.jpeg</code>,
+<code>.bmp</code>, <code>.tif</code> and <code>.tiff</code>. You can
+select several at once.</p>
+<p>A progress bar tells you which file and page it is on. When it
+finishes, all the text comes back as one combined block in the
+<strong>OCR result</strong> box — each file introduced by its name in
+square brackets, and each page of a PDF marked with its page number.
+That combined text is copied to the clipboard too.</p>
+<p>If you want to keep it, the <strong>Download OCR result</strong>
+button saves the whole thing to a plain text file.</p>
+<h2 id="a-few-settings-worth-knowing">A few settings worth knowing</h2>
+<p>These live under <strong>Screen capture &amp; OCR</strong> in
+<strong>Settings</strong> (<strong>Ctrl+Comma</strong>).</p>
+<ul>
+<li><strong>Invert screenshot before OCR</strong> — flips the colours
+before reading. Turn this on if you work with light text on a dark
+background; it usually improves accuracy a lot.</li>
+<li><strong>Free-tier page limit</strong> — if you are on Microsoft&#39;s
+free plan, this caps how many pages of each document get sent. The
+default is 2, so long PDFs are cut short unless you turn <strong>Use
+free tier</strong> off.</li>
+<li><strong>Max document size (MB)</strong> — any file or page bigger
+than this is skipped instead of being uploaded, so you never
+accidentally send something enormous. Set it to 0 to remove the
+limit.</li>
+</ul>
+<p>There is also an optional <strong>Send hotkey after OCR</strong>
+setting, which fires a keystroke of your choosing once the text is ready
+— handy for kicking off your screen reader automatically.</p>
+<p>The rest of the options are covered in <a href="settings.html">The
+Settings window</a>.</p>
+<h2 id="where-to-next">Where to next</h2>
+<ul>
+<li><a href="getting-started.html">Getting started</a> — setting up your
+Azure Computer Vision key</li>
+<li><a href="main-window.html">A tour of the main window</a> — where the
+<strong>Visual Capture</strong> card sits</li>
+<li><a href="read-aloud.html">Having text read aloud</a> — listen to the
+text you just captured</li>
+<li><a href="keyboard-shortcuts.html">Keyboard shortcuts</a> — the full
+list, and how to change them</li>
+</ul>
+<footer>
+<p><a href="index.html">Back to the contents page</a></p>
+<p>Generated from the Markdown source on 4 August 2026. The Markdown files are the source of truth – do not edit these HTML pages by hand.</p>
+</footer>
+</main>
+</div>
+</body>
+</html>

--- a/Documentation/UserGuide/html/settings.html
+++ b/Documentation/UserGuide/html/settings.html
@@ -61,8 +61,8 @@ border-left:5px solid var(--quote-rule); border-radius:0 8px 8px 0;
 }
 blockquote p{margin:.3rem 0}
 
-table{border-collapse:collapse; width:100%; margin:1rem 0; display:block; overflow-x:auto}
-thead,tbody,tr{width:100%}
+.table-wrap{overflow-x:auto; margin:1rem 0}
+table{border-collapse:collapse; width:100%; min-width:26rem}
 th,td{border:1px solid var(--rule); padding:.5rem .65rem; vertical-align:top}
 th{background:var(--surface); font-weight:700; text-align:left}
 tbody tr:nth-child(even){background:var(--surface)}
@@ -70,9 +70,10 @@ hr{border:none; border-top:1px solid var(--rule); margin:2rem 0}
 kbd{background:var(--surface); border:1px solid var(--rule); border-bottom-width:2px; border-radius:5px; padding:.1em .4em}
 footer{margin-top:3rem; padding-top:1rem; border-top:1px solid var(--rule); color:var(--muted); font-size:.9rem}
 @media (max-width:860px){
-.layout{flex-direction:column; padding:1rem}
+
+.layout{flex-direction:column; align-items:stretch; padding:1rem}
 .sidebar{position:static; flex:1 1 auto; width:100%}
-main{max-width:none}
+main{max-width:none; width:100%; min-width:0}
 }
 @media print{
 .sidebar,.skip{display:none}
@@ -143,6 +144,7 @@ simply hides that button.</p>
 <h2 id="the-categories">The categories</h2>
 <h3 id="audio">Audio</h3>
 <p>Your microphone and the little sounds Mutation makes.</p>
+<div class="table-wrap">
 <table>
 <thead>
 <tr>
@@ -173,9 +175,11 @@ you hear it.</td>
 </tr>
 </tbody>
 </table>
+</div>
 <h3 id="screen-capture--ocr">Screen capture &amp; OCR</h3>
 <p>Reading text out of pictures. OCR just means &quot;pulling the words out
 of an image&quot;.</p>
+<div class="table-wrap">
 <table>
 <thead>
 <tr>
@@ -217,11 +221,13 @@ delivered — <strong>Ctrl+V</strong> to paste, for example.</td>
 </tr>
 </tbody>
 </table>
+</div>
 <p>The timeout and the &quot;how many at a time&quot; numbers have sensible
 defaults and hover help. Leave them alone unless something is timing out
 on you.</p>
 <h3 id="speech-to-text">Speech to Text</h3>
 <p>Where your dictation gets turned into text.</p>
+<div class="table-wrap">
 <table>
 <thead>
 <tr>
@@ -264,6 +270,7 @@ think do not bloat the recording.</td>
 </tr>
 </tbody>
 </table>
+</div>
 <blockquote>
 <p>Adding, removing, or editing a service definition takes effect after
 you restart Mutation. The per-service prompt and your choice of active
@@ -276,6 +283,7 @@ hover help if you want to experiment.</p>
 <h3 id="api-keys">API keys</h3>
 <p>Your keys in one place. An API key is a long password that lets
 Mutation talk to a service on your behalf.</p>
+<div class="table-wrap">
 <table>
 <thead>
 <tr>
@@ -298,10 +306,12 @@ Mutation talk to a service on your behalf.</p>
 </tr>
 </tbody>
 </table>
+</div>
 <p>A speech service can override its key from the Speech to Text
 section. Otherwise the key here is the one used.</p>
 <h3 id="ai-assistance">AI assistance</h3>
 <p>The AI models Mutation can send your text to.</p>
+<div class="table-wrap">
 <table>
 <thead>
 <tr>
@@ -328,10 +338,12 @@ temperature empty to use the provider&#39;s own setting.</td>
 </tr>
 </tbody>
 </table>
+</div>
 <p>Your prompts themselves are edited on the main window, not here.</p>
 <h3 id="text-to-speech">Text to Speech</h3>
 <p>How Mutation reads text out loud. Voice, rate and volume live on the
 main window; this page holds everything else.</p>
+<div class="table-wrap">
 <table>
 <thead>
 <tr>
@@ -370,12 +382,14 @@ means at 25%, 50% and 75%.</td>
 </tr>
 </tbody>
 </table>
+</div>
 <p>The skip-back grace window and the two &quot;only announce above this many
 minutes&quot; numbers have sensible defaults and hover help.</p>
 <h3 id="transcript-formatting">Transcript formatting</h3>
 <p>Your own find-and-replace rules, applied to a transcript when you
 press <strong>Format</strong>. Rules run from top to bottom, so the
 order matters — use the up and down arrows to move them.</p>
+<div class="table-wrap">
 <table>
 <thead>
 <tr>
@@ -403,10 +417,12 @@ ignored.</td>
 </tr>
 </tbody>
 </table>
+</div>
 <p>See <a href="transcript-formatting.html">Automatic find-and-replace
 rules</a> for the full story.</p>
 <h3 id="interface">Interface</h3>
 <p>Small comforts for the main window.</p>
+<div class="table-wrap">
 <table>
 <thead>
 <tr>
@@ -434,6 +450,7 @@ if it has ended up off-screen.</td>
 </tr>
 </tbody>
 </table>
+</div>
 <h3 id="hotkeys">Hotkeys</h3>
 <p>Every keyboard shortcut in one place, plus the shortcut router. This
 one has a chapter of its own: <a href="keyboard-shortcuts.html">Keyboard

--- a/Documentation/UserGuide/html/settings.html
+++ b/Documentation/UserGuide/html/settings.html
@@ -1,0 +1,504 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>The Settings window - Mutation User Guide</title>
+<meta name="generator" content="pandoc 3.9.0.2" />
+<style type="text/css">
+:root{
+color-scheme: light dark;
+--bg:#ffffff; --fg:#1b1b1f; --muted:#5a5a66; --rule:#d9d9e0;
+--accent:#0b5fa5; --accent-fg:#ffffff; --surface:#f5f5f8; --code:#f0f0f4;
+--quote:#eef4fb; --quote-rule:#0b5fa5;
+}
+@media (prefers-color-scheme: dark){
+:root{
+--bg:#15151a; --fg:#eaeaf0; --muted:#a8a8b6; --rule:#3a3a45;
+--accent:#6fb3ff; --accent-fg:#10131a; --surface:#1e1e26; --code:#22222c;
+--quote:#1c2530; --quote-rule:#6fb3ff;
+}
+}
+*{box-sizing:border-box}
+html{font-size:106%}
+body{
+margin:0; background:var(--bg); color:var(--fg);
+font-family:"Segoe UI",system-ui,-apple-system,Arial,sans-serif;
+line-height:1.65;
+}
+.skip{
+position:absolute; left:-9999px; top:0; padding:.6rem 1rem; z-index:10;
+background:var(--accent); color:var(--accent-fg); font-weight:600;
+}
+.skip:focus{left:0}
+.layout{display:flex; align-items:flex-start; gap:2rem; max-width:1180px; margin:0 auto; padding:1.5rem}
+.sidebar{
+flex:0 0 16rem; position:sticky; top:1.5rem;
+background:var(--surface); border:1px solid var(--rule); border-radius:10px; padding:1rem 1.1rem;
+}
+.sidebar h2{font-size:1rem; margin:0 0 .6rem; text-transform:uppercase; letter-spacing:.04em; color:var(--muted)}
+.sidebar ol{list-style:none; margin:0; padding:0}
+.sidebar li{margin:.15rem 0}
+.sidebar a{display:block; padding:.3rem .45rem; border-radius:6px; text-decoration:none; color:var(--fg)}
+.sidebar a:hover{background:var(--bg); text-decoration:underline}
+.sidebar a[aria-current="page"]{background:var(--accent); color:var(--accent-fg); font-weight:600}
+main{flex:1 1 auto; min-width:0; max-width:52rem}
+h1{font-size:2.1rem; line-height:1.2; margin:.2rem 0 1rem; border-bottom:3px solid var(--accent); padding-bottom:.5rem}
+h2{font-size:1.5rem; margin:2.2rem 0 .7rem; border-bottom:1px solid var(--rule); padding-bottom:.3rem}
+h3{font-size:1.2rem; margin:1.7rem 0 .5rem}
+h4{font-size:1.05rem; margin:1.4rem 0 .4rem}
+p{margin:.7rem 0}
+a{color:var(--accent)}
+a:focus-visible,button:focus-visible,main:focus-visible{outline:3px solid var(--accent); outline-offset:2px}
+ul,ol{margin:.7rem 0; padding-left:1.6rem}
+li{margin:.3rem 0}
+code{background:var(--code); padding:.12em .38em; border-radius:4px; font-family:Consolas,"Cascadia Mono",monospace; font-size:.92em}
+pre{background:var(--code); border:1px solid var(--rule); border-radius:8px; padding:.9rem 1rem; overflow-x:auto}
+pre code{background:none; padding:0; font-size:.9em}
+blockquote{
+margin:1rem 0; padding:.7rem 1rem; background:var(--quote);
+border-left:5px solid var(--quote-rule); border-radius:0 8px 8px 0;
+}
+blockquote p{margin:.3rem 0}
+
+table{border-collapse:collapse; width:100%; margin:1rem 0; display:block; overflow-x:auto}
+thead,tbody,tr{width:100%}
+th,td{border:1px solid var(--rule); padding:.5rem .65rem; vertical-align:top}
+th{background:var(--surface); font-weight:700; text-align:left}
+tbody tr:nth-child(even){background:var(--surface)}
+hr{border:none; border-top:1px solid var(--rule); margin:2rem 0}
+kbd{background:var(--surface); border:1px solid var(--rule); border-bottom-width:2px; border-radius:5px; padding:.1em .4em}
+footer{margin-top:3rem; padding-top:1rem; border-top:1px solid var(--rule); color:var(--muted); font-size:.9rem}
+@media (max-width:860px){
+.layout{flex-direction:column; padding:1rem}
+.sidebar{position:static; flex:1 1 auto; width:100%}
+main{max-width:none}
+}
+@media print{
+.sidebar,.skip{display:none}
+body{background:#fff; color:#000}
+.layout{display:block; max-width:none; padding:0}
+a{color:#000}
+}
+</style>
+</head>
+<body>
+<a class="skip" href="#content">Skip to the main content</a>
+<div class="layout">
+<nav class="sidebar" aria-label="User guide contents">
+<h2>Mutation User Guide</h2>
+<ol>
+<li><a href="index.html">The Mutation User Guide</a></li>
+<li><a href="getting-started.html">Getting started</a></li>
+<li><a href="main-window.html">A tour of the main window</a></li>
+<li><a href="microphone.html">Muting your microphone</a></li>
+<li><a href="dictation.html">Dictation: turning speech into text</a></li>
+<li><a href="screen-capture-and-ocr.html">Screenshots and reading text from images</a></li>
+<li><a href="read-aloud.html">Having text read aloud</a></li>
+<li><a href="ai-prompts.html">Using AI prompts on your text</a></li>
+<li><a href="transcript-formatting.html">Automatic find-and-replace rules</a></li>
+<li><a href="keyboard-shortcuts.html">Keyboard shortcuts</a></li>
+<li><a href="settings.html" aria-current="page">The Settings window</a></li>
+<li><a href="accessibility.html">Screen reader and accessibility notes</a></li>
+<li><a href="troubleshooting.html">Troubleshooting</a></li>
+</ol>
+</nav>
+<main id="content" tabindex="-1">
+<h1 id="the-settings-window">The Settings window</h1>
+<p>Everything you can change about Mutation lives in one window. This
+chapter walks through it, category by category, so you know where to
+look.</p>
+<h2 id="opening-it-and-finding-your-way-around">Opening it and finding
+your way around</h2>
+<p>Press <strong>Ctrl+Comma</strong> while Mutation&#39;s window is in
+front. You can also open the menu (<strong>Alt</strong>, then
+<strong>H</strong>) and choose <strong>Settings</strong>.</p>
+<p>The window has two halves. Down the left is a list of categories. On
+the right are the settings for whichever category you have picked. Move
+between categories with the arrow keys; the heading above the right-hand
+side always tells you which one you are in.</p>
+<p>At the bottom are <strong>Save</strong> and <strong>Cancel</strong>.
+Nothing you change takes effect until you press <strong>Save</strong>.
+<strong>Cancel</strong> throws away everything you changed in that
+visit. <strong>Escape</strong> closes the window too.</p>
+<h2 id="the-search-box">The search box</h2>
+<p>Above the category list is a <strong>Search settings</strong> box.
+Type into it and two things happen at once: the category list shrinks to
+the categories that match, and the settings on the right hide any
+section that does not mention your word.</p>
+<p>Non-matching sections are removed rather than greyed out, so they
+disappear from the Tab order and from your screen reader as well as from
+the screen. A short line under the search box tells you how many
+categories and sections matched, and it is announced politely as you
+type — you never have to go hunting to find out whether your search
+found anything.</p>
+<p>Press <strong>Escape</strong> while you are in the search box to
+clear it and put everything back.</p>
+<h2 id="the-advanced-switch">The Advanced switch</h2>
+<p>Bottom right there is an <strong>Advanced</strong> switch. It does
+one thing: turning it on reveals an <strong>Open Mutation.json</strong>
+button, which opens the raw settings file in whatever program your PC
+uses for that file type. Most people never need it. Leaving Advanced off
+simply hides that button.</p>
+<h2 id="the-categories">The categories</h2>
+<h3 id="audio">Audio</h3>
+<p>Your microphone and the little sounds Mutation makes.</p>
+<table>
+<thead>
+<tr>
+<th scope="col">Setting</th>
+<th scope="col">What it does</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Microphone visualization</td>
+<td>Shows a live waveform of the microphone input while recording. Turn
+it off to save a bit of CPU.</td>
+</tr>
+<tr>
+<td>Toggle microphone mute</td>
+<td>The shortcut that mutes and unmutes everything.</td>
+</tr>
+<tr>
+<td>Use custom beeps</td>
+<td>Play your own sound files instead of the built-in beeps for status
+cues.</td>
+</tr>
+<tr>
+<td>Beep files</td>
+<td>One file each for Success, Failure, Start, End, Mute and Unmute.
+<strong>Browse...</strong> picks a file, and the small play button lets
+you hear it.</td>
+</tr>
+</tbody>
+</table>
+<h3 id="screen-capture--ocr">Screen capture &amp; OCR</h3>
+<p>Reading text out of pictures. OCR just means &quot;pulling the words out
+of an image&quot;.</p>
+<table>
+<thead>
+<tr>
+<th scope="col">Setting</th>
+<th scope="col">What it does</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Azure Computer Vision API key</td>
+<td>The long password that lets Mutation use the text-reading service on
+your behalf.</td>
+</tr>
+<tr>
+<td>Endpoint</td>
+<td>The web address of that service. Whoever gave you the key gives you
+this too.</td>
+</tr>
+<tr>
+<td>Use free tier</td>
+<td>Use the free OCR tier, which limits how many pages each document can
+contain.</td>
+</tr>
+<tr>
+<td>Invert screenshot before OCR</td>
+<td>Flips the image colours first, which helps a lot with light text on
+a dark background.</td>
+</tr>
+<tr>
+<td>Max document size (MB)</td>
+<td>Biggest file or page Mutation will send. Anything larger is skipped
+before upload, so you never accidentally send something huge. Set it to
+0 for no limit.</td>
+</tr>
+<tr>
+<td>Send hotkey after OCR</td>
+<td>Optional keystrokes sent to the app you are in once the text is
+delivered — <strong>Ctrl+V</strong> to paste, for example.</td>
+</tr>
+</tbody>
+</table>
+<p>The timeout and the &quot;how many at a time&quot; numbers have sensible
+defaults and hover help. Leave them alone unless something is timing out
+on you.</p>
+<h3 id="speech-to-text">Speech to Text</h3>
+<p>Where your dictation gets turned into text.</p>
+<table>
+<thead>
+<tr>
+<th scope="col">Setting</th>
+<th scope="col">What it does</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Service definitions</td>
+<td>The transcription services you can pick from. Each one has a name, a
+provider (OpenAI Whisper or Deepgram), an optional key of its own, a
+model, and a prompt.</td>
+</tr>
+<tr>
+<td>Per-service prompt</td>
+<td>Optional priming text sent with each transcription to nudge the
+spelling of names and the punctuation.</td>
+</tr>
+<tr>
+<td>Recording sessions to keep</td>
+<td>How many past recordings stay on disk. Once you pass this, the
+oldest go first; the recording in progress is never deleted. Anything
+from 1 to 500, and 10 by default.</td>
+</tr>
+<tr>
+<td>Temp directory</td>
+<td>The folder your recordings are written to while they are being
+made.</td>
+</tr>
+<tr>
+<td>Send hotkey after transcription</td>
+<td>Optional keystrokes sent to the app you are in once your text
+arrives, for example <strong>Ctrl+V</strong> to paste.</td>
+</tr>
+<tr>
+<td>Strip silent gaps from audio</td>
+<td>Removes long silences before the audio is sent, so pauses while you
+think do not bloat the recording.</td>
+</tr>
+</tbody>
+</table>
+<blockquote>
+<p>Adding, removing, or editing a service definition takes effect after
+you restart Mutation. The per-service prompt and your choice of active
+service apply straight away. You choose which service is active from the
+main window.</p>
+</blockquote>
+<p>The three silence numbers underneath (minimum silence, threshold,
+edge guard) fine tune that trimming. The defaults are good; each has
+hover help if you want to experiment.</p>
+<h3 id="api-keys">API keys</h3>
+<p>Your keys in one place. An API key is a long password that lets
+Mutation talk to a service on your behalf.</p>
+<table>
+<thead>
+<tr>
+<th scope="col">Setting</th>
+<th scope="col">What it does</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>OpenAI API key</td>
+<td>Used for OpenAI&#39;s AI models and for OpenAI/Whisper dictation.</td>
+</tr>
+<tr>
+<td>Anthropic API key</td>
+<td>Used for Anthropic (Claude) AI models.</td>
+</tr>
+<tr>
+<td>Deepgram API key</td>
+<td>Used for Deepgram dictation.</td>
+</tr>
+</tbody>
+</table>
+<p>A speech service can override its key from the Speech to Text
+section. Otherwise the key here is the one used.</p>
+<h3 id="ai-assistance">AI assistance</h3>
+<p>The AI models Mutation can send your text to.</p>
+<table>
+<thead>
+<tr>
+<th scope="col">Setting</th>
+<th scope="col">What it does</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Request timeout (seconds)</td>
+<td>How long to wait for the model to answer before giving up.</td>
+</tr>
+<tr>
+<td>Retries</td>
+<td>How many times to try again after a failed request. Retries help the
+very first request after a reboot succeed while the network warms up.
+Three by default.</td>
+</tr>
+<tr>
+<td>Models</td>
+<td>Your list of models. Each row has a name, a provider, and an
+optional temperature — which controls how random the answers are. Leave
+temperature empty to use the provider&#39;s own setting.</td>
+</tr>
+</tbody>
+</table>
+<p>Your prompts themselves are edited on the main window, not here.</p>
+<h3 id="text-to-speech">Text to Speech</h3>
+<p>How Mutation reads text out loud. Voice, rate and volume live on the
+main window; this page holds everything else.</p>
+<table>
+<thead>
+<tr>
+<th scope="col">Setting</th>
+<th scope="col">What it does</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Enable speech preprocessing</td>
+<td>Tidies text up before it is spoken — expanding abbreviations,
+dropping stray symbols. This is the master switch for all the
+clean-ups.</td>
+</tr>
+<tr>
+<td>Individual cleanup rules</td>
+<td>Seven switches you can flick on and off one at a time: remove code
+blocks, strip bold and italic symbols, strip heading marks, shorten web
+links, strip bullet markers, expand abbreviations, and normalise
+whitespace. They only apply while the master switch is on.</td>
+</tr>
+<tr>
+<td>Rewind on resume (words)</td>
+<td>When you carry on after a pause, rewind this many words so you
+regain your place. Set it to 0 for no rewind.</td>
+</tr>
+<tr>
+<td>Rewind on resume after (seconds)</td>
+<td>Only rewind if the pause lasted longer than this. A quick pause
+carries on from the exact word.</td>
+</tr>
+<tr>
+<td>Announce progress every (percent)</td>
+<td>How often your progress is spoken while reading something long. 25
+means at 25%, 50% and 75%.</td>
+</tr>
+</tbody>
+</table>
+<p>The skip-back grace window and the two &quot;only announce above this many
+minutes&quot; numbers have sensible defaults and hover help.</p>
+<h3 id="transcript-formatting">Transcript formatting</h3>
+<p>Your own find-and-replace rules, applied to a transcript when you
+press <strong>Format</strong>. Rules run from top to bottom, so the
+order matters — use the up and down arrows to move them.</p>
+<table>
+<thead>
+<tr>
+<th scope="col">Setting</th>
+<th scope="col">What it does</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Find / Replace with</td>
+<td>The text to look for, and what to put in its place.</td>
+</tr>
+<tr>
+<td>Match type</td>
+<td>How Find is read. <strong>Plain</strong> replaces the literal text.
+<strong>RegEx</strong> treats it as a search pattern.
+<strong>Smart</strong> matches the word with the surrounding spaces and
+punctuation tidied up, which is the friendly choice for replacing a
+spoken word or phrase.</td>
+</tr>
+<tr>
+<td>Case sensitive</td>
+<td>When on, capitals must match exactly. When off, case is
+ignored.</td>
+</tr>
+</tbody>
+</table>
+<p>See <a href="transcript-formatting.html">Automatic find-and-replace
+rules</a> for the full story.</p>
+<h3 id="interface">Interface</h3>
+<p>Small comforts for the main window.</p>
+<table>
+<thead>
+<tr>
+<th scope="col">Setting</th>
+<th scope="col">What it does</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Max text-box visible lines</td>
+<td>Caps how tall the transcript and OCR boxes grow on the main
+window.</td>
+</tr>
+<tr>
+<td>Dictation insert preference</td>
+<td>How your text reaches the app you are in. <strong>Paste</strong>
+puts it in via the clipboard, <strong>SendKeys</strong> types it out one
+key at a time, and <strong>DoNotInsert</strong> leaves the text in
+Mutation only.</td>
+</tr>
+<tr>
+<td>Reset window position</td>
+<td>Puts Mutation&#39;s window back to its starting position and size. Handy
+if it has ended up off-screen.</td>
+</tr>
+</tbody>
+</table>
+<h3 id="hotkeys">Hotkeys</h3>
+<p>Every keyboard shortcut in one place, plus the shortcut router. This
+one has a chapter of its own: <a href="keyboard-shortcuts.html">Keyboard
+shortcuts</a>.</p>
+<h2 id="the-reset-buttons">The reset buttons</h2>
+<p>Next to most settings sits a small circular-arrow button. Your screen
+reader calls it &quot;Reset to default&quot;, and hovering shows the same thing —
+on the Hotkeys page it even names the value, like &quot;Reset to default
+(ALT+Q)&quot;.</p>
+<p>Each button resets <strong>only the setting it sits beside</strong>.
+There is no button that wipes the whole page or the whole app back to
+factory settings. If you want to undo a whole visit, press
+<strong>Cancel</strong> instead of <strong>Save</strong>.</p>
+<h2 id="saving-and-when-saving-goes-wrong">Saving, and when saving goes
+wrong</h2>
+<p>Nothing is written down until you press <strong>Save</strong>. That
+is the moment your changes reach the running app and get written to
+disk.</p>
+<p>If the save fails — the file is locked, the disk is full, something
+like that — Mutation tells you rather than failing quietly. A red bar
+appears at the bottom of the Settings window titled <strong>Save
+failed</strong>, with the actual reason, followed by: &quot;Your changes were
+not saved. Fix the problem and press Save again, or press Cancel to
+discard the changes.&quot; You also hear the failure beep, and screen readers
+get an urgent announcement. Your changes are still sitting there in the
+window, so you can fix the problem and press Save again.</p>
+<p>The same treatment applies if the <strong>Open Mutation.json</strong>
+button cannot open the file: a bar titled &quot;Could not open settings
+file&quot;, with the reason.</p>
+<h2 id="where-your-settings-live">Where your settings live</h2>
+<p>Everything is kept in a single file called
+<strong>Mutation.json</strong>, in the folder Mutation itself is
+installed in. Turn on the <strong>Advanced</strong> switch and press
+<strong>Open Mutation.json</strong> to see it.</p>
+<p>Two things worth knowing:</p>
+<ul>
+<li><strong>Back it up.</strong> Copy that one file somewhere safe and
+you have your shortcuts, prompts, formatting rules and preferences
+saved. Dropping it back in place restores the lot.</li>
+<li><strong>Do not share it.</strong> Your API keys are in there in
+plain text. Anyone who has the file can spend money on your accounts.
+Never email it, paste it into a chat, or attach it to a support ticket
+without stripping the keys out first.</li>
+</ul>
+<h2 id="one-last-thing">One last thing</h2>
+<p>You do not have to memorise any of this. Nearly every setting in the
+window has a small help icon beside it, and hovering over it — or
+landing on the setting with a screen reader — gives you the same plain
+explanation you have just read here.</p>
+<h2 id="where-to-next">Where to next</h2>
+<ul>
+<li><a href="keyboard-shortcuts.html">Keyboard shortcuts</a> — the
+Hotkeys page in full, including the shortcut router.</li>
+<li><a href="getting-started.html">Getting started</a> — the handful of
+settings worth filling in first.</li>
+<li><a href="main-window.html">A tour of the main window</a> — the
+settings that live on the main screen instead.</li>
+<li><a href="troubleshooting.html">Troubleshooting</a> — when something
+is not behaving.</li>
+</ul>
+<footer>
+<p><a href="index.html">Back to the contents page</a></p>
+<p>Generated from the Markdown source on 4 August 2026. The Markdown files are the source of truth – do not edit these HTML pages by hand.</p>
+</footer>
+</main>
+</div>
+</body>
+</html>

--- a/Documentation/UserGuide/html/transcript-formatting.html
+++ b/Documentation/UserGuide/html/transcript-formatting.html
@@ -61,8 +61,8 @@ border-left:5px solid var(--quote-rule); border-radius:0 8px 8px 0;
 }
 blockquote p{margin:.3rem 0}
 
-table{border-collapse:collapse; width:100%; margin:1rem 0; display:block; overflow-x:auto}
-thead,tbody,tr{width:100%}
+.table-wrap{overflow-x:auto; margin:1rem 0}
+table{border-collapse:collapse; width:100%; min-width:26rem}
 th,td{border:1px solid var(--rule); padding:.5rem .65rem; vertical-align:top}
 th{background:var(--surface); font-weight:700; text-align:left}
 tbody tr:nth-child(even){background:var(--surface)}
@@ -70,9 +70,10 @@ hr{border:none; border-top:1px solid var(--rule); margin:2rem 0}
 kbd{background:var(--surface); border:1px solid var(--rule); border-bottom-width:2px; border-radius:5px; padding:.1em .4em}
 footer{margin-top:3rem; padding-top:1rem; border-top:1px solid var(--rule); color:var(--muted); font-size:.9rem}
 @media (max-width:860px){
-.layout{flex-direction:column; padding:1rem}
+
+.layout{flex-direction:column; align-items:stretch; padding:1rem}
 .sidebar{position:static; flex:1 1 auto; width:100%}
-main{max-width:none}
+main{max-width:none; width:100%; min-width:0}
 }
 @media print{
 .sidebar,.skip{display:none}
@@ -146,6 +147,7 @@ this is, you do not need it. (If a pattern is malformed, Mutation shows
 the error in red under the row so you can fix it.)</p>
 <hr />
 <h2 id="some-worked-examples">Some worked examples</h2>
+<div class="table-wrap">
 <table>
 <thead>
 <tr>
@@ -176,6 +178,7 @@ the error in red under the row so you can fix it.)</p>
 </tr>
 </tbody>
 </table>
+</div>
 <hr />
 <h2 id="when-rules-run">When rules run</h2>
 <p>Rules run automatically on every transcript, and they run

--- a/Documentation/UserGuide/html/transcript-formatting.html
+++ b/Documentation/UserGuide/html/transcript-formatting.html
@@ -1,0 +1,216 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Automatic find-and-replace rules - Mutation User Guide</title>
+<meta name="generator" content="pandoc 3.9.0.2" />
+<style type="text/css">
+:root{
+color-scheme: light dark;
+--bg:#ffffff; --fg:#1b1b1f; --muted:#5a5a66; --rule:#d9d9e0;
+--accent:#0b5fa5; --accent-fg:#ffffff; --surface:#f5f5f8; --code:#f0f0f4;
+--quote:#eef4fb; --quote-rule:#0b5fa5;
+}
+@media (prefers-color-scheme: dark){
+:root{
+--bg:#15151a; --fg:#eaeaf0; --muted:#a8a8b6; --rule:#3a3a45;
+--accent:#6fb3ff; --accent-fg:#10131a; --surface:#1e1e26; --code:#22222c;
+--quote:#1c2530; --quote-rule:#6fb3ff;
+}
+}
+*{box-sizing:border-box}
+html{font-size:106%}
+body{
+margin:0; background:var(--bg); color:var(--fg);
+font-family:"Segoe UI",system-ui,-apple-system,Arial,sans-serif;
+line-height:1.65;
+}
+.skip{
+position:absolute; left:-9999px; top:0; padding:.6rem 1rem; z-index:10;
+background:var(--accent); color:var(--accent-fg); font-weight:600;
+}
+.skip:focus{left:0}
+.layout{display:flex; align-items:flex-start; gap:2rem; max-width:1180px; margin:0 auto; padding:1.5rem}
+.sidebar{
+flex:0 0 16rem; position:sticky; top:1.5rem;
+background:var(--surface); border:1px solid var(--rule); border-radius:10px; padding:1rem 1.1rem;
+}
+.sidebar h2{font-size:1rem; margin:0 0 .6rem; text-transform:uppercase; letter-spacing:.04em; color:var(--muted)}
+.sidebar ol{list-style:none; margin:0; padding:0}
+.sidebar li{margin:.15rem 0}
+.sidebar a{display:block; padding:.3rem .45rem; border-radius:6px; text-decoration:none; color:var(--fg)}
+.sidebar a:hover{background:var(--bg); text-decoration:underline}
+.sidebar a[aria-current="page"]{background:var(--accent); color:var(--accent-fg); font-weight:600}
+main{flex:1 1 auto; min-width:0; max-width:52rem}
+h1{font-size:2.1rem; line-height:1.2; margin:.2rem 0 1rem; border-bottom:3px solid var(--accent); padding-bottom:.5rem}
+h2{font-size:1.5rem; margin:2.2rem 0 .7rem; border-bottom:1px solid var(--rule); padding-bottom:.3rem}
+h3{font-size:1.2rem; margin:1.7rem 0 .5rem}
+h4{font-size:1.05rem; margin:1.4rem 0 .4rem}
+p{margin:.7rem 0}
+a{color:var(--accent)}
+a:focus-visible,button:focus-visible,main:focus-visible{outline:3px solid var(--accent); outline-offset:2px}
+ul,ol{margin:.7rem 0; padding-left:1.6rem}
+li{margin:.3rem 0}
+code{background:var(--code); padding:.12em .38em; border-radius:4px; font-family:Consolas,"Cascadia Mono",monospace; font-size:.92em}
+pre{background:var(--code); border:1px solid var(--rule); border-radius:8px; padding:.9rem 1rem; overflow-x:auto}
+pre code{background:none; padding:0; font-size:.9em}
+blockquote{
+margin:1rem 0; padding:.7rem 1rem; background:var(--quote);
+border-left:5px solid var(--quote-rule); border-radius:0 8px 8px 0;
+}
+blockquote p{margin:.3rem 0}
+
+table{border-collapse:collapse; width:100%; margin:1rem 0; display:block; overflow-x:auto}
+thead,tbody,tr{width:100%}
+th,td{border:1px solid var(--rule); padding:.5rem .65rem; vertical-align:top}
+th{background:var(--surface); font-weight:700; text-align:left}
+tbody tr:nth-child(even){background:var(--surface)}
+hr{border:none; border-top:1px solid var(--rule); margin:2rem 0}
+kbd{background:var(--surface); border:1px solid var(--rule); border-bottom-width:2px; border-radius:5px; padding:.1em .4em}
+footer{margin-top:3rem; padding-top:1rem; border-top:1px solid var(--rule); color:var(--muted); font-size:.9rem}
+@media (max-width:860px){
+.layout{flex-direction:column; padding:1rem}
+.sidebar{position:static; flex:1 1 auto; width:100%}
+main{max-width:none}
+}
+@media print{
+.sidebar,.skip{display:none}
+body{background:#fff; color:#000}
+.layout{display:block; max-width:none; padding:0}
+a{color:#000}
+}
+</style>
+</head>
+<body>
+<a class="skip" href="#content">Skip to the main content</a>
+<div class="layout">
+<nav class="sidebar" aria-label="User guide contents">
+<h2>Mutation User Guide</h2>
+<ol>
+<li><a href="index.html">The Mutation User Guide</a></li>
+<li><a href="getting-started.html">Getting started</a></li>
+<li><a href="main-window.html">A tour of the main window</a></li>
+<li><a href="microphone.html">Muting your microphone</a></li>
+<li><a href="dictation.html">Dictation: turning speech into text</a></li>
+<li><a href="screen-capture-and-ocr.html">Screenshots and reading text from images</a></li>
+<li><a href="read-aloud.html">Having text read aloud</a></li>
+<li><a href="ai-prompts.html">Using AI prompts on your text</a></li>
+<li><a href="transcript-formatting.html" aria-current="page">Automatic find-and-replace rules</a></li>
+<li><a href="keyboard-shortcuts.html">Keyboard shortcuts</a></li>
+<li><a href="settings.html">The Settings window</a></li>
+<li><a href="accessibility.html">Screen reader and accessibility notes</a></li>
+<li><a href="troubleshooting.html">Troubleshooting</a></li>
+</ol>
+</nav>
+<main id="content" tabindex="-1">
+<h1 id="automatic-find-and-replace-rules">Automatic find-and-replace
+rules</h1>
+<p>Some corrections you end up making every single day. Dictation keeps
+hearing your company name &quot;Ardvark Holdings&quot; as &quot;aardvark holdings&quot;. Or
+you say &quot;um&quot; more than you would like, and there it is in the text every
+time.</p>
+<p>Formatting rules fix those once and for all. A rule is a plain
+find-and-replace instruction, and Mutation applies your rules to every
+transcript automatically. No AI involved, nothing to press, no cost.</p>
+<hr />
+<h2 id="setting-up-rules">Setting up rules</h2>
+<p>Open <strong>Settings</strong> with <strong>Ctrl+Comma</strong> and
+go to <strong>Transcript formatting</strong>. Press <strong>Add
+rule</strong> to create one.</p>
+<p>A rule has three parts.</p>
+<ul>
+<li><strong>Find</strong> — the text you want Mutation to look for.</li>
+<li><strong>Replace with</strong> — what to put in its place. Leave it
+empty to simply delete the found text.</li>
+<li><strong>Case sensitive</strong> — when this is on, capital letters
+have to match exactly. When it is off, case is ignored. Off is the usual
+choice.</li>
+</ul>
+<p>Rules run from top to bottom, so the order can matter. The up and
+down arrow buttons on each row let you rearrange them, and
+<strong>Delete</strong> removes a rule.</p>
+<hr />
+<h2 id="the-three-match-types">The three match types</h2>
+<p>Each rule also has a <strong>Match type</strong>, which decides how
+the Find text is interpreted.</p>
+<p><strong>Plain</strong> swaps the exact text wherever it turns up,
+including in the middle of longer words.</p>
+<p><strong>Smart</strong> matches the word properly, tidying up the
+spaces and punctuation around it as it goes. This is the one most people
+want, and it is especially good for removing a spoken word cleanly
+without leaving a double space or a stranded comma behind.</p>
+<p><strong>RegEx</strong> treats the Find box as a pattern written in a
+special pattern language for advanced users. If you do not know what
+this is, you do not need it. (If a pattern is malformed, Mutation shows
+the error in red under the row so you can fix it.)</p>
+<hr />
+<h2 id="some-worked-examples">Some worked examples</h2>
+<table>
+<thead>
+<tr>
+<th scope="col">Find</th>
+<th scope="col">Replace with</th>
+<th scope="col">Match type</th>
+<th scope="col">What it does</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>aardvark holdings</td>
+<td>Ardvark Holdings</td>
+<td>Smart</td>
+<td>Fixes a company name that dictation always mishears</td>
+</tr>
+<tr>
+<td>um</td>
+<td><em>(leave empty)</em></td>
+<td>Smart</td>
+<td>Strips out &quot;um&quot; and closes the gap neatly</td>
+</tr>
+<tr>
+<td>ASAP</td>
+<td>as soon as possible</td>
+<td>Plain</td>
+<td>Spells out an abbreviation everywhere it appears</td>
+</tr>
+</tbody>
+</table>
+<hr />
+<h2 id="when-rules-run">When rules run</h2>
+<p>Rules run automatically on every transcript, and they run
+<strong>before</strong> any AI prompt does. That order is deliberate:
+your names and jargon are already correct by the time the AI sees the
+text, so it has less chance of &quot;correcting&quot; them into something
+wrong.</p>
+<p>Mutation also does a small tidy-up pass of its own at the same time,
+collapsing doubled punctuation like &quot;word..&quot; down to a single mark.</p>
+<hr />
+<h2 id="running-rules-on-demand">Running rules on demand</h2>
+<p>You do not have to wait for a dictation. The <strong>Format with
+rules</strong> button sits next to the <strong>Raw Transcript</strong>
+box on the main window. Press it and Mutation applies your rules to
+whatever is in that box, puts the result in the <strong>Formatted
+Transcript</strong> box, copies it to your clipboard, and delivers it
+into the app you were working in.</p>
+<p>It is the same treatment a transcript gets automatically, just
+triggered by you — and it never contacts an AI, so it is instant and
+free.</p>
+<hr />
+<h2 id="where-to-next">Where to next</h2>
+<ul>
+<li><a href="dictation.html">Dictation: turning speech into text</a> —
+where most transcripts come from</li>
+<li><a href="ai-prompts.html">Using AI prompts on your text</a> — the AI
+step that runs after your rules</li>
+<li><a href="settings.html">The Settings window</a> — finding your way
+around Settings</li>
+</ul>
+<footer>
+<p><a href="index.html">Back to the contents page</a></p>
+<p>Generated from the Markdown source on 4 August 2026. The Markdown files are the source of truth – do not edit these HTML pages by hand.</p>
+</footer>
+</main>
+</div>
+</body>
+</html>

--- a/Documentation/UserGuide/html/troubleshooting.html
+++ b/Documentation/UserGuide/html/troubleshooting.html
@@ -1,0 +1,385 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Troubleshooting - Mutation User Guide</title>
+<meta name="generator" content="pandoc 3.9.0.2" />
+<style type="text/css">
+:root{
+color-scheme: light dark;
+--bg:#ffffff; --fg:#1b1b1f; --muted:#5a5a66; --rule:#d9d9e0;
+--accent:#0b5fa5; --accent-fg:#ffffff; --surface:#f5f5f8; --code:#f0f0f4;
+--quote:#eef4fb; --quote-rule:#0b5fa5;
+}
+@media (prefers-color-scheme: dark){
+:root{
+--bg:#15151a; --fg:#eaeaf0; --muted:#a8a8b6; --rule:#3a3a45;
+--accent:#6fb3ff; --accent-fg:#10131a; --surface:#1e1e26; --code:#22222c;
+--quote:#1c2530; --quote-rule:#6fb3ff;
+}
+}
+*{box-sizing:border-box}
+html{font-size:106%}
+body{
+margin:0; background:var(--bg); color:var(--fg);
+font-family:"Segoe UI",system-ui,-apple-system,Arial,sans-serif;
+line-height:1.65;
+}
+.skip{
+position:absolute; left:-9999px; top:0; padding:.6rem 1rem; z-index:10;
+background:var(--accent); color:var(--accent-fg); font-weight:600;
+}
+.skip:focus{left:0}
+.layout{display:flex; align-items:flex-start; gap:2rem; max-width:1180px; margin:0 auto; padding:1.5rem}
+.sidebar{
+flex:0 0 16rem; position:sticky; top:1.5rem;
+background:var(--surface); border:1px solid var(--rule); border-radius:10px; padding:1rem 1.1rem;
+}
+.sidebar h2{font-size:1rem; margin:0 0 .6rem; text-transform:uppercase; letter-spacing:.04em; color:var(--muted)}
+.sidebar ol{list-style:none; margin:0; padding:0}
+.sidebar li{margin:.15rem 0}
+.sidebar a{display:block; padding:.3rem .45rem; border-radius:6px; text-decoration:none; color:var(--fg)}
+.sidebar a:hover{background:var(--bg); text-decoration:underline}
+.sidebar a[aria-current="page"]{background:var(--accent); color:var(--accent-fg); font-weight:600}
+main{flex:1 1 auto; min-width:0; max-width:52rem}
+h1{font-size:2.1rem; line-height:1.2; margin:.2rem 0 1rem; border-bottom:3px solid var(--accent); padding-bottom:.5rem}
+h2{font-size:1.5rem; margin:2.2rem 0 .7rem; border-bottom:1px solid var(--rule); padding-bottom:.3rem}
+h3{font-size:1.2rem; margin:1.7rem 0 .5rem}
+h4{font-size:1.05rem; margin:1.4rem 0 .4rem}
+p{margin:.7rem 0}
+a{color:var(--accent)}
+a:focus-visible,button:focus-visible,main:focus-visible{outline:3px solid var(--accent); outline-offset:2px}
+ul,ol{margin:.7rem 0; padding-left:1.6rem}
+li{margin:.3rem 0}
+code{background:var(--code); padding:.12em .38em; border-radius:4px; font-family:Consolas,"Cascadia Mono",monospace; font-size:.92em}
+pre{background:var(--code); border:1px solid var(--rule); border-radius:8px; padding:.9rem 1rem; overflow-x:auto}
+pre code{background:none; padding:0; font-size:.9em}
+blockquote{
+margin:1rem 0; padding:.7rem 1rem; background:var(--quote);
+border-left:5px solid var(--quote-rule); border-radius:0 8px 8px 0;
+}
+blockquote p{margin:.3rem 0}
+
+table{border-collapse:collapse; width:100%; margin:1rem 0; display:block; overflow-x:auto}
+thead,tbody,tr{width:100%}
+th,td{border:1px solid var(--rule); padding:.5rem .65rem; vertical-align:top}
+th{background:var(--surface); font-weight:700; text-align:left}
+tbody tr:nth-child(even){background:var(--surface)}
+hr{border:none; border-top:1px solid var(--rule); margin:2rem 0}
+kbd{background:var(--surface); border:1px solid var(--rule); border-bottom-width:2px; border-radius:5px; padding:.1em .4em}
+footer{margin-top:3rem; padding-top:1rem; border-top:1px solid var(--rule); color:var(--muted); font-size:.9rem}
+@media (max-width:860px){
+.layout{flex-direction:column; padding:1rem}
+.sidebar{position:static; flex:1 1 auto; width:100%}
+main{max-width:none}
+}
+@media print{
+.sidebar,.skip{display:none}
+body{background:#fff; color:#000}
+.layout{display:block; max-width:none; padding:0}
+a{color:#000}
+}
+</style>
+</head>
+<body>
+<a class="skip" href="#content">Skip to the main content</a>
+<div class="layout">
+<nav class="sidebar" aria-label="User guide contents">
+<h2>Mutation User Guide</h2>
+<ol>
+<li><a href="index.html">The Mutation User Guide</a></li>
+<li><a href="getting-started.html">Getting started</a></li>
+<li><a href="main-window.html">A tour of the main window</a></li>
+<li><a href="microphone.html">Muting your microphone</a></li>
+<li><a href="dictation.html">Dictation: turning speech into text</a></li>
+<li><a href="screen-capture-and-ocr.html">Screenshots and reading text from images</a></li>
+<li><a href="read-aloud.html">Having text read aloud</a></li>
+<li><a href="ai-prompts.html">Using AI prompts on your text</a></li>
+<li><a href="transcript-formatting.html">Automatic find-and-replace rules</a></li>
+<li><a href="keyboard-shortcuts.html">Keyboard shortcuts</a></li>
+<li><a href="settings.html">The Settings window</a></li>
+<li><a href="accessibility.html">Screen reader and accessibility notes</a></li>
+<li><a href="troubleshooting.html" aria-current="page">Troubleshooting</a></li>
+</ol>
+</nav>
+<main id="content" tabindex="-1">
+<h1 id="troubleshooting">Troubleshooting</h1>
+<p>Most problems in Mutation fall into a handful of buckets. Find the
+one that sounds like yours below. Each entry says what is going on and
+what to do about it.</p>
+<h2 id="common-problems">Common problems</h2>
+<h3 id="a-shortcut-does-nothing">A shortcut does nothing</h3>
+<p><strong>What&#39;s happening.</strong> Windows only lets one app own a
+global shortcut at a time. If another app grabbed your combination
+first, Mutation cannot have it. This is usually the cause when one
+shortcut is dead but the others all work.</p>
+<p>Mutation does not hide this. When it starts up, if any shortcut could
+not be claimed you get a failure beep and a dialog titled &quot;Some hotkeys
+could not be registered&quot;, listing each one and the reason. A common
+reason reads &quot;The shortcut is already registered by another
+application.&quot;</p>
+<p><strong>What to do.</strong></p>
+<ol type="1">
+<li>Read the list in that dialog — it names the shortcuts that
+failed.</li>
+<li>Open <strong>Settings</strong> with <strong>Ctrl+Comma</strong> and
+go to the shortcuts section.</li>
+<li>Change the failed shortcut to a combination nothing else uses.
+Adding <strong>Shift</strong> to an existing combination is often
+enough.</li>
+<li>Save. Every default shortcut in Mutation can be changed, so nothing
+is stuck.</li>
+</ol>
+<p>If a shortcut you just typed into Settings is rejected outright, the
+combination could not be understood. Use the shortcut editor to record
+the keys rather than typing them by hand.</p>
+<h3 id="dictation-comes-back-empty-or-says-no-speech-was-detected">Dictation
+comes back empty, or says no speech was detected</h3>
+<p><strong>What&#39;s happening.</strong> Mutation trims silence off your
+recording before sending it. If what is left is too short to be worth
+transcribing, it skips the request entirely and tells you &quot;No speech
+detected — nothing to transcribe.&quot; That saves you the wait and the cost
+of a request that would have returned nothing.</p>
+<p><strong>What to do.</strong></p>
+<ol type="1">
+<li>Check the right microphone is selected on the
+<strong>Microphone</strong> card, and that it is not muted.</li>
+<li>Watch the level indicator while you talk — if it does not move, the
+microphone is not picking you up.</li>
+<li>Start speaking a beat after the start beep, not on top of it.</li>
+<li>If your input level is very low, raise it on the
+<strong>Microphone</strong> card.</li>
+</ol>
+<h3 id="dictation-says-the-recorder-is-still-busy">Dictation says the
+recorder is still busy</h3>
+<p><strong>What&#39;s happening.</strong> A previous recording is still
+being transcribed and the recorder is not free yet. Mutation refuses to
+start a new one on top of it rather than losing either recording.</p>
+<p><strong>What to do.</strong> Wait for the previous transcription to
+finish — the status area will say when it is done — then press your
+dictation shortcut again.</p>
+<h3 id="dictation-is-slow-or-fails-with-a-timeout">Dictation is slow, or
+fails with a timeout</h3>
+<p><strong>What&#39;s happening.</strong> Transcription happens over the
+internet, so a slow connection or a busy service makes it slow. Mutation
+retries a failed attempt, giving each retry a longer window than the
+last, before it gives up. Long recordings naturally take longer than
+short ones.</p>
+<p><strong>What to do.</strong></p>
+<ol type="1">
+<li>Give it a moment — the retries are automatic and you will hear the
+result.</li>
+<li>Record in shorter chunks. A two-minute note transcribes far faster
+than a twenty-minute one.</li>
+<li>If it consistently times out, raise the timeout in
+<strong>Settings</strong>. There are separate timeouts for live
+dictation and for transcribing a file, plus a per-attempt timeout on
+each speech service.</li>
+</ol>
+<h3 id="ocr-returns-nothing-useful-or-the-wrong-reading-order">OCR
+returns nothing useful, or the wrong reading order</h3>
+<p><strong>What&#39;s happening.</strong> OCR reads text out of a picture.
+If the picture is small, blurry, or is light text on a dark background,
+there may be nothing recognisable in it. Reading order is a separate
+matter: Mutation offers two layouts, and they suit different pages.</p>
+<p><strong>What to do.</strong></p>
+<ol type="1">
+<li>Capture a tighter region at a larger zoom level. More pixels per
+letter helps a lot.</li>
+<li>If your text is light on a dark background, turn on the setting that
+inverts the image colours before OCR.</li>
+<li>Try the other reading order. <strong>Natural</strong> layout follows
+the visual structure of the page, which is better for columns and
+tables. <strong>Basic</strong> layout reads strictly left to right, top
+to bottom, which is better for a plain block of text that Natural has
+scrambled. Each has its own shortcut, so you can just try the other
+one.</li>
+</ol>
+<h3 id="ocr-skipped-a-file-for-being-too-large">OCR skipped a file for
+being too large</h3>
+<p><strong>What&#39;s happening.</strong> There is a maximum size for a file
+or page sent for OCR, so a huge file cannot be uploaded by accident.
+Anything over it is skipped before upload, and the failure message names
+the file, its size, and the limit.</p>
+<p><strong>What to do.</strong> Open <strong>Settings</strong>, find the
+maximum document size under the OCR settings, and raise it — or set it
+to 0 for no limit at all. Alternatively, capture a smaller region or
+save the file at a lower resolution.</p>
+<h3 id="ocr-stops-after-a-couple-of-pages">OCR stops after a couple of
+pages</h3>
+<p><strong>What&#39;s happening.</strong> The free OCR tier limits how many
+pages a single document can contain. Mutation respects that limit by
+default, sending documents in small batches, with the page limit set to
+2 out of the box.</p>
+<p><strong>What to do.</strong> If you are on a paid tier, turn off the
+free-tier option in <strong>Settings</strong> under the OCR settings. If
+you are staying on the free tier, raise the page limit only as far as
+your tier allows.</p>
+<h3 id="nothing-happens-at-all--a-key-is-missing-or-wrong">Nothing
+happens at all — a key is missing or wrong</h3>
+<p><strong>What&#39;s happening.</strong> Mutation talks to outside services
+to do dictation, OCR and AI processing. Each needs an API key (a long
+password that lets Mutation use the service on your behalf). Without
+one, the feature has nothing to talk to.</p>
+<p>On a brand-new install Mutation shows a welcome dialog explaining
+which keys it needs, then opens Settings on the API keys tab. If a
+speech service has no key, it is disabled and Mutation tells you which
+ones and why. For OCR you need both an Azure Computer Vision key
+<strong>and</strong> an endpoint, and Mutation says specifically which
+of the two is missing.</p>
+<p><strong>What to do.</strong> Open <strong>Settings</strong> with
+<strong>Ctrl+Comma</strong>, go to the API keys tab, and paste in the
+key. Azure Computer Vision has its own tab, because the key and the
+endpoint live together there. Save, and try again.</p>
+<h3 id="the-text-didnt-paste-into-the-other-app">The text didn&#39;t paste
+into the other app</h3>
+<p><strong>What&#39;s happening.</strong> Mutation delivers text through the
+clipboard, and only one app can hold the clipboard at a time. If another
+app is holding it at that moment, the copy fails. Mutation retries a few
+times before giving up. If it still cannot get through, you get a
+failure beep and a message like &quot;The clipboard is in use by another
+application; the transcript could not be delivered. It is available in
+the Mutation window.&quot;</p>
+<p><strong>What to do.</strong></p>
+<ol type="1">
+<li>Your text is not lost. Open the main window and copy it from
+there.</li>
+<li>Clipboard manager tools and remote-desktop sessions are the usual
+culprits. Closing or pausing one often fixes it for good.</li>
+<li>If you rely on the text landing in another app automatically, set
+the &quot;send keys after&quot; option to <strong>Ctrl+V</strong> so Mutation
+pastes for you once the copy succeeds.</li>
+</ol>
+<h3 id="fast-mode-didnt-actually-run-fast">Fast mode didn&#39;t actually run
+fast</h3>
+<p><strong>What&#39;s happening.</strong> Fast mode is a faster setting for
+AI prompts. If it is not available, Mutation does not throw your text
+away — it quietly runs the prompt again at standard speed and then tells
+you why Fast mode could not be used. There are three different reasons,
+and each needs a different response:</p>
+<ul>
+<li>Fast mode is not enabled for your account. You need to request
+access for it.</li>
+<li>Fast mode was rate limited or at capacity. Wait a moment and try
+again.</li>
+<li>The model you chose does not offer Fast mode. Choose a different
+model.</li>
+</ul>
+<p><strong>What to do.</strong> Listen to which of the three you got —
+the wording is deliberately different for each. You can also turn Fast
+mode off for that prompt in the prompt editor, which stops the notice
+appearing every time.</p>
+<h3 id="the-wrong-microphone-is-being-used-or-the-mute-didnt-take">The
+wrong microphone is being used, or the mute didn&#39;t take</h3>
+<p><strong>What&#39;s happening.</strong> Mutation&#39;s mute shortcut mutes
+every microphone on the PC, not just the one it is recording with. It
+re-checks the list of devices when one is plugged in or unplugged, so a
+headset you just connected is covered too.</p>
+<p>Mutation also verifies that a mute actually took effect at the
+operating-system level. If it cannot confirm it, it will not pretend —
+you get &quot;Could not change the microphone mute state. The microphone may
+still be live — please try again.&quot;</p>
+<p><strong>What to do.</strong></p>
+<ol type="1">
+<li>Treat that message seriously. Assume the microphone is still live
+until you have confirmed otherwise.</li>
+<li>Press the mute shortcut again and listen for the mute beep.</li>
+<li>If Mutation is recording from the wrong device, pick the right one
+on the <strong>Microphone</strong> card. Setting the input level can
+also fail if a device is busy or was just unplugged — you will be told,
+and can try again.</li>
+</ol>
+<h3 id="no-voices-in-the-voice-list-or-the-voice-sounds-wrong">No voices
+in the voice list, or the voice sounds wrong</h3>
+<p><strong>What&#39;s happening.</strong> The voices Mutation offers for
+reading aloud come from Windows itself, not from Mutation. An empty or
+very short list means Windows has few voices installed.</p>
+<p><strong>What to do.</strong></p>
+<ol type="1">
+<li>Install more voices through Windows Settings, under the speech
+options. Restart Mutation afterwards so it picks them up.</li>
+<li>Choose the voice, rate and volume on the <strong>Voice &amp;
+Speech</strong> section of the main window.</li>
+<li>If the voice reads out stray symbols like asterisks and hash marks,
+turn on the text clean-up options in <strong>Settings</strong>. There
+are individual switches for stripping bold and italic marks, heading
+marks, bullet markers, code blocks, and for shortening long web
+links.</li>
+</ol>
+<h3 id="settings-wont-save">Settings won&#39;t save</h3>
+<p><strong>What&#39;s happening.</strong> Mutation writes your settings to a
+file. If that write fails — the file is read-only, a backup tool has it
+open, or the folder is not writable — the save cannot complete. Mutation
+plays the failure beep, announces the problem, and shows &quot;Save failed&quot;
+along with the actual reason and the words &quot;Your changes were not saved.
+Fix the problem and press Save again, or press Cancel to discard the
+changes.&quot;</p>
+<p><strong>What to do.</strong></p>
+<ol type="1">
+<li>Read the reason given — it is the real cause, not a generic
+message.</li>
+<li>Close anything that might have the settings file open, including a
+text editor.</li>
+<li>Press Save again. Your changes are still in the dialog until you
+press Cancel.</li>
+</ol>
+<h3 id="screen-capture-appears-to-be-blocked">Screen capture appears to
+be blocked</h3>
+<p><strong>What&#39;s happening.</strong> Some managed work PCs disable
+screen capture by policy, and some privacy and DRM-protected windows
+cannot be captured at all. Mutation tests this before it tries, and
+tells you when the test fails, with the technical detail included.</p>
+<p><strong>What to do.</strong> If you are on a work device, this is a
+policy set by your IT department and Mutation cannot work around it —
+ask them. Otherwise, check for privacy or screen-recording-blocker
+software, and make sure the window you are capturing is not playing
+protected video.</p>
+<h2 id="finding-the-log-file">Finding the log file</h2>
+<p>When something goes wrong, Mutation writes a timestamped entry to a
+log file called <code>Mutation_Errors.log</code>. It lives here:</p>
+<pre><code>%LOCALAPPDATA%\Mutation\logs\Mutation_Errors.log</code></pre>
+<p>To open the folder, press <strong>Windows+R</strong>, paste
+<code>%LOCALAPPDATA%\Mutation\logs</code> into the box, and press Enter.
+Mutation also writes a copy of the log next to its own program file, in
+case the first location is unavailable.</p>
+<p>The log is capped in size. When it gets too big, the old contents are
+moved to <code>Mutation_Errors.log.old</code> and a fresh file is
+started — so if the problem happened a while back, check the
+<code>.old</code> file too.</p>
+<p>Your API keys are stripped out of the log before anything is written,
+so it is safe to share.</p>
+<h2 id="reporting-a-problem">Reporting a problem</h2>
+<p>If none of the above fixes it, please report it. The project&#39;s issues
+page is at <a href="https://github.com/Subverting-complexity/Mutation/issues">github.com/Subverting-complexity/Mutation</a>.</p>
+<p>Include as much of this as you can:</p>
+<ul>
+<li>What you did, step by step, and what you expected to happen
+instead.</li>
+<li>The exact wording of any message you saw or heard.</li>
+<li>Which shortcut you pressed.</li>
+<li>The relevant entries from <code>Mutation_Errors.log</code>, with
+their timestamps.</li>
+<li>Your Windows version, and the name of your screen reader or
+magnifier if one was running.</li>
+</ul>
+<h2 id="where-to-next">Where to next</h2>
+<ul>
+<li><a href="settings.html">The Settings window</a> — where most of the
+fixes above live.</li>
+<li><a href="keyboard-shortcuts.html">Keyboard shortcuts</a> — changing
+a shortcut another app owns.</li>
+<li><a href="getting-started.html">Getting started</a> — first-run setup
+and API keys.</li>
+<li><a href="accessibility.html">Screen reader and accessibility
+notes</a> — beeps, announcements, and the keyboard-driven capture
+overlay.</li>
+</ul>
+<footer>
+<p><a href="index.html">Back to the contents page</a></p>
+<p>Generated from the Markdown source on 4 August 2026. The Markdown files are the source of truth – do not edit these HTML pages by hand.</p>
+</footer>
+</main>
+</div>
+</body>
+</html>

--- a/Documentation/UserGuide/html/troubleshooting.html
+++ b/Documentation/UserGuide/html/troubleshooting.html
@@ -61,8 +61,8 @@ border-left:5px solid var(--quote-rule); border-radius:0 8px 8px 0;
 }
 blockquote p{margin:.3rem 0}
 
-table{border-collapse:collapse; width:100%; margin:1rem 0; display:block; overflow-x:auto}
-thead,tbody,tr{width:100%}
+.table-wrap{overflow-x:auto; margin:1rem 0}
+table{border-collapse:collapse; width:100%; min-width:26rem}
 th,td{border:1px solid var(--rule); padding:.5rem .65rem; vertical-align:top}
 th{background:var(--surface); font-weight:700; text-align:left}
 tbody tr:nth-child(even){background:var(--surface)}
@@ -70,9 +70,10 @@ hr{border:none; border-top:1px solid var(--rule); margin:2rem 0}
 kbd{background:var(--surface); border:1px solid var(--rule); border-bottom-width:2px; border-radius:5px; padding:.1em .4em}
 footer{margin-top:3rem; padding-top:1rem; border-top:1px solid var(--rule); color:var(--muted); font-size:.9rem}
 @media (max-width:860px){
-.layout{flex-direction:column; padding:1rem}
+
+.layout{flex-direction:column; align-items:stretch; padding:1rem}
 .sidebar{position:static; flex:1 1 auto; width:100%}
-main{max-width:none}
+main{max-width:none; width:100%; min-width:0}
 }
 @media print{
 .sidebar,.skip{display:none}

--- a/Documentation/UserGuide/markdown/accessibility.md
+++ b/Documentation/UserGuide/markdown/accessibility.md
@@ -1,0 +1,117 @@
+# Screen reader and accessibility notes
+
+Mutation was written by a developer who is nearly blind, for his own daily use. That
+shows up all through the app. This chapter gathers the things that matter most if you
+work with a screen reader, a magnifier, or both.
+
+## Everything works from the keyboard
+
+There is no part of Mutation that needs a mouse. The global shortcuts do the real
+work, so most of the time you never open the app at all. When you do open the main
+window, you can Tab through every card, and every button, slider, list and text box
+can be reached and operated from the keyboard.
+
+Settings opens with **Ctrl+Comma** and is keyboard-driven too, including the search
+box at the top and the "Advanced" toggle.
+
+## Controls are named, and the help text is the same text you see
+
+Every control tells your screen reader what it is. Buttons that have a shortcut
+attached announce the shortcut as part of their name, so you hear something like
+"Mute, Ctrl+Shift+M". When a button changes state, the announced name changes with it
+— a button that becomes Unmute announces itself as Unmute, not as the name it had at
+startup.
+
+The help text for settings is written once and used twice. The sentence your screen
+reader reads out for a setting is exactly the sentence that appears in the tooltip
+when you hover it with the mouse. There is no short visual label with a longer hidden
+explanation, or the other way around. What you hear is what is there.
+
+## Sounds tell you what happened
+
+Mutation uses short beeps so you know an action landed without having to check the
+screen. There are distinct sounds for:
+
+- **Start** — a recording has begun.
+- **End** — a recording has stopped.
+- **Success** — a two-note rising chirp when something completed.
+- **Failure** — a low tone, repeated, when something went wrong.
+- **Mute** — a low tone when microphones are muted.
+- **Unmute** — a short high tone when they are live.
+
+You can replace all of them with your own sound files. Open **Settings** with
+**Ctrl+Comma**, go to the audio settings, turn on the option to play your own sound
+files instead of the built-in beeps, and pick a `.wav` file for each of the six cues.
+There is a preview button so you can hear a file before committing to it.
+
+## Spoken status announcements
+
+The main window has a status area at the bottom, named "Status notifications" for your
+screen reader. Everything that appears there is also announced out loud, even when the
+status area was already open — so a run of updates like "Recording…" then
+"Transcribing…" then the final result all reach you.
+
+Errors and warnings interrupt whatever your screen reader is currently saying, because
+they need you now. Routine progress updates wait their turn politely. If several
+updates arrive quickly, you hear the most recent one rather than a backlog of stale
+messages.
+
+## The screenshot overlay talks you through it
+
+Grabbing part of a screen you cannot see sounds impossible. It is not.
+
+When the screen-capture overlay opens, it announces itself and tells you the keys:
+move with the arrow keys, press **Enter** to set the first corner, move again, then
+**Enter** to capture. **Ctrl+A** selects the whole screen, which means any capture can
+be finished in two keystrokes. **Backspace** clears the corner you set. **Escape**
+cancels.
+
+As you move, it reads your position out. Before you set a corner you hear the caret
+position. After you set one you hear the size of the region and where its top-left
+corner sits, so you always know where on the screen you are. Hold **Ctrl** for
+one-pixel steps or **Shift** for big hundred-pixel jumps. When the capture finishes it
+tells you the size of what it grabbed, in pixels. If you press Enter twice without
+moving, it tells you the region is empty rather than silently doing nothing.
+
+## Reading aloud is a first-class feature
+
+Mutation can read the clipboard out loud, with its own voice, rate and volume, and its
+own pause, skip and rewind controls. It can announce roughly how long a piece of text
+will take to read before it starts, and read your progress out at intervals — "50%,
+about 3 minutes left". You can ask where you are at any moment and hear "Sentence 4 of
+22, about 40% through, about 2 minutes left".
+
+See [Having text read aloud](read-aloud.md) for the full picture.
+
+## Handing the result to your screen reader automatically
+
+This one is worth setting up. After an OCR run or a dictation finishes, Mutation can
+send a keystroke of your choosing to whatever app you were in.
+
+Say you dictate a note into an email. Mutation puts the transcript on the clipboard,
+then sends **Ctrl+V** to the email window for you, so the text lands where your cursor
+was without you touching anything. Or set it to your screen reader's own "read from
+here" shortcut, and the OCR result gets read to you the moment it is ready.
+
+You set it in **Settings**, under the shortcuts section: one box for "after OCR" and
+one for "after transcription". Leave a box empty and nothing is sent.
+
+## Alongside a screen reader and ZoomText
+
+Mutation is designed to sit next to your existing tools, not replace them. Its global
+shortcuts are registered with Windows, so they work whichever app has focus. If your
+screen reader or magnifier already owns a combination you want, Windows will refuse to
+give it to Mutation — you will get a message at startup listing the shortcuts that
+could not be registered and why, and you can pick different ones. See
+[Troubleshooting](troubleshooting.md) if that happens.
+
+Every default shortcut in Mutation can be changed, so you can fit it around the
+shortcuts you already have in your fingers.
+
+## Where to next
+
+- [Keyboard shortcuts](keyboard-shortcuts.md) — the full list, and how to change them.
+- [Having text read aloud](read-aloud.md) — voices, speed, and the reading controls.
+- [Screenshots and reading text from images](screen-capture-and-ocr.md) — the capture
+  overlay in context.
+- [Troubleshooting](troubleshooting.md) — when something does not behave.

--- a/Documentation/UserGuide/markdown/ai-prompts.md
+++ b/Documentation/UserGuide/markdown/ai-prompts.md
@@ -1,0 +1,117 @@
+# Using AI prompts on your text
+
+A prompt is a saved instruction that you can run on any piece of text. You write the instruction once — "fix the grammar", "make this shorter", "turn these rough notes into a polite email" — give it a name, and from then on it is one click or one keyboard shortcut away.
+
+That is the whole idea. You are not chatting with anything. You hand Mutation some text, Mutation hands it to an AI along with your saved instruction, and you get the tidied-up version back.
+
+Here are four that earn their keep in an ordinary working day.
+
+| Name | The instruction you would write |
+|---|---|
+| Fix Grammar | Fix the grammar, spelling and punctuation in the following text. Do not change the meaning or the tone. |
+| Shorten | Rewrite the following text so it says the same thing in about half the words. |
+| Make It an Email | Turn the following rough notes into a short, polite work email. Keep it plain and friendly. |
+| Key Points | Summarise the following text as a short bullet list of the main points. |
+
+---
+
+## Where the text comes from, and where the answer goes
+
+When you run a prompt, Mutation uses **whatever text is on your clipboard**. So the normal routine is: select the text anywhere — in Word, in your browser, in an email — press **Ctrl+C**, then run the prompt.
+
+When the answer comes back, three things happen at once. The answer appears in the **Formatted Transcript** box on the main window, it is copied onto your clipboard, and Mutation puts it into the app you were working in. You hear a success beep when all of that worked. If the clipboard was busy and the text could not be delivered, you get a failure beep and a message telling you the result is still sitting safely in the Mutation window.
+
+---
+
+## The prompt list
+
+Your prompts live on the **LLM Prompts** card on the main window. Each row shows the prompt's name, its keyboard shortcut if it has one, the model it uses, and the word "(Auto-Run)" if it is the automatic one.
+
+Each row has three buttons.
+
+- **Run** — runs that prompt on the clipboard text, right now.
+- **Edit** — opens the prompt so you can change it.
+- **Delete** — removes it.
+
+**Add Prompt**, at the top right of the card, creates a new one.
+
+---
+
+## Creating a prompt
+
+Press **Add Prompt** and the **Edit Prompt** window opens. Two fields matter most.
+
+**Name** is what you will see in the list. Keep it short — "Fix Grammar", "Shorten", "Draft Reply".
+
+**Prompt Instructions** is the instruction itself. This is the part that does the work.
+
+Three pointers for writing a good one:
+
+- Say what you want done, plainly, as if you were asking a colleague. "Fix the grammar and punctuation" beats "improve this".
+- Say what you want back. Adding "Reply with only the corrected text and nothing else" stops the AI from adding a chatty preamble.
+- Say what must not change. "Keep my wording and tone" is worth adding to any tidy-up prompt.
+
+There is a **Test Run** button at the bottom. It runs the prompt against your current clipboard content using the settings on screen, without saving anything. Use it to try an instruction before you commit to it.
+
+Then press **Save**, or **Cancel** to throw it away.
+
+---
+
+## Giving a prompt its own shortcut
+
+The **Hotkey** box in the prompt editor is optional. Fill it in and that key combination runs this prompt from anywhere — no need to switch to Mutation first. Copy some text in Outlook, press your shortcut, and the cleaned-up version lands back in Outlook.
+
+Pick combinations that nothing else is using. **Ctrl+Alt** plus a letter is usually safe. If a shortcut cannot be claimed because another program already has it, Mutation tells you.
+
+---
+
+## The Auto-Run prompt
+
+One prompt in your list can be marked **Run automatically after transcription**. That prompt then runs on its own as soon as a recording has been turned into text, without you pressing anything.
+
+This is what the record-and-process dictation shortcut uses: you dictate, Mutation transcribes, and your Auto-Run prompt cleans the result up in the same breath. See [Dictation: turning speech into text](dictation.md) for that shortcut.
+
+The **Process with LLM** button on the **Transcripts** card also reaches for the Auto-Run prompt.
+
+Only one prompt can hold this role. Marking a new one automatically clears it from the old one.
+
+---
+
+## Choosing a model
+
+A model is the particular AI that reads your text and writes the reply. Different models cost different amounts and are better at different jobs.
+
+The **Model** box in the prompt editor lets you pin a prompt to a specific one. **If you leave it alone, that is completely fine** — the prompt just uses the standard model. Only change it if you have a reason to.
+
+The list of available models is managed in **Settings** (**Ctrl+Comma**), under **AI assistance**. Each model belongs to one of two providers: **OpenAI** or **Anthropic** (whose models are called Claude). You need the matching key set up for the provider you choose — an OpenAI key for OpenAI models, an Anthropic key for Claude models. See [Getting started](getting-started.md) for how to add them.
+
+---
+
+## Fast mode
+
+**Fast mode** is a check box in the prompt editor. It runs the same model faster. The model, and the quality of its answers, are unchanged — only the speed and the price differ.
+
+The catch is the price. Fast mode is billed at roughly **twice** the standard rate, so turn it on only for prompts where waiting actually costs you something.
+
+Two more things to know. Not every model offers Fast mode. And on Anthropic (Claude) models it also needs research-preview access on your account, which you have to request.
+
+If Fast mode cannot be used for any reason, nothing breaks. The prompt still runs at normal speed, you still get your answer, and Mutation tells you why Fast mode was skipped — whether you need to request access, pick a different model, or simply try again later.
+
+---
+
+## Waiting, and when things go slowly
+
+Under **AI assistance** in **Settings** there are two knobs worth knowing about.
+
+**Request timeout** is how long Mutation waits for the model to respond before giving up. If you regularly send long documents and see things time out, raise it.
+
+**Retries** is how many times Mutation quietly tries again after a failed request, before telling you it did not work. The default of three is there for a good reason: it helps the very first request after you reboot succeed while your network is still warming up.
+
+---
+
+## Where to next
+
+- [Dictation: turning speech into text](dictation.md) — the record-and-process shortcut that uses your Auto-Run prompt
+- [Automatic find-and-replace rules](transcript-formatting.md) — fixing repeat offenders without involving an AI at all
+- [Getting started](getting-started.md) — adding your OpenAI and Anthropic keys
+- [Keyboard shortcuts](keyboard-shortcuts.md) — the full list, and how to change any of them

--- a/Documentation/UserGuide/markdown/dictation.md
+++ b/Documentation/UserGuide/markdown/dictation.md
@@ -1,0 +1,194 @@
+# Dictation: turning speech into text
+
+Dictation is the feature most people end up using every day. You press a shortcut,
+talk, press it again, and a second or two later your words are sitting there as
+text — ready to paste into an email, a chat message, or a document.
+
+## The basic loop
+
+1. Press **Shift+Alt+U**. Mutation plays a short beep and starts recording.
+2. Say what you want to write. Take your time — pauses are fine.
+3. Press **Shift+Alt+U** again. The beep tells you recording has stopped.
+4. A moment later — usually one to three seconds for a few sentences — the text
+   appears, and a success beep plays.
+
+That's it. The shortcut is global, so it works no matter which app you are in. You
+never have to switch to Mutation first.
+
+If you prefer clicking, the **Speech to Text** card on the main window has a
+**Record** button that does exactly the same thing.
+
+> **Shift+Alt+U** is just the default. Every shortcut in Mutation can be changed.
+> Open **Settings** with **Ctrl+Comma** and look on the **Hotkeys** tab.
+
+## Recording and cleaning up in one step
+
+There is a second shortcut, **Shift+Alt+I** by default, that records *and* then
+runs your chosen AI prompt on the result — all from the one press. So you can
+ramble a bit, and what comes back is already tidied into proper sentences.
+
+On the main window this is the **Record and Format** button, next to **Record**.
+
+Which prompt runs is up to you: it's the one you have marked as **Auto-Run**. See
+[Using AI prompts on your text](ai-prompts.md) for how to set that up.
+
+## Where the text ends up
+
+Once a recording is transcribed, the text lands in three places at once:
+
+- The **Raw Transcript** box on the main window — exactly what the transcription
+  service heard.
+- The **Formatted Transcript** box, just below it — the same text after your
+  find-and-replace rules have been applied. If you haven't set any rules up, the
+  two boxes will look the same. See
+  [Automatic find-and-replace rules](transcript-formatting.md).
+- Your **clipboard**. The formatted version is copied automatically, so you can
+  paste it anywhere with **Ctrl+V**.
+
+Both boxes are ordinary text boxes. You can read them with your screen reader,
+edit them, or select and copy from them.
+
+## Getting the text into the app you were using
+
+This is the part that trips people up, so it's worth reading slowly.
+
+On the **Automation** card there is a dropdown called **Third-party interaction**.
+It decides what Mutation does with your transcript *after* it has copied it to the
+clipboard. There are three choices:
+
+| Choice in the list | What happens |
+|---|---|
+| **Paste** | Mutation copies the text and then presses **Ctrl+V** for you, so it appears in whatever app was in front. |
+| **SendKeys** | Mutation types the text out, one keystroke at a time, as if you had typed it yourself. |
+| **DoNotInsert** | Mutation does nothing further. The text stays in the Mutation window and on the clipboard, and you paste it yourself. |
+
+> The three choices are shown using their short internal names — **Paste**,
+> **SendKeys** and **DoNotInsert**. They are not the friendliest labels, but a line of
+> explanation appears underneath the dropdown as soon as you pick one.
+
+**Which should you pick?**
+
+Start with **Paste**. It is the fastest and it handles long text without trouble.
+
+Switch to **SendKeys** when an app refuses to accept a paste, or mangles it. Some
+older apps, some remote-desktop sessions, and some web forms behave that way. Typing
+is slower and you will see the letters appear one by one, but it works almost
+everywhere.
+
+Choose **DoNotInsert** when you want to look at the text before it goes anywhere —
+or when you are dictating notes into Mutation itself and don't want stray text
+landing in another window.
+
+One thing worth knowing: if the Mutation window itself is the one in front, nothing
+is inserted anywhere. Mutation won't paste into itself.
+
+### Sending a shortcut afterwards
+
+In **Settings**, on the **Speech to Text** page, there is an optional box called
+**Send hotkey after transcription**. Whatever shortcut you put there is sent to the
+active app once the transcript has been delivered.
+
+It exists for apps that need one extra keypress to finish the job — for example
+sending **Ctrl+V** to paste, or a **Tab** or **Enter** to move on. Leave it blank
+if you don't need it.
+
+## Choosing a transcription service
+
+At the top of the **Speech to Text** card is a dropdown listing your transcription
+services.
+
+A transcription service is simply an online service that receives your recording,
+listens to it, and sends the text back. Mutation doesn't do the listening itself —
+it hands the audio over and waits for the answer. Different services differ in how
+fast they are, how accurate they are, and what they charge, so it's worth trying a
+couple and settling on the one you like.
+
+Out of the box, Mutation knows about:
+
+- **OpenAI gpt-4o-transcribe** (and its smaller, cheaper sibling
+  gpt-4o-mini-transcribe)
+- **Groq Whisper 3**
+- **Deepgram Nova3**
+- Any other service that speaks the same language as OpenAI's Whisper
+
+Each service needs an API key — a long password that lets Mutation talk to the
+service on your behalf. See [Getting started](getting-started.md) for where those go.
+
+> Switching which service is *active* takes effect straight away — just pick a
+> different one from the dropdown. But if you **add**, **remove**, or **edit** a
+> service definition in Settings, you need to restart Mutation before the change
+> takes hold.
+
+## The Prompt box
+
+Under the session buttons there is a box simply labelled **Prompt**. It's optional
+and easy to overlook, but it can noticeably improve your results.
+
+Whatever you type here is sent along with each recording as a hint about what kind
+of words to expect. It is especially good at getting unusual spellings right.
+
+Say you work with a colleague called Siobhán, a product called Kestrel Nine, and
+you keep saying "EBITDA". Type those into the Prompt box and the service will
+spell them properly instead of guessing:
+
+```
+Siobhán, Kestrel Nine, EBITDA, Bloemfontein, Anthropic
+```
+
+The Prompt box belongs to whichever service is currently selected, so you can keep
+a different list of terms for each one. It saves itself as you type.
+
+## Working with past recordings
+
+Mutation keeps your recent recordings so you can go back to them.
+
+- The **older** and **newer** arrow buttons step back and forward through your
+  recent sessions.
+- **Play selected session** plays the one you've landed on, so you can hear what
+  you actually said.
+- The **Speed** dropdown changes how fast it plays back, from half speed up to
+  three times normal. Voices stay at their natural pitch at every speed — nobody
+  turns into a chipmunk.
+- **Retry transcription** sends the selected recording off to be transcribed again.
+  This is the useful one: if a transcript came back wrong, pick a different service
+  or add some terms to the Prompt box, then press Retry.
+
+By default Mutation keeps the last **10** recordings, and quietly deletes the
+oldest ones beyond that. You can set this anywhere from 1 to 500 in **Settings**,
+under **Recording sessions to keep**. A recording that is still in progress is
+never deleted.
+
+## Transcribing a file you already have
+
+You don't have to record inside Mutation. If someone sends you a voice note, or you
+have a recording of a meeting, use the **Upload audio for transcription** button on
+the **Speech to Text** card. Pick the file and Mutation transcribes it the same way
+it would a live recording.
+
+It accepts audio files — MP3, WAV, M4A, AAC, FLAC, OGG, OPUS, WMA — and video
+files — WEBM, MP4, AVI, MKV, MOV, WMV, M4V. With a video, Mutation pulls out the
+soundtrack and transcribes that. Long files take longer, naturally; Mutation allows
+a much more generous wait for them than for a quick live recording.
+
+## Trimming the quiet bits
+
+Mutation trims long silent gaps out of your audio before sending it off. This means
+the pauses while you think don't make the recording bigger and slower than it needs
+to be. It applies to recordings you make and to files you upload, and it is on by
+default — leave it on unless you have a reason not to.
+
+If you want to fine-tune how aggressive the trimming is, the dials live in
+[The Settings window](settings.md).
+
+---
+
+## Where to next
+
+- [Using AI prompts on your text](ai-prompts.md) — clean up, rewrite, or summarise
+  what you dictated.
+- [Automatic find-and-replace rules](transcript-formatting.md) — fix recurring
+  mistakes automatically.
+- [Keyboard shortcuts](keyboard-shortcuts.md) — the full list, and how to change
+  them.
+- [Muting your microphone](microphone.md) — choosing which microphone Mutation
+  records from.

--- a/Documentation/UserGuide/markdown/getting-started.md
+++ b/Documentation/UserGuide/markdown/getting-started.md
@@ -1,0 +1,93 @@
+# Getting started
+
+Welcome. Mutation is a small Windows program that sits quietly in the background and gives your keyboard some extra powers. Press one key combination to mute every microphone on your PC at once. Press another to dictate a sentence instead of typing it. Press another to pull the text out of a screenshot, or to have whatever you copied read out loud.
+
+The clever part is that these shortcuts work everywhere. You do not have to switch to Mutation first. Whether you are in Outlook, Teams, Word or your browser, the same key combination does the same thing. Mutation was built by a developer who is almost blind, for his own daily work, so it is designed to be usable without hunting for tiny icons on screen.
+
+---
+
+## What you need before you start
+
+**Windows.** Mutation is a Windows desktop app.
+
+**The .NET 10 runtime.** This is a free piece of Microsoft plumbing that Mutation needs in order to run. Install it once, then start **Mutation.exe**. If you already have it, nothing more to do.
+
+**A key or two for the online services.** Some of Mutation's features do their thinking on the internet rather than on your PC. Turning speech into text, or asking an AI to tidy up your writing, happens on someone else's servers. To use those servers you need an API key.
+
+An API key is simply a long password that lets Mutation talk to a service on your behalf. You create one on that company's website, copy it, and paste it into Mutation. Treat it exactly like a password: do not email it, do not paste it into a chat, and do not put it in a shared document. Anyone who has your key can spend money on your account.
+
+You only need the keys for the features you actually want. Here is what each one unlocks.
+
+| Key | What it gives you |
+|---|---|
+| OpenAI | Dictation (speech to text) and AI prompts |
+| Anthropic | AI prompts using Claude models |
+| Deepgram | An alternative dictation service, if you prefer it to OpenAI |
+| Azure Computer Vision (key *and* endpoint) | Reading text out of screenshots and images |
+
+If all you want is the microphone mute, you need no keys at all. That feature works straight away.
+
+> The Azure Computer Vision service needs two things, not one: a key, and an "endpoint", which is just the web address of your own Azure service. You get both from the same place when you set the service up.
+
+---
+
+## Your very first launch
+
+The first time you run Mutation, it creates its settings file with sensible defaults, and every keyboard shortcut is already set up and ready to change later.
+
+If you have not yet added an OpenAI or Anthropic key, Mutation greets you with a short welcome message titled **Welcome to Mutation**. It explains that at least one key is needed, and lists which key does what. Press **Continue**.
+
+The **Settings** window then opens on its own, so you can paste your keys in right away. That is the whole of first-run setup. If you would rather do it later, just close Settings — you can reopen it at any time with **Ctrl+Comma**.
+
+One other message you might see later: if you have set up a dictation service but its key is missing, Mutation tells you which service it has switched off and opens Settings on the API keys page. Add the key, save, then restart Mutation so the service becomes available again.
+
+---
+
+## Entering your keys
+
+1. Press **Ctrl+Comma** to open **Settings**.
+2. Choose **API keys** in the list on the left.
+3. Paste your key into the matching box: **OpenAI API key**, **Anthropic API key** or **Deepgram API key**.
+4. Save.
+
+The OpenAI key covers both AI prompts and OpenAI dictation, so one key does double duty there. The Deepgram key is only for Deepgram dictation.
+
+The Azure Computer Vision key lives somewhere else, because it belongs to the screenshot features. You will find it under **Screen capture & OCR** in Settings, together with the **Endpoint** box.
+
+---
+
+## Where your settings are kept
+
+Everything you configure is stored in a single file called **Mutation.json**, which sits in the same folder as **Mutation.exe**.
+
+You do not need to open it. Everything in it can be changed from the Settings window. But it is worth knowing where it is for one reason: if you copy that file somewhere safe now and then, you have a backup of all your shortcuts, prompts and settings. Copy it back into the folder and Mutation picks up exactly where you left off.
+
+Because your API keys are stored in that file, keep any copies of it somewhere private.
+
+---
+
+## Try it in five minutes
+
+Give these a go, in any app you like. These are the shortcuts Mutation starts with — you can change every one of them later.
+
+1. **Mute your microphone.** Press **Alt+Q**. Every microphone on the PC mutes at once, and you hear a beep confirming which way it went. Press it again to unmute. See [Muting your microphone](microphone.md).
+2. **Dictate a sentence.** Press **Shift+Alt+U**, say something, then press it again to stop. A few seconds later your words come back as text. See [Dictation: turning speech into text](dictation.md).
+3. **Have something read aloud.** Copy any text, then press **Ctrl+Shift+Alt+Q** to hear it spoken. See [Having text read aloud](read-aloud.md).
+4. **Read text off the screen.** Press **Shift+Alt+J**, drag a rectangle over some text in an image, and the text lands on your clipboard. This one needs the Azure key. See [Screenshots and reading text from images](screen-capture-and-ocr.md).
+
+That is the core of it. Everything else builds on those four ideas.
+
+---
+
+## Leave it running
+
+Mutation does its job from the background. Once it is started you can minimise the main window and forget about it — the shortcuts keep working no matter which app you are using. Closing the window shuts the app down, and the shortcuts stop with it, so minimise rather than close if you want them to stay live.
+
+---
+
+## Where to next
+
+- [A tour of the main window](main-window.md) — what each part of the screen does.
+- [Keyboard shortcuts](keyboard-shortcuts.md) — the full list, and how to change any of them.
+- [The Settings window](settings.md) — every option, explained.
+- [Troubleshooting](troubleshooting.md) — if something is not behaving.

--- a/Documentation/UserGuide/markdown/index.md
+++ b/Documentation/UserGuide/markdown/index.md
@@ -1,0 +1,91 @@
+# The Mutation User Guide
+
+Welcome. Mutation is a small Windows app that sits quietly in the background and
+gives you a set of keyboard shortcuts that work *everywhere* — in your email, in a
+meeting, in a spreadsheet, in your browser. You don't have to switch to Mutation to
+use it. You just press a key.
+
+It does six main jobs for you:
+
+- **Mutes every microphone on your PC at once**, so you always know for certain
+  whether you are muted.
+- **Grabs a piece of your screen and pulls the words out of it**, so text trapped in
+  a picture becomes text you can copy, search and paste.
+- **Turns what you say into typed text**, so you can dictate a message instead of
+  typing it.
+- **Runs your text past an AI assistant** to fix the grammar, shorten it, or turn
+  rough notes into a proper email.
+- **Reads text out loud**, with proper pause, resume and skip controls.
+- **Turns one keyboard shortcut into another**, so an awkward shortcut in some other
+  app becomes an easy one.
+
+Mutation was built by a nearly-blind developer for his own daily work, so everything
+in it can be done from the keyboard, and everything it does it also tells you about
+out loud or with a sound.
+
+---
+
+## Where to start
+
+If you are brand new, read these two, in this order:
+
+1. **[Getting started](getting-started.md)** — what you need, what happens the first
+   time you run Mutation, and a five-minute first try.
+2. **[A tour of the main window](main-window.md)** — a quick map of what every part
+   of the screen does.
+
+After that, dip into whichever chapter covers the job you want to do.
+
+---
+
+## All the chapters
+
+### Getting going
+
+| Chapter | What's in it |
+|---|---|
+| [Getting started](getting-started.md) | What you need before you begin, setting up your account keys, where your settings are kept, and a quick first try. |
+| [A tour of the main window](main-window.md) | Every section of the main screen, what each button does, and where to read more. |
+
+### The things Mutation does
+
+| Chapter | What's in it |
+|---|---|
+| [Muting your microphone](microphone.md) | One shortcut to mute and unmute every microphone at once, the confirmation beeps, the input level meter, and pinning your input level. |
+| [Dictation: turning speech into text](dictation.md) | Recording your voice and getting text back, choosing a transcription service, where the text is delivered, replaying past recordings, and transcribing files you already have. |
+| [Screenshots and reading text from images](screen-capture-and-ocr.md) | Capturing part of your screen with the mouse or the keyboard, pulling the text out of pictures and PDFs, and choosing the right reading order. |
+| [Having text read aloud](read-aloud.md) | Reading the clipboard or your selection out loud, pausing and resuming, skipping around sentence by sentence, and picking a voice, speed and volume. |
+| [Using AI prompts on your text](ai-prompts.md) | Saving your own instructions like "fix the grammar" or "turn this into an email", giving each one a shortcut, and choosing which AI model runs it. |
+| [Automatic find-and-replace rules](transcript-formatting.md) | Teaching Mutation to fix the words it always gets wrong, and to strip out filler, automatically. |
+
+### Settings and reference
+
+| Chapter | What's in it |
+|---|---|
+| [Keyboard shortcuts](keyboard-shortcuts.md) | The full list of shortcuts and their defaults, how to change one, and how to make one shortcut stand in for another. |
+| [The Settings window](settings.md) | A guided walk through every settings page, what each option does, and how to put things back the way they were. |
+| [Screen reader and accessibility notes](accessibility.md) | How Mutation works with a screen reader and ZoomText, what it announces, and the sounds it uses to tell you what happened. |
+| [Troubleshooting](troubleshooting.md) | When something doesn't work: the usual causes, the quick fixes, and where the log file lives. |
+
+---
+
+## A few things worth knowing up front
+
+- **Every shortcut in this guide can be changed.** The ones printed here are just what
+  Mutation starts with. If a combination clashes with something you already use, go to
+  Settings and pick your own — see [Keyboard shortcuts](keyboard-shortcuts.md).
+- **You only need to set up the parts you want.** Mutation asks for account keys for
+  the online services it uses, but they are separate. If you only want the microphone
+  mute, you don't need any of them.
+- **Settings open with Ctrl+Comma** from anywhere in the app.
+- **Most settings have hover help.** If a setting isn't clear, rest your mouse on it,
+  or tab to it with a screen reader — the same explanation is available both ways.
+
+---
+
+## About this guide
+
+The chapters live as Markdown files in the `markdown` folder, and the matching web
+pages in the `html` folder are generated from them. The Markdown is always the
+authoritative version. To rebuild the web pages after an edit, run
+`Build-UserGuide.cmd` in the `Documentation` folder.

--- a/Documentation/UserGuide/markdown/keyboard-shortcuts.md
+++ b/Documentation/UserGuide/markdown/keyboard-shortcuts.md
@@ -1,0 +1,176 @@
+# Keyboard shortcuts
+
+Keyboard shortcuts are how you actually use Mutation day to day. This chapter
+lists every one of them, shows you how to change them, and explains what to do
+when a combination refuses to work.
+
+## What "global" means
+
+Almost every Mutation shortcut is **global**. That means it works no matter which
+app you are in. You can be halfway through an email, a spreadsheet, or a video
+call, and the shortcut still fires. Mutation's own window does not need to be
+open, in front, or even visible. It just sits quietly in the background and
+listens.
+
+There is one exception, and it is noted in the tables below: **Ctrl+Comma** opens
+Settings, and that one only works when Mutation's own window is in front.
+
+Every default shortcut listed here can be changed. Nothing is fixed.
+
+## The full list
+
+### Microphone
+
+| What it does | Default shortcut | More about it |
+|---|---|---|
+| Mute or unmute every microphone at once | **Alt+Q** | [Muting your microphone](microphone.md) |
+
+### Dictation
+
+| What it does | Default shortcut | More about it |
+|---|---|---|
+| Start or stop recording your voice, then turn it into text | **Shift+Alt+U** | [Dictation](dictation.md) |
+| Same, then send the text straight through an AI prompt | **Shift+Alt+I** | [Dictation](dictation.md) |
+| Send a key to the app you are in, after the text is delivered | None — set your own | [Dictation](dictation.md) |
+
+### Screenshots and OCR
+
+| What it does | Default shortcut | More about it |
+|---|---|---|
+| Take a screenshot of part of the screen | **Shift+Alt+K** | [Screenshots and OCR](screen-capture-and-ocr.md) |
+| Take a screenshot and pull the text out of it | **Shift+Alt+J** | [Screenshots and OCR](screen-capture-and-ocr.md) |
+| Same, but read strictly left to right, top to bottom | **Shift+Alt+E** | [Screenshots and OCR](screen-capture-and-ocr.md) |
+| Pull the text out of an image already on the clipboard | **Alt+J** | [Screenshots and OCR](screen-capture-and-ocr.md) |
+| Same, but read strictly left to right, top to bottom | **Alt+K** | [Screenshots and OCR](screen-capture-and-ocr.md) |
+| Send a key to the app you are in, after the text is delivered | None — set your own | [Screenshots and OCR](screen-capture-and-ocr.md) |
+
+### Reading aloud
+
+| What it does | Default shortcut | More about it |
+|---|---|---|
+| Read whatever is on the clipboard | **Ctrl+Shift+Alt+Q** | [Having text read aloud](read-aloud.md) |
+| Read the text you have selected | **Ctrl+Shift+Q** | [Having text read aloud](read-aloud.md) |
+| Pause, or carry on from where you paused | **Ctrl+Shift+Space** | [Having text read aloud](read-aloud.md) |
+| Start again from the beginning | **Ctrl+Shift+B** | [Having text read aloud](read-aloud.md) |
+| Go back a sentence | **Ctrl+Shift+J** | [Having text read aloud](read-aloud.md) |
+| Go forward a sentence | **Ctrl+Shift+K** | [Having text read aloud](read-aloud.md) |
+| Say how far through the text you are | **Ctrl+Shift+P** | [Having text read aloud](read-aloud.md) |
+| Save the spoken audio to a file | None, and see the note below | [Having text read aloud](read-aloud.md) |
+
+> **Speak to file** is the one action without a row on the Hotkeys page. Use the
+> **Speak to file** button on the main window. If you really want a shortcut for it,
+> it can only be added by editing the settings file by hand — see
+> [The Settings window](settings.md) for where that file lives.
+
+### AI prompts
+
+| What it does | Default shortcut | More about it |
+|---|---|---|
+| Run one of your AI prompts | None — set your own, one per prompt | [Using AI prompts](ai-prompts.md) |
+
+Each prompt you create can have its own shortcut. You set it in the prompt editor
+on the main window, not on the Hotkeys page. None are filled in for you.
+
+### App
+
+| What it does | Default shortcut | More about it |
+|---|---|---|
+| Open Settings (only when Mutation's window is in front) | **Ctrl+Comma** | [The Settings window](settings.md) |
+| Open Mutation's menu (only when Mutation's window is in front) | **Alt**, then **H** | [A tour of the main window](main-window.md) |
+
+## Changing a shortcut
+
+Open **Settings** with **Ctrl+Comma**, then pick **Hotkeys** from the list on the
+left. Every shortcut in the tables above is on that one page, in roughly the same
+order — the only exception is **Speak to file**, noted above.
+
+Each row has the name of the action, a box holding the current combination, a
+**Record** button, a **Clear** button, and a small reset button. Hover over the
+reset button and it tells you what the default is, for example "Reset to default
+(ALT+Q)".
+
+To record a new combination:
+
+1. Press the **Record** button. Its label changes to "Press keys...".
+2. Hold down the modifiers you want and press the final key. Holding Ctrl, Shift,
+   Alt or the Windows key on their own does nothing — Mutation waits for a real
+   key before it decides you are finished.
+3. The box fills in with what you pressed, in Mutation's own style, like
+   `CTRL+ALT+J`. Recording stops on its own.
+
+Changed your mind mid-recording? Press **Escape** and nothing is captured.
+
+You can also just type into the box if you prefer. Write the keys separated by
+plus signs. Mutation tidies up the capitals for you when you move away from the
+box. The **Clear** button empties a box, which is what you want for the two
+optional "send a key afterwards" fields.
+
+Your changes are held until you press **Save** at the bottom of Settings. Press
+**Cancel** and nothing you changed is kept.
+
+## When a combination is taken or not allowed
+
+Mutation checks as you go, and shows the problem in red just under the box. Screen
+readers announce it straight away.
+
+- **Left blank when a shortcut is required** — "Enter a hotkey."
+- **Only modifier keys** — "Hotkey must include a non-modifier key." Ctrl+Shift on
+  its own is not a shortcut; it needs a letter, number, or other key on the end.
+- **A key Mutation does not recognise** — "Unsupported key", followed by the key
+  you typed.
+- **The same combination used twice inside Mutation** — an orange **Duplicate
+  hotkey** note appears under both rows. Give one of them a different combination,
+  otherwise only one of the two will ever fire.
+- **Another app already owns it** — Mutation cannot tell until it actually tries to
+  claim the combination. When it fails, you get a beep and a message titled "Some
+  hotkeys could not be registered", listing each action, its combination, and the
+  reason, usually "The shortcut is already registered by another application."
+  Go back to the Hotkeys page and pick something else.
+
+## Choosing combinations that won't clash
+
+1. **Use three modifiers.** Combinations like **Ctrl+Shift+Alt+Q** are almost never
+   claimed by anything else. That is exactly why Mutation uses one for reading the
+   clipboard.
+2. **Stay away from the famous ones.** Ctrl+C, Ctrl+V, Ctrl+S, Ctrl+Z, Ctrl+F,
+   Alt+Tab and Alt+F4 are used everywhere. So are most combinations that include
+   the Windows key, which Windows itself reserves.
+3. **Test it in the app you use most.** Set the shortcut, switch to that app, and
+   press it. If Mutation responds and the other app does not, you are fine. If
+   nothing happens at all, something else grabbed it first — try another.
+
+## The shortcut router
+
+The router does one thing: you press one combination, and Mutation presses a
+different one for you. It never runs a Mutation feature. It just passes a
+different set of keys along to whatever app you are in.
+
+Two reasons people use it:
+
+- **To make an awkward shortcut easy.** Some other app has a shortcut that is a
+  stretch for one hand. Give yourself a comfortable one instead.
+- **To get around a clash.** A combination you want is blocked or occupied, so you
+  reach the same action a different way.
+
+Here is a worked example. Your video call app mutes with **Ctrl+Shift+M**, which is
+a fiddly reach while you are holding a coffee. Add a mapping with **Ctrl+Alt+1** in
+the "From" box and **Ctrl+Shift+M** in the "To" box. From then on, pressing
+**Ctrl+Alt+1** anywhere makes Mutation send **Ctrl+Shift+M** to whatever app you
+are in, and the call mutes.
+
+To set one up, go to **Settings** (**Ctrl+Comma**), pick **Hotkeys**, and scroll
+down to the **Hotkey Router** section. Press **Add mapping**, fill in the "From"
+and "To" boxes, and press **Save**. Each row shows a small status marker: a tick
+once the mapping is live, or an error marker with a message if something is wrong.
+Two mappings listening for the same "From" combination get a "Duplicate 'From'
+hotkey" message. **Delete** removes a mapping.
+
+> As the in-app help puts it: map one shortcut to another so a single key press can
+> trigger a more complex shortcut. Changes apply when you save settings.
+
+## Where to next
+
+- [The Settings window](settings.md) — where the Hotkeys page lives, and everything else you can change.
+- [A tour of the main window](main-window.md) — the buttons behind these shortcuts.
+- [Troubleshooting](troubleshooting.md) — what to do when a shortcut stops responding.
+- [Screen reader and accessibility notes](accessibility.md) — how Mutation announces what it is doing.

--- a/Documentation/UserGuide/markdown/main-window.md
+++ b/Documentation/UserGuide/markdown/main-window.md
@@ -1,0 +1,175 @@
+# A tour of the main window
+
+Most of the time you will not look at Mutation at all. You press a keyboard shortcut in whatever app you are using, and Mutation does its job in the background. But there is a main window, and it is worth knowing your way around it.
+
+The window is titled **Mutation Workspace**. Think of it as the control panel. Everything on it is also available as a keyboard shortcut that works from any other app, so the window is where you go to change a setting, check a result, or run something once without remembering a shortcut.
+
+The window is laid out as a set of cards, one per feature. On a wide window the cards sit two to a row. Narrow the window and they stack into a single column, so nothing is ever hidden off to the side.
+
+> Everything here is reachable from the keyboard. **Tab** moves forward through the controls, **Shift+Tab** moves back, **Space** or **Enter** presses a button, and the arrow keys open and move through dropdowns. Many buttons also have an access key: hold **Alt** and the underlined letter.
+
+---
+
+## The menu at the top
+
+Top left is a single **Menu** button (the three-line "hamburger" icon). Press **Alt** then **H** to open it, or just click it.
+
+| Item | What it does |
+|---|---|
+| **Settings** | Opens the Settings window. Same as pressing **Ctrl+Comma** from anywhere in Mutation. |
+| **Debug** | A submenu with three "Simulate ... Crash" items. These exist so the developer can test error handling. Ordinary users can ignore them entirely. |
+
+See [The Settings window](settings.md) for what is inside Settings.
+
+---
+
+## The Microphone card
+
+This is the mute switch. It turns every microphone on your PC on or off at once, so you never have to hunt for the mute button in whichever meeting app you happen to be in.
+
+| Control | What it does |
+|---|---|
+| **Microphone selection** (dropdown) | Chooses the input microphone. |
+| **Toggle microphone** (button) | Mutes or unmutes. The icon shows a line through the microphone when you are muted. |
+| **Toggle microphone visualization** | The big waveform panel is itself a button. Press it to turn the live waveform drawing on or off. When it is off it simply reads "Off". |
+| Level meter | The thin bar beside the waveform. It rises and falls with how loud you are. Nothing to press. |
+| **Pin input level** (on/off switch) | Keeps the Windows recording level fixed at the value you choose. Mutation re-applies it every time you record, change microphone, or start the app. |
+| **Input level** (slider) | Sets the Windows recording level from 0 to 100. The change takes effect straight away, even when you are not recording. |
+
+Full details: [Muting your microphone](microphone.md).
+
+---
+
+## The Speech to Text card
+
+This is dictation. You press record, you talk, you press stop, and a few seconds later your words appear as text.
+
+| Control | What it does |
+|---|---|
+| **Speech-to-text service selection** (dropdown) | Picks which transcription service does the listening. |
+| **Record** (button) | Starts or stops speech capture. The transcript appears in the **Raw Transcript** box. |
+| **Record and Format** (button) | Starts or stops speech capture, then automatically sends the transcript to the AI model for tidying up. |
+| **Play selected session** | Plays back the recording you currently have selected. |
+| **Go to older session** / **Go to newer session** | Step backwards and forwards through your recent recordings. |
+| **Retry transcription** | Transcribes the selected recording again. Useful if the first attempt failed. |
+| **Upload audio for transcription** | Pick an audio file from your PC and have it transcribed. |
+| **Speed** (dropdown) | How fast recordings play back. Voices stay at their natural pitch at every speed. |
+| **Prompt** (text box) | Optional. A few words of context or a list of names, to help the service spell things the way you want. |
+
+Full details: [Dictation: turning speech into text](dictation.md).
+
+---
+
+## The LLM Prompts card
+
+An LLM is an AI writing assistant. This card is where you keep your list of instructions for it — "make this into a polite email", "summarise this in three bullets", and so on. The card's own description says it plainly: configure multiple prompts for LLM processing.
+
+| Control | What it does |
+|---|---|
+| **Add Prompt** (button) | Creates a new prompt. |
+| The list | One row per prompt. Each row shows the prompt's name, its shortcut, its model, and the words **(Auto-Run)** if it is set to run by itself. |
+| **(Auto-Run)** label | Means that prompt runs automatically after a recording finishes, instead of waiting for you to trigger it. |
+| **Run** | Runs that prompt now, on the text in the **Raw Transcript** box. |
+| **Edit** | Opens the prompt so you can change its wording, model or shortcut. |
+| **Delete** | Removes the prompt. |
+
+Full details: [Using AI prompts on your text](ai-prompts.md).
+
+---
+
+## The transcript boxes
+
+This card has no heading of its own — just two labelled boxes stacked one above the other. It is where your dictated words land, and where the tidied-up version appears.
+
+| Control | What it does |
+|---|---|
+| **Raw Transcript** (text box) | Exactly what came back from the transcription service. You can edit it by hand. |
+| **Format with rules** (button) | Applies your own find-and-replace rules to the raw transcript. No AI involved, so it is instant. |
+| **Process with LLM** (button) | Sends the raw transcript to the AI model for formatting. |
+| **Formatted Transcript** (text box) | The result, ready to copy or share. |
+
+Full details: [Automatic find-and-replace rules](transcript-formatting.md) and [Using AI prompts on your text](ai-prompts.md).
+
+---
+
+## The Automation card
+
+One small but important setting: it controls where your finished transcripts are delivered. The card's own subtitle is "Control where transcripts are delivered."
+
+| Control | What it does |
+|---|---|
+| **Third-party interaction mode** (dropdown) | Chooses how the text reaches the app you were working in. |
+
+There are three choices, and the line of text underneath the dropdown explains whichever one you have picked:
+
+- **Paste** — copies the transcript and pastes it into the active application.
+- **SendKeys** — types the transcript into the active app as if you entered it yourself.
+- **DoNotInsert** — keeps the transcript inside Mutation without sending it anywhere.
+
+Full details: [Dictation: turning speech into text](dictation.md).
+
+---
+
+## The Visual Capture card
+
+Screenshots, and pulling the text out of pictures. OCR simply means reading the words in an image so you can copy them as text.
+
+Each button in this card shows its current keyboard shortcut in small print underneath it, so you never have to go looking.
+
+| Control | What it does |
+|---|---|
+| **Screenshot to clipboard** | Grab part of the screen and put the picture on the clipboard. |
+| **OCR clipboard** | Read the text out of whatever image is on the clipboard. |
+| **OCR clipboard (L→R)** | The same, but reading strictly left to right and top to bottom. Use this when the normal order jumbles columns or tables. |
+| **Screenshot & OCR** | Grab part of the screen and read its text, in one step. |
+| **Screenshot & OCR (L→R)** | The same, in strict left-to-right, top-to-bottom order. |
+| **OCR documents** | Pick several PDFs or images and read them all into one result. A progress bar appears while it works. |
+| **OCR result** (text box) | Where the extracted text appears. |
+| **Download OCR result** | Saves that text to a document. Stays greyed out until there is something to save. |
+
+Full details: [Screenshots and reading text from images](screen-capture-and-ocr.md).
+
+---
+
+## The Voice & Speech card
+
+This is the read-aloud feature. Its subtitle says it well: speak the current clipboard contents and tune the voice.
+
+| Control | What it does |
+|---|---|
+| **Voice** (dropdown) | Which voice reads to you. |
+| **Rate** (slider) | How fast it speaks. |
+| **Volume** (slider) | How loud, independent of your system volume. |
+| **Announce reading time at start** (on/off) | Speaks an estimate of how long the text will take before it starts reading. |
+| **Announce progress while reading** (on/off) | Speaks your progress at regular points through a long text. |
+| **Speak clipboard** | Reads whatever you last copied. |
+| **Speak selection** | Copies whatever is highlighted in the app you were in, and reads that. |
+| **Restart** | Starts again from the beginning, ignoring the saved position. |
+| **Skip sentence backward** / **Skip sentence forward** | Jump one sentence back or forward. |
+| **Position** | Speaks where you are: the sentence, the percentage, and the time left. |
+| **Speak to file** | Saves the spoken version as a WAV audio file. |
+
+Full details: [Having text read aloud](read-aloud.md).
+
+---
+
+## Status messages
+
+Mutation tells you what it is doing through a status bar that appears in the **top right** of the window, not at the bottom. It stays out of the way until there is something to say — "Transcribing", "OCR complete", an error — then slides into view. It is announced to screen readers politely, so it will not interrupt you mid-sentence. Close it with its own close button, or leave it; it goes away on its own.
+
+---
+
+## Two useful habits
+
+**You rarely need this window.** Every button here has an equivalent shortcut that works from any app. The window is for setting things up and checking results. See [Keyboard shortcuts](keyboard-shortcuts.md) for the full list, and remember that every shortcut can be changed in Settings.
+
+**The window remembers itself.** Mutation saves the window's position and size when you close it, and puts it back exactly there next time. The very first time you run it, with no saved size yet, it opens at three-quarters of your screen, centred. If you later unplug a monitor, Mutation nudges the window back onto a screen you can actually see.
+
+---
+
+## Where to next
+
+- [Getting started](getting-started.md) — set up your keys and take Mutation for its first run.
+- [Keyboard shortcuts](keyboard-shortcuts.md) — the shortcuts behind every button on this window.
+- [The Settings window](settings.md) — everything the main window does not show.
+- [Screen reader and accessibility notes](accessibility.md) — navigating Mutation without looking at it.

--- a/Documentation/UserGuide/markdown/microphone.md
+++ b/Documentation/UserGuide/markdown/microphone.md
@@ -1,0 +1,132 @@
+# Muting your microphone
+
+This is the feature Mutation was built for in the first place, and it is still the
+one most people use every day.
+
+Press one shortcut and every microphone on your PC goes quiet. Press it again and
+they all come back. It works no matter which app you are in — you do not have to
+find the meeting window first, and you do not have to learn a different mute
+shortcut for Teams, Zoom, Slack and everything else.
+
+## Why it mutes *every* microphone
+
+Most PCs have more than one microphone. There is the one in your headset, maybe one
+in your webcam, and maybe one built into the laptop lid. Meeting apps do not always
+pick the one you expect, and they can quietly switch to a different one.
+
+That is the trap. You mute what you think is "the" microphone, carry on talking to
+someone in the room, and the call has been listening through a different mic the
+whole time.
+
+Mutation avoids that by muting all of them together. When it says muted, every
+microphone on the machine is muted.
+
+## The shortcut
+
+The default shortcut is **Alt+Q**.
+
+You can change it. Open **Settings** with **Ctrl+Comma**, go to the **Audio** page,
+and set a new shortcut in the "Toggle microphone mute" box. Every shortcut in
+Mutation can be changed this way.
+
+You can also click the microphone button on the **Microphone** card on the main
+window. It does exactly the same thing as the shortcut.
+
+## How you know it worked
+
+Two things tell you the new state.
+
+- **A beep.** One sound for muted, a different one for unmuted.
+- **A message** on the main window: "Microphone muted." or "Microphone is live."
+
+If the change could not be confirmed, you get the failure beep instead and a
+message saying the microphone may still be live. That is deliberate. Mutation will
+never tell you that you are muted unless it has checked each microphone and
+confirmed it.
+
+> Tip: tapping the shortcut twice very quickly is safe. The second press is ignored
+> while the first is still working, so you cannot accidentally end up back where you
+> started.
+
+### Using your own sounds
+
+If you do not like the built-in beeps, you can swap in your own sound files — one
+for mute, one for unmute, and for Mutation's other status sounds too. Turn on
+"Custom beeps" on the **Audio** page in **Settings**, then browse for a sound file
+for each one. There is a play button next to each so you can hear it before you
+commit. See [The Settings window](settings.md) for the full walkthrough.
+
+## Choosing the active microphone
+
+The **Microphone** card has a dropdown listing the microphones Mutation can see.
+The one you pick is the *active* microphone — the one Mutation records from for
+dictation, and the one the level meter and the level controls apply to.
+
+This choice does not affect muting. Muting always covers every microphone,
+whichever one is selected. Your choice is remembered the next time you start
+Mutation.
+
+## The live level display
+
+Underneath the dropdown is a live picture of what your microphone is hearing: a
+waveform that moves as you speak, and a vertical bar next to it that rises and falls
+with how loud you are. It is a quick way to check that the mic is actually picking
+you up before you start talking.
+
+To turn it off, click on the waveform itself — it is a toggle. Click it again to
+turn it back on. When it is off it simply shows the word "Off".
+
+It is reachable from the keyboard too: tab to "Toggle microphone visualization" and
+press Space or Enter. There is also a "Microphone visualization" switch on the
+**Audio** page in **Settings** if you prefer to set it there. Either way, the
+setting is remembered.
+
+## Pin input level
+
+Windows lets any app change your microphone's input volume, and some of them do it
+without telling you. You set your mic to a comfortable level, join a call a few days
+later, and suddenly nobody can hear you.
+
+"Pin input level" stops that. It works like this:
+
+1. Use the **Input level** slider to set the volume you want, from 0 to 100. The
+   change applies to Windows straight away, even when you are not recording.
+2. Turn **Pin input level** on. Mutation remembers that number as your target.
+
+From then on, Mutation puts the level back to your number whenever it matters: when
+you start recording, when you switch microphones, and when the app starts up. If
+something moved it in the meantime, it gets moved back.
+
+Turning the pin off stops the re-checking. It does not change the level you are
+currently on — it just stops Mutation from correcting it.
+
+Some microphones have a fixed input level that software cannot change at all. On
+those, the switch and the slider are greyed out, and Mutation tells you why.
+
+## Plugging microphones in and out
+
+You can plug in a headset or unplug one while Mutation is running. It notices and
+updates the list on its own.
+
+- **A mic appears or disappears somewhere else in the list** — your selected
+  microphone is untouched, and Mutation stays quiet about it. Nothing about your
+  audio changed, so there is nothing to interrupt you with.
+- **Your selected microphone is unplugged** — Mutation switches to the first
+  microphone in the list and tells you: "The selected microphone was disconnected.
+  Now using ...".
+- **No microphones at all** — you get a message saying none are available.
+
+There is one more nicety. If you are muted and then plug in a new microphone, the
+new one comes up muted too. Connecting a headset mid-call will not quietly put you
+back on air.
+
+## Where to next
+
+- [A tour of the main window](main-window.md) — where the **Microphone** card sits
+  and what else shares the screen with it.
+- [The Settings window](settings.md) — changing the shortcut, and using your own
+  sound files instead of the beeps.
+- [Dictation: turning speech into text](dictation.md) — the other half of what your
+  microphone does in Mutation.
+- [Troubleshooting](troubleshooting.md) — what to try when a mute does not take or a
+  mic goes missing.

--- a/Documentation/UserGuide/markdown/read-aloud.md
+++ b/Documentation/UserGuide/markdown/read-aloud.md
@@ -1,0 +1,182 @@
+# Having text read aloud
+
+Mutation can read text out loud to you. Copy an email, a report, a long article —
+then press a shortcut and listen while you do something else.
+
+Once you know a handful of shortcuts you can drive it like a music player: play,
+pause, skip ahead, jump back.
+
+## Starting a reading
+
+There are two ways to get text into Mutation's ears.
+
+**Read the clipboard.** Copy some text anywhere (the usual **Ctrl+C**), then press
+**Ctrl+Shift+Alt+Q**. Mutation starts reading it.
+
+**Read what you have selected.** Highlight text in any app and press
+**Ctrl+Shift+Q**. Mutation grabs the selection for you, so you don't need to copy
+first.
+
+Both shortcuts are global. That means they work no matter which app is in front —
+you never have to switch back to Mutation. All of these shortcuts are just
+defaults, and you can change any of them in **Settings** (**Ctrl+Comma**) on the
+**Hotkeys** tab.
+
+If you prefer buttons, the **Voice & Speech** card on the main window has **Speak
+clipboard** and **Speak selection** buttons that do the same thing.
+
+## Pausing and picking up again
+
+There are two ways to interrupt a reading, and they behave slightly differently.
+
+**Pause properly: Ctrl+Shift+Space.** This is the real pause button. Press it while
+Mutation is reading and it says "Paused." Press it again and it says "Resuming." and
+carries on. If nothing is being read, it tells you "Nothing to resume."
+
+When it resumes, it rewinds a few words first — five by default — so you get your
+bearings instead of being dropped mid-sentence. That rewind only happens if your
+pause was long enough to lose the thread. A quick pause of a few seconds picks up
+from exactly where it stopped. By default, "long enough" means more than 10 seconds.
+
+Both of those numbers are yours to set, on the **Text to Speech** tab in
+**Settings**: "Rewind on resume (words)" (0 to 20, where 0 means no rewind at all)
+and "Rewind on resume after (seconds)" (set it to 0 to always rewind, however brief
+the pause).
+
+**Stop with the same key you started with: Ctrl+Shift+Alt+Q.** Pressing the speak
+shortcut again while it is reading stops it, and Mutation says "Stopped." Press it
+once more and it picks the same text up again from where it left off — so in
+everyday use it works like a play/stop button on the one key.
+
+One handy detail: if you copy something new before pressing it again, Mutation
+notices and reads the *new* clipboard text instead of carrying on with the old one.
+It tells you so: "Speaking new clipboard text."
+
+## Moving around the text
+
+You can move through the text sentence by sentence, the way you skip tracks on a
+music player.
+
+| What you want | Shortcut |
+|---|---|
+| Pause, then carry on again | **Ctrl+Shift+Space** |
+| Skip forward one sentence | **Ctrl+Shift+K** |
+| Skip back one sentence | **Ctrl+Shift+J** |
+| Start again from the very beginning | **Ctrl+Shift+B** |
+| Tell me where I am | **Ctrl+Shift+P** |
+
+Skipping back is a little cleverer than it looks. If you have only just landed on a
+sentence, pressing back jumps to the previous one — because you probably missed
+that one. If you have been listening to the current sentence for a moment, pressing
+back restarts the current sentence instead — because you probably want to hear that
+bit again.
+
+The dividing line is a short grace window, 1.5 seconds by default. You can adjust
+it under "Skip-back grace window (milliseconds)" on the **Text to Speech** tab. A
+larger value makes stepping back to the previous sentence easier; a smaller value
+favours re-reading the sentence you are on.
+
+If you skip past the end, Mutation says "End of text." If you skip back before the
+start, it says "Beginning of text."
+
+The **Position** button on the **Voice & Speech** card (or **Ctrl+Shift+P**) tells
+you where you are in the text. You hear something like "Sentence 4 of 22, about 40%
+through, about 2 minutes left." If nothing is being read, it simply says "Not
+currently reading."
+
+## Choosing a voice, speed, and volume
+
+The **Voice & Speech** card on the main window holds three controls.
+
+- **Voice** — a list of every voice installed on Windows, plus "(System default)".
+  Pick one and Mutation immediately speaks a short sample in that voice, so you can
+  hear it before committing.
+- **Rate** — how fast it reads, from -10 (slow) to +10 (fast). The default is 8,
+  which is brisk. Slide it down if that is too quick.
+- **Volume** — 0 to 100%, separate from your Windows volume.
+
+Your choices are saved automatically. There is no Save button to press.
+
+Want more voices? Install them through Windows' own speech settings, and they turn
+up in Mutation's Voice list next time.
+
+## Being told how long it will take
+
+Two switches on the **Voice & Speech** card keep you informed while you listen.
+
+**Announce reading time at start** speaks a short estimate before it begins, such
+as "Reading approximately 3 minutes of text."
+
+**Announce progress while reading** speaks your progress at regular points along
+the way, such as "50%, about 3 minutes left."
+
+Short texts stay quiet. On the **Text to Speech** tab in **Settings** you can set a
+minimum length for each announcement: "Announce reading time only above (minutes)"
+and "Announce progress only above (minutes)". Set either to 0 to hear it for any
+length of text. You can also set how often progress is spoken with "Announce
+progress every (percent)" — 25 gives you 25%, 50%, and 75%.
+
+## Tidier reading
+
+Text copied from the web or from notes is often littered with symbols that sound
+awful when read out. So before speaking, Mutation quietly cleans the text up. This
+is on by default.
+
+Here is what it tidies:
+
+- **Remove code blocks** — drops chunks of code (text between triple backticks)
+  rather than reading them out.
+- **Strip bold, italic, and inline-code symbols** — removes asterisks, underscores,
+  and backticks, keeping the words between them.
+- **Strip heading marks** — removes leading `#` symbols so headings read as plain
+  text.
+- **Shorten web links** — reads "link to example.com" instead of the full address.
+- **Strip bullet markers** — removes the `-`, `*`, or `+` at the start of list
+  items.
+- **Expand abbreviations** — "e.g." becomes "for example", "i.e." becomes "that
+  is", "etc." becomes "et cetera", and "vs." becomes "versus".
+- **Normalise paragraph breaks and whitespace** — collapses blank lines and runs of
+  spaces so you don't sit through long silent gaps.
+
+Each of those is its own switch on the **Text to Speech** tab in **Settings**, so
+you can keep the ones you like and turn off the ones you don't. Above them is a
+master switch, "Enable speech preprocessing". Turn that off and you hear the text
+exactly as written, symbols and all.
+
+> Every setting on the page has a small reset button next to it that puts it back
+> to the default, so experimenting is safe.
+
+## Saving a reading as an audio file
+
+The **Speak to file** button on the **Voice & Speech** card takes whatever text is
+on your clipboard and saves it as a spoken audio file (a `.wav` file) instead of
+playing it. Mutation suggests a name with the date and time in it, and you choose
+where to put it.
+
+This is useful when you want to listen later — on your phone during a commute, for
+instance — or when you want to keep a spoken copy of a document.
+
+## When Mutation can't read something
+
+If there is nothing to read, Mutation tells you out loud rather than sitting
+silently. You will hear one of these:
+
+- "No text on the clipboard." — nothing has been copied yet.
+- "The clipboard contains an image, not text. Use OCR to extract text first." — see
+  [Screenshots and reading text from images](screen-capture-and-ocr.md) for how to
+  pull the words out of a picture.
+- "The clipboard is in use by another application. Try again in a moment." — just
+  press the shortcut again.
+
+Each of these also appears as a message on the main window, and plays the failure
+beep.
+
+## Where to next
+
+- [Screenshots and reading text from images](screen-capture-and-ocr.md) — get text
+  out of a picture so it can be read aloud.
+- [The Settings window](settings.md) — where the **Text to Speech** tab lives.
+- [Keyboard shortcuts](keyboard-shortcuts.md) — the full list, and how to change
+  them.
+- [A tour of the main window](main-window.md) — where the **Voice & Speech** card
+  sits.

--- a/Documentation/UserGuide/markdown/screen-capture-and-ocr.md
+++ b/Documentation/UserGuide/markdown/screen-capture-and-ocr.md
@@ -1,0 +1,125 @@
+# Screenshots and reading text from images
+
+Sometimes the words you need are trapped inside a picture. A screenshot a colleague
+sent you. A scanned invoice. A PDF that will not let you select anything.
+
+OCR is the answer to that. It stands for optical character recognition, and it simply
+means reading the words out of a picture so you can copy, search, or paste them.
+Mutation does this for you, and puts the resulting text straight onto your clipboard.
+
+Everything in this chapter lives in the **Visual Capture** card on the main window.
+
+> Before any of the OCR buttons will work, Mutation needs an Azure Computer Vision key
+> (a long password that lets Mutation send your image to Microsoft's text-reading
+> service and get the words back). See [Getting started](getting-started.md) for how to
+> set that up.
+
+## Taking a screenshot of part of the screen
+
+Press the screenshot shortcut — **Shift+Alt+K** by default. The screen freezes, and an
+overlay appears over everything. You then pick a rectangle. As soon as you finish
+picking, that rectangle is copied to your clipboard as an image, and you are back where
+you were.
+
+Press **Esc** at any point to cancel. Nothing is copied, and Mutation tells you so.
+
+### Picking the rectangle with the mouse
+
+Hold the left mouse button down at one corner of the area you want, drag to the
+opposite corner, and let go. That is it. A right-click cancels instead.
+
+### Picking the rectangle with the keyboard
+
+You never need to see the screen to do this. The overlay talks you through it. When it
+opens it says what it wants from you, then as you move it announces the position you
+are at, the size of the rectangle you have built so far, and finally the size of what
+was captured.
+
+Think of it as a moving pointer that you park at one corner, pin down, and then drag to
+the other corner.
+
+| Key | Action |
+|---|---|
+| Arrow keys | Move the pointer (hold **Ctrl** for fine steps, **Shift** for large steps) |
+| **Home** / **End** | Jump the pointer to the left / right edge |
+| **Page Up** / **Page Down** | Jump the pointer to the top / bottom edge |
+| **Enter** or **Space** | First press pins one corner; second press captures the region |
+| **Ctrl+A** | Select the whole screen — then **Enter** to capture it |
+| **Backspace** | Clear the pinned corner and start the selection again |
+| **Esc** | Cancel |
+
+So the quickest possible capture is **Ctrl+A** then **Enter**: the whole screen, in two
+keystrokes.
+
+## The two reading orders
+
+A page of text can be read in two sensible ways, and Mutation offers both.
+
+- **Natural** follows the shape of the page. It reads down one column, then down the
+  next, keeping sections together. Choose it for newspapers, magazines, brochures, and
+  multi-column PDFs.
+- **Basic** reads straight across each row, left to right, all the way down. The app
+  labels this one **(L→R)**. Choose it for tables, spreadsheets, forms, and invoices.
+
+Rule of thumb: if the thing you are reading has *columns*, use Natural. If it has
+*rows*, use Basic.
+
+If one order gives you a jumbled result, just try the other on the same image.
+
+## The buttons and their shortcuts
+
+| Button | Default shortcut | What it does |
+|---|---|---|
+| Screenshot to clipboard | **Shift+Alt+K** | Picks a rectangle and copies it to the clipboard as an image. No text reading. |
+| OCR clipboard | **Alt+J** | Reads the text out of whatever image is already on your clipboard, in Natural order. |
+| OCR clipboard (L→R) | **Alt+K** | The same, but in Basic left-to-right order. |
+| Screenshot & OCR | **Shift+Alt+J** | Picks a rectangle *and* reads its text, in Natural order. One step. |
+| Screenshot & OCR (L→R) | **Shift+Alt+E** | The same, in Basic left-to-right order. |
+
+Every one of these shortcuts can be changed in **Settings** (**Ctrl+Comma**).
+
+In all four OCR cases the text lands on your clipboard, ready to paste, and also
+appears in the **OCR result** box at the bottom of the card so you can read it in
+place.
+
+## Reading a batch of files at once
+
+The **OCR documents** button handles whole files rather than screenshots. Click it,
+pick one or more files, and Mutation reads them all.
+
+It accepts PDFs and image files: `.pdf`, `.png`, `.jpg`, `.jpeg`, `.bmp`, `.tif` and
+`.tiff`. You can select several at once.
+
+A progress bar tells you which file and page it is on. When it finishes, all the text
+comes back as one combined block in the **OCR result** box — each file introduced by
+its name in square brackets, and each page of a PDF marked with its page number. That
+combined text is copied to the clipboard too.
+
+If you want to keep it, the **Download OCR result** button saves the whole thing to a
+plain text file.
+
+## A few settings worth knowing
+
+These live under **Screen capture & OCR** in **Settings** (**Ctrl+Comma**).
+
+- **Invert screenshot before OCR** — flips the colours before reading. Turn this on if
+  you work with light text on a dark background; it usually improves accuracy a lot.
+- **Free-tier page limit** — if you are on Microsoft's free plan, this caps how many
+  pages of each document get sent. The default is 2, so long PDFs are cut short unless
+  you turn **Use free tier** off.
+- **Max document size (MB)** — any file or page bigger than this is skipped instead of
+  being uploaded, so you never accidentally send something enormous. Set it to 0 to
+  remove the limit.
+
+There is also an optional **Send hotkey after OCR** setting, which fires a keystroke of
+your choosing once the text is ready — handy for kicking off your screen reader
+automatically.
+
+The rest of the options are covered in [The Settings window](settings.md).
+
+## Where to next
+
+- [Getting started](getting-started.md) — setting up your Azure Computer Vision key
+- [A tour of the main window](main-window.md) — where the **Visual Capture** card sits
+- [Having text read aloud](read-aloud.md) — listen to the text you just captured
+- [Keyboard shortcuts](keyboard-shortcuts.md) — the full list, and how to change them

--- a/Documentation/UserGuide/markdown/settings.md
+++ b/Documentation/UserGuide/markdown/settings.md
@@ -1,0 +1,215 @@
+# The Settings window
+
+Everything you can change about Mutation lives in one window. This chapter walks
+through it, category by category, so you know where to look.
+
+## Opening it and finding your way around
+
+Press **Ctrl+Comma** while Mutation's window is in front. You can also open the
+menu (**Alt**, then **H**) and choose **Settings**.
+
+The window has two halves. Down the left is a list of categories. On the right are
+the settings for whichever category you have picked. Move between categories with
+the arrow keys; the heading above the right-hand side always tells you which one
+you are in.
+
+At the bottom are **Save** and **Cancel**. Nothing you change takes effect until
+you press **Save**. **Cancel** throws away everything you changed in that visit.
+**Escape** closes the window too.
+
+## The search box
+
+Above the category list is a **Search settings** box. Type into it and two things
+happen at once: the category list shrinks to the categories that match, and the
+settings on the right hide any section that does not mention your word.
+
+Non-matching sections are removed rather than greyed out, so they disappear from
+the Tab order and from your screen reader as well as from the screen. A short line
+under the search box tells you how many categories and sections matched, and it is
+announced politely as you type — you never have to go hunting to find out whether
+your search found anything.
+
+Press **Escape** while you are in the search box to clear it and put everything
+back.
+
+## The Advanced switch
+
+Bottom right there is an **Advanced** switch. It does one thing: turning it on
+reveals an **Open Mutation.json** button, which opens the raw settings file in
+whatever program your PC uses for that file type. Most people never need it.
+Leaving Advanced off simply hides that button.
+
+## The categories
+
+### Audio
+
+Your microphone and the little sounds Mutation makes.
+
+| Setting | What it does |
+|---|---|
+| Microphone visualization | Shows a live waveform of the microphone input while recording. Turn it off to save a bit of CPU. |
+| Toggle microphone mute | The shortcut that mutes and unmutes everything. |
+| Use custom beeps | Play your own sound files instead of the built-in beeps for status cues. |
+| Beep files | One file each for Success, Failure, Start, End, Mute and Unmute. **Browse...** picks a file, and the small play button lets you hear it. |
+
+### Screen capture & OCR
+
+Reading text out of pictures. OCR just means "pulling the words out of an image".
+
+| Setting | What it does |
+|---|---|
+| Azure Computer Vision API key | The long password that lets Mutation use the text-reading service on your behalf. |
+| Endpoint | The web address of that service. Whoever gave you the key gives you this too. |
+| Use free tier | Use the free OCR tier, which limits how many pages each document can contain. |
+| Invert screenshot before OCR | Flips the image colours first, which helps a lot with light text on a dark background. |
+| Max document size (MB) | Biggest file or page Mutation will send. Anything larger is skipped before upload, so you never accidentally send something huge. Set it to 0 for no limit. |
+| Send hotkey after OCR | Optional keystrokes sent to the app you are in once the text is delivered — **Ctrl+V** to paste, for example. |
+
+The timeout and the "how many at a time" numbers have sensible defaults and hover
+help. Leave them alone unless something is timing out on you.
+
+### Speech to Text
+
+Where your dictation gets turned into text.
+
+| Setting | What it does |
+|---|---|
+| Service definitions | The transcription services you can pick from. Each one has a name, a provider (OpenAI Whisper or Deepgram), an optional key of its own, a model, and a prompt. |
+| Per-service prompt | Optional priming text sent with each transcription to nudge the spelling of names and the punctuation. |
+| Recording sessions to keep | How many past recordings stay on disk. Once you pass this, the oldest go first; the recording in progress is never deleted. Anything from 1 to 500, and 10 by default. |
+| Temp directory | The folder your recordings are written to while they are being made. |
+| Send hotkey after transcription | Optional keystrokes sent to the app you are in once your text arrives, for example **Ctrl+V** to paste. |
+| Strip silent gaps from audio | Removes long silences before the audio is sent, so pauses while you think do not bloat the recording. |
+
+> Adding, removing, or editing a service definition takes effect after you restart
+> Mutation. The per-service prompt and your choice of active service apply straight
+> away. You choose which service is active from the main window.
+
+The three silence numbers underneath (minimum silence, threshold, edge guard) fine
+tune that trimming. The defaults are good; each has hover help if you want to
+experiment.
+
+### API keys
+
+Your keys in one place. An API key is a long password that lets Mutation talk to a
+service on your behalf.
+
+| Setting | What it does |
+|---|---|
+| OpenAI API key | Used for OpenAI's AI models and for OpenAI/Whisper dictation. |
+| Anthropic API key | Used for Anthropic (Claude) AI models. |
+| Deepgram API key | Used for Deepgram dictation. |
+
+A speech service can override its key from the Speech to Text section. Otherwise
+the key here is the one used.
+
+### AI assistance
+
+The AI models Mutation can send your text to.
+
+| Setting | What it does |
+|---|---|
+| Request timeout (seconds) | How long to wait for the model to answer before giving up. |
+| Retries | How many times to try again after a failed request. Retries help the very first request after a reboot succeed while the network warms up. Three by default. |
+| Models | Your list of models. Each row has a name, a provider, and an optional temperature — which controls how random the answers are. Leave temperature empty to use the provider's own setting. |
+
+Your prompts themselves are edited on the main window, not here.
+
+### Text to Speech
+
+How Mutation reads text out loud. Voice, rate and volume live on the main window;
+this page holds everything else.
+
+| Setting | What it does |
+|---|---|
+| Enable speech preprocessing | Tidies text up before it is spoken — expanding abbreviations, dropping stray symbols. This is the master switch for all the clean-ups. |
+| Individual cleanup rules | Seven switches you can flick on and off one at a time: remove code blocks, strip bold and italic symbols, strip heading marks, shorten web links, strip bullet markers, expand abbreviations, and normalise whitespace. They only apply while the master switch is on. |
+| Rewind on resume (words) | When you carry on after a pause, rewind this many words so you regain your place. Set it to 0 for no rewind. |
+| Rewind on resume after (seconds) | Only rewind if the pause lasted longer than this. A quick pause carries on from the exact word. |
+| Announce progress every (percent) | How often your progress is spoken while reading something long. 25 means at 25%, 50% and 75%. |
+
+The skip-back grace window and the two "only announce above this many minutes"
+numbers have sensible defaults and hover help.
+
+### Transcript formatting
+
+Your own find-and-replace rules, applied to a transcript when you press **Format**.
+Rules run from top to bottom, so the order matters — use the up and down arrows to
+move them.
+
+| Setting | What it does |
+|---|---|
+| Find / Replace with | The text to look for, and what to put in its place. |
+| Match type | How Find is read. **Plain** replaces the literal text. **RegEx** treats it as a search pattern. **Smart** matches the word with the surrounding spaces and punctuation tidied up, which is the friendly choice for replacing a spoken word or phrase. |
+| Case sensitive | When on, capitals must match exactly. When off, case is ignored. |
+
+See [Automatic find-and-replace rules](transcript-formatting.md) for the full story.
+
+### Interface
+
+Small comforts for the main window.
+
+| Setting | What it does |
+|---|---|
+| Max text-box visible lines | Caps how tall the transcript and OCR boxes grow on the main window. |
+| Dictation insert preference | How your text reaches the app you are in. **Paste** puts it in via the clipboard, **SendKeys** types it out one key at a time, and **DoNotInsert** leaves the text in Mutation only. |
+| Reset window position | Puts Mutation's window back to its starting position and size. Handy if it has ended up off-screen. |
+
+### Hotkeys
+
+Every keyboard shortcut in one place, plus the shortcut router. This one has a
+chapter of its own: [Keyboard shortcuts](keyboard-shortcuts.md).
+
+## The reset buttons
+
+Next to most settings sits a small circular-arrow button. Your screen reader calls
+it "Reset to default", and hovering shows the same thing — on the Hotkeys page it
+even names the value, like "Reset to default (ALT+Q)".
+
+Each button resets **only the setting it sits beside**. There is no button that
+wipes the whole page or the whole app back to factory settings. If you want to
+undo a whole visit, press **Cancel** instead of **Save**.
+
+## Saving, and when saving goes wrong
+
+Nothing is written down until you press **Save**. That is the moment your changes
+reach the running app and get written to disk.
+
+If the save fails — the file is locked, the disk is full, something like that —
+Mutation tells you rather than failing quietly. A red bar appears at the bottom of
+the Settings window titled **Save failed**, with the actual reason, followed by:
+"Your changes were not saved. Fix the problem and press Save again, or press Cancel
+to discard the changes." You also hear the failure beep, and screen readers get an
+urgent announcement. Your changes are still sitting there in the window, so you can
+fix the problem and press Save again.
+
+The same treatment applies if the **Open Mutation.json** button cannot open the
+file: a bar titled "Could not open settings file", with the reason.
+
+## Where your settings live
+
+Everything is kept in a single file called **Mutation.json**, in the folder
+Mutation itself is installed in. Turn on the **Advanced** switch and press **Open
+Mutation.json** to see it.
+
+Two things worth knowing:
+
+- **Back it up.** Copy that one file somewhere safe and you have your shortcuts,
+  prompts, formatting rules and preferences saved. Dropping it back in place
+  restores the lot.
+- **Do not share it.** Your API keys are in there in plain text. Anyone who has the
+  file can spend money on your accounts. Never email it, paste it into a chat, or
+  attach it to a support ticket without stripping the keys out first.
+
+## One last thing
+
+You do not have to memorise any of this. Nearly every setting in the window has a
+small help icon beside it, and hovering over it — or landing on the setting with a
+screen reader — gives you the same plain explanation you have just read here.
+
+## Where to next
+
+- [Keyboard shortcuts](keyboard-shortcuts.md) — the Hotkeys page in full, including the shortcut router.
+- [Getting started](getting-started.md) — the handful of settings worth filling in first.
+- [A tour of the main window](main-window.md) — the settings that live on the main screen instead.
+- [Troubleshooting](troubleshooting.md) — when something is not behaving.

--- a/Documentation/UserGuide/markdown/transcript-formatting.md
+++ b/Documentation/UserGuide/markdown/transcript-formatting.md
@@ -1,0 +1,65 @@
+# Automatic find-and-replace rules
+
+Some corrections you end up making every single day. Dictation keeps hearing your company name "Ardvark Holdings" as "aardvark holdings". Or you say "um" more than you would like, and there it is in the text every time.
+
+Formatting rules fix those once and for all. A rule is a plain find-and-replace instruction, and Mutation applies your rules to every transcript automatically. No AI involved, nothing to press, no cost.
+
+---
+
+## Setting up rules
+
+Open **Settings** with **Ctrl+Comma** and go to **Transcript formatting**. Press **Add rule** to create one.
+
+A rule has three parts.
+
+- **Find** — the text you want Mutation to look for.
+- **Replace with** — what to put in its place. Leave it empty to simply delete the found text.
+- **Case sensitive** — when this is on, capital letters have to match exactly. When it is off, case is ignored. Off is the usual choice.
+
+Rules run from top to bottom, so the order can matter. The up and down arrow buttons on each row let you rearrange them, and **Delete** removes a rule.
+
+---
+
+## The three match types
+
+Each rule also has a **Match type**, which decides how the Find text is interpreted.
+
+**Plain** swaps the exact text wherever it turns up, including in the middle of longer words.
+
+**Smart** matches the word properly, tidying up the spaces and punctuation around it as it goes. This is the one most people want, and it is especially good for removing a spoken word cleanly without leaving a double space or a stranded comma behind.
+
+**RegEx** treats the Find box as a pattern written in a special pattern language for advanced users. If you do not know what this is, you do not need it. (If a pattern is malformed, Mutation shows the error in red under the row so you can fix it.)
+
+---
+
+## Some worked examples
+
+| Find | Replace with | Match type | What it does |
+|---|---|---|---|
+| aardvark holdings | Ardvark Holdings | Smart | Fixes a company name that dictation always mishears |
+| um | *(leave empty)* | Smart | Strips out "um" and closes the gap neatly |
+| ASAP | as soon as possible | Plain | Spells out an abbreviation everywhere it appears |
+
+---
+
+## When rules run
+
+Rules run automatically on every transcript, and they run **before** any AI prompt does. That order is deliberate: your names and jargon are already correct by the time the AI sees the text, so it has less chance of "correcting" them into something wrong.
+
+Mutation also does a small tidy-up pass of its own at the same time, collapsing doubled punctuation like "word.." down to a single mark.
+
+---
+
+## Running rules on demand
+
+You do not have to wait for a dictation. The **Format with rules** button sits next to the **Raw Transcript** box on the main window. Press it and Mutation applies your rules to whatever is in that box, puts the result in the **Formatted Transcript** box, copies it to your clipboard, and delivers it into the app you were working in.
+
+It is the same treatment a transcript gets automatically, just triggered by you — and it never contacts an AI, so it is instant and free.
+
+---
+
+## Where to next
+
+- [Dictation: turning speech into text](dictation.md) — where most transcripts come from
+- [Using AI prompts on your text](ai-prompts.md) — the AI step that runs after your rules
+- [The Settings window](settings.md) — finding your way around Settings

--- a/Documentation/UserGuide/markdown/troubleshooting.md
+++ b/Documentation/UserGuide/markdown/troubleshooting.md
@@ -1,0 +1,258 @@
+# Troubleshooting
+
+Most problems in Mutation fall into a handful of buckets. Find the one that sounds like
+yours below. Each entry says what is going on and what to do about it.
+
+## Common problems
+
+### A shortcut does nothing
+
+**What's happening.** Windows only lets one app own a global shortcut at a time.
+If another app grabbed your combination first, Mutation cannot have it. This is
+usually the cause when one shortcut is dead but the others all work.
+
+Mutation does not hide this. When it starts up, if any shortcut could not be claimed
+you get a failure beep and a dialog titled "Some hotkeys could not be registered",
+listing each one and the reason. A common reason reads "The shortcut is already
+registered by another application."
+
+**What to do.**
+
+1. Read the list in that dialog — it names the shortcuts that failed.
+2. Open **Settings** with **Ctrl+Comma** and go to the shortcuts section.
+3. Change the failed shortcut to a combination nothing else uses. Adding **Shift** to
+   an existing combination is often enough.
+4. Save. Every default shortcut in Mutation can be changed, so nothing is stuck.
+
+If a shortcut you just typed into Settings is rejected outright, the combination could
+not be understood. Use the shortcut editor to record the keys rather than typing them
+by hand.
+
+### Dictation comes back empty, or says no speech was detected
+
+**What's happening.** Mutation trims silence off your recording before sending it. If
+what is left is too short to be worth transcribing, it skips the request entirely and
+tells you "No speech detected — nothing to transcribe." That saves you the wait and
+the cost of a request that would have returned nothing.
+
+**What to do.**
+
+1. Check the right microphone is selected on the **Microphone** card, and that it is
+   not muted.
+2. Watch the level indicator while you talk — if it does not move, the microphone is
+   not picking you up.
+3. Start speaking a beat after the start beep, not on top of it.
+4. If your input level is very low, raise it on the **Microphone** card.
+
+### Dictation says the recorder is still busy
+
+**What's happening.** A previous recording is still being transcribed and the recorder
+is not free yet. Mutation refuses to start a new one on top of it rather than losing
+either recording.
+
+**What to do.** Wait for the previous transcription to finish — the status area will
+say when it is done — then press your dictation shortcut again.
+
+### Dictation is slow, or fails with a timeout
+
+**What's happening.** Transcription happens over the internet, so a slow connection or
+a busy service makes it slow. Mutation retries a failed attempt, giving each retry a
+longer window than the last, before it gives up. Long recordings naturally take longer
+than short ones.
+
+**What to do.**
+
+1. Give it a moment — the retries are automatic and you will hear the result.
+2. Record in shorter chunks. A two-minute note transcribes far faster than a
+   twenty-minute one.
+3. If it consistently times out, raise the timeout in **Settings**. There are separate
+   timeouts for live dictation and for transcribing a file, plus a per-attempt timeout
+   on each speech service.
+
+### OCR returns nothing useful, or the wrong reading order
+
+**What's happening.** OCR reads text out of a picture. If the picture is small,
+blurry, or is light text on a dark background, there may be nothing recognisable in
+it. Reading order is a separate matter: Mutation offers two layouts, and they suit
+different pages.
+
+**What to do.**
+
+1. Capture a tighter region at a larger zoom level. More pixels per letter helps a lot.
+2. If your text is light on a dark background, turn on the setting that inverts the
+   image colours before OCR.
+3. Try the other reading order. **Natural** layout follows the visual structure of the
+   page, which is better for columns and tables. **Basic** layout reads strictly left
+   to right, top to bottom, which is better for a plain block of text that Natural has
+   scrambled. Each has its own shortcut, so you can just try the other one.
+
+### OCR skipped a file for being too large
+
+**What's happening.** There is a maximum size for a file or page sent for OCR, so a
+huge file cannot be uploaded by accident. Anything over it is skipped before upload,
+and the failure message names the file, its size, and the limit.
+
+**What to do.** Open **Settings**, find the maximum document size under the OCR
+settings, and raise it — or set it to 0 for no limit at all. Alternatively, capture a
+smaller region or save the file at a lower resolution.
+
+### OCR stops after a couple of pages
+
+**What's happening.** The free OCR tier limits how many pages a single document can
+contain. Mutation respects that limit by default, sending documents in small batches,
+with the page limit set to 2 out of the box.
+
+**What to do.** If you are on a paid tier, turn off the free-tier option in
+**Settings** under the OCR settings. If you are staying on the free tier, raise the
+page limit only as far as your tier allows.
+
+### Nothing happens at all — a key is missing or wrong
+
+**What's happening.** Mutation talks to outside services to do dictation, OCR and AI
+processing. Each needs an API key (a long password that lets Mutation use the service
+on your behalf). Without one, the feature has nothing to talk to.
+
+On a brand-new install Mutation shows a welcome dialog explaining which keys it needs,
+then opens Settings on the API keys tab. If a speech service has no key, it is
+disabled and Mutation tells you which ones and why. For OCR you need both an Azure
+Computer Vision key **and** an endpoint, and Mutation says specifically which of the
+two is missing.
+
+**What to do.** Open **Settings** with **Ctrl+Comma**, go to the API keys tab, and
+paste in the key. Azure Computer Vision has its own tab, because the key and the
+endpoint live together there. Save, and try again.
+
+### The text didn't paste into the other app
+
+**What's happening.** Mutation delivers text through the clipboard, and only one app
+can hold the clipboard at a time. If another app is holding it at that moment, the copy
+fails. Mutation retries a few times before giving up. If it still cannot get through,
+you get a failure beep and a message like "The clipboard is in use by another
+application; the transcript could not be delivered. It is available in the Mutation
+window."
+
+**What to do.**
+
+1. Your text is not lost. Open the main window and copy it from there.
+2. Clipboard manager tools and remote-desktop sessions are the usual culprits. Closing
+   or pausing one often fixes it for good.
+3. If you rely on the text landing in another app automatically, set the "send keys
+   after" option to **Ctrl+V** so Mutation pastes for you once the copy succeeds.
+
+### Fast mode didn't actually run fast
+
+**What's happening.** Fast mode is a faster setting for AI prompts. If it is not
+available, Mutation does not throw your text away — it quietly runs the prompt again at
+standard speed and then tells you why Fast mode could not be used. There are three
+different reasons, and each needs a different response:
+
+- Fast mode is not enabled for your account. You need to request access for it.
+- Fast mode was rate limited or at capacity. Wait a moment and try again.
+- The model you chose does not offer Fast mode. Choose a different model.
+
+**What to do.** Listen to which of the three you got — the wording is deliberately
+different for each. You can also turn Fast mode off for that prompt in the prompt
+editor, which stops the notice appearing every time.
+
+### The wrong microphone is being used, or the mute didn't take
+
+**What's happening.** Mutation's mute shortcut mutes every microphone on the PC, not
+just the one it is recording with. It re-checks the list of devices when one is plugged
+in or unplugged, so a headset you just connected is covered too.
+
+Mutation also verifies that a mute actually took effect at the operating-system level.
+If it cannot confirm it, it will not pretend — you get "Could not change the microphone
+mute state. The microphone may still be live — please try again."
+
+**What to do.**
+
+1. Treat that message seriously. Assume the microphone is still live until you have
+   confirmed otherwise.
+2. Press the mute shortcut again and listen for the mute beep.
+3. If Mutation is recording from the wrong device, pick the right one on the
+   **Microphone** card. Setting the input level can also fail if a device is busy or
+   was just unplugged — you will be told, and can try again.
+
+### No voices in the voice list, or the voice sounds wrong
+
+**What's happening.** The voices Mutation offers for reading aloud come from Windows
+itself, not from Mutation. An empty or very short list means Windows has few voices
+installed.
+
+**What to do.**
+
+1. Install more voices through Windows Settings, under the speech options. Restart
+   Mutation afterwards so it picks them up.
+2. Choose the voice, rate and volume on the **Voice & Speech** section of the main
+   window.
+3. If the voice reads out stray symbols like asterisks and hash marks, turn on the
+   text clean-up options in **Settings**. There are individual switches for stripping
+   bold and italic marks, heading marks, bullet markers, code blocks, and for
+   shortening long web links.
+
+### Settings won't save
+
+**What's happening.** Mutation writes your settings to a file. If that write fails —
+the file is read-only, a backup tool has it open, or the folder is not writable — the
+save cannot complete. Mutation plays the failure beep, announces the problem, and shows
+"Save failed" along with the actual reason and the words "Your changes were not saved.
+Fix the problem and press Save again, or press Cancel to discard the changes."
+
+**What to do.**
+
+1. Read the reason given — it is the real cause, not a generic message.
+2. Close anything that might have the settings file open, including a text editor.
+3. Press Save again. Your changes are still in the dialog until you press Cancel.
+
+### Screen capture appears to be blocked
+
+**What's happening.** Some managed work PCs disable screen capture by policy, and some
+privacy and DRM-protected windows cannot be captured at all. Mutation tests this before
+it tries, and tells you when the test fails, with the technical detail included.
+
+**What to do.** If you are on a work device, this is a policy set by your IT
+department and Mutation cannot work around it — ask them. Otherwise, check for privacy
+or screen-recording-blocker software, and make sure the window you are capturing is not
+playing protected video.
+
+## Finding the log file
+
+When something goes wrong, Mutation writes a timestamped entry to a log file called
+`Mutation_Errors.log`. It lives here:
+
+```
+%LOCALAPPDATA%\Mutation\logs\Mutation_Errors.log
+```
+
+To open the folder, press **Windows+R**, paste `%LOCALAPPDATA%\Mutation\logs` into the
+box, and press Enter. Mutation also writes a copy of the log next to its own program
+file, in case the first location is unavailable.
+
+The log is capped in size. When it gets too big, the old contents are moved to
+`Mutation_Errors.log.old` and a fresh file is started — so if the problem happened a
+while back, check the `.old` file too.
+
+Your API keys are stripped out of the log before anything is written, so it is safe to
+share.
+
+## Reporting a problem
+
+If none of the above fixes it, please report it. The project's issues page is at
+[github.com/Subverting-complexity/Mutation](https://github.com/Subverting-complexity/Mutation/issues).
+
+Include as much of this as you can:
+
+- What you did, step by step, and what you expected to happen instead.
+- The exact wording of any message you saw or heard.
+- Which shortcut you pressed.
+- The relevant entries from `Mutation_Errors.log`, with their timestamps.
+- Your Windows version, and the name of your screen reader or magnifier if one was
+  running.
+
+## Where to next
+
+- [The Settings window](settings.md) — where most of the fixes above live.
+- [Keyboard shortcuts](keyboard-shortcuts.md) — changing a shortcut another app owns.
+- [Getting started](getting-started.md) — first-run setup and API keys.
+- [Screen reader and accessibility notes](accessibility.md) — beeps, announcements,
+  and the keyboard-driven capture overlay.

--- a/Documentation/userguide-template.html
+++ b/Documentation/userguide-template.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="$lang$"$if(dir)$ dir="$dir$"$endif$>
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>$pagetitle$</title>
+<meta name="generator" content="pandoc $pandoc-version$" />
+$for(header-includes)$
+$header-includes$
+$endfor$
+$for(css)$
+<link rel="stylesheet" href="$css$" />
+$endfor$
+</head>
+<body>
+<a class="skip" href="#content">Skip to the main content</a>
+<div class="layout">
+$for(include-before)$
+$include-before$
+$endfor$
+<main id="content" tabindex="-1">
+$body$
+$for(include-after)$
+$include-after$
+$endfor$
+</main>
+</div>
+</body>
+</html>

--- a/Documentation/userguide.css
+++ b/Documentation/userguide.css
@@ -74,9 +74,13 @@ blockquote{
 }
 blockquote p{margin:.3rem 0}
 
-/* Pandoc emits bare tables; the wrapper keeps wide ones scrollable on phones. */
-table{border-collapse:collapse; width:100%; margin:1rem 0; display:block; overflow-x:auto}
-thead,tbody,tr{width:100%}
+/*
+	The wrapper scrolls, not the table. Setting `display: block` on a <table> to
+	make it scroll costs the element its table semantics in some screen readers,
+	so userguide.lua wraps each table in .table-wrap and the table stays a table.
+*/
+.table-wrap{overflow-x:auto; margin:1rem 0}
+table{border-collapse:collapse; width:100%; min-width:26rem}
 th,td{border:1px solid var(--rule); padding:.5rem .65rem; vertical-align:top}
 th{background:var(--surface); font-weight:700; text-align:left}
 tbody tr:nth-child(even){background:var(--surface)}
@@ -87,9 +91,15 @@ kbd{background:var(--surface); border:1px solid var(--rule); border-bottom-width
 footer{margin-top:3rem; padding-top:1rem; border-top:1px solid var(--rule); color:var(--muted); font-size:.9rem}
 
 @media (max-width:860px){
-	.layout{flex-direction:column; padding:1rem}
+	/*
+		align-items must go back to stretch when the layout stacks. Left at
+		flex-start, main sizes to its widest child instead of the viewport, so a
+		wide table drags the whole page sideways rather than scrolling inside
+		its own .table-wrap.
+	*/
+	.layout{flex-direction:column; align-items:stretch; padding:1rem}
 	.sidebar{position:static; flex:1 1 auto; width:100%}
-	main{max-width:none}
+	main{max-width:none; width:100%; min-width:0}
 }
 
 @media print{

--- a/Documentation/userguide.css
+++ b/Documentation/userguide.css
@@ -1,0 +1,100 @@
+/*
+	userguide.css — styling for the generated Mutation user guide pages.
+
+	This file is inlined into every page at build time (pandoc --embed-resources),
+	so the generated HTML has no external dependencies and opens straight off disk.
+
+	Built to stay readable for a screen-reader and ZoomText user: real focus
+	outlines, generous text size, high contrast in both themes, and a print
+	stylesheet that drops the navigation.
+*/
+
+:root{
+	color-scheme: light dark;
+	--bg:#ffffff; --fg:#1b1b1f; --muted:#5a5a66; --rule:#d9d9e0;
+	--accent:#0b5fa5; --accent-fg:#ffffff; --surface:#f5f5f8; --code:#f0f0f4;
+	--quote:#eef4fb; --quote-rule:#0b5fa5;
+}
+@media (prefers-color-scheme: dark){
+	:root{
+		--bg:#15151a; --fg:#eaeaf0; --muted:#a8a8b6; --rule:#3a3a45;
+		--accent:#6fb3ff; --accent-fg:#10131a; --surface:#1e1e26; --code:#22222c;
+		--quote:#1c2530; --quote-rule:#6fb3ff;
+	}
+}
+
+*{box-sizing:border-box}
+html{font-size:106%}
+body{
+	margin:0; background:var(--bg); color:var(--fg);
+	font-family:"Segoe UI",system-ui,-apple-system,Arial,sans-serif;
+	line-height:1.65;
+}
+
+.skip{
+	position:absolute; left:-9999px; top:0; padding:.6rem 1rem; z-index:10;
+	background:var(--accent); color:var(--accent-fg); font-weight:600;
+}
+.skip:focus{left:0}
+
+.layout{display:flex; align-items:flex-start; gap:2rem; max-width:1180px; margin:0 auto; padding:1.5rem}
+
+.sidebar{
+	flex:0 0 16rem; position:sticky; top:1.5rem;
+	background:var(--surface); border:1px solid var(--rule); border-radius:10px; padding:1rem 1.1rem;
+}
+.sidebar h2{font-size:1rem; margin:0 0 .6rem; text-transform:uppercase; letter-spacing:.04em; color:var(--muted)}
+.sidebar ol{list-style:none; margin:0; padding:0}
+.sidebar li{margin:.15rem 0}
+.sidebar a{display:block; padding:.3rem .45rem; border-radius:6px; text-decoration:none; color:var(--fg)}
+.sidebar a:hover{background:var(--bg); text-decoration:underline}
+.sidebar a[aria-current="page"]{background:var(--accent); color:var(--accent-fg); font-weight:600}
+
+main{flex:1 1 auto; min-width:0; max-width:52rem}
+
+h1{font-size:2.1rem; line-height:1.2; margin:.2rem 0 1rem; border-bottom:3px solid var(--accent); padding-bottom:.5rem}
+h2{font-size:1.5rem; margin:2.2rem 0 .7rem; border-bottom:1px solid var(--rule); padding-bottom:.3rem}
+h3{font-size:1.2rem; margin:1.7rem 0 .5rem}
+h4{font-size:1.05rem; margin:1.4rem 0 .4rem}
+p{margin:.7rem 0}
+
+a{color:var(--accent)}
+a:focus-visible,button:focus-visible,main:focus-visible{outline:3px solid var(--accent); outline-offset:2px}
+
+ul,ol{margin:.7rem 0; padding-left:1.6rem}
+li{margin:.3rem 0}
+
+code{background:var(--code); padding:.12em .38em; border-radius:4px; font-family:Consolas,"Cascadia Mono",monospace; font-size:.92em}
+pre{background:var(--code); border:1px solid var(--rule); border-radius:8px; padding:.9rem 1rem; overflow-x:auto}
+pre code{background:none; padding:0; font-size:.9em}
+
+blockquote{
+	margin:1rem 0; padding:.7rem 1rem; background:var(--quote);
+	border-left:5px solid var(--quote-rule); border-radius:0 8px 8px 0;
+}
+blockquote p{margin:.3rem 0}
+
+/* Pandoc emits bare tables; the wrapper keeps wide ones scrollable on phones. */
+table{border-collapse:collapse; width:100%; margin:1rem 0; display:block; overflow-x:auto}
+thead,tbody,tr{width:100%}
+th,td{border:1px solid var(--rule); padding:.5rem .65rem; vertical-align:top}
+th{background:var(--surface); font-weight:700; text-align:left}
+tbody tr:nth-child(even){background:var(--surface)}
+
+hr{border:none; border-top:1px solid var(--rule); margin:2rem 0}
+kbd{background:var(--surface); border:1px solid var(--rule); border-bottom-width:2px; border-radius:5px; padding:.1em .4em}
+
+footer{margin-top:3rem; padding-top:1rem; border-top:1px solid var(--rule); color:var(--muted); font-size:.9rem}
+
+@media (max-width:860px){
+	.layout{flex-direction:column; padding:1rem}
+	.sidebar{position:static; flex:1 1 auto; width:100%}
+	main{max-width:none}
+}
+
+@media print{
+	.sidebar,.skip{display:none}
+	body{background:#fff; color:#000}
+	.layout{display:block; max-width:none; padding:0}
+	a{color:#000}
+}

--- a/Documentation/userguide.lua
+++ b/Documentation/userguide.lua
@@ -1,0 +1,50 @@
+--[[
+	userguide.lua — pandoc filter for the Mutation user guide.
+
+	Two jobs:
+
+	1. Rewrite relative links that point at a .md chapter so they point at the
+	   generated .html page instead. The Markdown stays correct on its own terms
+	   (chapters link to chapters), and the built site stays self-consistent.
+
+	2. Mark every table header cell with scope="col". Pandoc does not emit scope
+	   itself, and screen readers rely on it to say which column a value is under.
+	   Every table in this guide is column-headed, so this is safe across the set.
+]]
+
+--- Rewrite chapter.md -> chapter.html, leaving absolute URLs alone.
+function Link(el)
+	local target = el.target
+
+	-- Anything with a scheme (http:, https:, mailto:) is external: leave it.
+	if target:match("^%a[%w+.-]*:") then
+		return nil
+	end
+
+	-- chapter.md#anchor -> chapter.html#anchor
+	-- Lua patterns have no alternation, so the two cases are matched separately.
+	local base, anchor = target:match("^(.-)%.md(#.*)$")
+	if base then
+		el.target = base .. ".html" .. anchor
+		return el
+	end
+
+	-- chapter.md -> chapter.html
+	base = target:match("^(.-)%.md$")
+	if base then
+		el.target = base .. ".html"
+		return el
+	end
+
+	return nil
+end
+
+--- Add scope="col" to the header cells of every table.
+function Table(tbl)
+	for _, row in ipairs(tbl.head.rows) do
+		for _, cell in ipairs(row.cells) do
+			cell.attr.attributes["scope"] = "col"
+		end
+	end
+	return tbl
+end

--- a/Documentation/userguide.lua
+++ b/Documentation/userguide.lua
@@ -39,12 +39,25 @@ function Link(el)
 	return nil
 end
 
---- Add scope="col" to the header cells of every table.
+--- Add scope="col" to the header cells of every table, and wrap the table in a
+--- scrollable div.
+---
+--- The wrapper matters for accessibility, not just looks. A wide table has to be
+--- able to scroll sideways on a narrow window, but doing that with
+--- `table { display: block }` drops the element's implicit table semantics in
+--- several browser and screen-reader combinations, so the rows and columns stop
+--- being announced as a table. Scrolling the wrapper instead leaves the table a
+--- table.
 function Table(tbl)
 	for _, row in ipairs(tbl.head.rows) do
 		for _, cell in ipairs(row.cells) do
 			cell.attr.attributes["scope"] = "col"
 		end
 	end
-	return tbl
+
+	return {
+		pandoc.RawBlock("html", '<div class="table-wrap">'),
+		tbl,
+		pandoc.RawBlock("html", "</div>"),
+	}
 end


### PR DESCRIPTION
## What this adds

A 13-chapter **user guide** for Mutation, written for a general office worker rather than a developer, plus a one-click build that renders it to self-contained HTML.

The Markdown in `Documentation/UserGuide/markdown` is the source of truth. The generated pages in `Documentation/UserGuide/html` are checked in so the app can open the guide locally later without a build step.

### Chapters

Getting started · main window tour · microphone · dictation · screenshots & OCR · read aloud · AI prompts · find-and-replace rules · keyboard shortcuts · settings · accessibility · troubleshooting, all reachable from `index.md`. Around 17,000 words.

### Build

```
Documentation/Build-UserGuide.cmd      double-click to rebuild
Documentation/Convert-UserGuide.ps1    finds pandoc, drives the build
Documentation/userguide-template.html  page shell
Documentation/userguide.css            styling, inlined into each page
Documentation/userguide.lua            .md -> .html links, table scope
```

## Heads-up: `pandoc.exe` is gitignored

At ~220 MB it is over **GitHub's 100 MB per-file limit**, so a push containing it would be rejected outright. It is excluded in `.gitignore`.

The build looks for pandoc in `Documentation/`, then on `PATH`, then at `-Pandoc <path>`. If none match it stops with a plain message saying where to put it. Anyone cloning fresh needs to drop pandoc in themselves — documented in `Documentation/UserGuide/README.md`.

## Accessibility of the generated pages

This project is used with a screen reader and ZoomText, so the output is accessible by construction and verified in a browser: `lang` set, skip-to-content link, labelled `<nav>` landmark with `aria-current` on the current page, `<main>` landmark, headings in document order, `scope="col"` on every table header, visible focus outlines, light/dark theme following the OS, and a print stylesheet.

## Corrections made while writing

Chapter content was checked against the code, not the README — they disagree in places. The README's example JSON in particular shows values that are **not** the shipped defaults.

| Topic | What the guide says, and why |
|---|---|
| Dictation shortcuts | `SHIFT+ALT+U` / `SHIFT+ALT+I` per `SettingsDefaults.cs`, not the README's `Ctrl+Shift+T` / `Ctrl+Shift+Y` |
| Pause/resume | `CTRL+SHIFT+SPACE` is the real pause; the speak key stops and restarts. Two distinct behaviours |
| Automation dropdown | Displays `Paste` / `SendKeys` / `DoNotInsert` — it binds enum values with no converter, so the friendly `[Description]` strings never appear |
| Speak to file | Registered as a global hotkey but has no row on the Hotkeys settings page and no default |

## Possible bugs spotted, not fixed here

- `README.md`'s example configuration lists different shortcuts than the actual defaults — anyone following it configures something other than what ships.
- `MainWindow.xaml` has `VisualState` setters targeting `FormattingActionsPanel.Orientation` (lines 981 and 1008), but no element with that name exists in the file. Looks like a leftover from a removed panel.

Happy to file these as issues if you want them tracked.

## Testing

- `dotnet test --configuration Release` — **923 passed, 0 failed**. No production code changed.
- Build run end to end via the `.cmd` wrapper; exit code 0.
- Failure paths checked: missing pandoc, bad `-Pandoc` path, missing markdown folder — each gives a plain one-line message and exit code 1.
- Generated pages verified in a browser for structure, link rewriting, inlined CSS and the accessibility points above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)