### PR TITLE
Add a User guide button, a Documentation README, and a docs-sync rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,11 +60,74 @@ development:
   a GitHub issue. Never silently skip problems.
 - **Blocks current story**: Fix it first on its own branch.
 
+## Documentation
+
+The user guide lives in `Documentation/UserGuide/markdown/`. It is the
+source of truth; `Documentation/UserGuide/html/` is generated output.
+See `Documentation/README.md` for the folder layout and the build.
+
+### Keep it in sync — same PR, every time
+
+**Whenever behaviour a user can see changes, update the guide in the same
+pull request.** Never leave it for later; a guide that lies is worse than
+no guide. That includes:
+
+- New features, or features removed.
+- Changed default hotkeys, setting names, ranges, or defaults.
+- Renamed or moved buttons, cards, menus, or settings pages.
+- Changed messages, beeps, or announcements the user hears or reads.
+- New failure modes worth a `troubleshooting.md` entry.
+
+Then rebuild and commit the HTML:
+
+```bash
+Documentation\Build-UserGuide.cmd
+```
+
+Markdown and generated HTML must be committed together so they never
+drift. Add a new chapter by following `Documentation/UserGuide/README.md`,
+and link it from `index.md`.
+
+**Verify against the code, not the README.** Root `README.md` has drifted
+from the shipped defaults before. `Mutation.Ui/Views/Settings/SettingsDefaults.cs`
+is authoritative for defaults, and the XAML is authoritative for what a
+control is actually labelled on screen.
+
+### Tone — plain, friendly, and for a general office worker
+
+The reader is **not** a developer. Write for someone who has never heard
+the words "API", "regex", or "endpoint".
+
+- Short sentences, one idea each. Address the reader as "you".
+- Warm and helpful, like a colleague showing someone the ropes. Never
+  stiff, never salesy, never patronising.
+- Explain any unavoidable technical term in plain words the first time it
+  appears, in the same sentence — for example, "an API key (a long
+  password that lets Mutation talk to the service on your behalf)".
+- Prefer a concrete example over an abstract description. Say what the
+  reader does, and what they see or hear happen.
+- Say it once, briefly. If a feature is simple, two lines is the right
+  length. No padding, no marketing language, no "leverage" or "seamlessly".
+- Never invent behaviour. Everything must be traceable to the code. If you
+  are unsure, leave it out rather than guess.
+- Bold for keyboard shortcuts (**Ctrl+Shift+M**) and for on-screen names,
+  matching the label the app actually shows.
+- Make clear that default shortcuts can be changed.
+- End each chapter with a short **Where to next** section linking to the
+  2–4 most related chapters.
+
+Write Markdown, not HTML — raw HTML is escaped by the build on purpose, so
+a stray tag cannot break the screen-reader landmarks in the page.
+
 ## Accessibility
 
 This app is used by a blind developer with ZoomText; screen-reader
 accessibility is a core requirement for all UI work. Prefer configurable
 controls exposed in the UI over hidden simplified defaults.
+
+This extends to generated documentation: the guide's HTML keeps proper
+landmarks, heading order, table header scope, and visible focus outlines.
+Do not regress those when changing the page template or stylesheet.
 
 ## Session Hygiene
 
@@ -87,6 +150,8 @@ relevant to what you're working on.
 | `ClaudeProject.md` | Project identity, labels, quality gate, branch convention, board config. Read at the start of any workflow command. |
 | `AGENTS.md` | Tech stack (.NET 10, WinUI 3), build & test commands, code conventions. |
 | `docs/review.config.md` | Review label definitions, non-compliance gates, tech-stack review rules. Read when performing or preparing for code review. |
+| `Documentation/README.md` | User guide folder layout, which files are authoritative, and how to regenerate the HTML. Read whenever a change affects what users see. |
+| `Documentation/UserGuide/README.md` | Adding a chapter, supported Markdown, how the generated pages stay accessible. |
 | `.claude/ecosystem.md` | Installed Claude Code companion tool cheat-sheet — graphify queries, cost tracking, security scanning. |
 
 Add your own reference docs to this table as needed — architecture

--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -1,0 +1,68 @@
+# Documentation
+
+Everything written for people who *use* Mutation lives here. Notes for people who
+*build* Mutation live in `AGENTS.md` and `CLAUDE.md` at the root of the repository.
+
+## What is in each folder
+
+| Folder or file | What it holds |
+|---|---|
+| `UserGuide/markdown/` | **The user guide itself.** One Markdown file per chapter. This is the source of truth — edit these. |
+| `UserGuide/html/` | The same guide as web pages. **Generated. Never edit by hand.** Checked in so the app can open the guide without a build step. |
+| `UserGuide/README.md` | Notes for whoever maintains the guide: how to add a chapter, which Markdown features are supported, how the pages are made accessible. |
+| `UserGuideBuilder/` | The small .NET program that turns the Markdown into the web pages. |
+| `Build-UserGuide.cmd` | Double-click this to regenerate the web pages. |
+
+## The Markdown is the authority
+
+`UserGuide/markdown/*.md` is the real guide. The HTML in `UserGuide/html/` is output —
+it is produced from the Markdown every time the build runs.
+
+That means two rules, and they matter:
+
+1. **Change the Markdown, never the HTML.** Any edit made directly to an HTML file is
+   silently thrown away the next time someone builds.
+2. **Commit the regenerated HTML with your Markdown change**, so the two never drift
+   apart. The app opens the HTML, so stale HTML means users read stale instructions.
+
+## Generating the HTML
+
+Double-click `Build-UserGuide.cmd`, or run it from a prompt:
+
+```bash
+Documentation\Build-UserGuide.cmd
+```
+
+That is the whole process. It rewrites every page in `UserGuide/html/` and reports what
+it wrote.
+
+Everything needed is in this repository. The only thing you need installed is the .NET
+SDK, which you already have if you can build Mutation itself — there is no separate
+tool to download and nothing to put on your PATH.
+
+If you are working on the converter, you can also run it directly:
+
+```bash
+dotnet run --project Documentation/UserGuideBuilder
+```
+
+The converter is covered by tests that run with the normal suite:
+
+```bash
+dotnet test --configuration Release
+```
+
+## Reading the guide
+
+Open `UserGuide/html/index.html` in any browser, or click **User guide** in the top
+right of Mutation's main window.
+
+Each page is self-contained — the styling is built into the file — so the pages work
+straight off disk with no internet connection and no other files needed.
+
+## Keeping the guide honest
+
+When you change how Mutation behaves, update the guide in the same pull request. The
+rules on when and how are in [`CLAUDE.md`](../CLAUDE.md) under **Documentation**; the
+short version is that the guide is written in plain, friendly language for an ordinary
+office worker, and it should stay that way.

--- a/Documentation/UserGuide/html/getting-started.html
+++ b/Documentation/UserGuide/html/getting-started.html
@@ -216,6 +216,10 @@ footer{margin-top:3rem; padding-top:1rem; border-top:1px solid var(--rule); colo
 <li><strong>Read text off the screen.</strong> Press <strong>Shift+Alt+J</strong>, drag a rectangle over some text in an image, and the text lands on your clipboard. This one needs the Azure key. See <a href="screen-capture-and-ocr.html">Screenshots and reading text from images</a>.</li>
 </ol>
 <p>That is the core of it. Everything else builds on those four ideas.</p>
+<blockquote>
+<p><strong>Lost at any point?</strong> Click <strong>User guide</strong> in the top right of Mutation's main
+window, or press <strong>Alt</strong> then <strong>G</strong>, and this guide opens in your browser.</p>
+</blockquote>
 <hr />
 <h2 id="leave-it-running">Leave it running</h2>
 <p>Mutation does its job from the background. Once it is started you can minimise the main window and forget about it — the shortcuts keep working no matter which app you are using. Closing the window shuts the app down, and the shortcuts stop with it, so minimise rather than close if you want them to stay live.</p>

--- a/Documentation/UserGuide/html/main-window.html
+++ b/Documentation/UserGuide/html/main-window.html
@@ -174,6 +174,12 @@ footer{margin-top:3rem; padding-top:1rem; border-top:1px solid var(--rule); colo
 </table>
 </div>
 <p>See <a href="settings.html">The Settings window</a> for what is inside Settings.</p>
+<h2 id="the-user-guide-button">The User guide button</h2>
+<p>Top right, opposite the menu, is a <strong>User guide</strong> button with the subtext &quot;Read the
+documentation&quot;. Click it — or press <strong>Alt</strong> then <strong>G</strong> — and this guide opens in your
+usual web browser, at the contents page.</p>
+<p>The guide is installed along with Mutation and lives on your own computer, so it works
+with no internet connection.</p>
 <hr />
 <h2 id="the-microphone-card">The Microphone card</h2>
 <p>This is the mute switch. It turns every microphone on your PC on or off at once, so you never have to hunt for the mute button in whichever meeting app you happen to be in.</p>

--- a/Documentation/UserGuide/markdown/getting-started.md
+++ b/Documentation/UserGuide/markdown/getting-started.md
@@ -77,6 +77,9 @@ Give these a go, in any app you like. These are the shortcuts Mutation starts wi
 
 That is the core of it. Everything else builds on those four ideas.
 
+> **Lost at any point?** Click **User guide** in the top right of Mutation's main
+> window, or press **Alt** then **G**, and this guide opens in your browser.
+
 ---
 
 ## Leave it running

--- a/Documentation/UserGuide/markdown/main-window.md
+++ b/Documentation/UserGuide/markdown/main-window.md
@@ -21,6 +21,15 @@ Top left is a single **Menu** button (the three-line "hamburger" icon). Press **
 
 See [The Settings window](settings.md) for what is inside Settings.
 
+## The User guide button
+
+Top right, opposite the menu, is a **User guide** button with the subtext "Read the
+documentation". Click it — or press **Alt** then **G** — and this guide opens in your
+usual web browser, at the contents page.
+
+The guide is installed along with Mutation and lives on your own computer, so it works
+with no internet connection.
+
 ---
 
 ## The Microphone card

--- a/Mutation.Tests/UserGuideLocatorTests.cs
+++ b/Mutation.Tests/UserGuideLocatorTests.cs
@@ -1,0 +1,101 @@
+using System;
+using System.IO;
+using Mutation.Ui.Services;
+
+namespace Mutation.Tests;
+
+/// <summary>
+/// Covers finding the user guide that the User guide button on the main window
+/// opens. The guide ships beside the executable, so the lookup has to agree with
+/// where the build puts it.
+/// </summary>
+public class UserGuideLocatorTests
+{
+	[Fact]
+	public void GetIndexPath_points_at_the_guide_folder_beside_the_executable()
+	{
+		string path = UserGuideLocator.GetIndexPath(@"C:\Program Files\Mutation");
+
+		Assert.Equal(@"C:\Program Files\Mutation\UserGuide\index.html", path);
+	}
+
+	[Theory]
+	[InlineData("")]
+	[InlineData("   ")]
+	public void GetIndexPath_rejects_a_missing_base_directory(string baseDirectory)
+	{
+		Assert.Throws<ArgumentException>(() => UserGuideLocator.GetIndexPath(baseDirectory));
+	}
+
+	[Fact]
+	public void GetIndexPath_rejects_a_null_base_directory()
+	{
+		Assert.Throws<ArgumentNullException>(() => UserGuideLocator.GetIndexPath(null!));
+	}
+
+	[Fact]
+	public void Locate_finds_the_guide_when_it_is_installed()
+	{
+		using TempDirectory root = new();
+		string guideFolder = Path.Combine(root.Path, UserGuideLocator.GuideFolderName);
+		Directory.CreateDirectory(guideFolder);
+		string indexPath = Path.Combine(guideFolder, UserGuideLocator.IndexFileName);
+		File.WriteAllText(indexPath, "<p>guide</p>");
+
+		UserGuideLocator.Result result = UserGuideLocator.Locate(root.Path);
+
+		Assert.True(result.Found);
+		Assert.Equal(indexPath, result.IndexPath);
+		Assert.Null(result.ErrorMessage);
+	}
+
+	[Fact]
+	public void Locate_explains_itself_when_the_guide_is_not_installed()
+	{
+		using TempDirectory root = new();
+
+		UserGuideLocator.Result result = UserGuideLocator.Locate(root.Path);
+
+		Assert.False(result.Found);
+		Assert.NotNull(result.ErrorMessage);
+		// The message is read aloud and shown on screen, so it has to say where it
+		// looked and what to do - not just that something went wrong.
+		Assert.Contains(result.IndexPath, result.ErrorMessage!, StringComparison.Ordinal);
+		Assert.Contains("reinstalling", result.ErrorMessage!, StringComparison.OrdinalIgnoreCase);
+	}
+
+	[Fact]
+	public void Locate_still_reports_the_path_it_looked_in_when_the_guide_is_missing()
+	{
+		using TempDirectory root = new();
+
+		UserGuideLocator.Result result = UserGuideLocator.Locate(root.Path);
+
+		Assert.Equal(UserGuideLocator.GetIndexPath(root.Path), result.IndexPath);
+	}
+
+	private sealed class TempDirectory : IDisposable
+	{
+		public string Path { get; }
+
+		public TempDirectory()
+		{
+			Path = System.IO.Path.Combine(
+				System.IO.Path.GetTempPath(),
+				"mutation-guide-locator-" + Guid.NewGuid().ToString("n"));
+			Directory.CreateDirectory(Path);
+		}
+
+		public void Dispose()
+		{
+			try
+			{
+				Directory.Delete(Path, recursive: true);
+			}
+			catch (IOException)
+			{
+				// A locked temp file must not fail the test run.
+			}
+		}
+	}
+}

--- a/Mutation.Ui/MainWindow.xaml
+++ b/Mutation.Ui/MainWindow.xaml
@@ -78,44 +78,55 @@
                 <FontIcon Glyph="&#xE700;" FontFamily="Segoe Fluent Icons"/>
             </Button>
 
-            <StackPanel Grid.Column="1" Margin="32,24,32,12" Spacing="4">
-                <TextBlock Text="Mutation Workspace" Style="{StaticResource TitleTextStyle}" AutomationProperties.Name="Application Title" />
-                <TextBlock Text="Capture ideas, format transcripts, and automate workflows from one polished surface." Style="{StaticResource SubtitleTextStyle}" />
-            </StackPanel>
+            <!--
+                Title on the left, User guide button on the right, sharing the same
+                column as the content below so the button lines up with the cards.
+                The button column is Auto so its text never wraps; the title takes
+                whatever is left and wraps instead when the window is narrow.
+            -->
+            <Grid Grid.Column="1" Margin="32,24,32,12" ColumnSpacing="16">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
 
-            <!-- User guide (Top Right) -->
-            <Button
-                x:Name="UserGuideButton"
-                Grid.Column="2"
-                Style="{StaticResource SubtleButtonStyle}"
-                Margin="0,24,16,12"
-                HorizontalAlignment="Right"
-                VerticalAlignment="Top"
-                AccessKey="G"
-                Click="UserGuideButton_Click"
-                AutomationProperties.Name="User guide"
-                AutomationProperties.HelpText="Read the documentation. Opens the Mutation user guide in your web browser."
-                ToolTipService.ToolTip="Read the documentation (opens in your browser)">
-                <Grid ColumnSpacing="12">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="Auto" />
-                        <ColumnDefinition Width="*" />
-                    </Grid.ColumnDefinitions>
-                    <FontIcon
-                        Glyph="&#xE897;"
-                        FontFamily="Segoe Fluent Icons"
-                        HorizontalAlignment="Left"
-                        VerticalAlignment="Center" />
-                    <StackPanel Grid.Column="1" Spacing="2" VerticalAlignment="Center">
-                        <TextBlock Text="User guide" TextWrapping="Wrap" />
-                        <TextBlock
-                            Text="Read the documentation"
-                            Style="{StaticResource CaptionTextStyle}"
-                            TextWrapping="Wrap"
-                            Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
-                    </StackPanel>
-                </Grid>
-            </Button>
+                <StackPanel Spacing="4" VerticalAlignment="Top">
+                    <TextBlock Text="Mutation Workspace" Style="{StaticResource TitleTextStyle}" AutomationProperties.Name="Application Title" />
+                    <TextBlock Text="Capture ideas, format transcripts, and automate workflows from one polished surface." Style="{StaticResource SubtitleTextStyle}" />
+                </StackPanel>
+
+                <!-- User guide (Top Right) -->
+                <Button
+                    x:Name="UserGuideButton"
+                    Grid.Column="1"
+                    Style="{StaticResource SubtleButtonStyle}"
+                    VerticalAlignment="Top"
+                    AccessKey="G"
+                    Click="UserGuideButton_Click"
+                    AutomationProperties.Name="User guide"
+                    AutomationProperties.HelpText="Read the documentation. Opens the Mutation user guide in your web browser."
+                    ToolTipService.ToolTip="Read the documentation (opens in your browser)">
+                    <Grid ColumnSpacing="12">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <FontIcon
+                            Glyph="&#xE897;"
+                            FontFamily="Segoe Fluent Icons"
+                            HorizontalAlignment="Left"
+                            VerticalAlignment="Center" />
+                        <StackPanel Grid.Column="1" Spacing="2" VerticalAlignment="Center">
+                            <TextBlock Text="User guide" TextWrapping="NoWrap" />
+                            <TextBlock
+                                Text="Read the documentation"
+                                Style="{StaticResource CaptionTextStyle}"
+                                TextWrapping="NoWrap"
+                                Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                        </StackPanel>
+                    </Grid>
+                </Button>
+            </Grid>
         </Grid>
 
         <Grid Grid.Row="1">

--- a/Mutation.Ui/MainWindow.xaml
+++ b/Mutation.Ui/MainWindow.xaml
@@ -82,6 +82,40 @@
                 <TextBlock Text="Mutation Workspace" Style="{StaticResource TitleTextStyle}" AutomationProperties.Name="Application Title" />
                 <TextBlock Text="Capture ideas, format transcripts, and automate workflows from one polished surface." Style="{StaticResource SubtitleTextStyle}" />
             </StackPanel>
+
+            <!-- User guide (Top Right) -->
+            <Button
+                x:Name="UserGuideButton"
+                Grid.Column="2"
+                Style="{StaticResource SubtleButtonStyle}"
+                Margin="0,24,16,12"
+                HorizontalAlignment="Right"
+                VerticalAlignment="Top"
+                AccessKey="G"
+                Click="UserGuideButton_Click"
+                AutomationProperties.Name="User guide"
+                AutomationProperties.HelpText="Read the documentation. Opens the Mutation user guide in your web browser."
+                ToolTipService.ToolTip="Read the documentation (opens in your browser)">
+                <Grid ColumnSpacing="12">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <FontIcon
+                        Glyph="&#xE897;"
+                        FontFamily="Segoe Fluent Icons"
+                        HorizontalAlignment="Left"
+                        VerticalAlignment="Center" />
+                    <StackPanel Grid.Column="1" Spacing="2" VerticalAlignment="Center">
+                        <TextBlock Text="User guide" TextWrapping="Wrap" />
+                        <TextBlock
+                            Text="Read the documentation"
+                            Style="{StaticResource CaptionTextStyle}"
+                            TextWrapping="Wrap"
+                            Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                    </StackPanel>
+                </Grid>
+            </Button>
         </Grid>
 
         <Grid Grid.Row="1">

--- a/Mutation.Ui/MainWindow.xaml.cs
+++ b/Mutation.Ui/MainWindow.xaml.cs
@@ -2611,6 +2611,44 @@ public sealed partial class MainWindow : Window, IDisposable
 		await ShowSettingsDialogAsync();
 	}
 
+	/// <summary>
+	/// Opens the user guide's contents page in whatever browser the user has set as
+	/// their default. The guide ships beside the executable, so this works offline.
+	/// </summary>
+	private async void UserGuideButton_Click(object sender, RoutedEventArgs e)
+	{
+		UserGuideLocator.Result guide = UserGuideLocator.Locate(AppContext.BaseDirectory);
+
+		if (!guide.Found)
+		{
+			BeepPlayer.Play(BeepType.Failure);
+			ShowStatus("User guide", guide.ErrorMessage!, InfoBarSeverity.Warning);
+			return;
+		}
+
+		try
+		{
+			// Handing a file to the shell can block while the browser starts, so it
+			// stays off the UI thread.
+			await Task.Run(() =>
+			{
+				using var _ = System.Diagnostics.Process.Start(
+					new System.Diagnostics.ProcessStartInfo(guide.IndexPath) { UseShellExecute = true });
+			});
+
+			ShowStatus("User guide", "Opening the user guide in your browser.", InfoBarSeverity.Informational);
+		}
+		catch (Exception ex)
+		{
+			ErrorLogger.LogError(nameof(UserGuideButton_Click), ex);
+			BeepPlayer.Play(BeepType.Failure);
+			ShowStatus(
+				"User guide",
+				"The user guide could not be opened. Check that a web browser is set as the default for .html files.",
+				InfoBarSeverity.Warning);
+		}
+	}
+
 	internal void ApplyLiveSettings()
 	{
 		try

--- a/Mutation.Ui/Mutation.Ui.csproj
+++ b/Mutation.Ui/Mutation.Ui.csproj
@@ -35,6 +35,19 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<!--
+			Ship the generated user guide beside the executable so the User guide
+			button works on an installed copy with no internet connection. The pages
+			are self-contained (styling is inlined), so the .html files are all that
+			is needed. Regenerate them with Documentation\Build-UserGuide.cmd.
+		-->
+		<Content Include="..\Documentation\UserGuide\html\*.html"
+		         Link="UserGuide\%(Filename)%(Extension)">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</Content>
+	</ItemGroup>
+
+	<ItemGroup>
 		<Content Include="Assets\SplashScreen.scale-200.png" />
 		<Content Include="Assets\LockScreenLogo.scale-200.png" />
 		<Content Include="Assets\Square150x150Logo.scale-200.png" />

--- a/Mutation.Ui/Services/UserGuideLocator.cs
+++ b/Mutation.Ui/Services/UserGuideLocator.cs
@@ -1,0 +1,60 @@
+using System;
+using System.IO;
+
+namespace Mutation.Ui.Services;
+
+/// <summary>
+/// Finds the user guide's contents page on disk.
+///
+/// The guide ships beside the executable, under a UserGuide folder, copied there
+/// from Documentation\UserGuide\html by the build. Keeping the lookup separate
+/// from the launching means the interesting part - deciding where the guide is
+/// and what to say when it is missing - can be tested without opening a browser.
+/// </summary>
+public static class UserGuideLocator
+{
+	/// <summary>Folder beside the executable that holds the generated pages.</summary>
+	public const string GuideFolderName = "UserGuide";
+
+	/// <summary>The page the button opens.</summary>
+	public const string IndexFileName = "index.html";
+
+	/// <summary>Where the guide was looked for, and whether it was there.</summary>
+	/// <param name="Found">True when the contents page exists.</param>
+	/// <param name="IndexPath">Full path to index.html, whether or not it exists.</param>
+	/// <param name="ErrorMessage">
+	/// A sentence explaining what to do about it, or null when <paramref name="Found"/> is true.
+	/// </param>
+	public sealed record Result(bool Found, string IndexPath, string? ErrorMessage);
+
+	/// <summary>
+	/// Works out the path to the guide's contents page relative to the folder the
+	/// application is running from.
+	/// </summary>
+	public static string GetIndexPath(string baseDirectory)
+	{
+		ArgumentException.ThrowIfNullOrWhiteSpace(baseDirectory);
+
+		return Path.Combine(baseDirectory, GuideFolderName, IndexFileName);
+	}
+
+	/// <summary>
+	/// Locates the guide, reporting a message a non-technical user can act on if it
+	/// is not there.
+	/// </summary>
+	public static Result Locate(string baseDirectory)
+	{
+		string indexPath = GetIndexPath(baseDirectory);
+
+		if (File.Exists(indexPath))
+		{
+			return new Result(Found: true, indexPath, ErrorMessage: null);
+		}
+
+		return new Result(
+			Found: false,
+			indexPath,
+			$"The user guide could not be found at {indexPath}. It is installed alongside Mutation, " +
+			"so reinstalling should restore it.");
+	}
+}


### PR DESCRIPTION
Three related changes so the user guide is discoverable, explained, and stays current.

## 1. A User guide button on the main window

An icon plus **User guide** and the subtext **Read the documentation**, in the header beside "Mutation Workspace". Clicking it — or pressing **Alt** then **G** — opens the guide's contents page in the default browser.

The generated pages are copied beside the executable by the build, so **the guide works on an installed copy with no internet connection**. The pages are self-contained, so only the `.html` files ship.

`UserGuideLocator` keeps the path lookup separate from the launching, so the part worth testing — where the guide is, and what to say when it is missing — is covered without opening a browser. A missing guide gives a failure beep and a message naming the path it looked in. Launching happens off the UI thread, since handing a file to the shell can block while the browser starts.

## 2. `Documentation/README.md`

Explains what each folder holds, which files are authoritative (Markdown in, HTML out), and how to regenerate the pages.

## 3. Docs-sync rule in `CLAUDE.md`

A new **Documentation** section requiring the guide to be updated in the same PR as any user-visible behaviour change, with the trigger list spelled out. It pins down the guide's tone — plain, friendly, written for a general office worker, no jargon, always traceable to the code — so future work matches what is there.

It also notes that `SettingsDefaults.cs` and the XAML are authoritative over the root `README.md`, which has drifted from the shipped defaults before.

This PR follows its own rule: `main-window.md` and `getting-started.md` document the new button, and the HTML is rebuilt in the same commit.

## A bug self-review caught

The button first went in the header's right-hand gutter column, which is an eighth of the window width. At a 760px window that made **"Read the documentation" wrap onto eight lines — a 477px tall button**. Worth catching rather than shipping, because ZoomText magnification narrows the usable width the same way resizing does.

The title and button now share the header's centre column, with the button in an `Auto` column so its text never wraps and the title takes what is left. It also lines the button up with the right edge of the cards below.

## Testing

Verified by actually running the app and querying the UI Automation tree — what a screen reader sees:

- Accessible name **User guide**, help text **"Read the documentation. Opens the Mutation user guide in your web browser."**, keyboard focusable, enabled, invoke pattern supported.
- Invoking it opened the guide in the browser — end to end, not just a unit test.
- Measured at 1440 / 1000 / 760 / 620 px window widths: a steady 208×61 button, fully inside the window at every size.
- All 13 pages confirmed present beside the built executable, and identical to the committed HTML.

Plus **969 tests pass, 0 failed** (8 new for `UserGuideLocator`), and the solution builds with 0 warnings under `TreatWarningsAsErrors`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)