### PR TITLE
Show startup dialogs after the window can host them

### DIFF
--- a/Documentation/UserGuide/html/getting-started.html
+++ b/Documentation/UserGuide/html/getting-started.html
@@ -189,7 +189,7 @@ footer{margin-top:3rem; padding-top:1rem; border-top:1px solid var(--rule); colo
 <h2 id="your-very-first-launch">Your very first launch</h2>
 <p>The first time you run Mutation, it creates its settings file with sensible defaults, and every keyboard shortcut is already set up and ready to change later.</p>
 <p>If you have not yet added an OpenAI or Anthropic key, Mutation greets you with a short welcome message titled <strong>Welcome to Mutation</strong>. It explains that at least one key is needed, and lists which key does what. Press <strong>Continue</strong>.</p>
-<p>The <strong>Settings</strong> window then opens on its own, so you can paste your keys in right away. That is the whole of first-run setup. If you would rather do it later, just close Settings — you can reopen it at any time with <strong>Ctrl+Comma</strong>.</p>
+<p>The <strong>Settings</strong> window then opens on its own, already on the <strong>API keys</strong> page, so you can paste your keys in right away. That is the whole of first-run setup. If you would rather do it later, just close Settings — you can reopen it at any time with <strong>Ctrl+Comma</strong>.</p>
 <p>One other message you might see later: if you have set up a dictation service but its key is missing, Mutation tells you which service it has switched off and opens Settings on the API keys page. Add the key, save, then restart Mutation so the service becomes available again.</p>
 <hr />
 <h2 id="entering-your-keys">Entering your keys</h2>

--- a/Documentation/UserGuide/markdown/getting-started.md
+++ b/Documentation/UserGuide/markdown/getting-started.md
@@ -37,7 +37,7 @@ The first time you run Mutation, it creates its settings file with sensible defa
 
 If you have not yet added an OpenAI or Anthropic key, Mutation greets you with a short welcome message titled **Welcome to Mutation**. It explains that at least one key is needed, and lists which key does what. Press **Continue**.
 
-The **Settings** window then opens on its own, so you can paste your keys in right away. That is the whole of first-run setup. If you would rather do it later, just close Settings — you can reopen it at any time with **Ctrl+Comma**.
+The **Settings** window then opens on its own, already on the **API keys** page, so you can paste your keys in right away. That is the whole of first-run setup. If you would rather do it later, just close Settings — you can reopen it at any time with **Ctrl+Comma**.
 
 One other message you might see later: if you have set up a dictation service but its key is missing, Mutation tells you which service it has switched off and opens Settings on the API keys page. Add the key, save, then restart Mutation so the service becomes available again.
 

--- a/Mutation.Tests/ContentReadyGateTests.cs
+++ b/Mutation.Tests/ContentReadyGateTests.cs
@@ -11,109 +11,188 @@ public class ContentReadyGateTests
 	private static readonly TimeSpan Poll = TimeSpan.FromMilliseconds(50);
 	private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(5);
 
-	// Records what it was asked to wait for instead of actually waiting, so the polling
-	// behaviour is exercised with no real time passing.
-	private sealed class RecordingDelay
+	// A clock the test drives instead of waiting: each "delay" advances it by however
+	// much the caller asked to wait, optionally stretched to model a UI thread that is
+	// too busy to honour the interval — which is the case the real timeout exists for.
+	private sealed class FakeClock
 	{
+		private readonly double _stretchFactor;
+
+		public FakeClock(double stretchFactor = 1.0) => _stretchFactor = stretchFactor;
+
+		public TimeSpan Now { get; private set; } = TimeSpan.Zero;
+
 		public List<TimeSpan> Delays { get; } = new();
 
-		public Func<TimeSpan, Task> Func => interval =>
+		public Func<TimeSpan, Task> Delay => interval =>
 		{
 			Delays.Add(interval);
+			Now += interval * _stretchFactor;
 			return Task.CompletedTask;
 		};
+
+		public Func<TimeSpan> Elapsed => () => Now;
 	}
 
 	[Fact]
 	public async Task ContentAlreadyReady_ReturnsImmediatelyWithoutWaiting()
 	{
-		var delay = new RecordingDelay();
+		var clock = new FakeClock();
+		int checks = 0;
 
-		bool ready = await ContentReadyGate.WaitAsync(() => true, delay.Func, Poll, Timeout);
+		bool ready = await ContentReadyGate.WaitAsync(
+			() => { checks++; return true; }, clock.Delay, clock.Elapsed, Poll, Timeout);
 
 		Assert.True(ready);
-		Assert.Empty(delay.Delays);
+		Assert.Equal(1, checks);
+		Assert.Empty(clock.Delays);
 	}
 
 	[Fact]
 	public async Task ContentReadyAfterAFewTurns_ReturnsReadyAndStopsPolling()
 	{
-		var delay = new RecordingDelay();
+		var clock = new FakeClock();
 		int checks = 0;
 
-		bool ready = await ContentReadyGate.WaitAsync(() => ++checks > 3, delay.Func, Poll, Timeout);
+		bool ready = await ContentReadyGate.WaitAsync(
+			() => ++checks > 3, clock.Delay, clock.Elapsed, Poll, Timeout);
 
 		Assert.True(ready);
 		// Three "not ready" checks, so three waits, then the fourth check succeeds.
-		Assert.Equal(3, delay.Delays.Count);
-		Assert.All(delay.Delays, d => Assert.Equal(Poll, d));
+		Assert.Equal(3, clock.Delays.Count);
+		Assert.All(clock.Delays, d => Assert.Equal(Poll, d));
 	}
 
 	// A window that never loads must not wedge startup: the caller has a degraded path
 	// (a system message box) and has to be allowed to reach it.
 	[Fact]
-	public async Task ContentNeverReady_GivesUpAtTheTimeoutInsteadOfHanging()
+	public async Task ContentNeverReady_GivesUpOnceTheTimeoutHasElapsed()
 	{
-		var delay = new RecordingDelay();
+		var clock = new FakeClock();
 
 		bool ready = await ContentReadyGate.WaitAsync(
 			() => false,
-			delay.Func,
+			clock.Delay,
+			clock.Elapsed,
 			TimeSpan.FromMilliseconds(100),
 			TimeSpan.FromMilliseconds(500));
 
 		Assert.False(ready);
-		Assert.Equal(5, delay.Delays.Count);
+		Assert.Equal(TimeSpan.FromMilliseconds(500), clock.Now);
+	}
+
+	// The bound has to be real time, not a count of poll intervals. A UI thread too busy
+	// to load its content is exactly the thread that takes far longer than the interval
+	// asked for, so counting intervals would stretch a 500 ms bound to 5 seconds here.
+	[Fact]
+	public async Task PollsThatOverrunTheirInterval_StillStopAtTheTimeout()
+	{
+		var clock = new FakeClock(stretchFactor: 10);
+
+		bool ready = await ContentReadyGate.WaitAsync(
+			() => false,
+			clock.Delay,
+			clock.Elapsed,
+			TimeSpan.FromMilliseconds(100),
+			TimeSpan.FromMilliseconds(500));
+
+		Assert.False(ready);
+		// One poll costs 1000 ms of real time, so the very next check gives up.
+		Assert.Single(clock.Delays);
 	}
 
 	[Fact]
 	public async Task ZeroTimeout_ChecksOnceAndGivesUp()
 	{
-		var delay = new RecordingDelay();
+		var clock = new FakeClock();
+		int checks = 0;
+
+		bool ready = await ContentReadyGate.WaitAsync(
+			() => { checks++; return false; }, clock.Delay, clock.Elapsed, Poll, TimeSpan.Zero);
+
+		Assert.False(ready);
+		Assert.Equal(1, checks);
+		Assert.Empty(clock.Delays);
+	}
+
+	[Fact]
+	public async Task NegativeTimeout_ChecksOnceAndGivesUp()
+	{
+		var clock = new FakeClock();
 		int checks = 0;
 
 		bool ready = await ContentReadyGate.WaitAsync(
 			() => { checks++; return false; },
-			delay.Func,
+			clock.Delay,
+			clock.Elapsed,
 			Poll,
-			TimeSpan.Zero);
+			TimeSpan.FromMilliseconds(-1));
 
 		Assert.False(ready);
 		Assert.Equal(1, checks);
-		Assert.Empty(delay.Delays);
+		Assert.Empty(clock.Delays);
 	}
 
-	// The last poll lands exactly on the timeout; content that became ready during that
-	// final wait is still reported as ready rather than being reported as a timeout.
+	// A timeout that is not a whole multiple of the poll interval still stops at the
+	// first check past it rather than running on to the next multiple.
+	[Fact]
+	public async Task TimeoutThatIsNotAMultipleOfThePollInterval_StopsAtTheFirstCheckPastIt()
+	{
+		var clock = new FakeClock();
+
+		bool ready = await ContentReadyGate.WaitAsync(
+			() => false,
+			clock.Delay,
+			clock.Elapsed,
+			TimeSpan.FromMilliseconds(100),
+			TimeSpan.FromMilliseconds(250));
+
+		Assert.False(ready);
+		Assert.Equal(3, clock.Delays.Count);
+		Assert.Equal(TimeSpan.FromMilliseconds(300), clock.Now);
+	}
+
+	// Content that becomes ready during the last permitted wait is reported as ready,
+	// not as a timeout — the check always precedes the give-up test.
 	[Fact]
 	public async Task ContentReadyOnTheFinalCheck_IsReportedAsReady()
 	{
-		var delay = new RecordingDelay();
+		var clock = new FakeClock();
 		int checks = 0;
 
 		bool ready = await ContentReadyGate.WaitAsync(
 			() => ++checks > 2,
-			delay.Func,
+			clock.Delay,
+			clock.Elapsed,
 			TimeSpan.FromMilliseconds(100),
 			TimeSpan.FromMilliseconds(200));
 
 		Assert.True(ready);
-		Assert.Equal(2, delay.Delays.Count);
+		Assert.Equal(2, clock.Delays.Count);
 	}
 
-	[Fact]
-	public async Task NonPositivePollInterval_IsRejected()
+	[Theory]
+	[InlineData(0)]
+	[InlineData(-1)]
+	public async Task NonPositivePollInterval_IsRejected(int milliseconds)
 	{
 		await Assert.ThrowsAsync<ArgumentOutOfRangeException>(
-			() => ContentReadyGate.WaitAsync(() => false, _ => Task.CompletedTask, TimeSpan.Zero, Timeout));
+			() => ContentReadyGate.WaitAsync(
+				() => false,
+				_ => Task.CompletedTask,
+				() => TimeSpan.Zero,
+				TimeSpan.FromMilliseconds(milliseconds),
+				Timeout));
 	}
 
 	[Fact]
 	public async Task MissingCallbacks_AreRejected()
 	{
 		await Assert.ThrowsAsync<ArgumentNullException>(
-			() => ContentReadyGate.WaitAsync(null!, _ => Task.CompletedTask, Poll, Timeout));
+			() => ContentReadyGate.WaitAsync(null!, _ => Task.CompletedTask, () => TimeSpan.Zero, Poll, Timeout));
 		await Assert.ThrowsAsync<ArgumentNullException>(
-			() => ContentReadyGate.WaitAsync(() => false, null!, Poll, Timeout));
+			() => ContentReadyGate.WaitAsync(() => false, null!, () => TimeSpan.Zero, Poll, Timeout));
+		await Assert.ThrowsAsync<ArgumentNullException>(
+			() => ContentReadyGate.WaitAsync(() => false, _ => Task.CompletedTask, null!, Poll, Timeout));
 	}
 }

--- a/Mutation.Tests/ContentReadyGateTests.cs
+++ b/Mutation.Tests/ContentReadyGateTests.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Mutation.Ui.Core;
+using Xunit;
+
+namespace Mutation.Tests;
+
+public class ContentReadyGateTests
+{
+	private static readonly TimeSpan Poll = TimeSpan.FromMilliseconds(50);
+	private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(5);
+
+	// Records what it was asked to wait for instead of actually waiting, so the polling
+	// behaviour is exercised with no real time passing.
+	private sealed class RecordingDelay
+	{
+		public List<TimeSpan> Delays { get; } = new();
+
+		public Func<TimeSpan, Task> Func => interval =>
+		{
+			Delays.Add(interval);
+			return Task.CompletedTask;
+		};
+	}
+
+	[Fact]
+	public async Task ContentAlreadyReady_ReturnsImmediatelyWithoutWaiting()
+	{
+		var delay = new RecordingDelay();
+
+		bool ready = await ContentReadyGate.WaitAsync(() => true, delay.Func, Poll, Timeout);
+
+		Assert.True(ready);
+		Assert.Empty(delay.Delays);
+	}
+
+	[Fact]
+	public async Task ContentReadyAfterAFewTurns_ReturnsReadyAndStopsPolling()
+	{
+		var delay = new RecordingDelay();
+		int checks = 0;
+
+		bool ready = await ContentReadyGate.WaitAsync(() => ++checks > 3, delay.Func, Poll, Timeout);
+
+		Assert.True(ready);
+		// Three "not ready" checks, so three waits, then the fourth check succeeds.
+		Assert.Equal(3, delay.Delays.Count);
+		Assert.All(delay.Delays, d => Assert.Equal(Poll, d));
+	}
+
+	// A window that never loads must not wedge startup: the caller has a degraded path
+	// (a system message box) and has to be allowed to reach it.
+	[Fact]
+	public async Task ContentNeverReady_GivesUpAtTheTimeoutInsteadOfHanging()
+	{
+		var delay = new RecordingDelay();
+
+		bool ready = await ContentReadyGate.WaitAsync(
+			() => false,
+			delay.Func,
+			TimeSpan.FromMilliseconds(100),
+			TimeSpan.FromMilliseconds(500));
+
+		Assert.False(ready);
+		Assert.Equal(5, delay.Delays.Count);
+	}
+
+	[Fact]
+	public async Task ZeroTimeout_ChecksOnceAndGivesUp()
+	{
+		var delay = new RecordingDelay();
+		int checks = 0;
+
+		bool ready = await ContentReadyGate.WaitAsync(
+			() => { checks++; return false; },
+			delay.Func,
+			Poll,
+			TimeSpan.Zero);
+
+		Assert.False(ready);
+		Assert.Equal(1, checks);
+		Assert.Empty(delay.Delays);
+	}
+
+	// The last poll lands exactly on the timeout; content that became ready during that
+	// final wait is still reported as ready rather than being reported as a timeout.
+	[Fact]
+	public async Task ContentReadyOnTheFinalCheck_IsReportedAsReady()
+	{
+		var delay = new RecordingDelay();
+		int checks = 0;
+
+		bool ready = await ContentReadyGate.WaitAsync(
+			() => ++checks > 2,
+			delay.Func,
+			TimeSpan.FromMilliseconds(100),
+			TimeSpan.FromMilliseconds(200));
+
+		Assert.True(ready);
+		Assert.Equal(2, delay.Delays.Count);
+	}
+
+	[Fact]
+	public async Task NonPositivePollInterval_IsRejected()
+	{
+		await Assert.ThrowsAsync<ArgumentOutOfRangeException>(
+			() => ContentReadyGate.WaitAsync(() => false, _ => Task.CompletedTask, TimeSpan.Zero, Timeout));
+	}
+
+	[Fact]
+	public async Task MissingCallbacks_AreRejected()
+	{
+		await Assert.ThrowsAsync<ArgumentNullException>(
+			() => ContentReadyGate.WaitAsync(null!, _ => Task.CompletedTask, Poll, Timeout));
+		await Assert.ThrowsAsync<ArgumentNullException>(
+			() => ContentReadyGate.WaitAsync(() => false, null!, Poll, Timeout));
+	}
+}

--- a/Mutation.Ui/App.xaml.cs
+++ b/Mutation.Ui/App.xaml.cs
@@ -276,90 +276,18 @@ public partial class App : Application
 
 			_window.Activate();
 
-			// Activate() returns before the content has loaded, and until it has there
-			// is no XamlRoot to host a ContentDialog. Every notice below — the screen
-			// capture warning, the beep settings warning, the hotkey failures and the
-			// first-run onboarding — was raised inside that window, so each either
-			// degraded to a bare Win32 message box with no automation name or (for the
-			// hotkey failures) was dropped and left only an unexplained beep.
-			if (_window is MainWindow readyWindow)
-				await readyWindow.WaitForContentReadyAsync();
-
-                        var preflight = ScreenCapturePreflight.TryCaptureProbe();
-			if (!preflight.ok)
-			{
-				string title = "Screen Capture Disabled";
-				string message = preflight.message ?? "Screen capture may be disabled by system policy.";
-				if (_window.Content is FrameworkElement fe0 && fe0.XamlRoot is not null)
-				{
-					var dialog = new ContentDialog
-					{
-						Title = title,
-						Content = new TextBlock { Text = message, TextWrapping = Microsoft.UI.Xaml.TextWrapping.Wrap },
-						CloseButtonText = "OK",
-						XamlRoot = fe0.XamlRoot
-					};
-					Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(dialog, title);
-					Microsoft.UI.Xaml.Automation.AutomationProperties.SetHelpText(dialog, message);
-					await dialog.ShowAsync();
-				}
-				else
-				{
-					System.Windows.Forms.MessageBox.Show(message, title,
-						System.Windows.Forms.MessageBoxButtons.OK,
-						System.Windows.Forms.MessageBoxIcon.Warning);
-				}
-			}
-
-			if (BeepPlayer.LastInitializationIssues.Count > 0)
-			{
-				const string title = "Custom Beep Settings Issues";
-				string message = "The following issues were found with the custom beep settings:\n\n" +
-										  string.Join("\n", BeepPlayer.LastInitializationIssues);
-
-				if (_window.Content is FrameworkElement fe && fe.XamlRoot is not null)
-				{
-					var dialog = new ContentDialog
-					{
-						Title = title,
-						Content = new TextBlock { Text = message, TextWrapping = Microsoft.UI.Xaml.TextWrapping.Wrap },
-						CloseButtonText = "OK",
-						XamlRoot = fe.XamlRoot
-					};
-					// Provide accessible name/help text for screen readers
-					Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(dialog, title);
-					Microsoft.UI.Xaml.Automation.AutomationProperties.SetHelpText(dialog, message);
-					await dialog.ShowAsync();
-				}
-				else
-				{
-					System.Windows.Forms.MessageBox.Show(
-							  message,
-							  title,
-							  System.Windows.Forms.MessageBoxButtons.OK,
-							  System.Windows.Forms.MessageBoxIcon.Warning);
-				}
-			}
-
 			var ocrMgr = _host.Services.GetRequiredService<OcrManager>();
 			ocrMgr.InitializeWindow(_window);
 
-                        var hkManager = _host.Services.GetRequiredService<HotkeyManager>();
-                        // Register core, prompt, and router hotkeys, then surface any that could not be
-                        // bound the same way (dialog + failure beep). AttachHotkeyManager registers the
-                        // prompt and router hotkeys and RegisterCoreHotkeys registers the core ones; both
-                        // return the failures they encountered.
-                        var hotkeyFailures = new List<HotkeyManager.HotkeyBindingFailure>();
-                        if (_window is MainWindow main)
-                        {
-                                hotkeyFailures.AddRange(main.AttachHotkeyManager(hkManager));
-                                hotkeyFailures.AddRange(main.RegisterCoreHotkeys(hkManager));
-                        }
-                        var settingsSvc = _host.Services.GetRequiredService<Settings>();
+			var hkManager = _host.Services.GetRequiredService<HotkeyManager>();
 
-			if (hotkeyFailures.Count > 0 && _window is MainWindow mainWindow)
-				await mainWindow.ShowHotkeyBindingFailuresAsync(hotkeyFailures);
-
+			// Wired before anything that can put a dialog on screen and park this method.
+			// A WinUI ContentDialog does not disable its window, so the user can still
+			// close the app from behind one — and every startup notice below now really
+			// does open a dialog (before, they degraded to a Win32 message box or were
+			// dropped, so this method ran to the end in one dispatcher turn). Closing
+			// with this handler unwired skips ShutdownAsync entirely: the keyboard hook
+			// stays installed and the process lingers invisibly.
 			_window.Closed += async (_, __) =>
 			{
 				// Ensure global hooks are released promptly
@@ -376,6 +304,56 @@ public partial class App : Application
 				// Stop background host services and exit the app
 				await ShutdownAsync();
 			};
+
+			// Register core, prompt, and router hotkeys. AttachHotkeyManager registers the
+			// prompt and router hotkeys and RegisterCoreHotkeys registers the core ones;
+			// both return the failures they encountered, which are surfaced below once the
+			// window can host the dialog that lists them.
+			var hotkeyFailures = new List<HotkeyManager.HotkeyBindingFailure>();
+			if (_window is MainWindow main)
+			{
+				hotkeyFailures.AddRange(main.AttachHotkeyManager(hkManager));
+				hotkeyFailures.AddRange(main.RegisterCoreHotkeys(hkManager));
+			}
+
+			// Activate() returns before the content has loaded, and until it has there
+			// is no XamlRoot to host a ContentDialog. Every notice below — the screen
+			// capture warning, the beep settings warning, the hotkey failures and the
+			// first-run onboarding — was raised inside that window, so each either
+			// degraded to a bare Win32 message box with no automation name or (for the
+			// hotkey failures) was dropped and left only an unexplained beep.
+			if (_window is MainWindow readyWindow && !await readyWindow.WaitForContentReadyAsync())
+			{
+				// Not fatal — every notice has a message box fallback — but it means the
+				// accessible surface was abandoned, which is worth a trace of its own.
+				ErrorLogger.LogError(
+					"Startup",
+					new TimeoutException(
+						"The window content did not become ready in time; startup notices fall back to system message boxes."));
+			}
+
+			var preflight = ScreenCapturePreflight.TryCaptureProbe();
+			if (!preflight.ok && _window is MainWindow preflightWindow)
+			{
+				await preflightWindow.ShowNoticeAsync(
+					"Screen Capture Disabled",
+					preflight.message ?? "Screen capture may be disabled by system policy.",
+					"OK",
+					NoticeSeverity.Warning);
+			}
+
+			if (BeepPlayer.LastInitializationIssues.Count > 0 && _window is MainWindow beepWindow)
+			{
+				await beepWindow.ShowNoticeAsync(
+					"Custom Beep Settings Issues",
+					"The following issues were found with the custom beep settings:\n\n" +
+						string.Join("\n", BeepPlayer.LastInitializationIssues),
+					"OK",
+					NoticeSeverity.Warning);
+			}
+
+			if (hotkeyFailures.Count > 0 && _window is MainWindow mainWindow)
+				await mainWindow.ShowHotkeyBindingFailuresAsync(hotkeyFailures);
 
 			// First-run / unconfigured onboarding. Replaces opening Mutation.json
 			// in Notepad: show a friendly welcome, then open the in-app Settings

--- a/Mutation.Ui/App.xaml.cs
+++ b/Mutation.Ui/App.xaml.cs
@@ -276,6 +276,15 @@ public partial class App : Application
 
 			_window.Activate();
 
+			// Activate() returns before the content has loaded, and until it has there
+			// is no XamlRoot to host a ContentDialog. Every notice below — the screen
+			// capture warning, the beep settings warning, the hotkey failures and the
+			// first-run onboarding — was raised inside that window, so each either
+			// degraded to a bare Win32 message box with no automation name or (for the
+			// hotkey failures) was dropped and left only an unexplained beep.
+			if (_window is MainWindow readyWindow)
+				await readyWindow.WaitForContentReadyAsync();
+
                         var preflight = ScreenCapturePreflight.TryCaptureProbe();
 			if (!preflight.ok)
 			{

--- a/Mutation.Ui/Core/ContentReadyGate.cs
+++ b/Mutation.Ui/Core/ContentReadyGate.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Mutation.Ui.Core;
+
+/// <summary>
+/// Waits for a window's content to become usable as a dialog host.
+///
+/// <see cref="Microsoft.UI.Xaml.Window.Activate"/> returns before the content has been
+/// loaded, so for the first few dispatcher turns after it the root element still has no
+/// <c>XamlRoot</c>. A <c>ContentDialog</c> opened in that window either throws or has to
+/// fall back to a bare Win32 message box, which carries no automation name and no help
+/// text for a screen reader. Anything that shows a dialog at startup therefore waits
+/// here first.
+///
+/// The wait polls instead of hooking <c>Loaded</c>: by the time a caller asks, that event
+/// may already have been raised and gone, and a missed event would stall startup for the
+/// whole timeout for no reason. Awaiting the delay on the UI thread is also what yields
+/// the dispatcher turns the content needs in order to load.
+/// </summary>
+public static class ContentReadyGate
+{
+	/// <summary>
+	/// Completes once <paramref name="isReady"/> returns true, or when
+	/// <paramref name="timeout"/> has elapsed — whichever comes first. Returns whether the
+	/// content became ready. It never throws and never waits indefinitely: a window that
+	/// somehow never loads must still let startup continue, degraded rather than hung.
+	/// </summary>
+	public static async Task<bool> WaitAsync(
+		Func<bool> isReady,
+		Func<TimeSpan, Task> delay,
+		TimeSpan pollInterval,
+		TimeSpan timeout)
+	{
+		if (isReady is null) throw new ArgumentNullException(nameof(isReady));
+		if (delay is null) throw new ArgumentNullException(nameof(delay));
+		if (pollInterval <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(pollInterval));
+
+		TimeSpan waited = TimeSpan.Zero;
+		while (true)
+		{
+			if (isReady())
+				return true;
+
+			if (waited >= timeout)
+				return false;
+
+			await delay(pollInterval).ConfigureAwait(true);
+			waited += pollInterval;
+		}
+	}
+}

--- a/Mutation.Ui/Core/ContentReadyGate.cs
+++ b/Mutation.Ui/Core/ContentReadyGate.cs
@@ -21,32 +21,40 @@ namespace Mutation.Ui.Core;
 public static class ContentReadyGate
 {
 	/// <summary>
-	/// Completes once <paramref name="isReady"/> returns true, or when
-	/// <paramref name="timeout"/> has elapsed — whichever comes first. Returns whether the
-	/// content became ready. It never throws and never waits indefinitely: a window that
-	/// somehow never loads must still let startup continue, degraded rather than hung.
+	/// Completes once <paramref name="isReady"/> returns true, or once
+	/// <paramref name="elapsed"/> reports that <paramref name="timeout"/> has passed —
+	/// whichever comes first. Returns whether the content became ready. It never throws
+	/// and never waits indefinitely: a window that somehow never loads must still let
+	/// startup continue, degraded rather than hung.
 	/// </summary>
+	/// <param name="isReady">Whether the content can host a dialog yet.</param>
+	/// <param name="delay">How to wait one poll interval. Awaiting it on the UI thread is
+	/// what returns control to the message pump so the content can load.</param>
+	/// <param name="elapsed">Real time since the wait started. The timeout is measured
+	/// against this rather than against a count of poll intervals, because the case this
+	/// bound exists for — a UI thread too busy to load its content — is exactly the case
+	/// where each poll takes far longer than the interval asked for.</param>
 	public static async Task<bool> WaitAsync(
 		Func<bool> isReady,
 		Func<TimeSpan, Task> delay,
+		Func<TimeSpan> elapsed,
 		TimeSpan pollInterval,
 		TimeSpan timeout)
 	{
 		if (isReady is null) throw new ArgumentNullException(nameof(isReady));
 		if (delay is null) throw new ArgumentNullException(nameof(delay));
+		if (elapsed is null) throw new ArgumentNullException(nameof(elapsed));
 		if (pollInterval <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(pollInterval));
 
-		TimeSpan waited = TimeSpan.Zero;
 		while (true)
 		{
 			if (isReady())
 				return true;
 
-			if (waited >= timeout)
+			if (elapsed() >= timeout)
 				return false;
 
 			await delay(pollInterval).ConfigureAwait(true);
-			waited += pollInterval;
 		}
 	}
 }

--- a/Mutation.Ui/MainWindow.Notices.cs
+++ b/Mutation.Ui/MainWindow.Notices.cs
@@ -1,0 +1,132 @@
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
+using Microsoft.UI.Xaml.Controls;
+using Mutation.Ui.Core;
+
+namespace Mutation.Ui;
+
+/// <summary>
+/// How serious a notice is. Kept separate from the WinForms
+/// <see cref="System.Windows.Forms.MessageBoxIcon"/> so that type stays behind the one
+/// fallback that needs it instead of appearing at every call site.
+/// </summary>
+public enum NoticeSeverity
+{
+	Information,
+	Warning,
+}
+
+// Raising a message the user has to acknowledge, and the wait that makes an accessible
+// one possible at startup.
+public sealed partial class MainWindow
+{
+	// How long startup will wait for the window's content to become a usable dialog
+	// host before showing its notices the degraded way. Generous compared with the
+	// couple of dispatcher turns it normally takes, so a slow machine still gets the
+	// accessible dialog, but bounded so a window that never loads cannot wedge startup.
+	private static readonly TimeSpan ContentReadyTimeout = TimeSpan.FromSeconds(5);
+	private static readonly TimeSpan ContentReadyPollInterval = TimeSpan.FromMilliseconds(50);
+
+	// Awaited by App.OnLaunched after Activate() and before any startup dialog.
+	// Activate() returns before the content is loaded, so for the first dispatcher
+	// turns after it there is no XamlRoot — and a ContentDialog without one cannot
+	// open. Every startup notice used to be shown in that window, which is why the
+	// first-run welcome arrived as a bare Win32 message box with no automation name
+	// and the hotkey-failure list was dropped entirely.
+	//
+	// Returns whether the content became ready; false means the caller's notices will
+	// take their fallback surface.
+	internal Task<bool> WaitForContentReadyAsync()
+	{
+		// A real clock, not a count of polls: the reason content would fail to load is a
+		// UI thread too busy to pump, which is exactly when each "50 ms" poll costs far
+		// more than 50 ms. Counting intervals would stretch a 5 second bound to whatever
+		// 100 dispatcher round-trips happen to take.
+		var clock = Stopwatch.StartNew();
+		return ContentReadyGate.WaitAsync(
+			HasLiveXamlRoot,
+			Task.Delay,
+			() => clock.Elapsed,
+			ContentReadyPollInterval,
+			ContentReadyTimeout);
+	}
+
+	// ContentDialog.ShowAsync needs a loaded visual tree, not merely an assigned
+	// XamlRoot, so both are required before the wait is satisfied.
+	private bool HasLiveXamlRoot() => Content is FrameworkElement { IsLoaded: true, XamlRoot: not null };
+
+	/// <summary>
+	/// Shows a message the user has to acknowledge, as an in-app dialog whenever the
+	/// window can host one and as a system message box when it cannot — including when
+	/// the dialog was attempted and failed.
+	///
+	/// The fallback exists so a notice is never simply dropped: a message that does not
+	/// appear leaves the user with an unexplained beep and no way to find out what
+	/// happened. Both surfaces carry the same text, and the dialog carries it as an
+	/// automation name and help text so a screen reader reads it on open.
+	/// </summary>
+	internal async Task ShowNoticeAsync(
+		string title,
+		string message,
+		string closeButtonText,
+		NoticeSeverity severity)
+	{
+		if (Content is FrameworkElement rootElement && rootElement.XamlRoot is not null)
+		{
+			var dialog = new ContentDialog
+			{
+				Title = title,
+				Content = new TextBlock { Text = message, TextWrapping = TextWrapping.Wrap },
+				CloseButtonText = closeButtonText,
+				XamlRoot = rootElement.XamlRoot,
+				RequestedTheme = rootElement.ActualTheme
+			};
+			AutomationProperties.SetName(dialog, title);
+			AutomationProperties.SetHelpText(dialog, message);
+
+			// Only fall through when the dialog never made it on screen. ShowDialogAsync
+			// turns a failed show into a status-bar line, which is not an acknowledgement
+			// and is exactly the "it beeped and said nothing" symptom this helper exists
+			// to prevent.
+			if (await TryShowDialogAsync(dialog))
+				return;
+		}
+
+		ShowNoticeMessageBox(title, message, severity);
+	}
+
+	// Owned by the main window so it cannot open behind it: an unowned modal box that
+	// is hidden but still taking input is worse than no message at all, and worst of all
+	// for a screen-reader user who has no visual cue where the focus went.
+	private void ShowNoticeMessageBox(string title, string message, NoticeSeverity severity)
+	{
+		var icon = severity == NoticeSeverity.Warning
+			? System.Windows.Forms.MessageBoxIcon.Warning
+			: System.Windows.Forms.MessageBoxIcon.Information;
+
+		try
+		{
+			var owner = new Win32WindowHandle(WinRT.Interop.WindowNative.GetWindowHandle(this));
+			System.Windows.Forms.MessageBox.Show(
+				owner, message, title, System.Windows.Forms.MessageBoxButtons.OK, icon);
+		}
+		catch (Exception ex)
+		{
+			// The handle is gone (the window is closing). An unowned box still delivers
+			// the message, which is the point.
+			Debug.WriteLine($"Owned notice message box failed: {ex.Message}");
+			System.Windows.Forms.MessageBox.Show(
+				message, title, System.Windows.Forms.MessageBoxButtons.OK, icon);
+		}
+	}
+
+	private sealed class Win32WindowHandle : System.Windows.Forms.IWin32Window
+	{
+		public Win32WindowHandle(IntPtr handle) => Handle = handle;
+
+		public IntPtr Handle { get; }
+	}
+}

--- a/Mutation.Ui/MainWindow.Onboarding.cs
+++ b/Mutation.Ui/MainWindow.Onboarding.cs
@@ -1,19 +1,42 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Controls;
+using Mutation.Ui.Core;
 using Mutation.Ui.Views;
 
 namespace Mutation.Ui;
 
 public sealed partial class MainWindow
 {
-	// First-run onboarding: show a friendly welcome, then open Settings so the
-	// user can add their API keys. Replaces the old behaviour of opening
-	// Mutation.json in Notepad. Called from App.OnLaunched when no LLM key is
-	// configured.
+	// How long startup will wait for the window's content to become a usable dialog
+	// host before showing its notices the degraded way. Generous compared with the
+	// couple of dispatcher turns it normally takes, so a slow machine still gets the
+	// accessible dialog, but bounded so a window that never loads cannot wedge startup.
+	private static readonly TimeSpan ContentReadyTimeout = TimeSpan.FromSeconds(5);
+	private static readonly TimeSpan ContentReadyPollInterval = TimeSpan.FromMilliseconds(50);
+
+	// Awaited by App.OnLaunched after Activate() and before any startup dialog.
+	// Activate() returns before the content is loaded, so for the first dispatcher
+	// turns after it there is no XamlRoot — and a ContentDialog without one cannot
+	// open. Every startup notice used to be shown in that window, which is why the
+	// first-run welcome arrived as a bare Win32 message box with no automation name
+	// and the hotkey-failure list was dropped entirely.
+	internal Task<bool> WaitForContentReadyAsync() =>
+		ContentReadyGate.WaitAsync(
+			HasLiveXamlRoot,
+			Task.Delay,
+			ContentReadyPollInterval,
+			ContentReadyTimeout);
+
+	private bool HasLiveXamlRoot() => Content is FrameworkElement { XamlRoot: not null };
+
+	// First-run onboarding: show a friendly welcome, then open Settings on the API keys
+	// page so the user can add their API keys. Replaces the old behaviour of opening
+	// Mutation.json in Notepad. Called from App.OnLaunched when no LLM key is configured.
 	//
 	// The two dialogs must NOT be opened back-to-back in the same continuation:
 	// WinUI throws "Only a single ContentDialog can be open at any time" because
@@ -24,11 +47,13 @@ public sealed partial class MainWindow
 	{
 		await ShowFirstRunWelcomeAsync();
 		await YieldToDispatcherAsync();
-		await ShowSettingsDialogAsync();
+		// The welcome says the Settings window opens "so you can add your keys", so it
+		// opens where the keys are rather than on whichever page happens to be first.
+		await ShowSettingsDialogAsync("apikeys");
 	}
 
 	// Friendly, screen-reader-accessible welcome shown on first run.
-	private async Task ShowFirstRunWelcomeAsync()
+	private Task ShowFirstRunWelcomeAsync()
 	{
 		const string title = "Welcome to Mutation";
 		const string message =
@@ -39,28 +64,7 @@ public sealed partial class MainWindow
 			"All hotkeys are preset and fully editable. The Settings window will now open so you can add your keys. " +
 			"You can reopen it anytime with Ctrl+Comma.";
 
-		if (Content is not FrameworkElement rootElement || rootElement.XamlRoot is null)
-		{
-			System.Windows.Forms.MessageBox.Show(
-				message,
-				title,
-				System.Windows.Forms.MessageBoxButtons.OK,
-				System.Windows.Forms.MessageBoxIcon.Information);
-			return;
-		}
-
-		var dialog = new ContentDialog
-		{
-			Title = title,
-			Content = new TextBlock { Text = message, TextWrapping = Microsoft.UI.Xaml.TextWrapping.Wrap },
-			CloseButtonText = "Continue",
-			XamlRoot = rootElement.XamlRoot,
-			RequestedTheme = rootElement.ActualTheme
-		};
-		AutomationProperties.SetName(dialog, title);
-		AutomationProperties.SetHelpText(dialog, message);
-
-		await ShowDialogAsync(dialog);
+		return ShowNoticeAsync(title, message, "Continue", System.Windows.Forms.MessageBoxIcon.Information);
 	}
 
 	// Opens the Settings dialog. Reused by the Settings menu item, the Ctrl+,
@@ -102,13 +106,36 @@ public sealed partial class MainWindow
 			"\n\nThe Settings window will now open on the API keys tab so you can add the missing key. " +
 			"Restart Mutation after saving for the service to become available.";
 
+		await ShowNoticeAsync(title, message, "Continue", System.Windows.Forms.MessageBoxIcon.Warning);
+
+		// Yield a dispatcher turn so the warning dialog fully closes before the
+		// Settings dialog opens (WinUI allows only one ContentDialog at a time).
+		await YieldToDispatcherAsync();
+		await ShowSettingsDialogAsync("apikeys");
+	}
+
+	/// <summary>
+	/// Shows a message the user has to acknowledge, as an in-app dialog whenever the
+	/// window can host one and as a system message box when it cannot.
+	///
+	/// The fallback exists so a notice is never simply dropped: a message that does not
+	/// appear leaves the user with an unexplained beep and no way to find out what
+	/// happened. Both surfaces carry the same text, and the dialog carries it as an
+	/// automation name and help text so a screen reader reads it on open.
+	/// </summary>
+	internal async Task ShowNoticeAsync(
+		string title,
+		string message,
+		string closeButtonText,
+		System.Windows.Forms.MessageBoxIcon fallbackIcon)
+	{
 		if (Content is FrameworkElement rootElement && rootElement.XamlRoot is not null)
 		{
 			var dialog = new ContentDialog
 			{
 				Title = title,
-				Content = new TextBlock { Text = message, TextWrapping = Microsoft.UI.Xaml.TextWrapping.Wrap },
-				CloseButtonText = "Continue",
+				Content = new TextBlock { Text = message, TextWrapping = TextWrapping.Wrap },
+				CloseButtonText = closeButtonText,
 				XamlRoot = rootElement.XamlRoot,
 				RequestedTheme = rootElement.ActualTheme
 			};
@@ -116,20 +143,14 @@ public sealed partial class MainWindow
 			AutomationProperties.SetHelpText(dialog, message);
 
 			await ShowDialogAsync(dialog);
-		}
-		else
-		{
-			System.Windows.Forms.MessageBox.Show(
-				message,
-				title,
-				System.Windows.Forms.MessageBoxButtons.OK,
-				System.Windows.Forms.MessageBoxIcon.Warning);
+			return;
 		}
 
-		// Yield a dispatcher turn so the warning dialog fully closes before the
-		// Settings dialog opens (WinUI allows only one ContentDialog at a time).
-		await YieldToDispatcherAsync();
-		await ShowSettingsDialogAsync("apikeys");
+		System.Windows.Forms.MessageBox.Show(
+			message,
+			title,
+			System.Windows.Forms.MessageBoxButtons.OK,
+			fallbackIcon);
 	}
 
 	// Completes on a fresh dispatcher turn, breaking out of the current

--- a/Mutation.Ui/MainWindow.Onboarding.cs
+++ b/Mutation.Ui/MainWindow.Onboarding.cs
@@ -1,39 +1,13 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Automation;
-using Microsoft.UI.Xaml.Controls;
-using Mutation.Ui.Core;
 using Mutation.Ui.Views;
 
 namespace Mutation.Ui;
 
 public sealed partial class MainWindow
 {
-	// How long startup will wait for the window's content to become a usable dialog
-	// host before showing its notices the degraded way. Generous compared with the
-	// couple of dispatcher turns it normally takes, so a slow machine still gets the
-	// accessible dialog, but bounded so a window that never loads cannot wedge startup.
-	private static readonly TimeSpan ContentReadyTimeout = TimeSpan.FromSeconds(5);
-	private static readonly TimeSpan ContentReadyPollInterval = TimeSpan.FromMilliseconds(50);
-
-	// Awaited by App.OnLaunched after Activate() and before any startup dialog.
-	// Activate() returns before the content is loaded, so for the first dispatcher
-	// turns after it there is no XamlRoot — and a ContentDialog without one cannot
-	// open. Every startup notice used to be shown in that window, which is why the
-	// first-run welcome arrived as a bare Win32 message box with no automation name
-	// and the hotkey-failure list was dropped entirely.
-	internal Task<bool> WaitForContentReadyAsync() =>
-		ContentReadyGate.WaitAsync(
-			HasLiveXamlRoot,
-			Task.Delay,
-			ContentReadyPollInterval,
-			ContentReadyTimeout);
-
-	private bool HasLiveXamlRoot() => Content is FrameworkElement { XamlRoot: not null };
-
 	// First-run onboarding: show a friendly welcome, then open Settings on the API keys
 	// page so the user can add their API keys. Replaces the old behaviour of opening
 	// Mutation.json in Notepad. Called from App.OnLaunched when no LLM key is configured.
@@ -64,7 +38,7 @@ public sealed partial class MainWindow
 			"All hotkeys are preset and fully editable. The Settings window will now open so you can add your keys. " +
 			"You can reopen it anytime with Ctrl+Comma.";
 
-		return ShowNoticeAsync(title, message, "Continue", System.Windows.Forms.MessageBoxIcon.Information);
+		return ShowNoticeAsync(title, message, "Continue", NoticeSeverity.Information);
 	}
 
 	// Opens the Settings dialog. Reused by the Settings menu item, the Ctrl+,
@@ -106,51 +80,12 @@ public sealed partial class MainWindow
 			"\n\nThe Settings window will now open on the API keys tab so you can add the missing key. " +
 			"Restart Mutation after saving for the service to become available.";
 
-		await ShowNoticeAsync(title, message, "Continue", System.Windows.Forms.MessageBoxIcon.Warning);
+		await ShowNoticeAsync(title, message, "Continue", NoticeSeverity.Warning);
 
 		// Yield a dispatcher turn so the warning dialog fully closes before the
 		// Settings dialog opens (WinUI allows only one ContentDialog at a time).
 		await YieldToDispatcherAsync();
 		await ShowSettingsDialogAsync("apikeys");
-	}
-
-	/// <summary>
-	/// Shows a message the user has to acknowledge, as an in-app dialog whenever the
-	/// window can host one and as a system message box when it cannot.
-	///
-	/// The fallback exists so a notice is never simply dropped: a message that does not
-	/// appear leaves the user with an unexplained beep and no way to find out what
-	/// happened. Both surfaces carry the same text, and the dialog carries it as an
-	/// automation name and help text so a screen reader reads it on open.
-	/// </summary>
-	internal async Task ShowNoticeAsync(
-		string title,
-		string message,
-		string closeButtonText,
-		System.Windows.Forms.MessageBoxIcon fallbackIcon)
-	{
-		if (Content is FrameworkElement rootElement && rootElement.XamlRoot is not null)
-		{
-			var dialog = new ContentDialog
-			{
-				Title = title,
-				Content = new TextBlock { Text = message, TextWrapping = TextWrapping.Wrap },
-				CloseButtonText = closeButtonText,
-				XamlRoot = rootElement.XamlRoot,
-				RequestedTheme = rootElement.ActualTheme
-			};
-			AutomationProperties.SetName(dialog, title);
-			AutomationProperties.SetHelpText(dialog, message);
-
-			await ShowDialogAsync(dialog);
-			return;
-		}
-
-		System.Windows.Forms.MessageBox.Show(
-			message,
-			title,
-			System.Windows.Forms.MessageBoxButtons.OK,
-			fallbackIcon);
 	}
 
 	// Completes on a fresh dispatcher turn, breaking out of the current

--- a/Mutation.Ui/MainWindow.xaml.cs
+++ b/Mutation.Ui/MainWindow.xaml.cs
@@ -2254,6 +2254,18 @@ public sealed partial class MainWindow : Window, IDisposable
 	}
 
     private async Task<ContentDialogResult> ShowDialogAsync(ContentDialog dialog)
+        => (await ShowDialogCoreAsync(dialog)).Result;
+
+    /// <summary>
+    /// Shows a dialog and reports whether it actually made it on screen. Callers that
+    /// owe the user a message they must acknowledge use this so they can fall back to
+    /// another surface: a failed show otherwise degrades to a status-bar line, which is
+    /// not an acknowledgement and can pass unnoticed entirely.
+    /// </summary>
+    private async Task<bool> TryShowDialogAsync(ContentDialog dialog)
+        => (await ShowDialogCoreAsync(dialog)).Shown;
+
+    private async Task<(ContentDialogResult Result, bool Shown)> ShowDialogCoreAsync(ContentDialog dialog)
     {
         // A dialog requested while another is open is announced now and queued;
         // the queue shows it when the current dialog closes rather than
@@ -2263,13 +2275,13 @@ public sealed partial class MainWindow : Window, IDisposable
 
         try
         {
-            return await _dialogQueue.EnqueueAsync(async () => await dialog.ShowAsync());
+            return (await _dialogQueue.EnqueueAsync(async () => await dialog.ShowAsync()), true);
         }
         catch (Exception ex)
         {
             // Fallback safety if something else goes wrong with the dialog
             ShowStatus("Dialog Error", $"Failed to show dialog: {ex.Message}", InfoBarSeverity.Error);
-            return ContentDialogResult.None;
+            return (ContentDialogResult.None, false);
         }
     }
 
@@ -2733,7 +2745,7 @@ public sealed partial class MainWindow : Window, IDisposable
 			// the window had no XamlRoot yet — which is the state startup is in when it
 			// registers the core hotkeys — so the failure beep above played and the list
 			// of dead hotkeys was never shown to anyone.
-			await ShowNoticeAsync(title, message, "OK", System.Windows.Forms.MessageBoxIcon.Warning);
+			await ShowNoticeAsync(title, message, "OK", NoticeSeverity.Warning);
 		}
 		catch (Exception ex)
 		{

--- a/Mutation.Ui/MainWindow.xaml.cs
+++ b/Mutation.Ui/MainWindow.xaml.cs
@@ -2726,28 +2726,14 @@ public sealed partial class MainWindow : Window, IDisposable
 
 		try
 		{
-			if (Content is not FrameworkElement rootElement || rootElement.XamlRoot is null)
-				return;
-
 			const string title = "Some hotkeys could not be registered";
 			string message = HotkeyManager.BuildFailureMessage(failures);
 
-			var dialog = new ContentDialog
-			{
-				Title = title,
-				Content = new TextBlock
-				{
-					Text = message,
-					TextWrapping = TextWrapping.Wrap,
-				},
-				CloseButtonText = "OK",
-				XamlRoot = rootElement.XamlRoot,
-				RequestedTheme = rootElement.ActualTheme,
-			};
-			Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(dialog, title);
-			Microsoft.UI.Xaml.Automation.AutomationProperties.SetHelpText(dialog, message);
-
-			await ShowDialogAsync(dialog);
+			// Shown on whichever surface is available. This used to return early when
+			// the window had no XamlRoot yet — which is the state startup is in when it
+			// registers the core hotkeys — so the failure beep above played and the list
+			// of dead hotkeys was never shown to anyone.
+			await ShowNoticeAsync(title, message, "OK", System.Windows.Forms.MessageBoxIcon.Warning);
 		}
 		catch (Exception ex)
 		{


### PR DESCRIPTION
## What was wrong

Reported after the latest pull: a burst of beeps within a minute of launch, a bare Windows message box saying **Mutation needs at least one API key before you can use it**, and after clicking OK the hotkeys no longer work.

`Window.Activate()` returns *before* the content is loaded. Until it is, the root element has no `XamlRoot`, and a `ContentDialog` cannot open without one. `App.OnLaunched` raised every startup notice inside that window:

- **`ShowHotkeyBindingFailuresAsync` returned early on a null `XamlRoot`.** That is exactly the state startup registers the core hotkeys in — so the failure beep played and the list of shortcuts that could not be claimed was silently dropped. `troubleshooting.md` has always promised that dialog; the code stopped delivering it in #183. This is the "beeps, then the hotkeys are dead, and nothing says why" half of the report.
- **The first-run welcome fell back to `System.Windows.Forms.MessageBox`** — no automation name or help text for a screen reader, no app theme, and an "OK" button where the guide says **Continue**. That is the exact box in the report.
- The missing-speech-key warning had the same fallback.

## The fix

- `Mutation.Ui/Core/ContentReadyGate.cs` — polls until the content has a live `XamlRoot`, bounded by a 5s timeout so a window that never loads leaves startup degraded rather than hung. Polls rather than hooking `Loaded`, because by the time a caller asks that event may already be gone.
- `App.OnLaunched` awaits it straight after `Activate()`, ahead of the screen-capture warning, the beep-settings warning, the hotkey failures and onboarding.
- `MainWindow.ShowNoticeAsync` is now the single way an acknowledgeable message is raised: in-app dialog when the window can host one, system message box when it cannot. **A notice is never dropped** — an unexplained beep leaves the user with no way to find out what happened.
- First-run onboarding opens Settings on the **API keys** page, which is what its own message says it will do. It opened on Audio.

## Verification

Reproduced against a build with no settings file, then re-run with the fix:

| | before | after |
| --- | --- | --- |
| Hotkey failures | beep only, dialog dropped | dialog lists all 16 unclaimable shortcuts and why |
| Welcome | top-level Win32 message box, "OK" | in-app dialog, named for a screen reader, "Continue" |
| Settings | opened on Audio | opens on API keys |

976 tests pass (`dotnet test --configuration Release`), including new `ContentReadyGateTests` covering already-ready, becomes-ready, never-ready (timeout, not hang), and argument validation.

User guide updated in the same PR: `getting-started.md` now says Settings opens on the API keys page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
