### PR TITLE
Restore the OCR end beep; stop two notices going where nobody can read them

### DIFF
--- a/CognitiveSupport/CustomBeepFileValidator.cs
+++ b/CognitiveSupport/CustomBeepFileValidator.cs
@@ -1,0 +1,77 @@
+namespace CognitiveSupport;
+
+/// <summary>
+/// Checks that every custom beep setting points at a <c>.wav</c> file that exists.
+///
+/// It reports rather than acts: the caller decides what to do with the issues (switch
+/// custom beeps back off, tell the user, both). This is what keeps the check out of
+/// <c>SettingsManager</c>, which used to raise its own bare Win32 message box from a
+/// point in startup where no window existed yet — a message a screen reader could make
+/// nothing of.
+/// </summary>
+public static class CustomBeepFileValidator
+{
+	private const string WavExtension = ".wav";
+
+	// The label used in the message for each setting, in the order they are reported.
+	private static readonly (string Label, Func<AudioSettings.CustomBeepSettingsData, string?> Read)[] Files =
+	{
+		("success", static s => s.BeepSuccessFile),
+		("failure", static s => s.BeepFailureFile),
+		("start", static s => s.BeepStartFile),
+		("end", static s => s.BeepEndFile),
+		("mute", static s => s.BeepMuteFile),
+		("unmute", static s => s.BeepUnmuteFile),
+	};
+
+	/// <summary>
+	/// One message per unusable custom beep file; empty when all six resolve to an
+	/// existing <c>.wav</c>, and empty when custom beeps are switched off (there is
+	/// nothing to load, so nothing to complain about).
+	/// </summary>
+	/// <param name="fileExists">Existence check, injected so the rule is testable
+	/// without laying real files on disk.</param>
+	public static IReadOnlyList<string> Validate(
+		AudioSettings.CustomBeepSettingsData? settings,
+		Func<string, bool> fileExists)
+	{
+		if (fileExists is null) throw new ArgumentNullException(nameof(fileExists));
+
+		if (settings is null || !settings.UseCustomBeeps)
+			return Array.Empty<string>();
+
+		var issues = new List<string>();
+		foreach (var (label, read) in Files)
+		{
+			string path = read(settings) ?? string.Empty;
+			if (IsUsable(settings, path, fileExists))
+				continue;
+
+			// A wrong extension is named separately: "could not load" sends the user
+			// looking for a missing file when the file is there and simply not a .wav.
+			issues.Add(HasWrongExtension(path)
+				? $"Custom {label} beep must be a .wav file: {path}"
+				: $"Could not load {label} beep file: {path}");
+		}
+
+		return issues;
+	}
+
+	private static bool IsUsable(
+		AudioSettings.CustomBeepSettingsData settings,
+		string path,
+		Func<string, bool> fileExists)
+	{
+		if (string.IsNullOrWhiteSpace(path))
+			return false;
+
+		if (!string.Equals(Path.GetExtension(path), WavExtension, StringComparison.OrdinalIgnoreCase))
+			return false;
+
+		return fileExists(settings.ResolveAudioFilePath(path));
+	}
+
+	private static bool HasWrongExtension(string path) =>
+		!string.IsNullOrWhiteSpace(path)
+		&& !string.Equals(Path.GetExtension(path), WavExtension, StringComparison.OrdinalIgnoreCase);
+}

--- a/CognitiveSupport/ErrorLogger.cs
+++ b/CognitiveSupport/ErrorLogger.cs
@@ -71,32 +71,33 @@ public static class ErrorLogger
 	/// Never throws; falls back to the EXE-folder path if the local-app-data path
 	/// cannot be computed. Follows <see cref="RedirectTo"/> when one is in effect.
 	/// </summary>
-	public static string PrimaryLogPath
-	{
-		get
-		{
-			string? redirected = s_logDirectoryOverride;
-			if (redirected is not null)
-			{
-				try { return Path.Combine(redirected, ErrorLogFileName); }
-				catch { return ErrorLogFileName; }
-			}
+	public static string PrimaryLogPath => ResolveLogPath(s_logDirectoryOverride);
 
+	// Split out so the path rules can be tested without touching the process-wide
+	// override — reading the default path by switching the redirect off would let
+	// concurrent tests log into the user's real file, which is the thing being avoided.
+	internal static string ResolveLogPath(string? overrideDirectory)
+	{
+		if (!string.IsNullOrWhiteSpace(overrideDirectory))
+		{
+			try { return Path.Combine(overrideDirectory, ErrorLogFileName); }
+			catch { return ErrorLogFileName; }
+		}
+
+		try
+		{
+			string localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+			return Path.Combine(localAppData, "Mutation", "logs", ErrorLogFileName);
+		}
+		catch
+		{
 			try
 			{
-				string localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-				return Path.Combine(localAppData, "Mutation", "logs", ErrorLogFileName);
+				return Path.Combine(AppContext.BaseDirectory, ErrorLogFileName);
 			}
 			catch
 			{
-				try
-				{
-					return Path.Combine(AppContext.BaseDirectory, ErrorLogFileName);
-				}
-				catch
-				{
-					return ErrorLogFileName;
-				}
+				return ErrorLogFileName;
 			}
 		}
 	}
@@ -165,7 +166,9 @@ public static class ErrorLogger
 		string? redirected = s_logDirectoryOverride;
 		if (redirected is not null)
 		{
-			AppendQuietly(redirected, entry);
+			// A redirect replaces both default locations rather than adding a third: its
+			// whole purpose is that nothing lands in the user's log.
+			AppendQuietly(redirected, entry, createDirectory: true);
 			return;
 		}
 
@@ -173,7 +176,7 @@ public static class ErrorLogger
 		try
 		{
 			string localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-			AppendQuietly(Path.Combine(localAppData, "Mutation", "logs"), entry);
+			AppendQuietly(Path.Combine(localAppData, "Mutation", "logs"), entry, createDirectory: true);
 		}
 		catch
 		{
@@ -181,18 +184,20 @@ public static class ErrorLogger
 		}
 
 		// (b) EXE folder. May fail if installed under a non-writable directory
-		// (e.g. Program Files); that must not stop the user-writable write above.
-		AppendQuietly(AppContext.BaseDirectory, entry);
+		// (e.g. Program Files); that must not stop the user-writable write above. It
+		// already exists by definition, so it is not created — that would put a
+		// filesystem call on every entry for nothing.
+		AppendQuietly(AppContext.BaseDirectory, entry, createDirectory: false);
 	}
 
-	// Appends to <directory>\Mutation_Errors.log, creating the directory if needed and
-	// swallowing every failure — a caller of the logger is usually already in a failure
-	// path and must not acquire a second one.
-	private static void AppendQuietly(string directory, string entry)
+	// Appends to <directory>\Mutation_Errors.log, swallowing every failure — a caller of
+	// the logger is usually already in a failure path and must not acquire a second one.
+	private static void AppendQuietly(string directory, string entry, bool createDirectory)
 	{
 		try
 		{
-			Directory.CreateDirectory(directory);
+			if (createDirectory)
+				Directory.CreateDirectory(directory);
 			AppendWithRotation(Path.Combine(directory, ErrorLogFileName), entry, MaxLogFileSizeBytes);
 		}
 		catch

--- a/CognitiveSupport/ErrorLogger.cs
+++ b/CognitiveSupport/ErrorLogger.cs
@@ -46,16 +46,42 @@ public static class ErrorLogger
 	// concurrent writer cannot race the rotation move.
 	private static readonly object s_gate = new();
 
+	// When set, the only place entries are written. See RedirectTo.
+	private static volatile string? s_logDirectoryOverride;
+
+	/// <summary>
+	/// Sends every subsequent entry to <paramref name="directory"/> alone, instead of
+	/// the two default locations, and points <see cref="PrimaryLogPath"/> there. Pass
+	/// <c>null</c> to restore the defaults.
+	///
+	/// The app itself never calls this. It exists for hosts that must not append to the
+	/// user's real log — above all the test suite, whose fixtures ("no audio device",
+	/// "your account is not approved for the fast-mode beta") are indistinguishable from
+	/// genuine runtime failures once they are sitting in the same file the user is asked
+	/// to read when something goes wrong.
+	/// </summary>
+	public static void RedirectTo(string? directory)
+	{
+		s_logDirectoryOverride = string.IsNullOrWhiteSpace(directory) ? null : directory;
+	}
+
 	/// <summary>
 	/// The user-writable log path (<c>%LOCALAPPDATA%\Mutation\logs\Mutation_Errors.log</c>),
 	/// suitable for surfacing in dialogs so the user knows where to find the log.
 	/// Never throws; falls back to the EXE-folder path if the local-app-data path
-	/// cannot be computed.
+	/// cannot be computed. Follows <see cref="RedirectTo"/> when one is in effect.
 	/// </summary>
 	public static string PrimaryLogPath
 	{
 		get
 		{
+			string? redirected = s_logDirectoryOverride;
+			if (redirected is not null)
+			{
+				try { return Path.Combine(redirected, ErrorLogFileName); }
+				catch { return ErrorLogFileName; }
+			}
+
 			try
 			{
 				string localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
@@ -134,14 +160,20 @@ public static class ErrorLogger
 		string timestamp = DateTimeOffset.Now.ToString("yyyy-MM-dd HH:mm:ss.fff zzz");
 		string entry = $"[{timestamp}] [{source}]{Environment.NewLine}{body}{Environment.NewLine}{Environment.NewLine}";
 
+		// A redirect replaces both default locations rather than adding a third: its
+		// whole purpose is that nothing lands in the user's log.
+		string? redirected = s_logDirectoryOverride;
+		if (redirected is not null)
+		{
+			AppendQuietly(redirected, entry);
+			return;
+		}
+
 		// (a) User-writable location: %LOCALAPPDATA%\Mutation\logs. Created if missing.
 		try
 		{
 			string localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-			string logDir = Path.Combine(localAppData, "Mutation", "logs");
-			Directory.CreateDirectory(logDir);
-			string logPath = Path.Combine(logDir, ErrorLogFileName);
-			AppendWithRotation(logPath, entry, MaxLogFileSizeBytes);
+			AppendQuietly(Path.Combine(localAppData, "Mutation", "logs"), entry);
 		}
 		catch
 		{
@@ -150,14 +182,22 @@ public static class ErrorLogger
 
 		// (b) EXE folder. May fail if installed under a non-writable directory
 		// (e.g. Program Files); that must not stop the user-writable write above.
+		AppendQuietly(AppContext.BaseDirectory, entry);
+	}
+
+	// Appends to <directory>\Mutation_Errors.log, creating the directory if needed and
+	// swallowing every failure — a caller of the logger is usually already in a failure
+	// path and must not acquire a second one.
+	private static void AppendQuietly(string directory, string entry)
+	{
 		try
 		{
-			string logPath = Path.Combine(AppContext.BaseDirectory, ErrorLogFileName);
-			AppendWithRotation(logPath, entry, MaxLogFileSizeBytes);
+			Directory.CreateDirectory(directory);
+			AppendWithRotation(Path.Combine(directory, ErrorLogFileName), entry, MaxLogFileSizeBytes);
 		}
 		catch
 		{
-			// Never let logging throw — callers may already be in a failure path.
+			// Never let logging throw.
 		}
 	}
 

--- a/Documentation/UserGuide/html/accessibility.html
+++ b/Documentation/UserGuide/html/accessibility.html
@@ -169,8 +169,8 @@ explanation, or the other way around. What you hear is what is there.</p>
 <p>Mutation uses short beeps so you know an action landed without having to check the
 screen. There are distinct sounds for:</p>
 <ul>
-<li><strong>Start</strong> — a recording has begun.</li>
-<li><strong>End</strong> — a recording has stopped.</li>
+<li><strong>Start</strong> — a recording has begun, or the screenshot overlay is ready for you to pick a region.</li>
+<li><strong>End</strong> — a recording has stopped, or your screenshot has been captured and sent off to be read.</li>
 <li><strong>Success</strong> — a two-note rising chirp when something completed.</li>
 <li><strong>Failure</strong> — a low tone, repeated, when something went wrong.</li>
 <li><strong>Mute</strong> — a low tone when microphones are muted.</li>

--- a/Documentation/UserGuide/html/accessibility.html
+++ b/Documentation/UserGuide/html/accessibility.html
@@ -238,7 +238,7 @@ overlay in context.</li>
 
 <footer>
 <p><a href="index.html">Back to the contents page</a></p>
-<p>Generated from the Markdown source on 4 August 2026. The Markdown files are the source of truth &ndash; do not edit these HTML pages by hand.</p>
+<p>Generated from the Markdown source on 5 August 2026. The Markdown files are the source of truth &ndash; do not edit these HTML pages by hand.</p>
 </footer>
 </main>
 </div>

--- a/Documentation/UserGuide/html/ai-prompts.html
+++ b/Documentation/UserGuide/html/ai-prompts.html
@@ -239,7 +239,7 @@ footer{margin-top:3rem; padding-top:1rem; border-top:1px solid var(--rule); colo
 
 <footer>
 <p><a href="index.html">Back to the contents page</a></p>
-<p>Generated from the Markdown source on 4 August 2026. The Markdown files are the source of truth &ndash; do not edit these HTML pages by hand.</p>
+<p>Generated from the Markdown source on 5 August 2026. The Markdown files are the source of truth &ndash; do not edit these HTML pages by hand.</p>
 </footer>
 </main>
 </div>

--- a/Documentation/UserGuide/html/dictation.html
+++ b/Documentation/UserGuide/html/dictation.html
@@ -321,7 +321,7 @@ records from.</li>
 
 <footer>
 <p><a href="index.html">Back to the contents page</a></p>
-<p>Generated from the Markdown source on 4 August 2026. The Markdown files are the source of truth &ndash; do not edit these HTML pages by hand.</p>
+<p>Generated from the Markdown source on 5 August 2026. The Markdown files are the source of truth &ndash; do not edit these HTML pages by hand.</p>
 </footer>
 </main>
 </div>

--- a/Documentation/UserGuide/html/getting-started.html
+++ b/Documentation/UserGuide/html/getting-started.html
@@ -234,7 +234,7 @@ window, or press <strong>Alt</strong> then <strong>G</strong>, and this guide op
 
 <footer>
 <p><a href="index.html">Back to the contents page</a></p>
-<p>Generated from the Markdown source on 4 August 2026. The Markdown files are the source of truth &ndash; do not edit these HTML pages by hand.</p>
+<p>Generated from the Markdown source on 5 August 2026. The Markdown files are the source of truth &ndash; do not edit these HTML pages by hand.</p>
 </footer>
 </main>
 </div>

--- a/Documentation/UserGuide/html/index.html
+++ b/Documentation/UserGuide/html/index.html
@@ -284,7 +284,7 @@ authoritative version. To rebuild the web pages after an edit, run
 
 <footer>
 <p><a href="index.html">Back to the contents page</a></p>
-<p>Generated from the Markdown source on 4 August 2026. The Markdown files are the source of truth &ndash; do not edit these HTML pages by hand.</p>
+<p>Generated from the Markdown source on 5 August 2026. The Markdown files are the source of truth &ndash; do not edit these HTML pages by hand.</p>
 </footer>
 </main>
 </div>

--- a/Documentation/UserGuide/html/keyboard-shortcuts.html
+++ b/Documentation/UserGuide/html/keyboard-shortcuts.html
@@ -439,7 +439,7 @@ trigger a more complex shortcut. Changes apply when you save settings.</p>
 
 <footer>
 <p><a href="index.html">Back to the contents page</a></p>
-<p>Generated from the Markdown source on 4 August 2026. The Markdown files are the source of truth &ndash; do not edit these HTML pages by hand.</p>
+<p>Generated from the Markdown source on 5 August 2026. The Markdown files are the source of truth &ndash; do not edit these HTML pages by hand.</p>
 </footer>
 </main>
 </div>

--- a/Documentation/UserGuide/html/main-window.html
+++ b/Documentation/UserGuide/html/main-window.html
@@ -490,7 +490,7 @@ with no internet connection.</p>
 
 <footer>
 <p><a href="index.html">Back to the contents page</a></p>
-<p>Generated from the Markdown source on 4 August 2026. The Markdown files are the source of truth &ndash; do not edit these HTML pages by hand.</p>
+<p>Generated from the Markdown source on 5 August 2026. The Markdown files are the source of truth &ndash; do not edit these HTML pages by hand.</p>
 </footer>
 </main>
 </div>

--- a/Documentation/UserGuide/html/microphone.html
+++ b/Documentation/UserGuide/html/microphone.html
@@ -252,7 +252,7 @@ mic goes missing.</li>
 
 <footer>
 <p><a href="index.html">Back to the contents page</a></p>
-<p>Generated from the Markdown source on 4 August 2026. The Markdown files are the source of truth &ndash; do not edit these HTML pages by hand.</p>
+<p>Generated from the Markdown source on 5 August 2026. The Markdown files are the source of truth &ndash; do not edit these HTML pages by hand.</p>
 </footer>
 </main>
 </div>

--- a/Documentation/UserGuide/html/read-aloud.html
+++ b/Documentation/UserGuide/html/read-aloud.html
@@ -316,7 +316,7 @@ sits.</li>
 
 <footer>
 <p><a href="index.html">Back to the contents page</a></p>
-<p>Generated from the Markdown source on 4 August 2026. The Markdown files are the source of truth &ndash; do not edit these HTML pages by hand.</p>
+<p>Generated from the Markdown source on 5 August 2026. The Markdown files are the source of truth &ndash; do not edit these HTML pages by hand.</p>
 </footer>
 </main>
 </div>

--- a/Documentation/UserGuide/html/screen-capture-and-ocr.html
+++ b/Documentation/UserGuide/html/screen-capture-and-ocr.html
@@ -268,9 +268,13 @@ labels this one <strong>(L→R)</strong>. Choose it for tables, spreadsheets, fo
 <p>In all four OCR cases the text lands on your clipboard, ready to paste, and also
 appears in the <strong>OCR result</strong> box at the bottom of the card so you can read it in
 place.</p>
-<p>You can follow the whole thing by ear. The start beep says the overlay is ready for
-you to pick a rectangle. The end beep says your picture has been captured and sent off
-to be read. Then the success beep says the text is on your clipboard — or the failure
+<p>You can follow all of this by ear.</p>
+<p>With <strong>Screenshot &amp; OCR</strong>, the start beep says the overlay is ready for you to pick a
+rectangle. The end beep says your picture has been captured and sent off to be read.</p>
+<p>With <strong>OCR clipboard</strong>, there is no rectangle to pick, so there is no start beep. The
+end beep is the first thing you hear, and it says your picture has been sent off to be
+read.</p>
+<p>Either way, the success beep then says the text is on your clipboard — or the failure
 beep says something went wrong, and the status area tells you what.</p>
 <h2 id="reading-a-batch-of-files-at-once">Reading a batch of files at once</h2>
 <p>The <strong>OCR documents</strong> button handles whole files rather than screenshots. Click it,
@@ -309,7 +313,7 @@ automatically.</p>
 
 <footer>
 <p><a href="index.html">Back to the contents page</a></p>
-<p>Generated from the Markdown source on 4 August 2026. The Markdown files are the source of truth &ndash; do not edit these HTML pages by hand.</p>
+<p>Generated from the Markdown source on 5 August 2026. The Markdown files are the source of truth &ndash; do not edit these HTML pages by hand.</p>
 </footer>
 </main>
 </div>

--- a/Documentation/UserGuide/html/screen-capture-and-ocr.html
+++ b/Documentation/UserGuide/html/screen-capture-and-ocr.html
@@ -268,6 +268,10 @@ labels this one <strong>(L→R)</strong>. Choose it for tables, spreadsheets, fo
 <p>In all four OCR cases the text lands on your clipboard, ready to paste, and also
 appears in the <strong>OCR result</strong> box at the bottom of the card so you can read it in
 place.</p>
+<p>You can follow the whole thing by ear. The start beep says the overlay is ready for
+you to pick a rectangle. The end beep says your picture has been captured and sent off
+to be read. Then the success beep says the text is on your clipboard — or the failure
+beep says something went wrong, and the status area tells you what.</p>
 <h2 id="reading-a-batch-of-files-at-once">Reading a batch of files at once</h2>
 <p>The <strong>OCR documents</strong> button handles whole files rather than screenshots. Click it,
 pick one or more files, and Mutation reads them all.</p>

--- a/Documentation/UserGuide/html/settings.html
+++ b/Documentation/UserGuide/html/settings.html
@@ -479,7 +479,7 @@ screen reader — gives you the same plain explanation you have just read here.<
 
 <footer>
 <p><a href="index.html">Back to the contents page</a></p>
-<p>Generated from the Markdown source on 4 August 2026. The Markdown files are the source of truth &ndash; do not edit these HTML pages by hand.</p>
+<p>Generated from the Markdown source on 5 August 2026. The Markdown files are the source of truth &ndash; do not edit these HTML pages by hand.</p>
 </footer>
 </main>
 </div>

--- a/Documentation/UserGuide/html/transcript-formatting.html
+++ b/Documentation/UserGuide/html/transcript-formatting.html
@@ -214,7 +214,7 @@ footer{margin-top:3rem; padding-top:1rem; border-top:1px solid var(--rule); colo
 
 <footer>
 <p><a href="index.html">Back to the contents page</a></p>
-<p>Generated from the Markdown source on 4 August 2026. The Markdown files are the source of truth &ndash; do not edit these HTML pages by hand.</p>
+<p>Generated from the Markdown source on 5 August 2026. The Markdown files are the source of truth &ndash; do not edit these HTML pages by hand.</p>
 </footer>
 </main>
 </div>

--- a/Documentation/UserGuide/html/troubleshooting.html
+++ b/Documentation/UserGuide/html/troubleshooting.html
@@ -323,17 +323,25 @@ or screen-recording-blocker software, and make sure the window you are capturing
 playing protected video.</p>
 <h3 id="your-own-beep-sounds-stopped-playing">Your own beep sounds stopped playing</h3>
 <p><strong>What's happening.</strong> At startup Mutation checks every sound file you picked for the
-custom beeps. If one of them has been moved, renamed, deleted, or is not a <code>.wav</code> file,
-it cannot be played. Rather than leave you with a silent cue, Mutation switches back to
-its built-in beeps and shows a message titled &quot;Custom Beep Settings Issues&quot;, naming each
-file and what is wrong with it.</p>
+custom beeps. Rather than leave you with a silent cue, it falls back to its built-in
+beeps and shows a message titled &quot;Custom Beep Settings Issues&quot;, naming each file and
+what is wrong with it. The message also tells you how far the fallback went, because
+that depends on the problem:</p>
+<ul>
+<li>If a file has been moved, renamed, deleted, or is not a <code>.wav</code> file, Mutation turns
+<strong>Use custom beeps</strong> off altogether. All six sounds go back to the built-in ones.</li>
+<li>If a file is there and is a <code>.wav</code> but still cannot be played — a truncated or
+damaged file, say — only that one sound falls back. Your other custom sounds carry
+on, and <strong>Use custom beeps</strong> stays on.</li>
+</ul>
 <p><strong>What to do.</strong></p>
 <ol>
 <li>Read the list — it names each sound and the file it could not use.</li>
 <li>Put the file back, or pick a new one: open <strong>Settings</strong> with <strong>Ctrl+Comma</strong>, go to
 <strong>Audio</strong>, and browse for a <code>.wav</code> file for that cue. The small play button lets you
 hear it before you commit.</li>
-<li>Turn <strong>Use custom beeps</strong> back on, and save.</li>
+<li>If the message told you <strong>Use custom beeps</strong> was turned off, turn it back on.</li>
+<li>Save.</li>
 </ol>
 <p>Until you do, everything still works — you just hear Mutation's own beeps.</p>
 <h2 id="finding-the-log-file">Finding the log file</h2>
@@ -372,7 +380,7 @@ and the keyboard-driven capture overlay.</li>
 
 <footer>
 <p><a href="index.html">Back to the contents page</a></p>
-<p>Generated from the Markdown source on 4 August 2026. The Markdown files are the source of truth &ndash; do not edit these HTML pages by hand.</p>
+<p>Generated from the Markdown source on 5 August 2026. The Markdown files are the source of truth &ndash; do not edit these HTML pages by hand.</p>
 </footer>
 </main>
 </div>

--- a/Documentation/UserGuide/html/troubleshooting.html
+++ b/Documentation/UserGuide/html/troubleshooting.html
@@ -321,6 +321,21 @@ it tries, and tells you when the test fails, with the technical detail included.
 department and Mutation cannot work around it — ask them. Otherwise, check for privacy
 or screen-recording-blocker software, and make sure the window you are capturing is not
 playing protected video.</p>
+<h3 id="your-own-beep-sounds-stopped-playing">Your own beep sounds stopped playing</h3>
+<p><strong>What's happening.</strong> At startup Mutation checks every sound file you picked for the
+custom beeps. If one of them has been moved, renamed, deleted, or is not a <code>.wav</code> file,
+it cannot be played. Rather than leave you with a silent cue, Mutation switches back to
+its built-in beeps and shows a message titled &quot;Custom Beep Settings Issues&quot;, naming each
+file and what is wrong with it.</p>
+<p><strong>What to do.</strong></p>
+<ol>
+<li>Read the list — it names each sound and the file it could not use.</li>
+<li>Put the file back, or pick a new one: open <strong>Settings</strong> with <strong>Ctrl+Comma</strong>, go to
+<strong>Audio</strong>, and browse for a <code>.wav</code> file for that cue. The small play button lets you
+hear it before you commit.</li>
+<li>Turn <strong>Use custom beeps</strong> back on, and save.</li>
+</ol>
+<p>Until you do, everything still works — you just hear Mutation's own beeps.</p>
 <h2 id="finding-the-log-file">Finding the log file</h2>
 <p>When something goes wrong, Mutation writes a timestamped entry to a log file called
 <code>Mutation_Errors.log</code>. It lives here:</p>

--- a/Documentation/UserGuide/markdown/accessibility.md
+++ b/Documentation/UserGuide/markdown/accessibility.md
@@ -32,8 +32,8 @@ explanation, or the other way around. What you hear is what is there.
 Mutation uses short beeps so you know an action landed without having to check the
 screen. There are distinct sounds for:
 
-- **Start** — a recording has begun.
-- **End** — a recording has stopped.
+- **Start** — a recording has begun, or the screenshot overlay is ready for you to pick a region.
+- **End** — a recording has stopped, or your screenshot has been captured and sent off to be read.
 - **Success** — a two-note rising chirp when something completed.
 - **Failure** — a low tone, repeated, when something went wrong.
 - **Mute** — a low tone when microphones are muted.

--- a/Documentation/UserGuide/markdown/screen-capture-and-ocr.md
+++ b/Documentation/UserGuide/markdown/screen-capture-and-ocr.md
@@ -82,6 +82,11 @@ In all four OCR cases the text lands on your clipboard, ready to paste, and also
 appears in the **OCR result** box at the bottom of the card so you can read it in
 place.
 
+You can follow the whole thing by ear. The start beep says the overlay is ready for
+you to pick a rectangle. The end beep says your picture has been captured and sent off
+to be read. Then the success beep says the text is on your clipboard — or the failure
+beep says something went wrong, and the status area tells you what.
+
 ## Reading a batch of files at once
 
 The **OCR documents** button handles whole files rather than screenshots. Click it,

--- a/Documentation/UserGuide/markdown/screen-capture-and-ocr.md
+++ b/Documentation/UserGuide/markdown/screen-capture-and-ocr.md
@@ -82,9 +82,16 @@ In all four OCR cases the text lands on your clipboard, ready to paste, and also
 appears in the **OCR result** box at the bottom of the card so you can read it in
 place.
 
-You can follow the whole thing by ear. The start beep says the overlay is ready for
-you to pick a rectangle. The end beep says your picture has been captured and sent off
-to be read. Then the success beep says the text is on your clipboard — or the failure
+You can follow all of this by ear.
+
+With **Screenshot & OCR**, the start beep says the overlay is ready for you to pick a
+rectangle. The end beep says your picture has been captured and sent off to be read.
+
+With **OCR clipboard**, there is no rectangle to pick, so there is no start beep. The
+end beep is the first thing you hear, and it says your picture has been sent off to be
+read.
+
+Either way, the success beep then says the text is on your clipboard — or the failure
 beep says something went wrong, and the status area tells you what.
 
 ## Reading a batch of files at once

--- a/Documentation/UserGuide/markdown/troubleshooting.md
+++ b/Documentation/UserGuide/markdown/troubleshooting.md
@@ -215,6 +215,24 @@ department and Mutation cannot work around it — ask them. Otherwise, check for
 or screen-recording-blocker software, and make sure the window you are capturing is not
 playing protected video.
 
+### Your own beep sounds stopped playing
+
+**What's happening.** At startup Mutation checks every sound file you picked for the
+custom beeps. If one of them has been moved, renamed, deleted, or is not a `.wav` file,
+it cannot be played. Rather than leave you with a silent cue, Mutation switches back to
+its built-in beeps and shows a message titled "Custom Beep Settings Issues", naming each
+file and what is wrong with it.
+
+**What to do.**
+
+1. Read the list — it names each sound and the file it could not use.
+2. Put the file back, or pick a new one: open **Settings** with **Ctrl+Comma**, go to
+   **Audio**, and browse for a `.wav` file for that cue. The small play button lets you
+   hear it before you commit.
+3. Turn **Use custom beeps** back on, and save.
+
+Until you do, everything still works — you just hear Mutation's own beeps.
+
 ## Finding the log file
 
 When something goes wrong, Mutation writes a timestamped entry to a log file called

--- a/Documentation/UserGuide/markdown/troubleshooting.md
+++ b/Documentation/UserGuide/markdown/troubleshooting.md
@@ -218,10 +218,16 @@ playing protected video.
 ### Your own beep sounds stopped playing
 
 **What's happening.** At startup Mutation checks every sound file you picked for the
-custom beeps. If one of them has been moved, renamed, deleted, or is not a `.wav` file,
-it cannot be played. Rather than leave you with a silent cue, Mutation switches back to
-its built-in beeps and shows a message titled "Custom Beep Settings Issues", naming each
-file and what is wrong with it.
+custom beeps. Rather than leave you with a silent cue, it falls back to its built-in
+beeps and shows a message titled "Custom Beep Settings Issues", naming each file and
+what is wrong with it. The message also tells you how far the fallback went, because
+that depends on the problem:
+
+- If a file has been moved, renamed, deleted, or is not a `.wav` file, Mutation turns
+  **Use custom beeps** off altogether. All six sounds go back to the built-in ones.
+- If a file is there and is a `.wav` but still cannot be played — a truncated or
+  damaged file, say — only that one sound falls back. Your other custom sounds carry
+  on, and **Use custom beeps** stays on.
 
 **What to do.**
 
@@ -229,7 +235,8 @@ file and what is wrong with it.
 2. Put the file back, or pick a new one: open **Settings** with **Ctrl+Comma**, go to
    **Audio**, and browse for a `.wav` file for that cue. The small play button lets you
    hear it before you commit.
-3. Turn **Use custom beeps** back on, and save.
+3. If the message told you **Use custom beeps** was turned off, turn it back on.
+4. Save.
 
 Until you do, everything still works — you just hear Mutation's own beeps.
 

--- a/Mutation.Tests/CustomBeepFileValidatorTests.cs
+++ b/Mutation.Tests/CustomBeepFileValidatorTests.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using CognitiveSupport;
+using Xunit;
+
+namespace Mutation.Tests;
+
+public class CustomBeepFileValidatorTests
+{
+	private static AudioSettings.CustomBeepSettingsData AllValid() => new()
+	{
+		UseCustomBeeps = true,
+		BeepSuccessFile = "./CustomAudio/Success.wav",
+		BeepFailureFile = "./CustomAudio/Failure.wav",
+		BeepStartFile = "./CustomAudio/Start.wav",
+		BeepEndFile = "./CustomAudio/End.wav",
+		BeepMuteFile = "./CustomAudio/Mute.wav",
+		BeepUnmuteFile = "./CustomAudio/Unmute.wav",
+	};
+
+	private static readonly Func<string, bool> EverythingExists = static _ => true;
+	private static readonly Func<string, bool> NothingExists = static _ => false;
+
+	[Fact]
+	public void AllSixResolveToAnExistingWav_ReportsNothing()
+	{
+		Assert.Empty(CustomBeepFileValidator.Validate(AllValid(), EverythingExists));
+	}
+
+	// Nothing is being loaded, so there is nothing to complain about — a user who has
+	// custom beeps switched off should not be nagged about paths they are not using.
+	[Fact]
+	public void CustomBeepsSwitchedOff_ReportsNothing_EvenWhenEveryFileIsMissing()
+	{
+		var settings = AllValid();
+		settings.UseCustomBeeps = false;
+
+		Assert.Empty(CustomBeepFileValidator.Validate(settings, NothingExists));
+	}
+
+	[Fact]
+	public void NullSettings_ReportsNothing()
+	{
+		Assert.Empty(CustomBeepFileValidator.Validate(null, NothingExists));
+	}
+
+	[Fact]
+	public void EveryFileMissing_ReportsOnePerFile()
+	{
+		var issues = CustomBeepFileValidator.Validate(AllValid(), NothingExists);
+
+		Assert.Equal(6, issues.Count);
+		Assert.All(issues, i => Assert.StartsWith("Could not load ", i));
+	}
+
+	// A file that is present but is not a .wav gets its own wording: "could not load"
+	// sends the user hunting for a missing file that is sitting right there.
+	[Fact]
+	public void WrongExtension_IsReportedAsAnExtensionProblemNotAMissingFile()
+	{
+		var settings = AllValid();
+		settings.BeepEndFile = "./CustomAudio/End.mp3";
+
+		var issues = CustomBeepFileValidator.Validate(settings, EverythingExists);
+
+		Assert.Equal(new[] { "Custom end beep must be a .wav file: ./CustomAudio/End.mp3" }, issues);
+	}
+
+	[Fact]
+	public void UppercaseExtension_IsAccepted()
+	{
+		var settings = AllValid();
+		settings.BeepStartFile = "./CustomAudio/Start.WAV";
+
+		Assert.Empty(CustomBeepFileValidator.Validate(settings, EverythingExists));
+	}
+
+	[Theory]
+	[InlineData(null)]
+	[InlineData("")]
+	[InlineData("   ")]
+	public void BlankPath_IsReportedAsUnloadable(string? path)
+	{
+		var settings = AllValid();
+		settings.BeepMuteFile = path;
+
+		var issues = CustomBeepFileValidator.Validate(settings, EverythingExists);
+
+		Assert.Single(issues);
+		Assert.StartsWith("Could not load mute beep file:", issues[0]);
+	}
+
+	// The existence check runs against the resolved path, not the raw setting: a
+	// relative path is resolved against the executable directory.
+	[Fact]
+	public void ExistenceIsCheckedAgainstTheResolvedPath()
+	{
+		var settings = AllValid();
+		var probed = new List<string>();
+
+		CustomBeepFileValidator.Validate(settings, path => { probed.Add(path); return true; });
+
+		Assert.Equal(6, probed.Count);
+		Assert.All(probed, p => Assert.True(System.IO.Path.IsPathRooted(p), $"'{p}' was not resolved"));
+	}
+
+	// Every label appears, so a user reading the list can tell which sound is broken.
+	[Fact]
+	public void EachBeepIsNamedInItsOwnMessage()
+	{
+		var issues = CustomBeepFileValidator.Validate(AllValid(), NothingExists);
+
+		foreach (string label in new[] { "success", "failure", "start", "end", "mute", "unmute" })
+			Assert.Contains(issues, i => i.Contains($" {label} beep ", StringComparison.Ordinal));
+	}
+
+	[Fact]
+	public void MissingExistenceCheck_IsRejected()
+	{
+		Assert.Throws<ArgumentNullException>(() => CustomBeepFileValidator.Validate(AllValid(), null!));
+	}
+}

--- a/Mutation.Tests/CustomBeepFileValidatorTests.cs
+++ b/Mutation.Tests/CustomBeepFileValidatorTests.cs
@@ -102,7 +102,44 @@ public class CustomBeepFileValidatorTests
 		CustomBeepFileValidator.Validate(settings, path => { probed.Add(path); return true; });
 
 		Assert.Equal(6, probed.Count);
-		Assert.All(probed, p => Assert.True(System.IO.Path.IsPathRooted(p), $"'{p}' was not resolved"));
+		Assert.All(probed, p => Assert.NotEqual("./CustomAudio/Success.wav", p));
+		Assert.Contains(probed, p => p.EndsWith(@"CustomAudio\Success.wav", StringComparison.OrdinalIgnoreCase)
+			&& System.IO.Path.IsPathRooted(p));
+	}
+
+	// A network path is refused by ResolveAudioFilePath, which hands back an empty
+	// string. That has to read as "could not load", not as a crash or a pass.
+	[Fact]
+	public void UncPath_IsReportedAsUnloadable()
+	{
+		var settings = AllValid();
+		settings.BeepSuccessFile = @"\\server\share\Success.wav";
+
+		var issues = CustomBeepFileValidator.Validate(settings, path => path.Length > 0);
+
+		Assert.Equal(new[] { @"Could not load success beep file: \\server\share\Success.wav" }, issues);
+	}
+
+	// Mixed problems are reported in setting order, so the list reads the same way the
+	// Audio settings page is laid out.
+	[Fact]
+	public void SeveralProblemsAtOnce_AreReportedInSettingOrder()
+	{
+		var settings = AllValid();
+		settings.BeepFailureFile = "./CustomAudio/Failure.ogg";
+		settings.BeepMuteFile = null;
+
+		var issues = CustomBeepFileValidator.Validate(
+			settings, path => !path.EndsWith("Start.wav", StringComparison.OrdinalIgnoreCase));
+
+		Assert.Equal(
+			new[]
+			{
+				"Custom failure beep must be a .wav file: ./CustomAudio/Failure.ogg",
+				"Could not load start beep file: ./CustomAudio/Start.wav",
+				"Could not load mute beep file: ",
+			},
+			issues);
 	}
 
 	// Every label appears, so a user reading the list can tell which sound is broken.

--- a/Mutation.Tests/CustomBeepIssueReportingTests.cs
+++ b/Mutation.Tests/CustomBeepIssueReportingTests.cs
@@ -1,0 +1,138 @@
+using System;
+using System.IO;
+using CognitiveSupport;
+using Mutation.Ui.Services;
+using Xunit;
+
+namespace Mutation.Tests;
+
+// The SettingsManager half of the custom-beep check: what it does to the settings, and
+// what it hands the caller to show the user. The rule itself lives in
+// CustomBeepFileValidatorTests.
+public class CustomBeepIssueReportingTests : IDisposable
+{
+	private readonly string _dir;
+	private readonly SettingsManager _manager;
+
+	public CustomBeepIssueReportingTests()
+	{
+		_dir = Path.Combine(Path.GetTempPath(), "MutationCustomBeepIssueTests_" + Guid.NewGuid().ToString("N"));
+		Directory.CreateDirectory(_dir);
+		_manager = new SettingsManager(Path.Combine(_dir, "Mutation.json"));
+	}
+
+	public void Dispose()
+	{
+		try { Directory.Delete(_dir, recursive: true); } catch { /* best-effort cleanup */ }
+	}
+
+	private static Settings WithCustomBeeps(string endFile)
+	{
+		var settings = new Settings
+		{
+			AudioSettings = new AudioSettings
+			{
+				CustomBeepSettings = new AudioSettings.CustomBeepSettingsData
+				{
+					UseCustomBeeps = true,
+					BeepSuccessFile = "./CustomAudio/Success.wav",
+					BeepFailureFile = "./CustomAudio/Failure.wav",
+					BeepStartFile = "./CustomAudio/Start.wav",
+					BeepEndFile = endFile,
+					BeepMuteFile = "./CustomAudio/Mute.wav",
+					BeepUnmuteFile = "./CustomAudio/Unmute.wav",
+				},
+			},
+		};
+		return settings;
+	}
+
+	// The real CustomAudio\*.wav files sit next to the test host, so the settings built
+	// above are the healthy case; this name is the one guaranteed not to resolve.
+	private const string MissingFile = "./CustomAudio/NoSuchSound.wav";
+
+	[Fact]
+	public void HealthyBeepFiles_ReportNothing_AndLeaveTheToggleOn()
+	{
+		var settings = WithCustomBeeps("./CustomAudio/End.wav");
+
+		_manager.EnsureSettings(settings, isNewFile: false);
+
+		Assert.Empty(_manager.CustomBeepIssues);
+		Assert.True(settings.AudioSettings!.CustomBeepSettings!.UseCustomBeeps);
+	}
+
+	[Fact]
+	public void AMissingBeepFile_IsReported_AndCustomBeepsAreSwitchedOff()
+	{
+		var settings = WithCustomBeeps(MissingFile);
+
+		_manager.EnsureSettings(settings, isNewFile: false);
+
+		Assert.Contains(_manager.CustomBeepIssues, i => i == $"Could not load end beep file: {MissingFile}");
+		Assert.False(settings.AudioSettings!.CustomBeepSettings!.UseCustomBeeps);
+	}
+
+	// Non-empty issues must make EnsureSettings report a change, or LoadAndEnsureSettings
+	// never writes the file back and custom beeps switch themselves off again on every
+	// single launch. Settled first, so the assertion is about the beep file alone and not
+	// about the defaults a fresh Settings object always picks up.
+	[Fact]
+	public void AMissingBeepFile_MarksTheSettingsAsChangedSoTheyAreSavedBack()
+	{
+		var settings = WithCustomBeeps("./CustomAudio/End.wav");
+		_manager.EnsureSettings(settings, isNewFile: false);
+		Assert.False(_manager.EnsureSettings(settings, isNewFile: false));
+
+		settings.AudioSettings!.CustomBeepSettings!.BeepEndFile = MissingFile;
+
+		Assert.True(_manager.EnsureSettings(settings, isNewFile: false));
+	}
+
+	[Fact]
+	public void CustomBeepsSwitchedOff_ReportsNothing_AndLeavesTheToggleAlone()
+	{
+		var settings = WithCustomBeeps(MissingFile);
+		settings.AudioSettings!.CustomBeepSettings!.UseCustomBeeps = false;
+
+		_manager.EnsureSettings(settings, isNewFile: false);
+
+		Assert.Empty(_manager.CustomBeepIssues);
+		Assert.False(settings.AudioSettings.CustomBeepSettings.UseCustomBeeps);
+	}
+
+	// A later load that finds nothing wrong has to clear the previous run's issues, or
+	// startup keeps raising a notice about a problem the user has already fixed.
+	[Fact]
+	public void ALaterCleanLoad_ClearsThePreviousIssues()
+	{
+		_manager.EnsureSettings(WithCustomBeeps(MissingFile), isNewFile: false);
+		Assert.NotEmpty(_manager.CustomBeepIssues);
+
+		_manager.EnsureSettings(WithCustomBeeps("./CustomAudio/End.wav"), isNewFile: false);
+
+		Assert.Empty(_manager.CustomBeepIssues);
+	}
+
+	[Fact]
+	public void AWrongExtension_IsReportedAsAnExtensionProblem()
+	{
+		var settings = WithCustomBeeps("./CustomAudio/End.mp3");
+
+		_manager.EnsureSettings(settings, isNewFile: false);
+
+		Assert.Contains(_manager.CustomBeepIssues, i => i == "Custom end beep must be a .wav file: ./CustomAudio/End.mp3");
+	}
+
+	// Nothing reaches the user from here — the notice is raised from startup, once the
+	// window can host an accessible dialog (issue #275).
+	[Fact]
+	public void NoBeepSettingsAtAll_IsHandledWithoutThrowing()
+	{
+		var settings = new Settings();
+
+		_manager.EnsureSettings(settings, isNewFile: false);
+
+		Assert.Empty(_manager.CustomBeepIssues);
+	}
+}

--- a/Mutation.Tests/ErrorLoggerCollection.cs
+++ b/Mutation.Tests/ErrorLoggerCollection.cs
@@ -1,0 +1,15 @@
+using Xunit;
+
+namespace Mutation.Tests;
+
+/// <summary>
+/// Serialises the test classes that drive <c>ErrorLogger</c>'s process-wide state — the
+/// registered-secret snapshot and the log directory redirect. xunit runs each class in
+/// its own collection in parallel by default, so two classes replacing the same static
+/// would otherwise assert against each other's values.
+/// </summary>
+[CollectionDefinition(Name)]
+public sealed class ErrorLoggerCollection
+{
+	public const string Name = "ErrorLogger statics";
+}

--- a/Mutation.Tests/ErrorLoggerRedactionTests.cs
+++ b/Mutation.Tests/ErrorLoggerRedactionTests.cs
@@ -5,7 +5,10 @@ namespace Mutation.Tests;
 
 // All tests in this class mutate ErrorLogger's static secret registry. xUnit
 // runs tests within a single class sequentially, so each test sets the registry
-// to a known state at the top and the tests stay order-independent.
+// to a known state at the top and the tests stay order-independent. The collection
+// extends that serialisation to ErrorLoggerRedirectTests, which drives the same
+// registry — separate classes otherwise run in parallel.
+[Collection(ErrorLoggerCollection.Name)]
 public class ErrorLoggerRedactionTests
 {
 	[Fact]

--- a/Mutation.Tests/ErrorLoggerRedirectTests.cs
+++ b/Mutation.Tests/ErrorLoggerRedirectTests.cs
@@ -5,10 +5,16 @@ using Xunit;
 
 namespace Mutation.Tests;
 
-// The redirect is a process-wide static, and TestLogRedirect has already pointed it at a
-// temp directory for the whole run. Each test here repoints it to its own directory and
-// restores the run-wide one afterwards, so nothing escapes to the user's real log even
-// if a test fails part way.
+// Shares a collection with ErrorLoggerRedactionTests: both drive ErrorLogger's
+// process-wide secret registry, and xunit runs separate classes in parallel by default,
+// so without this they would replace each other's snapshot mid-assertion.
+//
+// The redirect stays switched ON for the whole class — each test only ever repoints it
+// at its own directory, never back to the defaults. Turning it off, even briefly, would
+// let any test collection running in parallel append to the user's real log, which is
+// the thing this feature exists to prevent. The default-path rules are covered through
+// ErrorLogger.ResolveLogPath instead, which needs no global state.
+[Collection(ErrorLoggerCollection.Name)]
 public class ErrorLoggerRedirectTests : IDisposable
 {
 	private readonly string _dir;
@@ -23,6 +29,7 @@ public class ErrorLoggerRedirectTests : IDisposable
 
 	public void Dispose()
 	{
+		// Back to the run-wide temp directory, never to the defaults.
 		TestLogRedirect.Initialize();
 		try { Directory.Delete(_dir, recursive: true); } catch { /* best-effort cleanup */ }
 	}
@@ -39,21 +46,43 @@ public class ErrorLoggerRedirectTests : IDisposable
 	[Fact]
 	public void RedirectedLogging_DoesNotWriteBesideTheExe()
 	{
+		const string marker = "should not land beside the exe";
 		string exeSideLog = Path.Combine(AppContext.BaseDirectory, "Mutation_Errors.log");
-		DateTime? before = File.Exists(exeSideLog) ? File.GetLastWriteTimeUtc(exeSideLog) : null;
 
-		ErrorLogger.LogError("Test", new InvalidOperationException("should not land beside the exe"));
+		ErrorLogger.LogError("Test", new InvalidOperationException(marker));
 
-		DateTime? after = File.Exists(exeSideLog) ? File.GetLastWriteTimeUtc(exeSideLog) : null;
-		Assert.Equal(before, after);
-		// And it did go where it was told.
-		Assert.Contains("should not land beside the exe", File.ReadAllText(_logPath), StringComparison.Ordinal);
+		// Asserted on content rather than a timestamp: the file may not exist at all
+		// (which is also a pass), and file-time granularity is too coarse to trust.
+		string besideExe = File.Exists(exeSideLog) ? File.ReadAllText(exeSideLog) : string.Empty;
+		Assert.DoesNotContain(marker, besideExe, StringComparison.Ordinal);
+		Assert.Contains(marker, File.ReadAllText(_logPath), StringComparison.Ordinal);
 	}
 
 	[Fact]
 	public void PrimaryLogPath_FollowsTheRedirect()
 	{
 		Assert.Equal(_logPath, ErrorLogger.PrimaryLogPath);
+	}
+
+	[Fact]
+	public void RedirectingAgain_MovesSubsequentEntriesAndLeavesEarlierOnesBehind()
+	{
+		string second = Path.Combine(Path.GetTempPath(), "MutationErrorLoggerRedirectTests_" + Guid.NewGuid().ToString("N"));
+		try
+		{
+			ErrorLogger.LogInfo("Test", "before the move");
+			ErrorLogger.RedirectTo(second);
+			ErrorLogger.LogInfo("Test", "after the move");
+
+			Assert.Contains("before the move", File.ReadAllText(_logPath), StringComparison.Ordinal);
+			Assert.DoesNotContain("after the move", File.ReadAllText(_logPath), StringComparison.Ordinal);
+			Assert.Contains("after the move", File.ReadAllText(Path.Combine(second, "Mutation_Errors.log")), StringComparison.Ordinal);
+		}
+		finally
+		{
+			ErrorLogger.RedirectTo(_dir);
+			try { Directory.Delete(second, recursive: true); } catch { /* best-effort cleanup */ }
+		}
 	}
 
 	[Fact]
@@ -74,18 +103,26 @@ public class ErrorLoggerRedirectTests : IDisposable
 		}
 	}
 
+	// The default locations, exercised through the pure path resolver so no global is
+	// switched off to observe them.
 	[Theory]
 	[InlineData(null)]
 	[InlineData("")]
 	[InlineData("   ")]
-	public void BlankDirectory_RestoresTheDefaultLocations(string? directory)
+	public void NoRedirect_ResolvesToTheUserWritableDefault(string? directory)
 	{
-		ErrorLogger.RedirectTo(directory);
-
 		Assert.Equal(
 			Path.Combine(
 				Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
 				"Mutation", "logs", "Mutation_Errors.log"),
-			ErrorLogger.PrimaryLogPath);
+			ErrorLogger.ResolveLogPath(directory));
+	}
+
+	[Fact]
+	public void ARedirect_ResolvesIntoThatDirectory()
+	{
+		Assert.Equal(
+			Path.Combine(@"C:\somewhere", "Mutation_Errors.log"),
+			ErrorLogger.ResolveLogPath(@"C:\somewhere"));
 	}
 }

--- a/Mutation.Tests/ErrorLoggerRedirectTests.cs
+++ b/Mutation.Tests/ErrorLoggerRedirectTests.cs
@@ -1,0 +1,91 @@
+using System;
+using System.IO;
+using CognitiveSupport;
+using Xunit;
+
+namespace Mutation.Tests;
+
+// The redirect is a process-wide static, and TestLogRedirect has already pointed it at a
+// temp directory for the whole run. Each test here repoints it to its own directory and
+// restores the run-wide one afterwards, so nothing escapes to the user's real log even
+// if a test fails part way.
+public class ErrorLoggerRedirectTests : IDisposable
+{
+	private readonly string _dir;
+	private readonly string _logPath;
+
+	public ErrorLoggerRedirectTests()
+	{
+		_dir = Path.Combine(Path.GetTempPath(), "MutationErrorLoggerRedirectTests_" + Guid.NewGuid().ToString("N"));
+		_logPath = Path.Combine(_dir, "Mutation_Errors.log");
+		ErrorLogger.RedirectTo(_dir);
+	}
+
+	public void Dispose()
+	{
+		TestLogRedirect.Initialize();
+		try { Directory.Delete(_dir, recursive: true); } catch { /* best-effort cleanup */ }
+	}
+
+	[Fact]
+	public void RedirectedLogging_WritesIntoTheGivenDirectory_CreatingIt()
+	{
+		ErrorLogger.LogInfo("Test", "hello from a redirected logger");
+
+		Assert.True(File.Exists(_logPath));
+		Assert.Contains("hello from a redirected logger", File.ReadAllText(_logPath), StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public void RedirectedLogging_DoesNotWriteBesideTheExe()
+	{
+		string exeSideLog = Path.Combine(AppContext.BaseDirectory, "Mutation_Errors.log");
+		DateTime? before = File.Exists(exeSideLog) ? File.GetLastWriteTimeUtc(exeSideLog) : null;
+
+		ErrorLogger.LogError("Test", new InvalidOperationException("should not land beside the exe"));
+
+		DateTime? after = File.Exists(exeSideLog) ? File.GetLastWriteTimeUtc(exeSideLog) : null;
+		Assert.Equal(before, after);
+		// And it did go where it was told.
+		Assert.Contains("should not land beside the exe", File.ReadAllText(_logPath), StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public void PrimaryLogPath_FollowsTheRedirect()
+	{
+		Assert.Equal(_logPath, ErrorLogger.PrimaryLogPath);
+	}
+
+	[Fact]
+	public void RedirectedLogging_StillRedactsRegisteredSecrets()
+	{
+		ErrorLogger.RegisterSecretValues(new[] { "super-secret-key-value" });
+		try
+		{
+			ErrorLogger.LogInfo("Test", "the key is super-secret-key-value");
+
+			string written = File.ReadAllText(_logPath);
+			Assert.DoesNotContain("super-secret-key-value", written, StringComparison.Ordinal);
+			Assert.Contains("***REDACTED***", written, StringComparison.Ordinal);
+		}
+		finally
+		{
+			ErrorLogger.RegisterSecretValues(null);
+		}
+	}
+
+	[Theory]
+	[InlineData(null)]
+	[InlineData("")]
+	[InlineData("   ")]
+	public void BlankDirectory_RestoresTheDefaultLocations(string? directory)
+	{
+		ErrorLogger.RedirectTo(directory);
+
+		Assert.Equal(
+			Path.Combine(
+				Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+				"Mutation", "logs", "Mutation_Errors.log"),
+			ErrorLogger.PrimaryLogPath);
+	}
+}

--- a/Mutation.Tests/OcrManagerTests.cs
+++ b/Mutation.Tests/OcrManagerTests.cs
@@ -750,8 +750,11 @@ public class OcrManagerTests
 
 	// Issue #268: the end beep used to sound here as a side effect of OcrService's retry
 	// signal firing on attempt 1. #216 silenced that first attempt, which left OCR with
-	// no end beep at all, and #269 restored it only for dictation. The user hears start
-	// (region overlay), end (image captured, request going out), then success.
+	// no end beep at all, and #269 restored it only for dictation.
+	//
+	// This is the clipboard path: no region overlay, so no start beep — the user hears
+	// end (image sent) then success. The screenshot path adds a start beep in front,
+	// from the overlay.
 	[Fact]
 	public async Task ExtractTextFromClipboardImageAsync_BeepsEndWhenTheRequestGoesOut_ThenSuccess()
 	{

--- a/Mutation.Tests/OcrManagerTests.cs
+++ b/Mutation.Tests/OcrManagerTests.cs
@@ -9,6 +9,7 @@ using CognitiveSupport;
 using Mutation.Ui.Services;
 using PdfSharp.Pdf;
 using PdfSharp.Pdf.IO;
+using Windows.Graphics.Imaging;
 
 namespace Mutation.Tests;
 
@@ -747,6 +748,87 @@ public class OcrManagerTests
 		}
 	};
 
+	// Issue #268: the end beep used to sound here as a side effect of OcrService's retry
+	// signal firing on attempt 1. #216 silenced that first attempt, which left OCR with
+	// no end beep at all, and #269 restored it only for dictation. The user hears start
+	// (region overlay), end (image captured, request going out), then success.
+	[Fact]
+	public async Task ExtractTextFromClipboardImageAsync_BeepsEndWhenTheRequestGoesOut_ThenSuccess()
+	{
+		using var image = new SoftwareBitmap(BitmapPixelFormat.Bgra8, 2, 2, BitmapAlphaMode.Premultiplied);
+		var clipboard = new TestClipboard { Image = image };
+		var manager = new TestableOcrManager(CreateValidSettings(), new StubOcrService("recognised text"), clipboard);
+
+		var result = await manager.ExtractTextFromClipboardImageAsync(DefaultOrder);
+
+		Assert.True(result.Success);
+		WaitForBeep(manager, 2);
+		Assert.Equal(new[] { BeepType.End, BeepType.Success }, manager.Beeps.ToArray());
+	}
+
+	// The end beep says "the request went out", so a request that never went out must
+	// not claim one — the user would be told the image was sent when it was not.
+	[Fact]
+	public async Task ExtractTextFromClipboardImageAsync_NoEndBeep_WhenOcrIsNotConfigured()
+	{
+		using var image = new SoftwareBitmap(BitmapPixelFormat.Bgra8, 2, 2, BitmapAlphaMode.Premultiplied);
+		var clipboard = new TestClipboard { Image = image };
+		var manager = new TestableOcrManager(new Settings(), new StubOcrService(), clipboard);
+
+		var result = await manager.ExtractTextFromClipboardImageAsync(DefaultOrder);
+
+		Assert.False(result.Success);
+		WaitForBeep(manager, 1);
+		Assert.Equal(new[] { BeepType.Failure }, manager.Beeps.ToArray());
+	}
+
+	[Fact]
+	public async Task ExtractTextFromClipboardImageAsync_NoEndBeep_WhenThereIsNoImage()
+	{
+		var manager = new TestableOcrManager(CreateValidSettings(), new StubOcrService(), new TestClipboard());
+
+		var result = await manager.ExtractTextFromClipboardImageAsync(DefaultOrder);
+
+		Assert.False(result.Success);
+		WaitForBeep(manager, 1);
+		Assert.Equal(new[] { BeepType.Failure }, manager.Beeps.ToArray());
+	}
+
+	// A failing request still ended in the image being sent, so the end beep stands and
+	// the failure beep follows it.
+	[Fact]
+	public async Task ExtractTextFromClipboardImageAsync_BeepsEndThenFailure_WhenTheRequestFails()
+	{
+		using var image = new SoftwareBitmap(BitmapPixelFormat.Bgra8, 2, 2, BitmapAlphaMode.Premultiplied);
+		var clipboard = new TestClipboard { Image = image };
+		var service = new StubOcrService(new InvalidOperationException("service unavailable"));
+		var manager = new TestableOcrManager(CreateValidSettings(), service, clipboard);
+
+		var result = await manager.ExtractTextFromClipboardImageAsync(DefaultOrder);
+
+		Assert.False(result.Success);
+		WaitForBeep(manager, 2);
+		Assert.Equal(new[] { BeepType.End, BeepType.Failure }, manager.Beeps.ToArray());
+	}
+
+	// The batch path issues one request per segment; a beep each would be a burst, and
+	// it reports progress of its own.
+	[Fact]
+	public async Task ExtractTextFromFilesAsync_DoesNotBeepEndPerRequest()
+	{
+		using var first = new TempFile(".png");
+		using var second = new TempFile(".jpg");
+		var manager = new TestableOcrManager(
+			CreateValidSettings(), new StubOcrService("first", "second"), new TestClipboard());
+
+		var result = await manager.ExtractTextFromFilesAsync(
+			new[] { first.Path, second.Path }, DefaultOrder, CancellationToken.None);
+
+		Assert.True(result.Success);
+		WaitForBeep(manager, 1);
+		Assert.DoesNotContain(BeepType.End, manager.Beeps);
+	}
+
 	private static void WaitForBeep(TestableOcrManager manager, int expectedCount)
 	{
 		var reached = SpinWait.SpinUntil(() => manager.BeepCount >= expectedCount, TimeSpan.FromSeconds(1));
@@ -795,11 +877,18 @@ public class OcrManagerTests
 		public string? LastText { get; private set; }
 		public int SetTextCalls { get; private set; }
 
+		// The image ExtractTextFromClipboardImageAsync will find. Null means "no image
+		// on the clipboard", which is the path that beeps failure.
+		public SoftwareBitmap? Image { get; set; }
+
 		public override void SetText(string text)
 		{
 			SetTextCalls++;
 			LastText = text;
 		}
+
+		public override Task<SoftwareBitmap?> TryGetImageAsync(int attempts = 5, int delayMs = 150)
+			=> Task.FromResult(Image);
 	}
 
 	private sealed class StubOcrService : IOcrService

--- a/Mutation.Tests/TestLogRedirect.cs
+++ b/Mutation.Tests/TestLogRedirect.cs
@@ -1,0 +1,31 @@
+using System;
+using System.IO;
+using System.Runtime.CompilerServices;
+using CognitiveSupport;
+
+namespace Mutation.Tests;
+
+/// <summary>
+/// Points <see cref="ErrorLogger"/> at a temp directory for the whole test run.
+///
+/// Plenty of the code under test logs, and the logger's default destination is the
+/// user's real <c>%LOCALAPPDATA%\Mutation\logs\Mutation_Errors.log</c> — the first file
+/// anyone reads when the app misbehaves. Fixture output landing there ("no audio
+/// device", "your account is not approved for the fast-mode beta") is indistinguishable
+/// from a genuine failure, and it churns the 100 KB rotation so real entries roll out of
+/// the live file early. This has already cost real time during a diagnosis.
+///
+/// A module initializer rather than a fixture: it runs when the test assembly is
+/// loaded, so it cannot be raced by a test that logs before some fixture got its turn.
+/// </summary>
+internal static class TestLogRedirect
+{
+	[ModuleInitializer]
+	internal static void Initialize()
+	{
+		// A fixed path, not a per-run one: the logger's own rotation caps it, and a new
+		// directory per run would silt up the temp folder.
+		string directory = Path.Combine(Path.GetTempPath(), "Mutation.Tests", "logs");
+		ErrorLogger.RedirectTo(directory);
+	}
+}

--- a/Mutation.Ui/App.xaml.cs
+++ b/Mutation.Ui/App.xaml.cs
@@ -342,13 +342,18 @@ public partial class App : Application
 					NoticeSeverity.Warning);
 			}
 
-			// One notice for both checks. The settings layer rejects a path that is not a
-			// .wav or does not exist and switches custom beeps off; the player then finds
-			// anything that survives that but still will not load (a corrupt or
-			// unreadable file). Either way the user has the same problem to fix.
+			// One notice for both checks, which catch different things. The settings layer
+			// rejects a path that is not a .wav or does not exist, and switches custom
+			// beeps off wholesale. The player then finds a file that survived that and
+			// still will not load (truncated, or not really a PCM wav) — it falls back
+			// for that one sound only and leaves the toggle on. The closing advice
+			// differs accordingly: telling someone to re-enable a toggle that is still
+			// enabled sends them looking for a setting that is not the problem.
+			bool customBeepsSwitchedOff = settingsManager.CustomBeepIssues.Count > 0;
+			// The two lists never overlap — the settings check runs first and switches
+			// custom beeps off, which is what stops the player from looking at all.
 			var beepIssues = settingsManager.CustomBeepIssues
 				.Concat(BeepPlayer.LastInitializationIssues)
-				.Distinct(StringComparer.Ordinal)
 				.ToList();
 			if (beepIssues.Count > 0 && _window is MainWindow beepWindow)
 			{
@@ -356,8 +361,11 @@ public partial class App : Application
 					"Custom Beep Settings Issues",
 					"The following issues were found with the custom beep settings:\n\n" +
 						string.Join("\n", beepIssues) +
-						"\n\nMutation has switched back to its built-in beeps. Fix the files above, then turn " +
-						"Use custom beeps back on under Audio in Settings.",
+						(customBeepsSwitchedOff
+							? "\n\nMutation has switched back to its built-in beeps. Fix the files above, then turn " +
+								"Use custom beeps back on under Audio in Settings."
+							: "\n\nMutation will use its built-in beep for each sound listed above. Your other " +
+								"custom sounds still play. Replace the files above under Audio in Settings."),
 					"OK",
 					NoticeSeverity.Warning);
 			}

--- a/Mutation.Ui/App.xaml.cs
+++ b/Mutation.Ui/App.xaml.cs
@@ -342,12 +342,22 @@ public partial class App : Application
 					NoticeSeverity.Warning);
 			}
 
-			if (BeepPlayer.LastInitializationIssues.Count > 0 && _window is MainWindow beepWindow)
+			// One notice for both checks. The settings layer rejects a path that is not a
+			// .wav or does not exist and switches custom beeps off; the player then finds
+			// anything that survives that but still will not load (a corrupt or
+			// unreadable file). Either way the user has the same problem to fix.
+			var beepIssues = settingsManager.CustomBeepIssues
+				.Concat(BeepPlayer.LastInitializationIssues)
+				.Distinct(StringComparer.Ordinal)
+				.ToList();
+			if (beepIssues.Count > 0 && _window is MainWindow beepWindow)
 			{
 				await beepWindow.ShowNoticeAsync(
 					"Custom Beep Settings Issues",
 					"The following issues were found with the custom beep settings:\n\n" +
-						string.Join("\n", BeepPlayer.LastInitializationIssues),
+						string.Join("\n", beepIssues) +
+						"\n\nMutation has switched back to its built-in beeps. Fix the files above, then turn " +
+						"Use custom beeps back on under Audio in Settings.",
 					"OK",
 					NoticeSeverity.Warning);
 			}

--- a/Mutation.Ui/Services/ClipboardManager.cs
+++ b/Mutation.Ui/Services/ClipboardManager.cs
@@ -44,7 +44,9 @@ public class ClipboardManager
 		return success ? result : (ClipboardKind.Unavailable, string.Empty);
 	}
 
-	public async Task<SoftwareBitmap?> TryGetImageAsync(int attempts = 5, int delayMs = 150)
+	// Virtual for the same reason SetText is: it reaches the real Windows clipboard, so
+	// a test that wants to drive the OCR path has to be able to hand an image in.
+	public virtual async Task<SoftwareBitmap?> TryGetImageAsync(int attempts = 5, int delayMs = 150)
 	{
 		while (attempts-- > 0)
 		{

--- a/Mutation.Ui/Services/OcrManager.cs
+++ b/Mutation.Ui/Services/OcrManager.cs
@@ -392,6 +392,16 @@ public class OcrManager
         if (!IsOcrConfigured(out string configurationError))
             return new(false, configurationError);
 
+        // The image is captured and the request is going out — the same moment the
+        // dictation end beep marks (issue #268). It used to sound here as a side effect
+        // of OcrService's retry signal beeping on attempt 1; #216 silenced that first
+        // attempt, which was correct for retries and left OCR with no end beep at all.
+        // #269 restored it for dictation and missed this path.
+        //
+        // Raised here rather than in the batch path: that one issues a request per
+        // segment, so a beep each would be a burst, and it reports progress of its own.
+        await PlayBeepSafeAsync(BeepType.End);
+
         using var stream = new InMemoryRandomAccessStream();
         var encoder = await BitmapEncoder.CreateAsync(BitmapEncoder.PngEncoderId, stream);
         encoder.SetSoftwareBitmap(bitmap);

--- a/Mutation.Ui/Services/OcrManager.cs
+++ b/Mutation.Ui/Services/OcrManager.cs
@@ -392,21 +392,25 @@ public class OcrManager
         if (!IsOcrConfigured(out string configurationError))
             return new(false, configurationError);
 
-        // The image is captured and the request is going out — the same moment the
-        // dictation end beep marks (issue #268). It used to sound here as a side effect
-        // of OcrService's retry signal beeping on attempt 1; #216 silenced that first
-        // attempt, which was correct for retries and left OCR with no end beep at all.
-        // #269 restored it for dictation and missed this path.
-        //
-        // Raised here rather than in the batch path: that one issues a request per
-        // segment, so a beep each would be a burst, and it reports progress of its own.
-        await PlayBeepSafeAsync(BeepType.End);
-
         using var stream = new InMemoryRandomAccessStream();
         var encoder = await BitmapEncoder.CreateAsync(BitmapEncoder.PngEncoderId, stream);
         encoder.SetSoftwareBitmap(bitmap);
         await encoder.FlushAsync();
         stream.Seek(0);
+
+        // The image is encoded and the request is going out — the same moment the
+        // dictation end beep marks (issue #268). It used to sound here as a side effect
+        // of OcrService's retry signal beeping on attempt 1; #216 silenced that first
+        // attempt, which was correct for retries and left OCR with no end beep at all.
+        // #269 restored it for dictation and missed this path.
+        //
+        // After the encode, not before: the encode is not inside the catch below, so a
+        // failure there ends the call with no success or failure beep to follow. An end
+        // beep in front of that silence would have announced a request that never went.
+        //
+        // Raised here rather than in the batch path: that one issues a request per
+        // segment, so a beep each would be a burst, and it reports progress of its own.
+        await PlayBeepSafeAsync(BeepType.End);
 
         using Stream netStream = stream.AsStream();
         try

--- a/Mutation.Ui/Services/SettingsManager.cs
+++ b/Mutation.Ui/Services/SettingsManager.cs
@@ -22,6 +22,18 @@ internal class SettingsManager : ISettingsManager
 	public string SettingsFilePath { get; }
 	private string SettingsFileFullPath => Path.GetFullPath(SettingsFilePath);
 
+	/// <summary>
+	/// Custom beep files that could not be used, as found by the most recent
+	/// <see cref="EnsureSettings"/>. Empty when they are all fine or custom beeps are
+	/// off. Custom beeps have been switched off in the settings whenever this is
+	/// non-empty.
+	///
+	/// Deliberately not on <see cref="ISettingsManager"/>: only startup surfaces these,
+	/// and it holds the concrete manager. Everything else consumes settings, not the
+	/// story of how they were loaded.
+	/// </summary>
+	public IReadOnlyList<string> CustomBeepIssues { get; private set; } = Array.Empty<string>();
+
 	public SettingsManager(
 		string settingsFilePath)
 	{
@@ -184,114 +196,17 @@ internal class SettingsManager : ISettingsManager
 			audioSettings.PlaybackSpeed = normalizedSpeed;
 			somethingWasMissing = true;
 		}
-		if (audioSettings.CustomBeepSettings.UseCustomBeeps)
+		// Reported, not announced. This runs before there is a window to host a dialog,
+		// so anything shown from here can only be a bare Win32 message box with no
+		// automation name — nothing a screen reader can work with. The issues are handed
+		// to the caller instead, and App.OnLaunched raises them once the window is ready.
+		var beepIssues = CustomBeepFileValidator.Validate(audioSettings.CustomBeepSettings, File.Exists);
+		if (beepIssues.Count > 0)
 		{
-			string[] allowedExtensions = new[] { ".wav" };
-			var beepIssues = new List<string>();
-
-			string successPath = audioSettings.CustomBeepSettings.BeepSuccessFile ?? string.Empty;
-			string resolvedSuccessPath = audioSettings.CustomBeepSettings.ResolveAudioFilePath(successPath);
-			if (string.IsNullOrWhiteSpace(successPath) ||
-				!allowedExtensions.Contains(Path.GetExtension(successPath)?.ToLower()) ||
-				!File.Exists(resolvedSuccessPath))
-			{
-				somethingWasMissing = true;
-
-				if (!string.IsNullOrWhiteSpace(successPath) && Path.GetExtension(successPath)?.ToLower() != ".wav")
-					beepIssues.Add($"Custom success beep must be a .wav file: {successPath}");
-				else
-					beepIssues.Add($"Could not load success beep file: {successPath}");
-			}
-
-			string failurePath = audioSettings.CustomBeepSettings.BeepFailureFile ?? string.Empty;
-			string resolvedFailurePath = audioSettings.CustomBeepSettings.ResolveAudioFilePath(failurePath);
-			if (string.IsNullOrWhiteSpace(failurePath) ||
-				!allowedExtensions.Contains(Path.GetExtension(failurePath)?.ToLower()) ||
-				!File.Exists(resolvedFailurePath))
-			{
-				somethingWasMissing = true;
-
-				if (!string.IsNullOrWhiteSpace(failurePath) && Path.GetExtension(failurePath)?.ToLower() != ".wav")
-					beepIssues.Add($"Custom failure beep must be a .wav file: {failurePath}");
-				else
-					beepIssues.Add($"Could not load failure beep file: {failurePath}");
-			}
-
-			string startPath = audioSettings.CustomBeepSettings.BeepStartFile ?? string.Empty;
-			string resolvedStartPath = audioSettings.CustomBeepSettings.ResolveAudioFilePath(startPath);
-			if (string.IsNullOrWhiteSpace(startPath) ||
-				!allowedExtensions.Contains(Path.GetExtension(startPath)?.ToLower()) ||
-				!File.Exists(resolvedStartPath))
-			{
-				somethingWasMissing = true;
-
-				if (!string.IsNullOrWhiteSpace(startPath) && Path.GetExtension(startPath)?.ToLower() != ".wav")
-					beepIssues.Add($"Custom start beep must be a .wav file: {startPath}");
-				else
-					beepIssues.Add($"Could not load start beep file: {startPath}");
-			}
-
-			string endPath = audioSettings.CustomBeepSettings.BeepEndFile ?? string.Empty;
-			string resolvedEndPath = audioSettings.CustomBeepSettings.ResolveAudioFilePath(endPath);
-			if (string.IsNullOrWhiteSpace(endPath) ||
-				!allowedExtensions.Contains(Path.GetExtension(endPath)?.ToLower()) ||
-				!File.Exists(resolvedEndPath))
-			{
-				somethingWasMissing = true;
-
-				if (!string.IsNullOrWhiteSpace(endPath) && Path.GetExtension(endPath)?.ToLower() != ".wav")
-					beepIssues.Add($"Custom end beep must be a .wav file: {endPath}");
-				else
-					beepIssues.Add($"Could not load end beep file: {endPath}");
-			}
-
-			string mutePath = audioSettings.CustomBeepSettings.BeepMuteFile ?? string.Empty;
-			string resolvedMutePath = audioSettings.CustomBeepSettings.ResolveAudioFilePath(mutePath);
-			if (string.IsNullOrWhiteSpace(mutePath) ||
-				!allowedExtensions.Contains(Path.GetExtension(mutePath)?.ToLower()) ||
-				!File.Exists(resolvedMutePath))
-			{
-				somethingWasMissing = true;
-
-				if (!string.IsNullOrWhiteSpace(mutePath) && Path.GetExtension(mutePath)?.ToLower() != ".wav")
-					beepIssues.Add($"Custom mute beep must be a .wav file: {mutePath}");
-				else
-					beepIssues.Add($"Could not load mute beep file: {mutePath}");
-			}
-
-			string unmutePath = audioSettings.CustomBeepSettings.BeepUnmuteFile ?? string.Empty;
-			string resolvedUnmutePath = audioSettings.CustomBeepSettings.ResolveAudioFilePath(unmutePath);
-			if (string.IsNullOrWhiteSpace(unmutePath) ||
-				!allowedExtensions.Contains(Path.GetExtension(unmutePath)?.ToLower()) ||
-				!File.Exists(resolvedUnmutePath))
-			{
-				somethingWasMissing = true;
-
-				if (!string.IsNullOrWhiteSpace(unmutePath) && Path.GetExtension(unmutePath)?.ToLower() != ".wav")
-					beepIssues.Add($"Custom unmute beep must be a .wav file: {unmutePath}");
-				else
-					beepIssues.Add($"Could not load unmute beep file: {unmutePath}");
-			}
-
-			if (beepIssues.Any())
-			{
-				if (audioSettings.CustomBeepSettings != null)
-					audioSettings.CustomBeepSettings.UseCustomBeeps = false;
-
-				string message =
-					"The following issues were found with the custom beep settings:" + Environment.NewLine + Environment.NewLine +
-					string.Join(Environment.NewLine, beepIssues) + Environment.NewLine + Environment.NewLine +
-					"Falling back to default beep sounds. UseCustomBeeps has been disabled." + Environment.NewLine + Environment.NewLine +
-					"To use custom beeps again, fix the issues above and re-enable UseCustomBeeps in the settings file.";
-
-				System.Windows.Forms.MessageBox.Show(
-					message,
-					"Custom Beep Settings Issues",
-					System.Windows.Forms.MessageBoxButtons.OK,
-					System.Windows.Forms.MessageBoxIcon.Warning
-				);
-			}
+			audioSettings.CustomBeepSettings.UseCustomBeeps = false;
+			somethingWasMissing = true;
 		}
+		CustomBeepIssues = beepIssues;
 
 
 		if (settings.SpeechToTextSettings is null)


### PR DESCRIPTION
Closes #275. Closes #276. Also fixes the missing OCR end beep reported directly.

Three fixes sharing a cause: something the user is owed — a sound, a message — going somewhere it cannot reach them.

## The OCR end beep

The end beep used to sound at the start of an OCR request as a **side effect** of `OcrService`'s retry signal beeping on attempt 1. [#216](https://github.com/Subverting-complexity/Mutation/pull/216) silenced that first, non-retry attempt — right for retries, and it left OCR with no end beep at all. [#269](https://github.com/Subverting-complexity/Mutation/pull/269) restored it for dictation via `onRecordingStopped` and missed this path. Exactly the same regression as [#268](https://github.com/Subverting-complexity/Mutation/issues/268), one workflow over.

So the screenshot-to-OCR flow played **start** (overlay ready) and **success** (text on the clipboard) with silence across the one part that takes seconds.

`ExtractTextViaOcrAsync` now beeps `End` once the image is captured and the request is going out, covering both single-image workflows. Deliberately **not** the batch path — it issues a request per segment, so a beep each would be a burst, and it reports progress of its own. A test pins that.

`ClipboardManager.TryGetImageAsync` is now `virtual`, for the same reason `SetText` already was: the OCR path could not otherwise be driven in a test at all.

## #275 — custom beep validation showed an unreadable message box

`SettingsManager.EnsureSettings` raised its own bare Win32 message box from inside `LoadAndEnsureSettings` — before `_window` exists, so it could never have been anything else. No automation name, no help text. It is also a near-duplicate of the `BeepPlayer` check that #274 had just made accessible, so the app had two notices for one problem, one readable and one not.

The rule moved to `CustomBeepFileValidator` — reports rather than acts, and replaces six near-identical copy-pasted blocks with one table-driven pass. `EnsureSettings` switches custom beeps off and records the issues; `App.OnLaunched` merges them with `BeepPlayer.LastInitializationIssues` and raises one accessible notice that also says how to put it right.

## #276 — test runs wrote into the real error log

`dotnet test` was appending fixture output to `%LOCALAPPDATA%\Mutation\logs\Mutation_Errors.log` — "no audio device", "your account is not approved for the fast-mode beta" — indistinguishable from genuine failures in the first file anyone reads when the app misbehaves, and churning the 100 KB rotation so real entries rolled out early.

`ErrorLogger.RedirectTo` sends entries to one directory instead of the two defaults. A `[ModuleInitializer]` in the test assembly points it at temp — not a fixture, so it cannot be raced by a test that logs first. The app never calls it; default behaviour is unchanged.

Verified: a full test run now leaves the real log untouched, and its entries land in `%TEMP%\Mutation.Tests\logs`.

## Verification

1004 tests pass (`dotnet test --configuration Release`), including new `CustomBeepFileValidatorTests`, `ErrorLoggerRedirectTests`, and OCR beep-order tests covering success, request failure, unconfigured OCR, no image, and the batch path.

User guide updated in the same PR: the OCR chapter and the beep list in the accessibility chapter now cover the end beep, and troubleshooting gains "Your own beep sounds stopped playing".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
