### PR TITLE
Stop losing the tail of recordings, and tidy three more audio-path faults

### DIFF
--- a/CognitiveSupport/AudioFileConverter.cs
+++ b/CognitiveSupport/AudioFileConverter.cs
@@ -22,7 +22,10 @@ public static class AudioFileConverter
 	/// <returns>Path to the temporary OGG file. Caller is responsible for cleanup.</returns>
 	public static string ConvertToOgg(string inputPath, SilenceTrimmerOptions? silenceOptions = null)
 	{
-		string tempOggPath = Path.ChangeExtension(Path.GetTempFileName(), ".ogg");
+		// Not Path.GetTempFileName(): that *creates* a zero-byte .tmp on disk, and
+		// ChangeExtension then returns a different path string and walks away from it,
+		// leaking one stray file per call.
+		string tempOggPath = Path.Combine(Path.GetTempPath(), Path.ChangeExtension(Path.GetRandomFileName(), ".ogg"));
 		try
 		{
 			ConvertToOgg(inputPath, tempOggPath, silenceOptions);

--- a/CognitiveSupport/AudioPlayer.cs
+++ b/CognitiveSupport/AudioPlayer.cs
@@ -15,7 +15,8 @@ namespace CognitiveSupport;
 /// </summary>
 public class AudioPlayer : IDisposable
 {
-    private WaveOutEvent? _waveOut;
+    private readonly Func<IAudioOutputDevice> _outputDeviceFactory;
+    private IAudioOutputDevice? _waveOut;
     private MemoryStream? _pcmStream;
     private WaveStream? _sourceStream;
     private SoundTouchSampleProvider? _speedProvider;
@@ -26,6 +27,16 @@ public class AudioPlayer : IDisposable
     // Opus parameters matching AudioRecorder
     private const int SampleRate = 48000;
     private const int Channels = 1;
+
+    public AudioPlayer()
+        : this(() => new WaveOutAudioOutputDevice())
+    {
+    }
+
+    internal AudioPlayer(Func<IAudioOutputDevice> outputDeviceFactory)
+    {
+        _outputDeviceFactory = outputDeviceFactory ?? throw new ArgumentNullException(nameof(outputDeviceFactory));
+    }
 
     public bool IsPlaying => _waveOut?.PlaybackState == PlaybackState.Playing;
 
@@ -157,7 +168,7 @@ public class AudioPlayer : IDisposable
         _speedProvider = new SoundTouchSampleProvider(source.ToSampleProvider()) { Tempo = _speed };
         IWaveProvider output = new SampleToWaveProvider(_speedProvider);
 
-        _waveOut = new WaveOutEvent();
+        _waveOut = _outputDeviceFactory();
         _waveOut.PlaybackStopped += OnPlaybackStopped;
         _waveOut.Init(output);
         _waveOut.Play();
@@ -165,6 +176,18 @@ public class AudioPlayer : IDisposable
 
     private void OnPlaybackStopped(object? sender, StoppedEventArgs e)
     {
+        // A device that is no longer the current one has nothing to say: a newer Play already
+        // took over and disposed it on its way in. Checked before the events are raised, so a
+        // stopped notification cannot arrive after the next file has started and have a
+        // listener tear that one down instead.
+        lock (_playLock)
+        {
+            if (!ReferenceEquals(sender, _waveOut))
+                return;
+        }
+
+        // Raised outside the lock: these run listener code, which is free to call back into
+        // Play or Stop, and holding the lock across it invites a stall.
         if (e.Exception != null)
         {
             PlaybackFailed?.Invoke(this, $"Playback error: {e.Exception.Message}");
@@ -177,11 +200,11 @@ public class AudioPlayer : IDisposable
         // Release the output device and the decoded audio now that the file has run to its
         // end. Waiting for the next Stop/Dispose meant a recording played to completion kept
         // an open WinMM output handle and its whole PCM buffer resident for the rest of the
-        // app's life. Stop detaches this handler first, so this cannot recurse.
+        // app's life. StopCore detaches this handler first, so this cannot recurse.
         lock (_playLock)
         {
-            // A PlaybackEnded handler may have started the next file already. That instance
-            // owns the teardown now, and it disposed this one on its way in.
+            // Re-checked: a listener above may have started the next file, and that instance
+            // owns the teardown now.
             if (!ReferenceEquals(sender, _waveOut))
                 return;
 

--- a/CognitiveSupport/AudioPlayer.cs
+++ b/CognitiveSupport/AudioPlayer.cs
@@ -58,68 +58,67 @@ public class AudioPlayer : IDisposable
     /// </summary>
     public void Play(string filePath)
     {
-        lock (_playLock)
+        PreparedSource? prepared = null;
+        try
+        {
+            // Reading and decoding happen outside the lock. Decoding a long recording takes
+            // seconds, and doing it under _playLock blocked every Speed change made from the
+            // UI thread for that whole window, freezing the window.
+            prepared = Prepare(filePath);
+            if (prepared is null)
+            {
+                PlaybackFailed?.Invoke(this, "No audio data found in file.");
+                return;
+            }
+
+            lock (_playLock)
+            {
+                // Stopping and publishing happen under one lock, so two overlapping Play calls
+                // cannot leave the loser's output device attached with nothing to release it.
+                StopCore();
+
+                if (_disposed)
+                {
+                    prepared.Dispose();
+                    return;
+                }
+
+                _pcmStream = prepared.Pcm;
+                StartPlayback(prepared.Stream);
+            }
+        }
+        catch (Exception ex)
         {
             Stop();
-
-            try
-            {
-                string extension = Path.GetExtension(filePath).ToLowerInvariant();
-
-                if (extension == ".ogg" || extension == ".opus")
-                {
-                    PlayOgg(filePath);
-                }
-                else
-                {
-                    // For other formats, use NAudio's built-in readers
-                    PlayWithNAudio(filePath, extension);
-                }
-            }
-            catch (Exception ex)
-            {
-                Stop();
-                PlaybackFailed?.Invoke(this, $"Playback failed: {ex.Message}");
-            }
+            prepared?.Dispose();
+            PlaybackFailed?.Invoke(this, $"Playback failed: {ex.Message}");
         }
     }
 
     /// <summary>
-    /// Plays an OGG/Opus file by decoding it with <see cref="OggOpusPcmDecoder"/> and playing
-    /// via NAudio. The decoder is shared with the import path so files this app did not record
-    /// itself — WhatsApp voice notes and the like — play back rather than hanging.
+    /// Opens or decodes the file into a source ready to play, without touching any of the
+    /// player's own state. Returns null when the file holds no audio.
     /// </summary>
-    private void PlayOgg(string filePath)
+    private static PreparedSource? Prepare(string filePath)
     {
-        // Read and decode the entire OGG file to PCM
-        var allSamples = new List<short>();
-        OggOpusPcmDecoder.DecodeToMonoPcm(filePath, samples => allSamples.AddRange(samples));
+        string extension = Path.GetExtension(filePath).ToLowerInvariant();
 
-        if (allSamples.Count == 0)
+        // Ogg/Opus is decoded in managed code: Windows Media Foundation has no demuxer for it,
+        // so files this app did not record itself — WhatsApp voice notes and the like — would
+        // otherwise not open at all. The decoder is shared with the import path.
+        if (extension == ".ogg" || extension == ".opus")
         {
-            PlaybackFailed?.Invoke(this, "No audio data found in file.");
-            return;
+            MemoryStream pcm = OggOpusPcmDecoder.DecodeToPcmStream(filePath);
+            if (pcm.Length == 0)
+            {
+                pcm.Dispose();
+                return null;
+            }
+
+            var waveFormat = new WaveFormat(SampleRate, 16, Channels);
+            return new PreparedSource(new RawSourceWaveStream(pcm, waveFormat), pcm);
         }
 
-        // Convert shorts to bytes (16-bit PCM)
-        var pcmBytes = new byte[allSamples.Count * 2];
-        for (int i = 0; i < allSamples.Count; i++)
-        {
-            var sample = allSamples[i];
-            pcmBytes[i * 2] = (byte)(sample & 0xFF);
-            pcmBytes[i * 2 + 1] = (byte)((sample >> 8) & 0xFF);
-        }
-
-        _pcmStream = new MemoryStream(pcmBytes);
-        var waveFormat = new WaveFormat(SampleRate, 16, Channels);
-        StartPlayback(new RawSourceWaveStream(_pcmStream, waveFormat));
-    }
-
-    /// <summary>
-    /// Plays other audio formats using NAudio's built-in readers.
-    /// </summary>
-    private void PlayWithNAudio(string filePath, string extension)
-    {
         WaveStream reader = extension switch
         {
             ".wav" => new WaveFileReader(filePath),
@@ -127,7 +126,21 @@ public class AudioPlayer : IDisposable
             _ => new AudioFileReader(filePath) // Generic reader for other formats
         };
 
-        StartPlayback(reader);
+        return new PreparedSource(reader, null);
+    }
+
+    /// <summary>
+    /// A decoded source together with the backing buffer that has to outlive it —
+    /// <c>RawSourceWaveStream</c> does not dispose the stream it reads from. Built outside the
+    /// playback lock, then either published to the player's fields or thrown away whole.
+    /// </summary>
+    private sealed record PreparedSource(WaveStream Stream, MemoryStream? Pcm) : IDisposable
+    {
+        public void Dispose()
+        {
+            try { Stream.Dispose(); } catch { /* Already torn down by Stop. */ }
+            try { Pcm?.Dispose(); } catch { /* Already torn down by Stop. */ }
+        }
     }
 
     /// <summary>
@@ -160,43 +173,70 @@ public class AudioPlayer : IDisposable
         {
             PlaybackEnded?.Invoke(this, EventArgs.Empty);
         }
+
+        // Release the output device and the decoded audio now that the file has run to its
+        // end. Waiting for the next Stop/Dispose meant a recording played to completion kept
+        // an open WinMM output handle and its whole PCM buffer resident for the rest of the
+        // app's life. Stop detaches this handler first, so this cannot recurse.
+        lock (_playLock)
+        {
+            // A PlaybackEnded handler may have started the next file already. That instance
+            // owns the teardown now, and it disposed this one on its way in.
+            if (!ReferenceEquals(sender, _waveOut))
+                return;
+
+            StopCore();
+        }
     }
 
     public void Stop()
     {
         lock (_playLock)
         {
-            try
+            StopCore();
+        }
+    }
+
+    /// <summary>
+    /// Tears down the current playback chain. Callers must already hold <c>_playLock</c>.
+    /// </summary>
+    private void StopCore()
+    {
+        try
+        {
+            if (_waveOut != null)
             {
-                if (_waveOut != null)
-                {
-                    _waveOut.PlaybackStopped -= OnPlaybackStopped;
-                    _waveOut.Stop();
-                    _waveOut.Dispose();
-                    _waveOut = null;
-                }
-
-                _speedProvider = null;
-
-                _sourceStream?.Dispose();
-                _sourceStream = null;
-
-                _pcmStream?.Dispose();
-                _pcmStream = null;
+                _waveOut.PlaybackStopped -= OnPlaybackStopped;
+                _waveOut.Stop();
+                _waveOut.Dispose();
+                _waveOut = null;
             }
-            catch
-            {
-                // Ignore cleanup errors
-            }
+
+            _speedProvider = null;
+
+            _sourceStream?.Dispose();
+            _sourceStream = null;
+
+            _pcmStream?.Dispose();
+            _pcmStream = null;
+        }
+        catch
+        {
+            // Ignore cleanup errors
         }
     }
 
     public void Dispose()
     {
-        if (!_disposed)
+        lock (_playLock)
         {
+            if (_disposed)
+                return;
+
+            // Set under the lock so a Play that is still decoding sees it and throws its
+            // prepared source away instead of attaching it to a disposed player.
             _disposed = true;
-            Stop();
+            StopCore();
         }
     }
 }

--- a/CognitiveSupport/AudioRecorder.cs
+++ b/CognitiveSupport/AudioRecorder.cs
@@ -8,13 +8,24 @@ namespace CognitiveSupport;
 
 public class AudioRecorder : IAudioRecorder
 {
-	private WaveInEvent? _waveIn;
+	private readonly Func<int, IAudioCaptureSource> _captureSourceFactory;
+	private IAudioCaptureSource? _waveIn;
 	private OpusEncoder? _encoder;
 	private OpusOggWriteStream? _oggStream;
 	private Stream? _fileStream;
 	private SilenceTrimmer? _silenceTrimmer;
 	private readonly object _writeLock = new();
 	private Exception? _captureException;
+	private bool _disposed;
+
+	// Set when the capture source reports that it has finished delivering buffers. Starts
+	// signalled so a StopRecording with nothing running never waits.
+	private readonly ManualResetEventSlim _captureDrained = new(initialState: true);
+
+	// How long StopRecording will wait for the capture thread to hand over its last buffers.
+	// Bounded so a wedged audio driver costs a short pause rather than a hung app; the
+	// real drain takes about one buffer's worth of time.
+	private static readonly TimeSpan DrainTimeout = TimeSpan.FromSeconds(2);
 
 	// After StopRecording, the trimmed speech duration in seconds when silence stripping was
 	// active; null when stripping was disabled (so callers leave the recording untouched).
@@ -34,9 +45,25 @@ public class AudioRecorder : IAudioRecorder
 	private const int SamplesPerFrame = SampleRate * FrameSizeMs / 1000; // 960 samples
 	private const int Channels = 1;
 
+	// Larger buffers from NAudio, to reduce per-callback overhead.
+	private const int BufferMilliseconds = 100;
+
 	// Splits incoming PCM bytes into fixed 960-sample frames. Created per recording in
 	// StartRecording so no partial-frame remainder bleeds from one recording into the next.
 	private PcmFrameSplitter? _pcmFrameSplitter;
+
+	public AudioRecorder()
+		: this(deviceIndex => new WaveInCaptureSource(
+			deviceIndex,
+			new WaveFormat(SampleRate, 16, Channels),
+			BufferMilliseconds))
+	{
+	}
+
+	internal AudioRecorder(Func<int, IAudioCaptureSource> captureSourceFactory)
+	{
+		_captureSourceFactory = captureSourceFactory ?? throw new ArgumentNullException(nameof(captureSourceFactory));
+	}
 
 	public void StartRecording(int captureDeviceIndex, string outputFile, SilenceTrimmerOptions? silenceOptions = null)
 	{
@@ -49,18 +76,13 @@ public class AudioRecorder : IAudioRecorder
 			TrimmedSpeechSeconds = null;
 			_captureException = null;
 
-			WaveInEvent? waveIn = null;
+			IAudioCaptureSource? waveIn = null;
 			Stream? fileStream = null;
 			OpusEncoder? encoder = null;
 			OpusOggWriteStream? oggStream = null;
 			try
 			{
-				waveIn = new WaveInEvent
-				{
-					DeviceNumber = captureDeviceIndex,
-					WaveFormat = new WaveFormat(SampleRate, 16, Channels),
-					BufferMilliseconds = 100 // Request larger buffers from NAudio to reduce overhead
-				};
+				waveIn = _captureSourceFactory(captureDeviceIndex);
 
 				fileStream = new FileStream(outputFile, FileMode.Create, FileAccess.Write, FileShare.Read);
 
@@ -84,6 +106,10 @@ public class AudioRecorder : IAudioRecorder
 				_encoder = encoder;
 				_oggStream = oggStream;
 
+				// Armed only once the source is about to run, so a start that throws leaves the
+				// gate open rather than making the next StopRecording wait out the timeout.
+				_captureDrained.Reset();
+
 				try
 				{
 					_waveIn.StartRecording();
@@ -91,6 +117,7 @@ public class AudioRecorder : IAudioRecorder
 				catch
 				{
 					// Roll back field commits so subsequent calls / Dispose see clean state.
+					_captureDrained.Set();
 					_waveIn = null;
 					_fileStream = null;
 					_encoder = null;
@@ -144,13 +171,48 @@ public class AudioRecorder : IAudioRecorder
 
 	private void OnRecordingStopped(object? sender, StoppedEventArgs e)
 	{
-		// We handle cleanup/finishing in Dispose or explicit Stop
+		// Every buffer the capture thread had in hand has now been delivered, so StopRecording
+		// can safely close the encoder. Cleanup itself happens in Dispose or explicit Stop.
+		_captureDrained.Set();
 	}
 
 	public void StopRecording()
 	{
-		_waveIn?.StopRecording();
-		
+		IAudioCaptureSource? capture;
+		lock (_writeLock)
+		{
+			if (_disposed)
+				return;
+
+			capture = _waveIn;
+		}
+
+		if (capture is not null)
+		{
+			// StopRecording only *signals* the capture thread: buffers it has already filled
+			// are delivered to OnDataAvailable afterwards, on that thread. Finishing the Ogg
+			// stream before they arrive dropped them silently against the null guard in
+			// OnDataAvailable, cutting the last fraction of a second — often the last word —
+			// off every recording. Wait for the drain, outside _writeLock so those deliveries
+			// can still take it.
+			capture.StopRecording();
+			try
+			{
+				_captureDrained.Wait(DrainTimeout);
+
+				// Whether the source reported in or the wait timed out, this recording's
+				// drain is over. Latching it stops the repeat StopRecording that Dispose
+				// makes from sitting through the timeout a second time.
+				_captureDrained.Set();
+			}
+			catch (ObjectDisposedException)
+			{
+				// Another thread disposed the recorder while we were waiting. There is
+				// nothing left to drain into, so fall through and let the checks below
+				// find the encoder already gone.
+			}
+		}
+
 		lock (_writeLock)
 		{
 			if (_oggStream != null)
@@ -187,6 +249,9 @@ public class AudioRecorder : IAudioRecorder
 
 		lock (_writeLock)
 		{
+			if (_disposed)
+				return;
+
 			_waveIn?.Dispose();
 			_waveIn = null;
 
@@ -194,9 +259,16 @@ public class AudioRecorder : IAudioRecorder
 			// The stream is disposed here.
 			_fileStream?.Dispose();
 			_fileStream = null;
-			
+
 			_encoder = null;
 			_oggStream = null;
+
+			_disposed = true;
+
+			// Released the moment nothing can arm it again. A StopRecording that slipped past
+			// the _disposed check and is waiting here catches the ObjectDisposedException.
+			_captureDrained.Set();
+			_captureDrained.Dispose();
 		}
 	}
 }

--- a/CognitiveSupport/AudioRecorder.cs
+++ b/CognitiveSupport/AudioRecorder.cs
@@ -76,6 +76,11 @@ public class AudioRecorder : IAudioRecorder
 			TrimmedSpeechSeconds = null;
 			_captureException = null;
 
+			// A source left over from a previous recording still holds the microphone open, and
+			// its handlers still point here: its buffers would land in the new recording and
+			// its RecordingStopped would open the new drain gate early.
+			DetachCaptureSource();
+
 			IAudioCaptureSource? waveIn = null;
 			Stream? fileStream = null;
 			OpusEncoder? encoder = null;
@@ -243,6 +248,18 @@ public class AudioRecorder : IAudioRecorder
 		}
 	}
 
+	// Unhooks and releases the current capture source. Callers must hold _writeLock.
+	private void DetachCaptureSource()
+	{
+		if (_waveIn is null)
+			return;
+
+		_waveIn.DataAvailable -= OnDataAvailable;
+		_waveIn.RecordingStopped -= OnRecordingStopped;
+		try { _waveIn.Dispose(); } catch { /* Releasing a dead device must not fail the caller. */ }
+		_waveIn = null;
+	}
+
 	public void Dispose()
 	{
 		StopRecording();
@@ -252,8 +269,7 @@ public class AudioRecorder : IAudioRecorder
 			if (_disposed)
 				return;
 
-			_waveIn?.Dispose();
-			_waveIn = null;
+			DetachCaptureSource();
 
 			// _oggStream does not implement IDisposable but it uses the stream.
 			// The stream is disposed here.

--- a/CognitiveSupport/BeepPlayer.cs
+++ b/CognitiveSupport/BeepPlayer.cs
@@ -43,7 +43,7 @@ public static class BeepPlayer
 	{
 		lock (SyncLock)
 		{
-			DisposePlayers();
+			DisposePlayersCore();
 			var issues = new List<string>();
 			var custom = settings.AudioSettings?.CustomBeepSettings;
 			if (custom?.UseCustomBeeps == true)
@@ -136,14 +136,26 @@ public static class BeepPlayer
 
 	private static bool TryPlayCustomRepeated(BeepType type, int repeatCount)
 	{
-		var player = GetCustomPlayer(type);
-		if (player is null)
-			return false;
+		SoundPlayer player;
+		int generation;
 
-		if (repeatCount == 1)
+		// The player field and the generation counter are read together under the lock so
+		// they cannot disagree: DisposePlayers bumps the generation and disposes in one
+		// locked step, so a stale player never pairs with a still-current generation.
+		lock (SyncLock)
 		{
-			player.Play();
-			return true;
+			var candidate = GetCustomPlayer(type);
+			if (candidate is null)
+				return false;
+
+			if (repeatCount == 1)
+			{
+				PlaySafely(candidate);
+				return true;
+			}
+
+			player = candidate;
+			generation = Volatile.Read(ref _playerGeneration);
 		}
 
 		// PlaySync blocks, so the repeat runs off the caller's thread rather than
@@ -151,7 +163,6 @@ public static class BeepPlayer
 		// running while Initialize/DisposePlayers may replace these players (a Settings
 		// save, or shutdown), so it bails out the moment its generation is superseded
 		// instead of hammering a disposed SoundPlayer.
-		int generation = Volatile.Read(ref _playerGeneration);
 		Task.Run(() =>
 		{
 			for (var i = 0; i < repeatCount; i++)
@@ -175,13 +186,33 @@ public static class BeepPlayer
 
 	private static bool TryPlayCustom(BeepType type)
 	{
-		var player = GetCustomPlayer(type);
-		if (player != null)
+		// The lock covers the Play call, not just the field read. SoundPlayer.Play is
+		// asynchronous — it returns as soon as playback is queued — so holding the lock that
+		// long is cheap, and it is what stops DisposePlayers from disposing this player in
+		// the gap between reading the field and using it.
+		lock (SyncLock)
 		{
-			player.Play();
+			var player = GetCustomPlayer(type);
+			if (player is null)
+				return false;
+
+			PlaySafely(player);
 			return true;
 		}
-		return false;
+	}
+
+	// A beep that will not play must never take down the operation it is reporting on: this
+	// runs inside Polly retry lambdas, where an escaping exception aborts the transcription.
+	private static void PlaySafely(SoundPlayer player)
+	{
+		try
+		{
+			player.Play();
+		}
+		catch
+		{
+			// Nothing useful to do — the user simply does not hear this beep.
+		}
 	}
 
 	private static SoundPlayer? GetCustomPlayer(BeepType type) => type switch
@@ -200,8 +231,10 @@ public static class BeepPlayer
 	// way Console.Beep did (issue #169).
 	private static void PlayDefault(BeepType type, int repeatCount)
 	{
-		SoundPlayer player;
 		var key = (type, ClampRepeatCount(repeatCount));
+
+		// Play stays inside the lock so DisposePlayers cannot dispose the cached player — or
+		// clear the dictionary out from under this lookup — between the two.
 		lock (SyncLock)
 		{
 			if (!_defaultPlayers.TryGetValue(key, out var cached))
@@ -212,9 +245,9 @@ public static class BeepPlayer
 				cached.Player.Load();
 				_defaultPlayers[key] = cached;
 			}
-			player = cached.Player;
+
+			PlaySafely(cached.Player);
 		}
-		player.Play();
 	}
 
 	public static IReadOnlyList<(int Frequency, int Duration)> GetDefaultSequence(BeepType type) => type switch
@@ -256,7 +289,20 @@ public static class BeepPlayer
 		}
 	}
 
+	/// <summary>
+	/// Tears down every cached player. Stays public because the UI project calls it on window
+	/// close; every sibling that touches these statics holds <c>SyncLock</c>, and so does this.
+	/// </summary>
 	public static void DisposePlayers()
+	{
+		lock (SyncLock)
+			DisposePlayersCore();
+	}
+
+	// Callers already holding SyncLock use this, so Initialize does not re-enter the public
+	// entry point. Monitor is re-entrant, but routing through one core keeps it obvious that
+	// nothing here runs unlocked.
+	private static void DisposePlayersCore()
 	{
 		// Signal before disposing, so a repeat loop stops rather than racing the tear-down.
 		Interlocked.Increment(ref _playerGeneration);

--- a/CognitiveSupport/IAudioCaptureSource.cs
+++ b/CognitiveSupport/IAudioCaptureSource.cs
@@ -1,0 +1,31 @@
+using System;
+using NAudio.Wave;
+
+namespace CognitiveSupport;
+
+/// <summary>
+/// The microphone capture contract <see cref="AudioRecorder"/> depends on. Extracting it from
+/// NAudio's <c>WaveInEvent</c> (which needs a physical capture device) lets the recorder's
+/// stop-and-drain behaviour be exercised in a unit test.
+/// </summary>
+public interface IAudioCaptureSource : IDisposable
+{
+	/// <summary>Raised for each buffer of captured 16-bit PCM.</summary>
+	event EventHandler<WaveInEventArgs>? DataAvailable;
+
+	/// <summary>
+	/// Raised once, after the last <see cref="DataAvailable"/> buffer has been delivered.
+	/// <see cref="AudioRecorder.StopRecording"/> waits for this before closing the encoder, so
+	/// an implementation must raise it from a thread that does not need the caller of
+	/// <see cref="StopRecording"/> to make progress first.
+	/// </summary>
+	event EventHandler<StoppedEventArgs>? RecordingStopped;
+
+	void StartRecording();
+
+	/// <summary>
+	/// Signals the capture thread to stop. Buffers already filled may still be delivered
+	/// afterwards; <see cref="RecordingStopped"/> marks the point where they have all arrived.
+	/// </summary>
+	void StopRecording();
+}

--- a/CognitiveSupport/IAudioOutputDevice.cs
+++ b/CognitiveSupport/IAudioOutputDevice.cs
@@ -1,0 +1,26 @@
+using System;
+using NAudio.Wave;
+
+namespace CognitiveSupport;
+
+/// <summary>
+/// The output device contract <see cref="AudioPlayer"/> drives. Extracting it from NAudio's
+/// <c>WaveOutEvent</c> (which opens a real WinMM device) lets the player's teardown rules —
+/// releasing the device when a file reaches its end, and leaving a newer playback alone — be
+/// exercised in a unit test.
+/// </summary>
+public interface IAudioOutputDevice : IDisposable
+{
+	/// <summary>
+	/// Raised when playback ends, whether the audio ran out or <see cref="Stop"/> was called.
+	/// </summary>
+	event EventHandler<StoppedEventArgs>? PlaybackStopped;
+
+	PlaybackState PlaybackState { get; }
+
+	void Init(IWaveProvider waveProvider);
+
+	void Play();
+
+	void Stop();
+}

--- a/CognitiveSupport/OggOpusPcmDecoder.cs
+++ b/CognitiveSupport/OggOpusPcmDecoder.cs
@@ -148,6 +148,14 @@ public static class OggOpusPcmDecoder
 
 				DecodePacket(decoder, packet.Data, channels, buffer, ref remainingPreSkip, onSamples);
 			}
+
+			// The header sniff scans raw bytes, so it can match an "OpusHead" that is not
+			// actually an identification packet — inside a comment string, say. Say so instead
+			// of returning nothing: silently decoding to zero samples would have the converter
+			// write a valid but empty .ogg and the app transcribe silence.
+			if (audioSerialNumber is null)
+				throw new InvalidDataException(
+					$"'{Path.GetFileName(filePath)}' has no Opus identification header.");
 		}
 		finally
 		{

--- a/CognitiveSupport/OggOpusPcmDecoder.cs
+++ b/CognitiveSupport/OggOpusPcmDecoder.cs
@@ -2,6 +2,7 @@ using Concentus;
 using Concentus.Structs;
 using System;
 using System.IO;
+using System.Runtime.InteropServices;
 
 namespace CognitiveSupport;
 
@@ -118,17 +119,73 @@ public static class OggOpusPcmDecoder
 				"Convert it to mono or stereo first.");
 
 		var decoder = OpusCodecFactory.CreateDecoder(SampleRate, channels);
-		var buffer = new short[MaxFrameSamples * channels];
-		int remainingPreSkip = preSkipSamples;
-
-		using var stream = File.OpenRead(filePath);
-		foreach (byte[] packet in OggPacketReader.ReadPackets(stream))
+		try
 		{
-			if (IsHeaderPacket(packet))
-				continue;
+			var buffer = new short[MaxFrameSamples * channels];
+			int remainingPreSkip = preSkipSamples;
+			uint? audioSerialNumber = null;
 
-			DecodePacket(decoder, packet, channels, buffer, ref remainingPreSkip, onSamples);
+			using var stream = File.OpenRead(filePath);
+			foreach (OggPacket packet in OggPacketReader.ReadPackets(stream))
+			{
+				if (IsOpusHead(packet.Data))
+				{
+					// Lock onto the first Opus stream in the container and ignore every other
+					// logical bitstream. A multiplexed file (Theora video plus Opus audio, or
+					// Vorbis plus Opus) would otherwise feed non-Opus packets to the decoder as
+					// if they were audio — most bounce off the parse guard below, but any that
+					// happen to look like a valid TOC byte decode as noise. It also stops a
+					// chained file from having the first chain's pre-skip applied to the next.
+					audioSerialNumber ??= packet.SerialNumber;
+					continue;
+				}
+
+				if (audioSerialNumber != packet.SerialNumber)
+					continue;
+
+				if (IsOpusTags(packet.Data))
+					continue;
+
+				DecodePacket(decoder, packet.Data, channels, buffer, ref remainingPreSkip, onSamples);
+			}
 		}
+		finally
+		{
+			// IOpusDecoder does not extend IDisposable (Concentus 2.2.2), so `using` is not
+			// available without this cast — but the concrete OpusDecoder does implement it, and
+			// it holds pooled internal state that is otherwise reclaimed only by finalization.
+			// Batch-converting a folder abandoned one decoder per file.
+			(decoder as IDisposable)?.Dispose();
+		}
+	}
+
+	/// <summary>
+	/// Decodes the whole file into one 48 kHz mono 16-bit PCM buffer, ready to hand to NAudio's
+	/// <c>RawSourceWaveStream</c>. Bytes are written as each frame is decoded rather than
+	/// collecting shorts and converting afterwards, which held the entire recording twice over —
+	/// roughly 340 MB for a 30-minute voice note.
+	///
+	/// Samples are laid out in the machine's byte order, which on every platform this app ships
+	/// to is little-endian, as NAudio's 16-bit PCM formats expect.
+	/// </summary>
+	/// <exception cref="InvalidDataException">The file is not an Ogg/Opus stream.</exception>
+	/// <exception cref="NotSupportedException">The file is surround Opus, which Concentus
+	/// cannot decode.</exception>
+	public static MemoryStream DecodeToPcmStream(string filePath)
+	{
+		var pcm = new MemoryStream();
+		try
+		{
+			DecodeToMonoPcm(filePath, samples => pcm.Write(MemoryMarshal.AsBytes(samples.AsSpan())));
+		}
+		catch
+		{
+			pcm.Dispose();
+			throw;
+		}
+
+		pcm.Position = 0;
+		return pcm;
 	}
 
 	/// <summary>
@@ -248,8 +305,9 @@ public static class OggOpusPcmDecoder
 		onSamples(mono);
 	}
 
-	private static bool IsHeaderPacket(byte[] packet) =>
-		MatchesAt(packet, 0, OpusHeadMagic) || MatchesAt(packet, 0, OpusTagsMagic);
+	private static bool IsOpusHead(byte[] packet) => MatchesAt(packet, 0, OpusHeadMagic);
+
+	private static bool IsOpusTags(byte[] packet) => MatchesAt(packet, 0, OpusTagsMagic);
 
 	/// <summary>
 	/// Locates the OpusHead identification header near the start of the stream and reads the

--- a/CognitiveSupport/OggPacket.cs
+++ b/CognitiveSupport/OggPacket.cs
@@ -1,0 +1,13 @@
+namespace CognitiveSupport;
+
+/// <summary>
+/// One demuxed Ogg packet, together with the logical bitstream it came from.
+///
+/// An Ogg container can interleave several logical streams — video alongside audio, or one
+/// chain of encoded sections after another — and the page header's serial number is the only
+/// thing that tells them apart (RFC 3533 §6). Carrying it alongside the payload lets a
+/// consumer keep the one stream it can decode and ignore everybody else's packets.
+/// </summary>
+/// <param name="Data">The reassembled packet payload.</param>
+/// <param name="SerialNumber">The logical bitstream serial number of the page(s) it came from.</param>
+public readonly record struct OggPacket(byte[] Data, uint SerialNumber);

--- a/CognitiveSupport/OggPacketReader.cs
+++ b/CognitiveSupport/OggPacketReader.cs
@@ -1,11 +1,13 @@
 using System;
+using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.IO;
 
 namespace CognitiveSupport;
 
 /// <summary>
-/// Minimal Ogg container demuxer: yields the logical bitstream's packets in order.
+/// Minimal Ogg container demuxer: yields each logical bitstream's packets in order, tagged
+/// with the serial number of the stream they belong to.
 ///
 /// Concentus.Oggfile 1.0.6's own reader cannot be used for arbitrary third-party files —
 /// it stops producing audio partway through and then spins forever, because
@@ -17,6 +19,7 @@ namespace CognitiveSupport;
 public static class OggPacketReader
 {
 	private const int PageHeaderBytes = 27;
+	private const int SerialNumberOffset = 14;
 	private const int SegmentTableOffset = 26;
 	private const int ContinuedPacketFlag = 0x01;
 	private const int MaxSegmentLength = 255;
@@ -27,12 +30,16 @@ public static class OggPacketReader
 	/// does not start with the "OggS" capture pattern, which is how a truncated or corrupt
 	/// tail is tolerated rather than throwing away everything decoded so far.
 	/// </summary>
-	public static IEnumerable<byte[]> ReadPackets(Stream stream)
+	public static IEnumerable<OggPacket> ReadPackets(Stream stream)
 	{
 		if (stream is null) throw new ArgumentNullException(nameof(stream));
 
 		var header = new byte[PageHeaderBytes];
-		var packet = new List<byte>();
+
+		// One partial-packet buffer per logical stream. A multiplexed container interleaves
+		// pages from several streams, so a single shared buffer would splice one stream's
+		// continued packet onto segments belonging to another.
+		var partials = new Dictionary<uint, List<byte>>();
 
 		while (true)
 		{
@@ -42,8 +49,15 @@ public static class OggPacketReader
 			if (header[0] != (byte)'O' || header[1] != (byte)'g' || header[2] != (byte)'g' || header[3] != (byte)'S')
 				yield break;
 
+			uint serialNumber = BinaryPrimitives.ReadUInt32LittleEndian(header.AsSpan(SerialNumberOffset));
+			if (!partials.TryGetValue(serialNumber, out var packet))
+			{
+				packet = new List<byte>();
+				partials[serialNumber] = packet;
+			}
+
 			// A page whose continuation flag is clear starts a fresh packet; anything held over
-			// from a truncated previous page is then stale and must be dropped.
+			// from a truncated previous page of the same stream is then stale and must be dropped.
 			if ((header[5] & ContinuedPacketFlag) == 0)
 				packet.Clear();
 
@@ -72,7 +86,7 @@ public static class OggPacketReader
 				// means it continues in the next segment (possibly on the next page).
 				if (length < MaxSegmentLength)
 				{
-					yield return packet.ToArray();
+					yield return new OggPacket(packet.ToArray(), serialNumber);
 					packet.Clear();
 				}
 			}

--- a/CognitiveSupport/WaveInCaptureSource.cs
+++ b/CognitiveSupport/WaveInCaptureSource.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Threading;
+using NAudio.Wave;
+
+namespace CognitiveSupport;
+
+/// <summary>
+/// The real microphone: <see cref="IAudioCaptureSource"/> backed by NAudio's
+/// <c>WaveInEvent</c>.
+/// </summary>
+internal sealed class WaveInCaptureSource : IAudioCaptureSource
+{
+	private readonly WaveInEvent _waveIn;
+
+	public WaveInCaptureSource(int deviceNumber, WaveFormat waveFormat, int bufferMilliseconds)
+	{
+		// WaveInEvent captures SynchronizationContext.Current in its constructor and posts
+		// RecordingStopped to it. Constructed on the UI thread, the event would therefore be
+		// delivered on the UI thread — and AudioRecorder.StopRecording, called from that same
+		// thread, waits for it, which would deadlock until the wait times out. Building it
+		// with no context keeps the event on NAudio's own recording thread, where it is raised
+		// straight after the final buffer.
+		SynchronizationContext? previous = SynchronizationContext.Current;
+		SynchronizationContext.SetSynchronizationContext(null);
+		try
+		{
+			_waveIn = new WaveInEvent
+			{
+				DeviceNumber = deviceNumber,
+				WaveFormat = waveFormat,
+				BufferMilliseconds = bufferMilliseconds
+			};
+		}
+		finally
+		{
+			SynchronizationContext.SetSynchronizationContext(previous);
+		}
+
+		_waveIn.DataAvailable += (_, e) => DataAvailable?.Invoke(this, e);
+		_waveIn.RecordingStopped += (_, e) => RecordingStopped?.Invoke(this, e);
+	}
+
+	public event EventHandler<WaveInEventArgs>? DataAvailable;
+
+	public event EventHandler<StoppedEventArgs>? RecordingStopped;
+
+	public void StartRecording() => _waveIn.StartRecording();
+
+	public void StopRecording() => _waveIn.StopRecording();
+
+	public void Dispose() => _waveIn.Dispose();
+}

--- a/CognitiveSupport/WaveOutAudioOutputDevice.cs
+++ b/CognitiveSupport/WaveOutAudioOutputDevice.cs
@@ -1,0 +1,29 @@
+using System;
+using NAudio.Wave;
+
+namespace CognitiveSupport;
+
+/// <summary>
+/// The real speaker: <see cref="IAudioOutputDevice"/> backed by NAudio's <c>WaveOutEvent</c>.
+/// </summary>
+internal sealed class WaveOutAudioOutputDevice : IAudioOutputDevice
+{
+	private readonly WaveOutEvent _waveOut = new();
+
+	public WaveOutAudioOutputDevice()
+	{
+		_waveOut.PlaybackStopped += (_, e) => PlaybackStopped?.Invoke(this, e);
+	}
+
+	public event EventHandler<StoppedEventArgs>? PlaybackStopped;
+
+	public PlaybackState PlaybackState => _waveOut.PlaybackState;
+
+	public void Init(IWaveProvider waveProvider) => _waveOut.Init(waveProvider);
+
+	public void Play() => _waveOut.Play();
+
+	public void Stop() => _waveOut.Stop();
+
+	public void Dispose() => _waveOut.Dispose();
+}

--- a/Mutation.Tests/AudioPlayerTeardownTests.cs
+++ b/Mutation.Tests/AudioPlayerTeardownTests.cs
@@ -1,0 +1,186 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using CognitiveSupport;
+using NAudio.Wave;
+
+namespace Mutation.Tests;
+
+/// <summary>
+/// Covers what <see cref="AudioPlayer"/> does when playback ends. A file played to the end used
+/// to leave its output device open and its decoded audio resident for the rest of the app's
+/// life, because the only teardown was in Stop and Dispose. The output device is faked: the
+/// build machine has no speakers, and the rules under test are about ownership rather than
+/// sound.
+/// </summary>
+public class AudioPlayerTeardownTests : IDisposable
+{
+	private readonly string _workingDirectory = Directory.CreateTempSubdirectory("audio-player-tests").FullName;
+	private readonly List<FakeOutputDevice> _devices = new();
+
+	public void Dispose()
+	{
+		try { Directory.Delete(_workingDirectory, recursive: true); } catch { }
+	}
+
+	// A real .wav, so the player's own reader path runs rather than being stubbed out.
+	private string WriteWav(string fileName)
+	{
+		string path = Path.Combine(_workingDirectory, fileName);
+		File.WriteAllBytes(path, BeepToneSynthesizer.SynthesizeWav(new[] { (440, 200) }));
+		return path;
+	}
+
+	private AudioPlayer NewPlayer()
+	{
+		return new AudioPlayer(() =>
+		{
+			var device = new FakeOutputDevice();
+			_devices.Add(device);
+			return device;
+		});
+	}
+
+	[Fact]
+	public void Reaching_the_end_of_a_file_releases_the_device()
+	{
+		using var player = NewPlayer();
+		bool ended = false;
+		player.PlaybackEnded += (_, _) => ended = true;
+
+		player.Play(WriteWav("ends.wav"));
+		FakeOutputDevice device = Assert.Single(_devices);
+		Assert.True(device.IsPlaying);
+
+		device.RaisePlaybackStopped();
+
+		Assert.True(ended);
+		Assert.Equal(1, device.DisposeCount);
+		Assert.False(player.IsPlaying);
+	}
+
+	[Fact]
+	public void A_failed_playback_reports_the_error_and_still_releases_the_device()
+	{
+		using var player = NewPlayer();
+		string? failure = null;
+		player.PlaybackFailed += (_, message) => failure = message;
+
+		player.Play(WriteWav("fails.wav"));
+		FakeOutputDevice device = Assert.Single(_devices);
+
+		device.RaisePlaybackStopped(new InvalidOperationException("device lost"));
+
+		Assert.NotNull(failure);
+		Assert.Contains("device lost", failure);
+		Assert.Equal(1, device.DisposeCount);
+	}
+
+	// A PlaybackEnded listener that queues up the next file is the normal "play the whole
+	// list" pattern. The finishing device must not tear down the one that just started.
+	[Fact]
+	public void Starting_the_next_file_from_the_ended_handler_leaves_the_new_device_alone()
+	{
+		using var player = NewPlayer();
+		string next = WriteWav("next.wav");
+
+		player.PlaybackEnded += (_, _) =>
+		{
+			if (_devices.Count == 1)
+				player.Play(next);
+		};
+
+		player.Play(WriteWav("first.wav"));
+		FakeOutputDevice first = _devices[0];
+
+		first.RaisePlaybackStopped();
+
+		Assert.Equal(2, _devices.Count);
+		Assert.Equal(1, first.DisposeCount);
+
+		FakeOutputDevice second = _devices[1];
+		Assert.Equal(0, second.DisposeCount);
+		Assert.True(second.IsPlaying);
+		Assert.True(player.IsPlaying);
+	}
+
+	// Two overlapping Play calls must not strand the loser's device: the file is decoded
+	// outside the playback lock now, so the second call can arrive while the first is
+	// still preparing.
+	[Fact]
+	public void Playing_a_second_file_releases_the_first_files_device()
+	{
+		using var player = NewPlayer();
+
+		player.Play(WriteWav("one.wav"));
+		player.Play(WriteWav("two.wav"));
+
+		Assert.Equal(2, _devices.Count);
+		Assert.Equal(1, _devices[0].DisposeCount);
+		Assert.Equal(0, _devices[1].DisposeCount);
+	}
+
+	[Fact]
+	public void A_stopped_notification_from_a_superseded_device_is_ignored()
+	{
+		using var player = NewPlayer();
+		int endedCount = 0;
+		player.PlaybackEnded += (_, _) => endedCount++;
+
+		player.Play(WriteWav("stale.wav"));
+		FakeOutputDevice stale = _devices[0];
+		player.Play(WriteWav("current.wav"));
+		FakeOutputDevice current = _devices[1];
+
+		// The old device's PlaybackStopped, delivered late.
+		stale.RaisePlaybackStopped();
+
+		Assert.Equal(0, endedCount);
+		Assert.Equal(0, current.DisposeCount);
+		Assert.True(player.IsPlaying);
+	}
+
+	[Fact]
+	public void Dispose_releases_the_device()
+	{
+		var player = NewPlayer();
+		player.Play(WriteWav("disposed.wav"));
+
+		player.Dispose();
+
+		Assert.Equal(1, _devices[0].DisposeCount);
+		Assert.False(player.IsPlaying);
+	}
+
+	private sealed class FakeOutputDevice : IAudioOutputDevice
+	{
+		public int DisposeCount { get; private set; }
+
+		public bool IsPlaying => PlaybackState == PlaybackState.Playing;
+
+		public PlaybackState PlaybackState { get; private set; } = PlaybackState.Stopped;
+
+		public event EventHandler<StoppedEventArgs>? PlaybackStopped;
+
+		public void Init(IWaveProvider waveProvider)
+		{
+		}
+
+		public void Play() => PlaybackState = PlaybackState.Playing;
+
+		public void Stop() => PlaybackState = PlaybackState.Stopped;
+
+		/// <summary>Stands in for the device reporting that the audio ran out, or failed.</summary>
+		public void RaisePlaybackStopped(Exception? exception = null)
+		{
+			PlaybackState = PlaybackState.Stopped;
+			PlaybackStopped?.Invoke(this, new StoppedEventArgs(exception));
+		}
+
+		public void Dispose()
+		{
+			DisposeCount++;
+			PlaybackState = PlaybackState.Stopped;
+		}
+	}
+}

--- a/Mutation.Tests/AudioRecorderDrainTests.cs
+++ b/Mutation.Tests/AudioRecorderDrainTests.cs
@@ -75,8 +75,10 @@ public class AudioRecorderDrainTests : IDisposable
 		Assert.InRange(DecodedFrames(path), 19, 21);
 	}
 
-	[Fact]
-	public void Stop_gives_up_on_a_capture_source_that_never_reports_it_has_drained()
+	// The timeout is the assertion's safety net: if the drain wait ever regressed to
+	// unbounded, this must go red rather than hang the whole suite.
+	[Fact(Timeout = 20000)]
+	public async Task Stop_gives_up_on_a_capture_source_that_never_reports_it_has_drained()
 	{
 		// A wedged driver must cost a bounded pause, not a hung app: the recording is still
 		// closed and still readable, it just loses whatever the driver never handed over.
@@ -87,7 +89,10 @@ public class AudioRecorderDrainTests : IDisposable
 		{
 			recorder.StartRecording(0, path);
 			capture.Deliver(Tone(frames: 10));
-			recorder.StopRecording();
+
+			// Off the test thread only so xUnit's Timeout applies: a regression to an
+			// unbounded wait then fails this test instead of stalling the suite.
+			await Task.Run(recorder.StopRecording);
 		}
 
 		Assert.InRange(DecodedFrames(path), 9, 11);

--- a/Mutation.Tests/AudioRecorderDrainTests.cs
+++ b/Mutation.Tests/AudioRecorderDrainTests.cs
@@ -1,0 +1,187 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using CognitiveSupport;
+using NAudio.Wave;
+
+namespace Mutation.Tests;
+
+/// <summary>
+/// Covers what <see cref="AudioRecorder"/> does between "stop" being asked for and the Ogg
+/// stream being closed. NAudio's <c>StopRecording</c> only signals its capture thread — buffers
+/// it has already filled arrive afterwards — so closing the encoder straight away threw the tail
+/// of every recording away. The capture device is faked, both because the build machine has no
+/// microphone and because the ordering under test only reproduces reliably when it is scripted.
+/// </summary>
+public class AudioRecorderDrainTests : IDisposable
+{
+	private const int SampleRate = 48000;
+	private const int SamplesPerFrame = 960; // 20 ms, the Opus frame size the recorder uses
+
+	private readonly string _workingDirectory = Directory.CreateTempSubdirectory("audio-recorder-tests").FullName;
+
+	public void Dispose()
+	{
+		try { Directory.Delete(_workingDirectory, recursive: true); } catch { }
+	}
+
+	[Fact]
+	public void Buffers_delivered_before_stop_are_encoded()
+	{
+		using var capture = new FakeCaptureSource();
+		string path = Path.Combine(_workingDirectory, "before-stop.ogg");
+
+		using (var recorder = new AudioRecorder(_ => capture))
+		{
+			recorder.StartRecording(0, path);
+			capture.Deliver(Tone(frames: 25));
+			capture.ReleaseDrain();
+			recorder.StopRecording();
+
+			Assert.Null(recorder.CaptureException);
+		}
+
+		Assert.InRange(DecodedFrames(path), 24, 26);
+	}
+
+	[Fact]
+	public async Task Buffers_delivered_after_stop_is_signalled_are_still_encoded()
+	{
+		using var capture = new FakeCaptureSource
+		{
+			// Stands in for the ~300 ms NAudio still has queued when the user releases the
+			// hotkey: three 100 ms buffers, delivered on the capture thread after the stop.
+			BufferDeliveredWhileDraining = Tone(frames: 15)
+		};
+		string path = Path.Combine(_workingDirectory, "after-stop.ogg");
+
+		using (var recorder = new AudioRecorder(_ => capture))
+		{
+			recorder.StartRecording(0, path);
+			capture.Deliver(Tone(frames: 5));
+
+			// StopRecording blocks until the capture source has drained, so it runs off the
+			// test thread — which is what releases the drain.
+			Task stopping = Task.Run(recorder.StopRecording);
+			Assert.True(capture.StopSignalled.Wait(TimeSpan.FromSeconds(10)));
+			capture.ReleaseDrain();
+			await stopping.WaitAsync(TimeSpan.FromSeconds(10));
+
+			Assert.Null(recorder.CaptureException);
+		}
+
+		// All 20 frames, not just the 5 that arrived before the stop.
+		Assert.InRange(DecodedFrames(path), 19, 21);
+	}
+
+	[Fact]
+	public void Stop_gives_up_on_a_capture_source_that_never_reports_it_has_drained()
+	{
+		// A wedged driver must cost a bounded pause, not a hung app: the recording is still
+		// closed and still readable, it just loses whatever the driver never handed over.
+		using var capture = new FakeCaptureSource { NeverSignalsDrained = true };
+		string path = Path.Combine(_workingDirectory, "wedged.ogg");
+
+		using (var recorder = new AudioRecorder(_ => capture))
+		{
+			recorder.StartRecording(0, path);
+			capture.Deliver(Tone(frames: 10));
+			recorder.StopRecording();
+		}
+
+		Assert.InRange(DecodedFrames(path), 9, 11);
+	}
+
+	private static byte[] Tone(int frames)
+	{
+		var pcm = new byte[frames * SamplesPerFrame * 2];
+		for (int i = 0; i < frames * SamplesPerFrame; i++)
+		{
+			// A 440 Hz sine, so the encoder has real signal to work with rather than silence.
+			short sample = (short)(8000 * Math.Sin(2 * Math.PI * 440 * i / SampleRate));
+			pcm[i * 2] = (byte)(sample & 0xFF);
+			pcm[i * 2 + 1] = (byte)((sample >> 8) & 0xFF);
+		}
+
+		return pcm;
+	}
+
+	// Decoded 20 ms frames in the finished recording. Opus does not round-trip an exact sample
+	// count — the encoder's pre-skip is dropped on decode and a partial final frame is not
+	// written — so callers assert a frame or so either side.
+	private static int DecodedFrames(string path)
+	{
+		int samples = 0;
+		OggOpusPcmDecoder.DecodeToMonoPcm(path, frame => samples += frame.Length);
+		return (int)Math.Round(samples / (double)SamplesPerFrame);
+	}
+
+	/// <summary>
+	/// A scripted stand-in for NAudio's <c>WaveInEvent</c>. <see cref="StopRecording"/> returns
+	/// immediately, as the real one does, and the remaining buffers plus
+	/// <see cref="RecordingStopped"/> are delivered from a separate thread that the test lets
+	/// through when it chooses.
+	/// </summary>
+	private sealed class FakeCaptureSource : IAudioCaptureSource
+	{
+		private readonly ManualResetEventSlim _drainReleased = new(initialState: false);
+		private readonly object _stopLock = new();
+		private Thread? _drainThread;
+
+		/// <summary>Signalled as soon as the recorder asks the source to stop.</summary>
+		public ManualResetEventSlim StopSignalled { get; } = new(initialState: false);
+
+		/// <summary>PCM handed over after the stop, the way an already-filled buffer would be.</summary>
+		public byte[]? BufferDeliveredWhileDraining { get; init; }
+
+		/// <summary>Never raise <see cref="RecordingStopped"/>, standing in for a wedged driver.</summary>
+		public bool NeverSignalsDrained { get; init; }
+
+		public event EventHandler<WaveInEventArgs>? DataAvailable;
+
+		public event EventHandler<StoppedEventArgs>? RecordingStopped;
+
+		public void StartRecording()
+		{
+		}
+
+		public void Deliver(byte[] pcm) => DataAvailable?.Invoke(this, new WaveInEventArgs(pcm, pcm.Length));
+
+		public void StopRecording()
+		{
+			lock (_stopLock)
+			{
+				StopSignalled.Set();
+
+				// Idempotent: AudioRecorder.Dispose stops again on its way out.
+				if (_drainThread is not null)
+					return;
+
+				if (NeverSignalsDrained)
+					return;
+
+				_drainThread = new Thread(() =>
+				{
+					_drainReleased.Wait();
+					if (BufferDeliveredWhileDraining is not null)
+						Deliver(BufferDeliveredWhileDraining);
+
+					RecordingStopped?.Invoke(this, new StoppedEventArgs());
+				})
+				{ IsBackground = true, Name = "fake-capture-drain" };
+				_drainThread.Start();
+			}
+		}
+
+		public void ReleaseDrain() => _drainReleased.Set();
+
+		public void Dispose()
+		{
+			_drainReleased.Set();
+			_drainThread?.Join(TimeSpan.FromSeconds(10));
+			_drainReleased.Dispose();
+			StopSignalled.Dispose();
+		}
+	}
+}

--- a/Mutation.Tests/OggOpusPcmDecoderTests.cs
+++ b/Mutation.Tests/OggOpusPcmDecoderTests.cs
@@ -149,4 +149,94 @@ public class OggOpusPcmDecoderTests : IDisposable
 
 		Assert.Throws<InvalidDataException>(() => OggOpusPcmDecoder.DecodeToMonoPcm(wav, _ => { }));
 	}
+
+	// A multiplexed container carries several logical streams side by side — Opus audio next to
+	// Theora video, say. Without serial-number filtering every stream's packets were fed to the
+	// one Opus decoder; those that happened to parse as a plausible TOC byte decoded as noise.
+	[Fact]
+	public void PacketsFromOtherLogicalStreams_AreIgnored()
+	{
+		const uint opusSerial = 7;
+		const uint videoSerial = 8;
+
+		string path = Path.Combine(_workingDirectory, "multiplexed.ogg");
+		using (var stream = File.Create(path))
+		{
+			OggStreamBuilder.WritePage(stream, new[] { OggStreamBuilder.OpusHead(1) }, serial: opusSerial);
+			// The other stream's own identification header, as a real multiplexed file would have.
+			OggStreamBuilder.WritePage(stream, new[] { Filled(42, 0x80) }, serial: videoSerial);
+			OggStreamBuilder.WritePage(stream, new[] { OggStreamBuilder.OpusTags() }, serial: opusSerial, pageSequence: 1);
+			OggStreamBuilder.WritePage(stream, new[] { new[] { HybridSwb20MsMonoCode3, SixCbrFrames } }, serial: opusSerial, pageSequence: 2);
+			// Bytes that parse as a perfectly good six-frame Opus packet, but belong to the
+			// other stream. Unfiltered, these decode as another 120 ms of noise.
+			OggStreamBuilder.WritePage(stream, new[] { new[] { HybridSwb20MsMonoCode3, SixCbrFrames } }, serial: videoSerial, pageSequence: 1);
+		}
+
+		// Only the six frames of the one Opus packet: the foreign stream contributes nothing.
+		Assert.Equal(6 * 960, CountSamples(path));
+	}
+
+	// A chained file is several separately encoded sections concatenated, each with its own
+	// OpusHead and its own serial. Only the first chain is decoded, so its pre-skip is not
+	// re-applied to audio it does not belong to.
+	[Fact]
+	public void ChainedStreams_AfterTheFirstAreIgnored()
+	{
+		string path = Path.Combine(_workingDirectory, "chained.ogg");
+		using (var stream = File.Create(path))
+		{
+			OggStreamBuilder.WritePage(stream, new[] { OggStreamBuilder.OpusHead(1) }, serial: 1);
+			OggStreamBuilder.WritePage(stream, new[] { OggStreamBuilder.OpusTags() }, serial: 1, pageSequence: 1);
+			OggStreamBuilder.WritePage(stream, new[] { new[] { HybridSwb20MsMonoCode3, SixCbrFrames } }, serial: 1, pageSequence: 2);
+
+			OggStreamBuilder.WritePage(stream, new[] { OggStreamBuilder.OpusHead(1) }, serial: 2);
+			OggStreamBuilder.WritePage(stream, new[] { OggStreamBuilder.OpusTags() }, serial: 2, pageSequence: 1);
+			OggStreamBuilder.WritePage(stream, new[] { new[] { HybridSwb20MsMonoCode3, SixCbrFrames } }, serial: 2, pageSequence: 2);
+		}
+
+		Assert.Equal(6 * 960, CountSamples(path));
+	}
+
+	[Fact]
+	public void DecodeToPcmStream_ReturnsTwoLittleEndianBytesPerSample()
+	{
+		string path = WriteFixture("bytes.ogg", channels: 1, preSkip: 0,
+			new[] { HybridSwb20MsMonoCode3, SixCbrFrames });
+
+		int sampleCount = CountSamples(path);
+
+		using MemoryStream pcm = OggOpusPcmDecoder.DecodeToPcmStream(path);
+
+		Assert.Equal(0, pcm.Position);
+		Assert.Equal(sampleCount * 2L, pcm.Length);
+
+		// Same bytes the caller-side short-to-byte loop used to produce.
+		var expected = new List<byte>();
+		OggOpusPcmDecoder.DecodeToMonoPcm(path, samples =>
+		{
+			foreach (short sample in samples)
+			{
+				expected.Add((byte)(sample & 0xFF));
+				expected.Add((byte)((sample >> 8) & 0xFF));
+			}
+		});
+
+		Assert.Equal(expected, pcm.ToArray());
+	}
+
+	[Fact]
+	public void DecodeToPcmStream_DoesNotLeaveAStreamBehindWhenTheFileIsUnreadable()
+	{
+		string wav = Path.Combine(_workingDirectory, "bad.wav");
+		File.WriteAllBytes(wav, "RIFF\0\0\0\0WAVEfmt "u8.ToArray());
+
+		Assert.Throws<InvalidDataException>(() => OggOpusPcmDecoder.DecodeToPcmStream(wav));
+	}
+
+	private static byte[] Filled(int length, byte value)
+	{
+		var data = new byte[length];
+		Array.Fill(data, value);
+		return data;
+	}
 }

--- a/Mutation.Tests/OggPacketReaderTests.cs
+++ b/Mutation.Tests/OggPacketReaderTests.cs
@@ -7,7 +7,9 @@ namespace Mutation.Tests;
 
 public class OggPacketReaderTests
 {
-	private static List<byte[]> Read(Stream stream) => OggPacketReader.ReadPackets(stream).ToList();
+	private static List<OggPacket> ReadAll(Stream stream) => OggPacketReader.ReadPackets(stream).ToList();
+
+	private static List<byte[]> Read(Stream stream) => OggPacketReader.ReadPackets(stream).Select(p => p.Data).ToList();
 
 	private static byte[] Filled(int length, byte value)
 	{
@@ -105,5 +107,45 @@ public class OggPacketReaderTests
 		stream.Position = 0;
 
 		Assert.Empty(Read(stream));
+	}
+
+	[Fact]
+	public void TagsEachPacketWithItsLogicalStreamSerialNumber()
+	{
+		using var stream = new MemoryStream();
+		OggStreamBuilder.WritePage(stream, new[] { Filled(10, 1) }, serial: 111);
+		OggStreamBuilder.WritePage(stream, new[] { Filled(20, 2) }, serial: 222, pageSequence: 1);
+		stream.Position = 0;
+
+		var packets = ReadAll(stream);
+
+		Assert.Equal(2, packets.Count);
+		Assert.Equal(111u, packets[0].SerialNumber);
+		Assert.Equal(222u, packets[1].SerialNumber);
+	}
+
+	// A multiplexed container (video plus audio, say) interleaves pages from several logical
+	// streams. A packet split across two of one stream's pages must not pick up the segments
+	// of the other stream's page that landed in between.
+	[Fact]
+	public void DoesNotSpliceAnInterleavedStreamIntoAContinuedPacket()
+	{
+		using var stream = new MemoryStream();
+		OggStreamBuilder.WritePage(stream, new[] { Filled(255, 4) }, serial: 111); // no terminator: continues
+		OggStreamBuilder.WritePage(stream, new[] { Filled(17, 9) }, serial: 222, pageSequence: 1);
+		OggStreamBuilder.WritePage(stream, new[] { Filled(30, 5) }, continued: true, serial: 111, pageSequence: 1);
+		stream.Position = 0;
+
+		var packets = ReadAll(stream);
+
+		Assert.Equal(2, packets.Count);
+
+		var other = Assert.Single(packets, p => p.SerialNumber == 222);
+		Assert.Equal(17, other.Data.Length);
+
+		var reassembled = Assert.Single(packets, p => p.SerialNumber == 111);
+		Assert.Equal(285, reassembled.Data.Length);
+		Assert.Equal(4, reassembled.Data[254]);
+		Assert.Equal(5, reassembled.Data[255]);
 	}
 }

--- a/Mutation.Tests/OggStreamBuilder.cs
+++ b/Mutation.Tests/OggStreamBuilder.cs
@@ -15,7 +15,10 @@ internal static class OggStreamBuilder
 	/// Writes one Ogg page containing the given segments verbatim. CRC is left zero — the
 	/// reader under test does not verify it, which is what lets tests hand-assemble pages.
 	/// </summary>
-	public static void WritePage(Stream stream, IEnumerable<byte[]> segments, bool continued = false, long granule = 0, int pageSequence = 0)
+	/// <summary>The serial number pages get when a test does not care which stream they are in.</summary>
+	public const uint DefaultSerial = 1;
+
+	public static void WritePage(Stream stream, IEnumerable<byte[]> segments, bool continued = false, long granule = 0, int pageSequence = 0, uint serial = DefaultSerial)
 	{
 		var segmentList = new List<byte[]>(segments);
 
@@ -24,7 +27,7 @@ internal static class OggStreamBuilder
 		header[4] = 0; // stream structure version
 		header[5] = (byte)(continued ? 0x01 : 0x00);
 		BitConverter.GetBytes(granule).CopyTo(header, 6);
-		BitConverter.GetBytes(1).CopyTo(header, 14); // serial
+		BitConverter.GetBytes(serial).CopyTo(header, 14);
 		BitConverter.GetBytes(pageSequence).CopyTo(header, 18);
 		header[26] = (byte)segmentList.Count;
 

--- a/Mutation.Ui/Core/SpeechToTextManager.cs
+++ b/Mutation.Ui/Core/SpeechToTextManager.cs
@@ -235,11 +235,21 @@ public class SpeechToTextManager : IDisposable
 			var transcribeToken = _state.StartTranscription(token);
 			try
 			{
-				_audioRecorder?.StopRecording();
-				double? trimmedSpeechSeconds = _audioRecorder?.TrimmedSpeechSeconds;
-				Exception? captureError = _audioRecorder?.CaptureException;
-				_audioRecorder?.Dispose();
-				_audioRecorder = null;
+				// Stopping blocks: it resets the capture device and then waits for the
+				// driver to hand over the buffers it has already filled, and disposing
+				// flushes the encoder to disk. Run off the calling thread so a slow or
+				// wedged audio driver cannot freeze the window — and the screen reader
+				// with it — while the user waits to hear the end-of-recording beep.
+				(double? trimmedSpeechSeconds, Exception? captureError) = await Task.Run(() =>
+				{
+					IAudioRecorder? recorder = _audioRecorder;
+					_audioRecorder = null;
+					recorder?.StopRecording();
+					var trimmed = recorder?.TrimmedSpeechSeconds;
+					var error = recorder?.CaptureException;
+					recorder?.Dispose();
+					return (trimmed, error);
+				});
 
 				// Before the cancellation and capture-error checks below: capture has
 				// ended however this call turns out, so the end-of-recording signal is


### PR DESCRIPTION
Four contained defects in the `CognitiveSupport` audio path, grouped because they share one small blast radius.

Closes #221
Closes #237
Closes #238
Closes #246

## What was wrong, and what changed

### #221 — the last word of every recording was thrown away

`WaveInEvent.StopRecording()` only *signals* its capture thread. Buffers it has already filled are delivered to `DataAvailable` afterwards, on that thread — and `AudioRecorder.StopRecording` closed the Ogg stream immediately, so those late buffers hit `if (_oggStream == null) return;` and vanished. With 100 ms buffers and NAudio's three-deep queue that is up to ~300 ms of speech, which is why transcripts ended mid-word.

`StopRecording` now waits on `RecordingStopped` (bounded at 2 s, outside `_writeLock` so the deliveries can still take it) before finishing the stream.

Two supporting changes:

- The capture device moved behind `IAudioCaptureSource`, so the stop-and-drain ordering can be scripted in a test. `AudioRecorder` had no coverage at all before this.
- `WaveInCaptureSource` builds `WaveInEvent` with `SynchronizationContext.Current` cleared. `WaveInEvent` captures the context in its constructor and *posts* `RecordingStopped` to it — built on the UI thread, the event would be delivered on the UI thread, which is the same thread waiting for it. Clearing the context keeps it on NAudio's recording thread.

### #237 — decode under the playback lock, and a device never released

`Play` held `_playLock` across a full synchronous decode. A 30-minute import takes seconds, and every `Speed` set from the UI thread blocked behind it, freezing the window. Decoding now happens outside the lock; the lock is taken only to stop the previous chain and publish the new one, so two overlapping `Play` calls cannot strand the loser's output device.

`OnPlaybackStopped` raised `PlaybackEnded` and returned, leaving `WaveOutEvent` holding an open WinMM handle and `_pcmStream` holding the whole decoded buffer for the rest of the app's life. It now tears the chain down after raising the event, skipping it if a `PlaybackEnded` handler already started the next file.

Decoding writes bytes as each frame arrives (`OggOpusPcmDecoder.DecodeToPcmStream`) instead of filling a `List<short>` and then copying it to a `byte[]`, which halves peak memory — about 340 MB down to 170 MB for a 30-minute voice note.

### #238 — `BeepPlayer.DisposePlayers` raced its own caches

`DisposePlayers` was public and took no lock while every sibling mutated the same statics under `SyncLock`. Closing the window during a transcription retry could throw `Collection was modified` or `ObjectDisposedException` out through `ObjectExtensions.Beep` into the Polly retry lambda, aborting the transcription.

`DisposePlayers` now locks, with `Initialize` routed through a private unlocked core. `TryPlayCustom`, `TryPlayCustomRepeated` and `PlayDefault` read their fields — and call `Play` — under the same lock, and a beep that fails can no longer escape the call that was only reporting progress.

It stays `public`: `MainWindow` calls it on window close, from another assembly.

### #246 — three faults in the Ogg/Opus decode path

- `OggPacketReader` never read the page header's bitstream serial number, so a multiplexed container's streams were concatenated into one packet sequence. It now tags each packet with its serial **and** keeps a partial-packet buffer per stream, so an interleaved page cannot splice its segments into another stream's continued packet.
- `OggOpusPcmDecoder` locks onto the serial of the first stream carrying `OpusHead` and ignores the rest. That also stops a chained file from having the first chain's pre-skip applied to the next one — later chains are skipped rather than mis-decoded.
- The Concentus decoder is now disposed. `IOpusDecoder` does not extend `IDisposable`, but the concrete `OpusDecoder` does, so it goes through an `as IDisposable` cast in a `finally`.
- `AudioFileConverter.ConvertToOgg(string)` used `Path.GetTempFileName()`, which *creates* a zero-byte `.tmp` that `ChangeExtension` then walked away from. Replaced with `Path.GetRandomFileName()`.

## Tests

1042 pass. Eight new:

- `AudioRecorderDrainTests` — buffers before the stop, buffers delivered *after* the stop is signalled, and a wedged source that never reports drained (asserting the timeout closes the file rather than hanging).
- `OggPacketReaderTests` — packets carry their serial number; an interleaved stream is not spliced into a continued packet.
- `OggOpusPcmDecoderTests` — a multiplexed container ignores the foreign stream's audio-shaped packets; a chained file decodes only the first chain; `DecodeToPcmStream` produces exactly the bytes the old caller-side loop did, and disposes its stream on failure.

Verified falsifiable: with the drain wait and the serial filter reverted, `Buffers_delivered_after_stop_is_signalled_are_still_encoded`, `PacketsFromOtherLogicalStreams_AreIgnored` and `ChainedStreams_AfterTheFirstAreIgnored` all fail.

**No test for the `BeepPlayer` locking.** Reproducing that race needs `PlayDefault`, which actually plays sound — a test suite that beeps at random is worse than useless for a user who relies on those beeps as cues. The change is a lock-discipline fix verified by inspection.

## Documentation

No user guide change. Nothing a user configures or sees by name moved; #221 restores intended behaviour rather than changing it, and `troubleshooting.md` has no entry about truncated recordings to retire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
