### PR TITLE
Stop a failed reading going silent, and four faults around it

### DIFF
--- a/CognitiveSupport/ITextToSpeechService.cs
+++ b/CognitiveSupport/ITextToSpeechService.cs
@@ -2,6 +2,13 @@ namespace CognitiveSupport;
 
 public interface ITextToSpeechService : IDisposable
 {
+	// Raised when a read fails after Speak has already returned. Speak hands the work to a
+	// background thread and comes straight back, so there is no call left for the failure
+	// to come out of; without this a read that died is silent and indistinguishable from
+	// one that finished (issue #236). Raised off the UI thread — marshal before touching
+	// any control.
+	event EventHandler<Exception>? SpeakFailed;
+
 	bool IsSpeaking { get; }
 
 	// True only while a read is frozen by Pause(); false when stopped or actively speaking.

--- a/CognitiveSupport/SpokenWeave.cs
+++ b/CognitiveSupport/SpokenWeave.cs
@@ -66,7 +66,7 @@ public readonly struct SpokenWeaveMap
 
 	private readonly int _baseDelta;
 	private readonly int _realLength;
-	private readonly IReadOnlyList<Entry> _markers;
+	private readonly IReadOnlyList<Entry>? _markers;
 
 	public SpokenWeaveMap(int baseDelta, int realLength, IReadOnlyList<Entry> markers)
 	{
@@ -75,15 +75,26 @@ public readonly struct SpokenWeaveMap
 		_markers = markers ?? Array.Empty<Entry>();
 	}
 
+	// A map with nothing woven in, for a field or local that has no read in flight yet.
+	// `default(SpokenWeaveMap)` behaves identically — every member below tolerates the
+	// null marker list a defaulted struct leaves behind — but naming it says so out loud.
+	public static SpokenWeaveMap Empty => default;
+
+	// Marker count, treating a defaulted struct (which bypasses the constructor and so
+	// never gets the empty list) as having none. Both members below go through this
+	// rather than touching _markers.Count, which would throw on a defaulted map — on the
+	// synthesizer's callback thread, where an unhandled exception ends the process.
+	private int MarkerCount => _markers?.Count ?? 0;
+
 	// Map a spoken-string position back to a real-text offset. Positions before the
 	// first marker shift by the base delta; each marker crossed adds its length to
 	// the shift; a position inside a marker maps to that marker's boundary.
 	public int ToReal(int spokenPosition)
 	{
 		int real = spokenPosition + _baseDelta;
-		for (int i = 0; i < _markers.Count; i++)
+		for (int i = 0; i < MarkerCount; i++)
 		{
-			Entry m = _markers[i];
+			Entry m = _markers![i];
 			if (spokenPosition < m.SpokenStart) break;
 			if (spokenPosition < m.SpokenStart + m.Length) return m.RealOffset;
 			real -= m.Length;
@@ -98,9 +109,9 @@ public readonly struct SpokenWeaveMap
 	public int HighestMarkerPercentAtOrBefore(int realPosition)
 	{
 		int best = 0;
-		for (int i = 0; i < _markers.Count; i++)
+		for (int i = 0; i < MarkerCount; i++)
 		{
-			Entry m = _markers[i];
+			Entry m = _markers![i];
 			if (m.RealOffset <= realPosition && m.Percent > best)
 				best = m.Percent;
 		}

--- a/CognitiveSupport/SupersedingOperation.cs
+++ b/CognitiveSupport/SupersedingOperation.cs
@@ -1,0 +1,59 @@
+namespace CognitiveSupport;
+
+// The single "current operation" token for a service where anything new supersedes
+// whatever was already running — a read replaces a read, a skip replaces a read, a stop
+// ends both.
+//
+// The ordering inside Begin is the whole point: the outgoing token is cancelled *before*
+// the replacement is published. Cancelling afterwards — worse, after the caller has let
+// go of its lock — leaves a window in which a worker for the superseded operation can
+// still see a live token, take the lock and go ahead, so the stale work runs and the new
+// work merely queues behind it (issue #236). Callers therefore hold their own lock across
+// Begin, and nothing between the two halves can observe a half-finished handover.
+internal sealed class SupersedingOperation : IDisposable
+{
+	private readonly object _lock = new();
+	private CancellationTokenSource? _current;
+	private bool _disposed;
+
+	// Cancel whatever is running and hand back the token for its replacement. After
+	// Dispose this returns an already-cancelled token, so a caller racing disposal
+	// starts no work rather than starting work nothing will ever stop.
+	public CancellationToken Begin()
+	{
+		lock (_lock)
+		{
+			CancelCurrentLocked();
+			if (_disposed) return new CancellationToken(canceled: true);
+			_current = new CancellationTokenSource();
+			return _current.Token;
+		}
+	}
+
+	// Cancel whatever is running without starting anything in its place.
+	public void Cancel()
+	{
+		lock (_lock) CancelCurrentLocked();
+	}
+
+	public void Dispose()
+	{
+		lock (_lock)
+		{
+			_disposed = true;
+			CancelCurrentLocked();
+		}
+	}
+
+	private void CancelCurrentLocked()
+	{
+		CancellationTokenSource? cts = _current;
+		_current = null;
+		if (cts is null) return;
+
+		// Cancel first, then release the source. A worker still holding the token only
+		// polls IsCancellationRequested, which keeps answering true after disposal.
+		try { cts.Cancel(); } catch (ObjectDisposedException) { }
+		cts.Dispose();
+	}
+}

--- a/CognitiveSupport/TextToSpeechService.cs
+++ b/CognitiveSupport/TextToSpeechService.cs
@@ -28,7 +28,7 @@ namespace CognitiveSupport
 		// woven markers degrades to a single scalar shift, identical to the old
 		// _spokenToCurrentDelta; a read with progress markers carries one breakpoint
 		// per marker so OnSpeakProgress still reports the real position.
-		private SpokenWeaveMap _spokenMap;
+		private SpokenWeaveMap _spokenMap = SpokenWeaveMap.Empty;
 		private List<int>? _sentenceStarts;
 		// Authoritative navigation cursor: which sentence index we are on. Driven
 		// explicitly by SkipSentence and nudged forward by playback progress, so
@@ -54,7 +54,9 @@ namespace CognitiveSupport
 		private int _pendingSkipIndex;
 		private bool _speakingAnnouncement;
 		private bool _disposed;
-		private CancellationTokenSource? _opCts;
+		// The token for whatever is currently being spoken. Always handed over inside
+		// _gate so a superseded read cannot slip past the handover (issue #236).
+		private readonly SupersedingOperation _operation = new();
 
 		// Configurable announcement behaviour, pushed in from settings. Defaults mirror
 		// the settings defaults so the service behaves sensibly before it is configured.
@@ -69,9 +71,8 @@ namespace CognitiveSupport
 		// skip/resume never re-announces a threshold the listener already heard, and
 		// backward navigation does not re-announce a passed threshold.
 		private int _lastAnnouncedPercent;
-		// Bumped whenever a new top-level operation begins (read, stop, skip, spoken
-		// announcement) so a stale deferred task can detect it was superseded.
-		private long _playbackEpoch;
+
+		public event EventHandler<Exception>? SpeakFailed;
 
 		public bool IsSpeaking
 		{
@@ -119,31 +120,43 @@ namespace CognitiveSupport
 		{
 			if (string.IsNullOrEmpty(text)) return;
 
-			CancellationTokenSource? oldCts;
-			CancellationTokenSource newCts = new();
+			CancellationToken token;
 			lock (_gate)
 			{
-				if (_disposed) { newCts.Dispose(); return; }
+				if (_disposed) return;
 				EnsureSynth();
 				CancelAllAndClearPause();
 				_speakingAnnouncement = false;
-				oldCts = _opCts;
-				_opCts = newCts;
+				token = _operation.Begin();
 			}
-			oldCts?.Cancel();
-			oldCts?.Dispose();
 
-			CancellationToken token = newCts.Token;
-			Task.Run(() => RunSpeak(text, rate, volume, voiceName, resumeIfSame, preprocess, resumeRewindWordCount, options, token));
+			// The read itself runs off the caller's thread — preprocessing a long article
+			// is not instant and this is called from the UI thread. Nothing awaits it, but
+			// a failure is not lost either: the continuation reports it, so a read that
+			// died (a voice that vanished, an audio endpoint that went away) is not
+			// indistinguishable from one that finished.
+			Task.Run(() => RunSpeak(text, rate, volume, voiceName, resumeIfSame, preprocess, resumeRewindWordCount, options, token))
+				.ContinueWith(
+					t => ReportSpeakFailure(t.Exception!.GetBaseException()),
+					CancellationToken.None,
+					TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+					TaskScheduler.Default);
+		}
+
+		// Hand a failed read to whoever is listening. Raised on a thread-pool thread, so
+		// a UI subscriber has to marshal it. A listener that throws must not replace the
+		// original failure with an unobserved one of its own.
+		private void ReportSpeakFailure(Exception ex)
+		{
+			try { SpeakFailed?.Invoke(this, ex); }
+			catch { }
 		}
 
 		private void RunSpeak(string text, int rate, int volume, string? voiceName, bool resumeIfSame, bool preprocess, int resumeRewindWordCount, SpeechPreprocessingOptions? options, CancellationToken token)
 		{
 			if (token.IsCancellationRequested) return;
 
-			string processed;
-			try { processed = preprocess ? PreprocessForSpeech(text, options ?? SpeechPreprocessingOptions.All) : text; }
-			catch { return; }
+			string processed = preprocess ? PreprocessForSpeech(text, options ?? SpeechPreprocessingOptions.All) : text;
 
 			if (token.IsCancellationRequested || string.IsNullOrEmpty(processed)) return;
 
@@ -153,7 +166,6 @@ namespace CognitiveSupport
 				if (_synth is null) return;
 
 				ApplyVoiceParams(rate, volume, voiceName);
-				_playbackEpoch++;
 
 				bool sameContent = string.Equals(processed, _currentText, StringComparison.Ordinal);
 				bool canResume = resumeIfSame && sameContent
@@ -194,25 +206,18 @@ namespace CognitiveSupport
 
 		public void SkipSentence(int direction, int rate, int volume, string? voiceName, int graceWindowMs)
 		{
-			CancellationTokenSource? oldCts;
-			CancellationTokenSource newCts = new();
 			lock (_gate)
 			{
-				if (_disposed) { newCts.Dispose(); return; }
+				if (_disposed) return;
 				if (_currentText is null || _sentenceStarts is null || _sentenceStarts.Count == 0)
-				{
-					newCts.Dispose();
 					return;
-				}
 
 				EnsureSynth();
 				CancelAllAndClearPause();
 				_speakingAnnouncement = false;
-				oldCts = _opCts;
-				_opCts = newCts;
+				_operation.Begin();
 
 				ApplyVoiceParams(rate, volume, voiceName);
-				_playbackEpoch++;
 
 				int lastIndex = _sentenceStarts.Count - 1;
 				long now = Environment.TickCount64;
@@ -253,8 +258,6 @@ namespace CognitiveSupport
 					_currentPrompt = _synth!.SpeakAsync(BuildWovenSpeech(targetPos, string.Empty));
 				}
 			}
-			oldCts?.Cancel();
-			oldCts?.Dispose();
 		}
 
 		// Move the navigation cursor onto a sentence and reset the grace-window timer.
@@ -314,23 +317,17 @@ namespace CognitiveSupport
 		{
 			if (string.IsNullOrEmpty(text)) return;
 
-			CancellationTokenSource? oldCts;
-			CancellationTokenSource newCts = new();
 			lock (_gate)
 			{
-				if (_disposed) { newCts.Dispose(); return; }
+				if (_disposed) return;
 				EnsureSynth();
 				CancelAllAndClearPause();
-				oldCts = _opCts;
-				_opCts = newCts;
+				_operation.Begin();
 
 				ApplyVoiceParams(rate, volume, voiceName);
 				_speakingAnnouncement = true;
-				_playbackEpoch++;
 				_currentPrompt = _synth!.SpeakAsync(text);
 			}
-			oldCts?.Cancel();
-			oldCts?.Dispose();
 		}
 
 		public ReadingPosition GetReadingPosition()
@@ -366,12 +363,9 @@ namespace CognitiveSupport
 
 		public void Stop()
 		{
-			CancellationTokenSource? oldCts;
 			lock (_gate)
 			{
-				oldCts = _opCts;
-				_opCts = null;
-				_playbackEpoch++;
+				_operation.Cancel();
 				if (_synth is null) return;
 				try { _synth.SpeakAsyncCancelAll(); } catch { }
 				// If the read was frozen by Pause(), the engine is still in its Paused state with
@@ -384,8 +378,6 @@ namespace CognitiveSupport
 				_speakingAnnouncement = false;
 				_currentPrompt = null;
 			}
-			oldCts?.Cancel();
-			oldCts?.Dispose();
 		}
 
 		public void Pause(int rate, int volume, string? voiceName)
@@ -427,7 +419,6 @@ namespace CognitiveSupport
 				// Beyond the threshold: cancel the frozen utterance and respeak from a rewound
 				// position so the listener regains context. Mirrors RunSpeak's resume branch.
 				ApplyVoiceParams(rate, volume, voiceName);
-				_playbackEpoch++;
 
 				int resumePos = ComputeResumePosition(_currentText, _currentPosition, resumeRewindWordCount, rewind: true);
 				_currentPosition = resumePos;
@@ -634,13 +625,11 @@ namespace CognitiveSupport
 
 		public void Dispose()
 		{
-			CancellationTokenSource? oldCts;
 			lock (_gate)
 			{
 				if (_disposed) return;
 				_disposed = true;
-				oldCts = _opCts;
-				_opCts = null;
+				_operation.Dispose();
 				if (_synth is not null)
 				{
 					try { _synth.SpeakAsyncCancelAll(); } catch { }
@@ -660,8 +649,6 @@ namespace CognitiveSupport
 				_sentenceStarts = null;
 				_currentPrompt = null;
 			}
-			oldCts?.Cancel();
-			oldCts?.Dispose();
 		}
 
 		private static readonly Regex SentenceEndRegex = new(

--- a/Documentation/UserGuide/html/read-aloud.html
+++ b/Documentation/UserGuide/html/read-aloud.html
@@ -165,8 +165,12 @@ clipboard</strong> and <strong>Speak selection</strong> buttons that do the same
 <h2 id="pausing-and-picking-up-again">Pausing and picking up again</h2>
 <p>There are two ways to interrupt a reading, and they behave slightly differently.</p>
 <p><strong>Pause properly: Ctrl+Shift+Space.</strong> This is the real pause button. Press it while
-Mutation is reading and it says &quot;Paused.&quot; Press it again and it says &quot;Resuming.&quot; and
-carries on. If nothing is being read, it tells you &quot;Nothing to resume.&quot;</p>
+Mutation is reading and it says &quot;Paused.&quot; out loud. Press it again and the reading
+carries on, with &quot;Resuming.&quot; in the status area. If nothing is being read, it says
+&quot;Nothing to resume.&quot; out loud.</p>
+<p>Some of these replies are spoken in the reading voice and some appear in the status
+area instead. Either way you hear them: the status area is announced to your screen
+reader as it changes.</p>
 <p>When it resumes, it rewinds a few words first — five by default — so you get your
 bearings instead of being dropped mid-sentence. That rewind only happens if your
 pause was long enough to lose the thread. A quick pause of a few seconds picks up
@@ -176,12 +180,12 @@ from exactly where it stopped. By default, &quot;long enough&quot; means more th
 and &quot;Rewind on resume after (seconds)&quot; (set it to 0 to always rewind, however brief
 the pause).</p>
 <p><strong>Stop with the same key you started with: Ctrl+Shift+Alt+Q.</strong> Pressing the speak
-shortcut again while it is reading stops it, and Mutation says &quot;Stopped.&quot; Press it
-once more and it picks the same text up again from where it left off — so in
-everyday use it works like a play/stop button on the one key.</p>
+shortcut again while it is reading stops it, and &quot;Stopped.&quot; appears in the status
+area. Press it once more and it picks the same text up again from where it left off —
+so in everyday use it works like a play/stop button on the one key.</p>
 <p>One handy detail: if you copy something new before pressing it again, Mutation
 notices and reads the <em>new</em> clipboard text instead of carrying on with the old one.
-It tells you so: &quot;Speaking new clipboard text.&quot;</p>
+The status area says so: &quot;Speaking new clipboard text.&quot;</p>
 <h2 id="moving-around-the-text">Moving around the text</h2>
 <p>You can move through the text sentence by sentence, the way you skip tracks on a
 music player.</p>

--- a/Documentation/UserGuide/html/read-aloud.html
+++ b/Documentation/UserGuide/html/read-aloud.html
@@ -303,6 +303,12 @@ press the shortcut again.</li>
 </ul>
 <p>Each of these also appears as a message on the main window, and plays the failure
 beep.</p>
+<p>A reading can also fail once it has started — most often because the voice it was
+told to use is no longer installed on Windows. Mutation plays the failure beep,
+puts the reason on the main window, and opens a dialog with the details. If the
+missing voice is the cause, the message names it, so you know which one to pick a
+replacement for on the <strong>Voice &amp; Speech</strong> card. A shortcut that fails this way
+never just goes quiet on you.</p>
 <h2 id="where-to-next">Where to next</h2>
 <ul>
 <li><a href="screen-capture-and-ocr.html">Screenshots and reading text from images</a> — get text

--- a/Documentation/UserGuide/html/troubleshooting.html
+++ b/Documentation/UserGuide/html/troubleshooting.html
@@ -313,6 +313,22 @@ text clean-up options in <strong>Settings</strong>. There are individual switche
 bold and italic marks, heading marks, bullet markers, code blocks, and for
 shortening long web links.</li>
 </ol>
+<h3 id="reading-aloud-fails-or-the-voice-you-chose-has-gone">Reading aloud fails, or the voice you chose has gone</h3>
+<p><strong>What's happening.</strong> The voice Mutation was told to use is no longer installed —
+a Windows update removed it, or the settings came from another computer that had it.
+Reading can also fail if the audio device it was playing to has been unplugged.</p>
+<p>Mutation plays the failure beep, puts the reason on the main window, and opens a
+dialog with the details. When the chosen voice is the problem, the message names
+it. This happens whether you started the reading with the button or the shortcut,
+so a shortcut press never simply does nothing.</p>
+<p><strong>What to do.</strong></p>
+<ol>
+<li>Open the <strong>Voice</strong> list on the <strong>Voice &amp; Speech</strong> card and pick a voice that is
+there now. If the list is short, install more through Windows Settings and
+restart Mutation.</li>
+<li>If the voice is fine, check the speakers or headphones you were listening
+through are still connected, then press the shortcut again.</li>
+</ol>
 <h3 id="settings-wont-save">Settings won't save</h3>
 <p><strong>What's happening.</strong> Mutation writes your settings to a file. If that write fails —
 the file is read-only, a backup tool has it open, or the folder is not writable — the

--- a/Documentation/UserGuide/markdown/read-aloud.md
+++ b/Documentation/UserGuide/markdown/read-aloud.md
@@ -30,8 +30,13 @@ clipboard** and **Speak selection** buttons that do the same thing.
 There are two ways to interrupt a reading, and they behave slightly differently.
 
 **Pause properly: Ctrl+Shift+Space.** This is the real pause button. Press it while
-Mutation is reading and it says "Paused." Press it again and it says "Resuming." and
-carries on. If nothing is being read, it tells you "Nothing to resume."
+Mutation is reading and it says "Paused." out loud. Press it again and the reading
+carries on, with "Resuming." in the status area. If nothing is being read, it says
+"Nothing to resume." out loud.
+
+Some of these replies are spoken in the reading voice and some appear in the status
+area instead. Either way you hear them: the status area is announced to your screen
+reader as it changes.
 
 When it resumes, it rewinds a few words first — five by default — so you get your
 bearings instead of being dropped mid-sentence. That rewind only happens if your
@@ -44,13 +49,13 @@ and "Rewind on resume after (seconds)" (set it to 0 to always rewind, however br
 the pause).
 
 **Stop with the same key you started with: Ctrl+Shift+Alt+Q.** Pressing the speak
-shortcut again while it is reading stops it, and Mutation says "Stopped." Press it
-once more and it picks the same text up again from where it left off — so in
-everyday use it works like a play/stop button on the one key.
+shortcut again while it is reading stops it, and "Stopped." appears in the status
+area. Press it once more and it picks the same text up again from where it left off —
+so in everyday use it works like a play/stop button on the one key.
 
 One handy detail: if you copy something new before pressing it again, Mutation
 notices and reads the *new* clipboard text instead of carrying on with the old one.
-It tells you so: "Speaking new clipboard text."
+The status area says so: "Speaking new clipboard text."
 
 ## Moving around the text
 

--- a/Documentation/UserGuide/markdown/read-aloud.md
+++ b/Documentation/UserGuide/markdown/read-aloud.md
@@ -171,6 +171,13 @@ silently. You will hear one of these:
 Each of these also appears as a message on the main window, and plays the failure
 beep.
 
+A reading can also fail once it has started — most often because the voice it was
+told to use is no longer installed on Windows. Mutation plays the failure beep,
+puts the reason on the main window, and opens a dialog with the details. If the
+missing voice is the cause, the message names it, so you know which one to pick a
+replacement for on the **Voice & Speech** card. A shortcut that fails this way
+never just goes quiet on you.
+
 ## Where to next
 
 - [Screenshots and reading text from images](screen-capture-and-ocr.md) — get text

--- a/Documentation/UserGuide/markdown/troubleshooting.md
+++ b/Documentation/UserGuide/markdown/troubleshooting.md
@@ -206,6 +206,25 @@ installed.
    bold and italic marks, heading marks, bullet markers, code blocks, and for
    shortening long web links.
 
+### Reading aloud fails, or the voice you chose has gone
+
+**What's happening.** The voice Mutation was told to use is no longer installed —
+a Windows update removed it, or the settings came from another computer that had it.
+Reading can also fail if the audio device it was playing to has been unplugged.
+
+Mutation plays the failure beep, puts the reason on the main window, and opens a
+dialog with the details. When the chosen voice is the problem, the message names
+it. This happens whether you started the reading with the button or the shortcut,
+so a shortcut press never simply does nothing.
+
+**What to do.**
+
+1. Open the **Voice** list on the **Voice & Speech** card and pick a voice that is
+   there now. If the list is short, install more through Windows Settings and
+   restart Mutation.
+2. If the voice is fine, check the speakers or headphones you were listening
+   through are still connected, then press the shortcut again.
+
 ### Settings won't save
 
 **What's happening.** Mutation writes your settings to a file. If that write fails —

--- a/Mutation.Tests/GaplessProgressWeaveTests.cs
+++ b/Mutation.Tests/GaplessProgressWeaveTests.cs
@@ -186,4 +186,37 @@ public class GaplessProgressWeaveTests
 		Assert.Equal(50, map.HighestMarkerPercentAtOrBefore(60)); // second reached
 		Assert.Equal(50, map.HighestMarkerPercentAtOrBefore(100));
 	}
+
+	// ---- A defaulted map: no read in flight, and no NullReferenceException ----
+
+	// The struct's constructor is what substitutes an empty list for a null one, and a
+	// defaulted struct never runs it. TextToSpeechService holds one of these in a field
+	// read from the synthesizer's progress callback, where a throw would take the whole
+	// process down, so the defaulted value has to answer like an empty map (issue #241).
+	[Fact]
+	public void DefaultMap_MapsEveryPositionToZero_RatherThanThrowing()
+	{
+		SpokenWeaveMap map = default;
+
+		Assert.Equal(0, map.ToReal(0));
+		Assert.Equal(0, map.ToReal(50));
+	}
+
+	[Fact]
+	public void DefaultMap_HasReachedNoMarkers()
+	{
+		SpokenWeaveMap map = default;
+
+		Assert.Equal(0, map.HighestMarkerPercentAtOrBefore(0));
+		Assert.Equal(0, map.HighestMarkerPercentAtOrBefore(1000));
+	}
+
+	[Fact]
+	public void EmptyMap_BehavesLikeTheDefaultedOne()
+	{
+		SpokenWeaveMap empty = SpokenWeaveMap.Empty;
+
+		Assert.Equal(0, empty.ToReal(50));
+		Assert.Equal(0, empty.HighestMarkerPercentAtOrBefore(1000));
+	}
 }

--- a/Mutation.Tests/ReadmeSettingsCoverageTests.cs
+++ b/Mutation.Tests/ReadmeSettingsCoverageTests.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using CognitiveSupport;
+using Xunit;
+
+namespace Mutation.Tests;
+
+// The README's settings example is the only place a user hand-editing Mutation.json can
+// learn the key names. It had drifted to documenting 1 of the 27 text-to-speech options
+// (issue #258), which is worse than documenting none: the section looks complete.
+//
+// This test fails the moment a new TextToSpeechSettings property is added without a line
+// in the README, so the two cannot drift apart again silently.
+public class ReadmeSettingsCoverageTests
+{
+	[Fact]
+	public void ReadmeDocumentsEveryTextToSpeechSetting()
+	{
+		string readme = File.ReadAllText(FindReadme());
+
+		var undocumented = new List<string>();
+		foreach (PropertyInfo property in typeof(TextToSpeechSettings)
+			.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+		{
+			// Quoted, because that is how the key appears in the JSON example — a bare
+			// name would also match the surrounding prose and let a key slip through
+			// documented only in passing.
+			if (!readme.Contains($"\"{property.Name}\"", StringComparison.Ordinal))
+				undocumented.Add(property.Name);
+		}
+
+		Assert.True(
+			undocumented.Count == 0,
+			"README.md does not document these TextToSpeechSettings keys: "
+				+ string.Join(", ", undocumented)
+				+ ". Add them to the Configuration / Settings example.");
+	}
+
+	// Walks up from the test binary to the repository root. The solution file is the
+	// marker: it sits beside README.md and nothing below it does.
+	private static string FindReadme()
+	{
+		var directory = new DirectoryInfo(AppContext.BaseDirectory);
+		while (directory is not null)
+		{
+			string readme = Path.Combine(directory.FullName, "README.md");
+			if (File.Exists(Path.Combine(directory.FullName, "Mutation.slnx")) && File.Exists(readme))
+				return readme;
+
+			directory = directory.Parent;
+		}
+
+		throw new InvalidOperationException(
+			$"Could not find the repository README.md above {AppContext.BaseDirectory}.");
+	}
+}

--- a/Mutation.Tests/SupersedingOperationTests.cs
+++ b/Mutation.Tests/SupersedingOperationTests.cs
@@ -1,0 +1,112 @@
+using System.Threading;
+using CognitiveSupport;
+using Xunit;
+
+namespace Mutation.Tests;
+
+// Covers the handover that makes one read replace another in TextToSpeechService.
+// The bug this guards against (issue #236) was cancelling the outgoing token *after*
+// the replacement had been published and the caller's lock released: a worker for the
+// superseded read could get in during that window, see a live token, and read stale
+// text in full before the text the user actually asked for.
+//
+// Speaking itself needs a synthesizer and an audio device, so it is not exercised here.
+// The handover does not, and it is where the ordering lives.
+public class SupersedingOperationTests
+{
+	[Fact]
+	public void Begin_HandsOutALiveToken()
+	{
+		using var operation = new SupersedingOperation();
+
+		CancellationToken token = operation.Begin();
+
+		Assert.False(token.IsCancellationRequested);
+	}
+
+	[Fact]
+	public void Begin_CancelsThePreviousOperationBeforeItReturns()
+	{
+		using var operation = new SupersedingOperation();
+		CancellationToken first = operation.Begin();
+
+		CancellationToken second = operation.Begin();
+
+		// The point of the ordering: by the time the caller is holding the new token —
+		// still inside its own lock — the old one is already dead, so a worker for the
+		// old operation cannot find a live token whichever order the two threads run in.
+		Assert.True(first.IsCancellationRequested);
+		Assert.False(second.IsCancellationRequested);
+	}
+
+	[Fact]
+	public void Begin_CancelsEachOperationInTurn()
+	{
+		using var operation = new SupersedingOperation();
+
+		CancellationToken first = operation.Begin();
+		CancellationToken second = operation.Begin();
+		CancellationToken third = operation.Begin();
+
+		Assert.True(first.IsCancellationRequested);
+		Assert.True(second.IsCancellationRequested);
+		Assert.False(third.IsCancellationRequested);
+	}
+
+	[Fact]
+	public void Cancel_EndsTheCurrentOperationWithoutStartingAnother()
+	{
+		using var operation = new SupersedingOperation();
+		CancellationToken token = operation.Begin();
+
+		operation.Cancel();
+
+		Assert.True(token.IsCancellationRequested);
+	}
+
+	[Fact]
+	public void Cancel_WithNothingRunning_IsANoOp()
+	{
+		using var operation = new SupersedingOperation();
+
+		operation.Cancel();
+		operation.Cancel();
+
+		// Still usable afterwards: a Stop with nothing playing must not wedge the service.
+		Assert.False(operation.Begin().IsCancellationRequested);
+	}
+
+	[Fact]
+	public void Dispose_CancelsWhateverIsRunning()
+	{
+		var operation = new SupersedingOperation();
+		CancellationToken token = operation.Begin();
+
+		operation.Dispose();
+
+		Assert.True(token.IsCancellationRequested);
+	}
+
+	[Fact]
+	public void Begin_AfterDispose_HandsBackAnAlreadyCancelledToken()
+	{
+		var operation = new SupersedingOperation();
+		operation.Dispose();
+
+		CancellationToken token = operation.Begin();
+
+		// A caller racing shutdown gets a token that stops its worker at the first check,
+		// rather than one that nothing will ever cancel.
+		Assert.True(token.IsCancellationRequested);
+	}
+
+	[Fact]
+	public void Dispose_IsIdempotent()
+	{
+		var operation = new SupersedingOperation();
+		operation.Begin();
+
+		operation.Dispose();
+		operation.Dispose();
+	}
+}

--- a/Mutation.Tests/TextToSpeechFailureMessageTests.cs
+++ b/Mutation.Tests/TextToSpeechFailureMessageTests.cs
@@ -1,0 +1,78 @@
+using System;
+using Mutation.Ui.Core;
+using Xunit;
+
+namespace Mutation.Tests;
+
+// What a text-to-speech failure says to the user. The speak actions are reachable from
+// global hotkeys, where a failure otherwise produces nothing at all, so the wording is
+// the whole feedback the reader gets (issue #235). The usual cause — a voice that is no
+// longer installed — is named explicitly, because the engine's own message never is.
+public class TextToSpeechFailureMessageTests
+{
+	private static readonly string[] Installed = { "Microsoft David", "Microsoft Zira" };
+
+	[Fact]
+	public void InstalledVoice_KeepsTheEngineMessageAsIs()
+	{
+		string message = TextToSpeechFailureMessage.Compose(
+			"The audio device is unavailable.", "Microsoft Zira", Installed);
+
+		Assert.Equal("The audio device is unavailable.", message);
+	}
+
+	[Fact]
+	public void MissingVoice_NamesItAndSaysWhereToChangeIt()
+	{
+		string message = TextToSpeechFailureMessage.Compose(
+			"Speech failed.", "Microsoft Hazel", Installed);
+
+		Assert.Contains("Microsoft Hazel", message);
+		Assert.Contains("not installed", message);
+		Assert.Contains("Voice", message);
+	}
+
+	[Fact]
+	public void DefaultVoice_IsNeverReportedAsMissing()
+	{
+		// No voice configured means "use whatever Windows defaults to", which cannot be
+		// the missing one.
+		Assert.False(TextToSpeechFailureMessage.IsVoiceMissing(null, Installed));
+		Assert.False(TextToSpeechFailureMessage.IsVoiceMissing("", Installed));
+		Assert.False(TextToSpeechFailureMessage.IsVoiceMissing("   ", Installed));
+	}
+
+	[Fact]
+	public void VoiceMatchIgnoresCaseAndSurroundingSpace()
+	{
+		Assert.False(TextToSpeechFailureMessage.IsVoiceMissing(" microsoft david ", Installed));
+	}
+
+	[Fact]
+	public void UnknownVoiceList_DoesNotClaimTheVoiceIsMissing()
+	{
+		// Enumeration failing is its own problem. Guessing "your voice is gone" from an
+		// empty list would send the reader to change a setting that was never at fault.
+		Assert.False(TextToSpeechFailureMessage.IsVoiceMissing("Microsoft Hazel", Array.Empty<string>()));
+		Assert.False(TextToSpeechFailureMessage.IsVoiceMissing("Microsoft Hazel", null));
+	}
+
+	[Fact]
+	public void BlankEngineMessage_StillSaysSomething()
+	{
+		// Some speech exceptions carry no message at all; an empty status line reads as
+		// "nothing happened", which is exactly the failure mode being fixed.
+		string message = TextToSpeechFailureMessage.Compose("   ", null, Installed);
+
+		Assert.False(string.IsNullOrWhiteSpace(message));
+	}
+
+	[Fact]
+	public void BlankEngineMessage_WithMissingVoice_StillNamesTheVoice()
+	{
+		string message = TextToSpeechFailureMessage.Compose(null, "Microsoft Hazel", Installed);
+
+		Assert.False(string.IsNullOrWhiteSpace(message));
+		Assert.Contains("Microsoft Hazel", message);
+	}
+}

--- a/Mutation.Ui/Core/TextToSpeechFailureMessage.cs
+++ b/Mutation.Ui/Core/TextToSpeechFailureMessage.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+
+namespace Mutation.Ui.Core;
+
+/// <summary>
+/// Composes what the user is told when a text-to-speech action fails.
+/// <para>
+/// The common cause is a voice that is no longer there — a Windows update removed it,
+/// or a settings file was copied from another machine — and the raw exception from the
+/// speech engine says nothing a reader can act on. When the configured voice is missing
+/// from the installed list, the message says so and says where to pick another one.
+/// </para>
+/// Pure so the wording can be tested without a synthesizer (issue #235).
+/// </summary>
+public static class TextToSpeechFailureMessage
+{
+	/// <param name="failureDetail">The engine's own message; may be blank.</param>
+	/// <param name="configuredVoiceName">The voice the app was asked to use; blank or null means the system default.</param>
+	/// <param name="installedVoices">Voices currently installed. Pass an empty list when enumeration itself failed.</param>
+	public static string Compose(
+		string? failureDetail,
+		string? configuredVoiceName,
+		IReadOnlyList<string>? installedVoices)
+	{
+		string detail = string.IsNullOrWhiteSpace(failureDetail)
+			? "Speech failed."
+			: failureDetail!.Trim();
+
+		if (!IsVoiceMissing(configuredVoiceName, installedVoices))
+			return detail;
+
+		return $"{detail} The voice \"{configuredVoiceName!.Trim()}\" is not installed. " +
+			"Choose another one in the Voice list on the Voice & Speech card.";
+	}
+
+	/// <summary>
+	/// True when a specific voice is configured and it is not among the installed ones.
+	/// An empty installed list is treated as "cannot tell" rather than "none installed":
+	/// enumeration failing is its own problem and must not produce a wrong explanation.
+	/// </summary>
+	public static bool IsVoiceMissing(string? configuredVoiceName, IReadOnlyList<string>? installedVoices)
+	{
+		if (string.IsNullOrWhiteSpace(configuredVoiceName)) return false;
+		if (installedVoices is null || installedVoices.Count == 0) return false;
+
+		string wanted = configuredVoiceName!.Trim();
+		foreach (string installed in installedVoices)
+		{
+			if (string.Equals(installed?.Trim(), wanted, StringComparison.OrdinalIgnoreCase))
+				return false;
+		}
+		return true;
+	}
+}

--- a/Mutation.Ui/MainWindow.xaml.cs
+++ b/Mutation.Ui/MainWindow.xaml.cs
@@ -183,6 +183,7 @@ public sealed partial class MainWindow : Window, IDisposable
         _audioSessionManager.SelectedSessionChanged += AudioSessionManager_SelectedSessionChanged;
         _audioSessionManager.PlaybackStarted += AudioSessionManager_PlaybackStarted;
         _audioSessionManager.PlaybackStopped += AudioSessionManager_PlaybackStopped;
+        _textToSpeech.SpeakFailed += TextToSpeech_SpeakFailed;
 
         InitializeComponent();
 
@@ -502,7 +503,7 @@ public sealed partial class MainWindow : Window, IDisposable
 
 		if (!string.IsNullOrWhiteSpace(tts?.SpeakSelectionHotKey))
 			TryRegister(hk, failures, "Speak selection", tts.SpeakSelectionHotKey!, () =>
-				DispatcherQueue.TryEnqueue(() => SpeakActiveSelectionAsync()));
+				DispatcherQueue.TryEnqueue(() => BtnSpeakSelection_Click(null!, null!)));
 
 		if (!string.IsNullOrWhiteSpace(tts?.RestartFromBeginningHotKey))
 			TryRegister(hk, failures, "Restart speech from beginning", tts.RestartFromBeginningHotKey!, () =>
@@ -694,6 +695,9 @@ public sealed partial class MainWindow : Window, IDisposable
 		// sequence has stopped the recorder, and a device change arriving in that window
 		// would reach for this window's DispatcherQueue after it has been closed.
 		_audioDeviceManager.CaptureDeviceListChanged -= AudioDeviceManager_CaptureDeviceListChanged;
+		// Same reasoning for a read that is still running: its failure would otherwise
+		// arrive here and reach for a DispatcherQueue that no longer has a window.
+		_textToSpeech.SpeakFailed -= TextToSpeech_SpeakFailed;
 		// Signal shutdown to any in-flight transcription HTTP requests so they
 		// observe cancellation rather than running until their server timeout.
 		try { _shutdownCts.Cancel(); } catch (ObjectDisposedException) { }
@@ -1255,111 +1259,185 @@ public sealed partial class MainWindow : Window, IDisposable
 		}
 	}
 
-	private async void ShowMessage(string title, string message)
+	/// <summary>
+	/// Reports a text-to-speech action that threw. Every one of these can be fired from a
+	/// global hotkey as well as a button, and a hotkey press has no other feedback at all:
+	/// an escaping exception reaches App.OnUnhandledException, which logs it and marks it
+	/// handled, so the press just does nothing and there is no way to find out why
+	/// (issue #235). The beep comes first because it is the only part that lands
+	/// immediately, whatever else the app is doing.
+	/// </summary>
+	private async Task ReportTextToSpeechFailureAsync(string action, Exception ex)
 	{
-		var dialog = new ContentDialog
-		{
-			Title = title,
-			Content = new TextBlock { Text = message, TextWrapping = Microsoft.UI.Xaml.TextWrapping.Wrap },
-			CloseButtonText = "OK",
-			XamlRoot = this.Content.XamlRoot // important in WinUI 3
-		};
-		AutomationProperties.SetName(dialog, title);
-		AutomationProperties.SetHelpText(dialog, message);
+		BeepPlayer.Play(BeepType.Failure);
+		ShowStatus("Text to Speech", ComposeTextToSpeechFailureMessage(ex), InfoBarSeverity.Error);
+		await ShowErrorDialog($"{action} Error", ex);
+	}
 
-		await ShowDialogAsync(dialog);
+	/// <summary>
+	/// The engine's message, plus a pointer to the voice picker when the configured voice
+	/// has gone missing — the usual cause, and one the raw exception never names.
+	/// </summary>
+	private string ComposeTextToSpeechFailureMessage(Exception ex)
+	{
+		var tts = _settings.TextToSpeechSettings ?? new TextToSpeechSettings();
+
+		IReadOnlyList<string> voices;
+		try { voices = _textToSpeech.GetVoiceNames(); }
+		catch { voices = Array.Empty<string>(); }
+
+		return TextToSpeechFailureMessage.Compose(ex.Message, tts.VoiceName, voices);
+	}
+
+	/// <summary>
+	/// A read that failed after Speak had already returned. The work runs on a background
+	/// thread, so this arrives off the UI thread and has to be marshalled before anything
+	/// here touches a control (issue #236).
+	/// </summary>
+	private void TextToSpeech_SpeakFailed(object? sender, Exception ex)
+	{
+		DispatcherQueue?.TryEnqueue(async () =>
+		{
+			try { await ReportTextToSpeechFailureAsync("Speak", ex); }
+			catch (Exception reportFailure)
+			{
+				System.Diagnostics.Debug.WriteLine($"Reporting a speech failure failed: {reportFailure.Message}");
+			}
+		});
 	}
 
 	public async void BtnTextToSpeech_Click(object? sender, RoutedEventArgs? e)
 	{
-		var tts = _settings.TextToSpeechSettings ?? new TextToSpeechSettings();
-		var (kind, clipboardText) = await _clipboard.InspectAsync();
-		string trimmed = (clipboardText ?? string.Empty).Trim();
-
-		if (_textToSpeech.IsSpeaking)
+		try
 		{
-			string? wasSpeaking = _textToSpeech.CurrentText;
-			_textToSpeech.Stop();
+			var tts = _settings.TextToSpeechSettings ?? new TextToSpeechSettings();
+			var (kind, clipboardText) = await _clipboard.InspectAsync();
+			string trimmed = (clipboardText ?? string.Empty).Trim();
 
-			bool clipboardChanged = kind == ClipboardKind.Text
-				&& trimmed.Length > 0
-				&& !string.Equals(trimmed, wasSpeaking, StringComparison.Ordinal);
+			if (_textToSpeech.IsSpeaking)
+			{
+				string? wasSpeaking = _textToSpeech.CurrentText;
+				_textToSpeech.Stop();
 
-			if (clipboardChanged)
+				bool clipboardChanged = kind == ClipboardKind.Text
+					&& trimmed.Length > 0
+					&& !string.Equals(trimmed, wasSpeaking, StringComparison.Ordinal);
+
+				if (clipboardChanged)
+				{
+					_textToSpeech.Speak(trimmed, tts.Rate, tts.Volume, tts.VoiceName,
+						resumeIfSame: false, preprocess: tts.EnableSpeechPreprocessing,
+						options: SpeechPreprocessingOptions.FromSettings(tts));
+					ShowStatus("Text to Speech", "Speaking new clipboard text.", InfoBarSeverity.Informational);
+				}
+				else
+				{
+					ShowStatus("Text to Speech", "Stopped.", InfoBarSeverity.Informational);
+				}
+				return;
+			}
+
+			if (kind == ClipboardKind.Text && trimmed.Length > 0)
 			{
 				_textToSpeech.Speak(trimmed, tts.Rate, tts.Volume, tts.VoiceName,
-					resumeIfSame: false, preprocess: tts.EnableSpeechPreprocessing,
+					resumeIfSame: true, preprocess: tts.EnableSpeechPreprocessing,
+					resumeRewindWordCount: tts.ResumeRewindWordCount,
 					options: SpeechPreprocessingOptions.FromSettings(tts));
-				ShowStatus("Text to Speech", "Speaking new clipboard text.", InfoBarSeverity.Informational);
+				ShowStatus("Text to Speech", "Speaking…", InfoBarSeverity.Informational);
+				return;
 			}
-			else
-			{
-				ShowStatus("Text to Speech", "Stopped.", InfoBarSeverity.Informational);
-			}
-			return;
-		}
 
-		if (kind == ClipboardKind.Text && trimmed.Length > 0)
+			AnnounceUnreadableClipboard(kind, tts);
+		}
+		catch (Exception ex)
 		{
-			_textToSpeech.Speak(trimmed, tts.Rate, tts.Volume, tts.VoiceName,
-				resumeIfSame: true, preprocess: tts.EnableSpeechPreprocessing,
-				resumeRewindWordCount: tts.ResumeRewindWordCount,
-				options: SpeechPreprocessingOptions.FromSettings(tts));
-			ShowStatus("Text to Speech", "Speaking…", InfoBarSeverity.Informational);
-			return;
+			await ReportTextToSpeechFailureAsync("Speak Clipboard", ex);
 		}
-
-		AnnounceUnreadableClipboard(kind, tts);
 	}
 
 	public async void BtnRestartTts_Click(object? sender, RoutedEventArgs? e)
 	{
-		await ReadClipboardFreshAsync();
+		try
+		{
+			await ReadClipboardFreshAsync();
+		}
+		catch (Exception ex)
+		{
+			await ReportTextToSpeechFailureAsync("Restart Speech", ex);
+		}
 	}
 
-	public void BtnSkipSentenceBack_Click(object? sender, RoutedEventArgs? e)
+	public async void BtnSkipSentenceBack_Click(object? sender, RoutedEventArgs? e)
 	{
-		var tts = _settings.TextToSpeechSettings ?? new TextToSpeechSettings();
-		_textToSpeech.SkipSentence(-1, tts.Rate, tts.Volume, tts.VoiceName, tts.SkipSentenceGraceWindowMs);
+		try
+		{
+			var tts = _settings.TextToSpeechSettings ?? new TextToSpeechSettings();
+			_textToSpeech.SkipSentence(-1, tts.Rate, tts.Volume, tts.VoiceName, tts.SkipSentenceGraceWindowMs);
+		}
+		catch (Exception ex)
+		{
+			await ReportTextToSpeechFailureAsync("Skip Sentence", ex);
+		}
 	}
 
-	public void BtnSkipSentenceForward_Click(object? sender, RoutedEventArgs? e)
+	public async void BtnSkipSentenceForward_Click(object? sender, RoutedEventArgs? e)
 	{
-		var tts = _settings.TextToSpeechSettings ?? new TextToSpeechSettings();
-		_textToSpeech.SkipSentence(1, tts.Rate, tts.Volume, tts.VoiceName, tts.SkipSentenceGraceWindowMs);
+		try
+		{
+			var tts = _settings.TextToSpeechSettings ?? new TextToSpeechSettings();
+			_textToSpeech.SkipSentence(1, tts.Rate, tts.Volume, tts.VoiceName, tts.SkipSentenceGraceWindowMs);
+		}
+		catch (Exception ex)
+		{
+			await ReportTextToSpeechFailureAsync("Skip Sentence", ex);
+		}
 	}
 
-	public void BtnSpeakPosition_Click(object? sender, RoutedEventArgs? e)
+	public async void BtnSpeakPosition_Click(object? sender, RoutedEventArgs? e)
 	{
-		var tts = _settings.TextToSpeechSettings ?? new TextToSpeechSettings();
-		ReadingPosition position = _textToSpeech.GetReadingPosition();
-		string announcement = ReadingAnnouncements.Position(position);
-		_textToSpeech.SpeakAnnouncement(announcement, tts.Rate, tts.Volume, tts.VoiceName);
-		ShowStatus("Text to Speech", announcement, InfoBarSeverity.Informational);
+		try
+		{
+			var tts = _settings.TextToSpeechSettings ?? new TextToSpeechSettings();
+			ReadingPosition position = _textToSpeech.GetReadingPosition();
+			string announcement = ReadingAnnouncements.Position(position);
+			_textToSpeech.SpeakAnnouncement(announcement, tts.Rate, tts.Volume, tts.VoiceName);
+			ShowStatus("Text to Speech", announcement, InfoBarSeverity.Informational);
+		}
+		catch (Exception ex)
+		{
+			await ReportTextToSpeechFailureAsync("Announce Position", ex);
+		}
 	}
 
 	// Toggle pause/resume on its own hotkey, distinct from Stop. While speaking, freeze the
 	// read in place (the service speaks a brief "Paused" cue). While paused, resume it. When
 	// nothing is playing, announce that there is nothing to resume — this never starts a fresh
 	// read; that remains the job of the speak hotkey.
-	public void BtnPauseResume_Click(object? sender, RoutedEventArgs? e)
+	public async void BtnPauseResume_Click(object? sender, RoutedEventArgs? e)
 	{
-		var tts = _settings.TextToSpeechSettings ?? new TextToSpeechSettings();
-		if (_textToSpeech.IsPaused)
+		try
 		{
-			_textToSpeech.Resume(tts.Rate, tts.Volume, tts.VoiceName,
-				tts.ResumeRewindWordCount, tts.ResumeRewindAfterPauseSeconds);
-			ShowStatus("Text to Speech", "Resuming.", InfoBarSeverity.Informational);
+			var tts = _settings.TextToSpeechSettings ?? new TextToSpeechSettings();
+			if (_textToSpeech.IsPaused)
+			{
+				_textToSpeech.Resume(tts.Rate, tts.Volume, tts.VoiceName,
+					tts.ResumeRewindWordCount, tts.ResumeRewindAfterPauseSeconds);
+				ShowStatus("Text to Speech", "Resuming.", InfoBarSeverity.Informational);
+			}
+			else if (_textToSpeech.IsSpeaking)
+			{
+				_textToSpeech.Pause(tts.Rate, tts.Volume, tts.VoiceName);
+				ShowStatus("Text to Speech", "Paused.", InfoBarSeverity.Informational);
+			}
+			else
+			{
+				_textToSpeech.SpeakAnnouncement("Nothing to resume.", tts.Rate, tts.Volume, tts.VoiceName);
+				ShowStatus("Text to Speech", "Nothing to resume.", InfoBarSeverity.Informational);
+			}
 		}
-		else if (_textToSpeech.IsSpeaking)
+		catch (Exception ex)
 		{
-			_textToSpeech.Pause(tts.Rate, tts.Volume, tts.VoiceName);
-			ShowStatus("Text to Speech", "Paused.", InfoBarSeverity.Informational);
-		}
-		else
-		{
-			_textToSpeech.SpeakAnnouncement("Nothing to resume.", tts.Rate, tts.Volume, tts.VoiceName);
-			ShowStatus("Text to Speech", "Nothing to resume.", InfoBarSeverity.Informational);
+			await ReportTextToSpeechFailureAsync("Pause or Resume", ex);
 		}
 	}
 
@@ -1367,24 +1445,25 @@ public sealed partial class MainWindow : Window, IDisposable
 	{
 		var tts = _settings.TextToSpeechSettings ?? new TextToSpeechSettings();
 
-		var (kind, clipboardText) = await _clipboard.InspectAsync();
-		if (kind != ClipboardKind.Text)
-		{
-			AnnounceUnreadableClipboard(kind, tts);
-			return;
-		}
-
-		if (!TtsFileExport.TryResolveExportText(clipboardText, out string text, out string resolveError))
-		{
-			_textToSpeech.SpeakAnnouncement(resolveError, tts.Rate, tts.Volume, tts.VoiceName);
-			BeepPlayer.Play(BeepType.Failure);
-			ShowStatus("Speak to file", resolveError, InfoBarSeverity.Warning);
-			return;
-		}
-
+		string text;
 		StorageFile? file;
 		try
 		{
+			var (kind, clipboardText) = await _clipboard.InspectAsync();
+			if (kind != ClipboardKind.Text)
+			{
+				AnnounceUnreadableClipboard(kind, tts);
+				return;
+			}
+
+			if (!TtsFileExport.TryResolveExportText(clipboardText, out text, out string resolveError))
+			{
+				_textToSpeech.SpeakAnnouncement(resolveError, tts.Rate, tts.Volume, tts.VoiceName);
+				BeepPlayer.Play(BeepType.Failure);
+				ShowStatus("Speak to file", resolveError, InfoBarSeverity.Warning);
+				return;
+			}
+
 			var picker = new FileSavePicker
 			{
 				SuggestedStartLocation = PickerLocationId.MusicLibrary,
@@ -1397,8 +1476,7 @@ public sealed partial class MainWindow : Window, IDisposable
 		}
 		catch (Exception ex)
 		{
-			ShowStatus("Speak to file", ex.Message, InfoBarSeverity.Error);
-			await ShowErrorDialog("Speak to File Error", ex);
+			await ReportTextToSpeechFailureAsync("Speak to File", ex);
 			return;
 		}
 
@@ -1418,8 +1496,7 @@ public sealed partial class MainWindow : Window, IDisposable
 		}
 		catch (Exception ex)
 		{
-			ShowStatus("Speak to file", ex.Message, InfoBarSeverity.Error);
-			await ShowErrorDialog("Speak to File Error", ex);
+			await ReportTextToSpeechFailureAsync("Speak to File", ex);
 		}
 		finally
 		{
@@ -1427,7 +1504,10 @@ public sealed partial class MainWindow : Window, IDisposable
 		}
 	}
 
-	public async void SpeakActiveSelectionAsync()
+	// Awaitable rather than async void: this is not an event handler, and an async void
+	// method that throws takes the process down with it instead of merely failing the
+	// action. Every caller is a handler that owns the try/catch (issue #235).
+	private async Task SpeakActiveSelectionAsync()
 	{
 		var tts = _settings.TextToSpeechSettings ?? new TextToSpeechSettings();
 
@@ -1508,7 +1588,17 @@ public sealed partial class MainWindow : Window, IDisposable
 		ShowStatus("Text to Speech", message, InfoBarSeverity.Warning);
 	}
 
-	public void BtnSpeakSelection_Click(object? sender, RoutedEventArgs? e) => SpeakActiveSelectionAsync();
+	public async void BtnSpeakSelection_Click(object? sender, RoutedEventArgs? e)
+	{
+		try
+		{
+			await SpeakActiveSelectionAsync();
+		}
+		catch (Exception ex)
+		{
+			await ReportTextToSpeechFailureAsync("Speak Selection", ex);
+		}
+	}
 
 	private async Task ReadClipboardFreshAsync()
 	{
@@ -3020,6 +3110,7 @@ public sealed partial class MainWindow : Window, IDisposable
 		// Already unsubscribed by MainWindow_Closed on the normal path; repeated here so
 		// a Dispose that did not come through it still detaches the handler.
 		_audioDeviceManager.CaptureDeviceListChanged -= AudioDeviceManager_CaptureDeviceListChanged;
+		_textToSpeech.SpeakFailed -= TextToSpeech_SpeakFailed;
 		_audioSessionManager?.Dispose();
 		_microphoneVisualization?.Dispose();
 		_formatDebounceCts?.Dispose();

--- a/README.md
+++ b/README.md
@@ -128,9 +128,15 @@ Mutation can read text aloud — either whatever is on your clipboard or text yo
 | `SpeakClipboard` | `Ctrl+Shift+Alt+Q` | Copy text anywhere, then press this to read your clipboard aloud. |
 | `SpeakSelectionHotKey` | `Ctrl+Shift+Q` | Highlight text in any app and press this — Mutation reads the selection without you having to copy first. |
 
-If your clipboard is empty or holds something that can't be read (such as an image), Mutation announces that out loud rather than staying silent. For very long text (over ~5,000 characters) it first announces roughly how many minutes the reading will take.
+If your clipboard is empty or holds something that can't be read (such as an image), Mutation announces that out loud rather than staying silent. When the reading will run longer than a minute it first announces roughly how many minutes it will take, and on a reading longer than two minutes it calls out progress every 25% along the way. Both announcements are configurable, and both can be turned off.
 
-**Pause and resume:** The `SpeakClipboard` hotkey doubles as pause/resume. Press it while reading to **pause**; press it again to **resume**, backing up a few words first for context (5 words by default, configurable). If you copied new text while paused, pressing it reads the new clipboard instead of resuming.
+**Stopping and starting again:** Press `SpeakClipboard` while it is reading and the reading **stops**. Press it again and it picks up from where it stopped, backing up a few words first for context (5 words by default, configurable). If you copied different text in the meantime, that press reads the new clipboard instead.
+
+**Pause and resume** is separate, and keeps your exact place:
+
+| Hotkey | Default | Description |
+|--------|---------|-------------|
+| `PauseResumeHotKey` | `Ctrl+Shift+Space` | Freeze the reading mid-word (Mutation says "Paused"); press again to carry on. A pause longer than 10 seconds backs up a few words first for context. With nothing playing it says "Nothing to resume" — it never starts a fresh reading. |
 
 **Moving around the text** (sentence by sentence, like a media player's skip buttons):
 
@@ -139,6 +145,15 @@ If your clipboard is empty or holds something that can't be read (such as an ima
 | `SkipSentenceForwardHotKey` | `Ctrl+Shift+K` | Skip forward one sentence. Past the last sentence, announces "End of text." |
 | `SkipSentenceBackwardHotKey` | `Ctrl+Shift+J` | Skip back one sentence. Just landed on a sentence? Back jumps to the previous one; settled in for a moment? Back restarts the current sentence. Before the first sentence, announces "Beginning of text." |
 | `RestartFromBeginningHotKey` | `Ctrl+Shift+B` | Restart from the very beginning of the text. |
+| `SpeakPositionHotKey` | `Ctrl+Shift+P` | Say where you are — how far through the text, and which sentence. |
+
+**Saving a reading to a file:**
+
+| Hotkey | Default | Description |
+|--------|---------|-------------|
+| `SpeakToFileHotKey` | *(none set)* | Save the clipboard text as a spoken WAV file instead of playing it. Give it a hotkey yourself in the settings file or the **Hotkeys** tab; there is no default. The **Speak to file** button on the main window does the same thing. |
+
+If a reading fails — most often because the voice it was told to use is no longer installed — Mutation plays the failure beep, puts the reason in the status bar and shows it in a dialog, and names the missing voice so you know which one to replace.
 
 **Voice, rate, and volume:** The main window's **Voice & Speech** card lets you pick any voice installed on Windows (a short sample plays when you choose one), set the reading **Rate** from `-10` (slow) to `+10` (fast, default `8`), and set the **Volume** from 0–100%. To add more voices, install them through Windows' own speech settings and they'll appear in the dropdown.
 
@@ -245,7 +260,37 @@ All hotkeys are global and fully customisable. Below is an example covering ever
   ],
 
   "TextToSpeechSettings": {
-    "SpeakClipboard": "Ctrl+Shift+P"
+    "SpeakClipboard": "CTRL+SHIFT+ALT+Q",
+    "SpeakSelectionHotKey": "CTRL+SHIFT+Q",
+    "RestartFromBeginningHotKey": "CTRL+SHIFT+B",
+    "SkipSentenceBackwardHotKey": "CTRL+SHIFT+J",
+    "SkipSentenceForwardHotKey": "CTRL+SHIFT+K",
+    "SpeakPositionHotKey": "CTRL+SHIFT+P",
+    "PauseResumeHotKey": "CTRL+SHIFT+SPACE",
+    "SpeakToFileHotKey": null,
+
+    "VoiceName": null,
+    "Rate": 8,
+    "Volume": 100,
+
+    "EnableSpeechPreprocessing": true,
+    "PreprocessRemoveCodeBlocks": true,
+    "PreprocessStripBoldItalicCode": true,
+    "PreprocessStripHeadingMarks": true,
+    "PreprocessShortenWebLinks": true,
+    "PreprocessStripBulletMarkers": true,
+    "PreprocessExpandAbbreviations": true,
+    "PreprocessNormaliseWhitespace": true,
+
+    "SkipSentenceGraceWindowMs": 1500,
+    "ResumeRewindWordCount": 5,
+    "ResumeRewindAfterPauseSeconds": 10,
+
+    "AnnounceReadingTimeAtStart": true,
+    "AnnounceReadingTimeMinimumMinutes": 1,
+    "AnnounceProgressEnabled": true,
+    "AnnounceProgressEveryPercent": 25,
+    "AnnounceProgressMinimumMinutes": 2
   },
 
   "HotKeyRouterSettings": {
@@ -260,6 +305,8 @@ All hotkeys are global and fully customisable. Below is an example covering ever
   }
 }
 ```
+
+> **Note on `TextToSpeechSettings`:** unlike the other sections above, every value shown is the actual default, so you only need to write the ones you want to change. `SpeakToFileHotKey` and `VoiceName` are the exceptions — they have no default. Leave `VoiceName` as `null` to use whichever voice Windows defaults to, and give `SpeakToFileHotKey` a shortcut if you want to save readings to a WAV file without reaching for the button. The `Preprocess*` switches each turn off one cleanup rule applied before speaking; `EnableSpeechPreprocessing` turns all of them off at once.
 
 > **Note on transcript formatting rules:** `TranscriptFormatRules` is a top-level setting. Rules run as a pre-processing pass on the transcript before any LLM processing is applied.
 


### PR DESCRIPTION
Four small text-to-speech stories, all in the same corner of the app.

## What changed

### #235 — TTS actions had no error handling
None of the speak actions caught anything, and every one of them is reachable from a
global hotkey as well as a button. A throw reached `App.OnUnhandledException`, which
logs it and marks it handled, so the press produced no beep, no message and no dialog —
indistinguishable from a hotkey that never registered.

- Each handler now reports: failure beep first, then the status bar, then a dialog.
- When the configured voice is no longer installed, the message names it and points at
  the **Voice** list on the **Voice & Speech** card. Composed by a pure
  `TextToSpeechFailureMessage`, so the wording is tested without a synthesizer.
- `SpeakActiveSelectionAsync` is now `async Task` rather than `async void` — it is not
  an event handler, and an `async void` throw takes the process down.
- The unused `async void ShowMessage` is deleted.

### #236 — a superseded read could still be spoken
`Speak` cancelled the outgoing read *after* releasing `_gate`. A worker for the
superseded read that was queued on the gate could get in during that window, see a
token that was not cancelled yet, and read the stale text in full — with the text the
user actually asked for merely queued behind it.

- The handover now happens under the gate, inside a small `SupersedingOperation` that
  owns the cancel-before-publish ordering. That also collapses five duplicated
  cancel/dispose blocks in the service.
- The speak worker's task is observed: a read that dies (voice gone, audio endpoint
  gone) raises the new `ITextToSpeechService.SpeakFailed` instead of becoming an
  unobserved task exception. `MainWindow` marshals it to the dispatcher and reports it
  through the same path as #235.
- `_playbackEpoch` — incremented in five places, never read, with a comment describing
  a supersession mechanism that did not exist — is gone.

### #241 — `default(SpokenWeaveMap)` threw
The struct's constructor is what substitutes an empty list for a null one, and a
defaulted struct never runs it, so `ToReal` hit `_markers.Count` on null. Not currently
reachable, but the field lives in `TextToSpeechService` and is read on the synthesizer's
callback thread, where a throw ends the process. Both members are now null-tolerant and
`SpokenWeaveMap.Empty` says so out loud.

### #258 — README documented 1 of 27 TTS settings
All 27 `TextToSpeechSettings` properties are now in the JSON example with their **real**
defaults (verified against `SettingsDefaults.Tts` and `SettingsManager.EnsureSettings`,
not the old example values). `ReadmeSettingsCoverageTests` fails if a new property is
added without a line in the README, so it cannot drift silently again.

The prose section also gained the three hotkeys it never mentioned at all —
`PauseResumeHotKey`, `SpeakPositionHotKey`, `SpeakToFileHotKey` (which has no default) —
and its stale claims were corrected: `SpeakClipboard` stops rather than pauses, and the
startup length announcement is minutes-based, not the old 5,000-character cutoff.

## Documentation
`read-aloud.md` describes the new failure feedback; `troubleshooting.md` gains
"Reading aloud fails, or the voice you chose has gone". HTML regenerated with
`Documentation\Build-UserGuide.cmd` and committed alongside.

## Testing
`dotnet test --configuration Release` — 1173 passed, 0 failed.

New coverage: `SupersedingOperationTests` (the handover ordering),
`TextToSpeechFailureMessageTests` (what the user is told, including that an empty voice
list never produces a wrong explanation), `ReadmeSettingsCoverageTests`, and three cases
for the defaulted weave map.

Closes #235
Closes #236
Closes #241
Closes #258

🤖 Generated with [Claude Code](https://claude.com/claude-code)