### PR TITLE
Stop the log, the dialogs, and the formatting rules losing what the user chose

### DIFF
--- a/CognitiveSupport/ErrorLogger.cs
+++ b/CognitiveSupport/ErrorLogger.cs
@@ -212,22 +212,36 @@ public static class ErrorLogger
 	/// <paramref name="maxLogFileSizeBytes"/>, so the log cannot grow without
 	/// bound. Mirrors HotkeyManager's rotation. The rotate + append run under
 	/// the shared lock so two threads cannot both move the file at once.
+	///
+	/// Rotation is best-effort and cannot take the entry down with it: if the
+	/// caller has <c>.old</c> open in an editor, <c>File.Delete</c> throws on every
+	/// subsequent write and logging would be permanently dead for both locations,
+	/// exactly when a crash log matters most. An over-sized log still tells the
+	/// user what went wrong; a missing entry does not (issue #244).
 	/// </summary>
 	internal static void AppendWithRotation(string logPath, string entry, long maxLogFileSizeBytes)
 	{
 		lock (s_gate)
 		{
-			if (maxLogFileSizeBytes > 0 && File.Exists(logPath))
+			try
 			{
-				var fileInfo = new FileInfo(logPath);
-				if (fileInfo.Length > maxLogFileSizeBytes)
+				if (maxLogFileSizeBytes > 0 && File.Exists(logPath))
 				{
-					string backupPath = logPath + ".old";
-					if (File.Exists(backupPath))
-						File.Delete(backupPath);
-					File.Move(logPath, backupPath);
+					var fileInfo = new FileInfo(logPath);
+					if (fileInfo.Length > maxLogFileSizeBytes)
+					{
+						string backupPath = logPath + ".old";
+						if (File.Exists(backupPath))
+							File.Delete(backupPath);
+						File.Move(logPath, backupPath);
+					}
 				}
 			}
+			catch
+			{
+				// Rotation failed; keep the over-sized log and append to it anyway.
+			}
+
 			File.AppendAllText(logPath, entry, Encoding.UTF8);
 		}
 	}

--- a/Documentation/UserGuide/html/transcript-formatting.html
+++ b/Documentation/UserGuide/html/transcript-formatting.html
@@ -157,6 +157,7 @@ footer{margin-top:3rem; padding-top:1rem; border-top:1px solid var(--rule); colo
 <li><strong>Case sensitive</strong> — when this is on, capital letters have to match exactly. When it is off, case is ignored. Off is the usual choice.</li>
 </ul>
 <p>Rules run from top to bottom, so the order can matter. The up and down arrow buttons on each row let you rearrange them, and <strong>Delete</strong> removes a rule.</p>
+<p>Mutation starts you off with a set of ready-made rules the first time it runs. They are yours to change or throw away. If you delete every rule and save, the list stays empty next time you open Mutation — that is how you turn find-and-replace off altogether.</p>
 <hr />
 <h2 id="the-three-match-types">The three match types</h2>
 <p>Each rule also has a <strong>Match type</strong>, which decides how the Find text is interpreted.</p>

--- a/Documentation/UserGuide/html/troubleshooting.html
+++ b/Documentation/UserGuide/html/troubleshooting.html
@@ -413,7 +413,13 @@ file, in case the first location is unavailable.</p>
 <code>Mutation_Errors.log.old</code> and a fresh file is started — so if the problem happened a
 while back, check the <code>.old</code> file too.</p>
 <p>Your API keys are stripped out of the log before anything is written, so it is safe to
-share.</p>
+share. The same applies to anything Mutation shows you on screen or reads out — an error
+message never contains one of your keys.</p>
+<h3 id="when-an-error-message-appears">When an error message appears</h3>
+<p>An error message tells you what went wrong in a sentence or two, then points at the log
+file. The long technical detail — the part only a developer can use — goes to the log and
+not to the screen, so the message stays short enough to read or listen to. If you are
+reporting the problem, copy the message and then open the log for the rest.</p>
 <h2 id="reporting-a-problem">Reporting a problem</h2>
 <p>If none of the above fixes it, please report it. The project's issues page is at
 <a href="https://github.com/Subverting-complexity/Mutation/issues">github.com/Subverting-complexity/Mutation</a>.</p>

--- a/Documentation/UserGuide/markdown/transcript-formatting.md
+++ b/Documentation/UserGuide/markdown/transcript-formatting.md
@@ -18,6 +18,8 @@ A rule has three parts.
 
 Rules run from top to bottom, so the order can matter. The up and down arrow buttons on each row let you rearrange them, and **Delete** removes a rule.
 
+Mutation starts you off with a set of ready-made rules the first time it runs. They are yours to change or throw away. If you delete every rule and save, the list stays empty next time you open Mutation — that is how you turn find-and-replace off altogether.
+
 ---
 
 ## The three match types

--- a/Documentation/UserGuide/markdown/troubleshooting.md
+++ b/Documentation/UserGuide/markdown/troubleshooting.md
@@ -331,7 +331,15 @@ The log is capped in size. When it gets too big, the old contents are moved to
 while back, check the `.old` file too.
 
 Your API keys are stripped out of the log before anything is written, so it is safe to
-share.
+share. The same applies to anything Mutation shows you on screen or reads out — an error
+message never contains one of your keys.
+
+### When an error message appears
+
+An error message tells you what went wrong in a sentence or two, then points at the log
+file. The long technical detail — the part only a developer can use — goes to the log and
+not to the screen, so the message stays short enough to read or listen to. If you are
+reporting the problem, copy the message and then open the log for the rest.
 
 ## Reporting a problem
 

--- a/Mutation.Tests/CustomBeepIssueReportingTests.cs
+++ b/Mutation.Tests/CustomBeepIssueReportingTests.cs
@@ -9,6 +9,10 @@ namespace Mutation.Tests;
 // The SettingsManager half of the custom-beep check: what it does to the settings, and
 // what it hands the caller to show the user. The rule itself lives in
 // CustomBeepFileValidatorTests.
+//
+// Loading and saving settings replaces ErrorLogger's process-wide secret snapshot, so
+// this class shares the collection that serialises those statics (issue #250).
+[Collection(ErrorLoggerCollection.Name)]
 public class CustomBeepIssueReportingTests : IDisposable
 {
 	private readonly string _dir;

--- a/Mutation.Tests/ErrorDialogMessageTests.cs
+++ b/Mutation.Tests/ErrorDialogMessageTests.cs
@@ -1,0 +1,159 @@
+using System;
+using CognitiveSupport;
+using Mutation.Ui.Core;
+using Xunit;
+
+namespace Mutation.Tests;
+
+// The error dialog used to render the whole exception chain, unredacted, into both the
+// dialog body and its HelpText — so a screen reader read out anything the provider SDK
+// had put in the message, in a dialog users routinely screenshot into bug reports
+// (issue #242).
+//
+// These tests drive ErrorLogger's process-wide secret registry, so the class shares the
+// collection that serialises it.
+[Collection(ErrorLoggerCollection.Name)]
+public class ErrorDialogMessageTests
+{
+	private const string LogPath = @"C:\Users\someone\AppData\Local\Mutation\logs\Mutation_Errors.log";
+
+	[Fact]
+	public void ForException_RegisteredKey_IsRedacted()
+	{
+		string deepgramKey = "0123456789abcdef0123456789abcdef01234567"; // 40-char hex, matched by no pattern
+		ErrorLogger.RegisterSecretValues(new[] { deepgramKey });
+
+		string result = ErrorDialogMessage.ForException(
+			new InvalidOperationException($"Request rejected for key {deepgramKey}."), LogPath);
+
+		Assert.DoesNotContain(deepgramKey, result);
+		Assert.Contains("***REDACTED***", result);
+	}
+
+	[Fact]
+	public void ForException_KeyInsideTheInnerException_IsRedacted()
+	{
+		string key = "sk-abcdEFGH1234567890";
+		ErrorLogger.RegisterSecretValues(null);
+
+		string result = ErrorDialogMessage.ForException(
+			new InvalidOperationException("Chat completion failed.", new Exception($"401 for {key}")),
+			LogPath);
+
+		Assert.DoesNotContain(key, result);
+	}
+
+	[Fact]
+	public void ForException_DoesNotIncludeTheStackTrace()
+	{
+		ErrorLogger.RegisterSecretValues(null);
+		Exception thrown;
+		try { throw new InvalidOperationException("Chat completion failed."); }
+		catch (Exception ex) { thrown = ex; }
+
+		string result = ErrorDialogMessage.ForException(thrown, LogPath);
+
+		Assert.Contains("Chat completion failed.", result);
+		Assert.DoesNotContain("   at ", result);
+		Assert.DoesNotContain(nameof(ForException_DoesNotIncludeTheStackTrace), result);
+	}
+
+	[Fact]
+	public void ForException_PointsAtTheLogFile()
+	{
+		ErrorLogger.RegisterSecretValues(null);
+
+		string result = ErrorDialogMessage.ForException(new Exception("Nope."), LogPath);
+
+		Assert.Contains(ErrorDialogMessage.LogPointerLead, result);
+		Assert.Contains(LogPath, result);
+	}
+
+	// A wrapper says nothing on its own; without the innermost message the dialog would
+	// tell the reader only that something happened.
+	[Fact]
+	public void ForException_WrappedFailure_KeepsBothMessages()
+	{
+		ErrorLogger.RegisterSecretValues(null);
+
+		string result = ErrorDialogMessage.ForException(
+			new InvalidOperationException("Could not read the recording.", new Exception("The file is in use.")),
+			LogPath);
+
+		Assert.Contains("Could not read the recording.", result);
+		Assert.Contains("The file is in use.", result);
+	}
+
+	[Fact]
+	public void ForException_SameMessageBothLevels_IsNotRepeated()
+	{
+		ErrorLogger.RegisterSecretValues(null);
+
+		string result = ErrorDialogMessage.ForException(
+			new InvalidOperationException("Timed out.", new TimeoutException("Timed out.")), LogPath);
+
+		Assert.Equal(result.IndexOf("Timed out.", StringComparison.Ordinal),
+			result.LastIndexOf("Timed out.", StringComparison.Ordinal));
+	}
+
+	[Fact]
+	public void ForException_MessagelessException_NamesTheType()
+	{
+		ErrorLogger.RegisterSecretValues(null);
+
+		string result = ErrorDialogMessage.ForException(new OperationCanceledException(string.Empty), LogPath);
+
+		Assert.Contains(nameof(OperationCanceledException), result);
+	}
+
+	[Fact]
+	public void ForException_NullException_StillReadsAsAnError()
+	{
+		ErrorLogger.RegisterSecretValues(null);
+
+		string result = ErrorDialogMessage.ForException(null, LogPath);
+
+		Assert.Contains("An error occurred:", result);
+		Assert.Contains(LogPath, result);
+	}
+
+	// Promising a log file that has nothing in it sends the reader looking for nothing.
+	[Fact]
+	public void ForException_NoLogPath_OmitsThePointer()
+	{
+		ErrorLogger.RegisterSecretValues(null);
+
+		string result = ErrorDialogMessage.ForException(new Exception("Nope."), "   ");
+
+		Assert.DoesNotContain(ErrorDialogMessage.LogPointerLead, result);
+		Assert.Contains("Nope.", result);
+	}
+
+	[Fact]
+	public void ForMessage_RegisteredKey_IsRedacted()
+	{
+		string key = "0123456789abcdef0123456789abcdef01234567";
+		ErrorLogger.RegisterSecretValues(new[] { key });
+
+		string result = ErrorDialogMessage.ForMessage($"Test failed: bad key {key}");
+
+		Assert.DoesNotContain(key, result);
+		Assert.StartsWith("Test failed:", result);
+	}
+
+	[Fact]
+	public void ForMessage_PlainValidationText_IsUnchanged()
+	{
+		ErrorLogger.RegisterSecretValues(null);
+
+		Assert.Equal("Name is required.", ErrorDialogMessage.ForMessage("Name is required."));
+	}
+
+	[Fact]
+	public void ForMessage_Null_ReturnsEmpty()
+	{
+		ErrorLogger.RegisterSecretValues(null);
+
+		Assert.Equal(string.Empty, ErrorDialogMessage.ForMessage(null));
+	}
+}

--- a/Mutation.Tests/ErrorLoggerCollection.cs
+++ b/Mutation.Tests/ErrorLoggerCollection.cs
@@ -7,6 +7,15 @@ namespace Mutation.Tests;
 /// registered-secret snapshot and the log directory redirect. xunit runs each class in
 /// its own collection in parallel by default, so two classes replacing the same static
 /// would otherwise assert against each other's values.
+/// <para>
+/// It is not only the classes that call <c>ErrorLogger</c> directly. Every
+/// <c>SettingsManager.LoadAndEnsureSettings</c> and <c>SaveSettingsToFile</c> feeds the
+/// configured keys to <c>ErrorLogger.RegisterSecretValues</c>, which <em>replaces</em>
+/// the whole snapshot — and a settings file with placeholder keys registers an empty
+/// one. A class doing that in parallel wipes the key a redaction test just registered
+/// (issue #250). <c>ErrorLoggerStaticsCollectionTests</c> fails if a new test class
+/// loads or saves settings without joining this collection.
+/// </para>
 /// </summary>
 [CollectionDefinition(Name)]
 public sealed class ErrorLoggerCollection

--- a/Mutation.Tests/ErrorLoggerRotationTests.cs
+++ b/Mutation.Tests/ErrorLoggerRotationTests.cs
@@ -72,4 +72,44 @@ public class ErrorLoggerRotationTests : IDisposable
 		Assert.Equal(new string('y', 200), File.ReadAllText(_backupPath));
 		Assert.Equal("latest\n", File.ReadAllText(_logPath));
 	}
+
+	[Fact]
+	public void AppendWithRotation_BackupLocked_StillWritesTheEntry()
+	{
+		// The user has Mutation_Errors.log.old open in an editor holding a share
+		// lock, so File.Delete throws. Before issue #244 that took the entry down
+		// with it and logging stayed dead for the rest of the run.
+		File.WriteAllText(_backupPath, "stale backup");
+		string bulk = new string('z', 200);
+		File.WriteAllText(_logPath, bulk);
+
+		using (new FileStream(_backupPath, FileMode.Open, FileAccess.Read, FileShare.None))
+		{
+			ErrorLogger.AppendWithRotation(_logPath, "must survive\n", maxLogFileSizeBytes: 100);
+		}
+
+		// Rotation could not happen, so the entry lands on the end of the
+		// over-sized log rather than being discarded.
+		Assert.Equal(bulk + "must survive\n", File.ReadAllText(_logPath));
+		Assert.Equal("stale backup", File.ReadAllText(_backupPath));
+	}
+
+	[Fact]
+	public void AppendWithRotation_BackupUnlocked_RotatesOnTheNextEntry()
+	{
+		// The failure above must not be sticky: once the lock is gone, the next
+		// entry rotates as normal instead of growing the log forever.
+		File.WriteAllText(_backupPath, "stale backup");
+		File.WriteAllText(_logPath, new string('z', 200));
+
+		using (new FileStream(_backupPath, FileMode.Open, FileAccess.Read, FileShare.None))
+		{
+			ErrorLogger.AppendWithRotation(_logPath, "during lock\n", maxLogFileSizeBytes: 100);
+		}
+
+		ErrorLogger.AppendWithRotation(_logPath, "after lock\n", maxLogFileSizeBytes: 100);
+
+		Assert.Equal("after lock\n", File.ReadAllText(_logPath));
+		Assert.Equal(new string('z', 200) + "during lock\n", File.ReadAllText(_backupPath));
+	}
 }

--- a/Mutation.Tests/ErrorLoggerStaticsCollectionTests.cs
+++ b/Mutation.Tests/ErrorLoggerStaticsCollectionTests.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Xunit;
+
+namespace Mutation.Tests;
+
+// The race in issue #250 was invisible: every test passed, and the class that broke the
+// redaction tests did nothing wrong on its own — it just loaded settings, which replaces
+// ErrorLogger's process-wide secret snapshot, from a class xunit was free to run in
+// parallel with them.
+//
+// Attributes alone would not have stopped it coming back, because nothing about writing a
+// new settings test suggests you are touching a logger. This scans the test sources
+// instead, so the next one fails loudly at the point it is added rather than flaking
+// months later on someone else's machine.
+public class ErrorLoggerStaticsCollectionTests
+{
+	// Both go through SettingsManager.RegisterSecretsForRedaction.
+	private static readonly string[] RegisteringCalls =
+	[
+		"LoadAndEnsureSettings(",
+		"SaveSettingsToFile(",
+	];
+
+	[Fact]
+	public void EveryTestClassThatLoadsOrSavesSettingsSharesTheErrorLoggerCollection()
+	{
+		string testSourceDirectory = FindTestSourceDirectory();
+		string attribute = $"[Collection({nameof(ErrorLoggerCollection)}.{nameof(ErrorLoggerCollection.Name)})]";
+
+		var unserialised = new List<string>();
+		foreach (string path in Directory.EnumerateFiles(testSourceDirectory, "*.cs", SearchOption.AllDirectories))
+		{
+			string fileName = Path.GetFileName(path);
+
+			// Build output, and this scanner itself — it carries every marker it
+			// looks for, as string literals.
+			if (path.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+				|| path.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+				|| fileName == $"{nameof(ErrorLoggerStaticsCollectionTests)}.cs")
+				continue;
+
+			string source = File.ReadAllText(path);
+
+			// A real manager, not one of the ISettingsManager fakes: only the real one
+			// reaches ErrorLogger.
+			if (!source.Contains("new SettingsManager(", StringComparison.Ordinal))
+				continue;
+
+			bool registers = false;
+			foreach (string call in RegisteringCalls)
+				registers |= source.Contains(call, StringComparison.Ordinal);
+
+			if (registers && !source.Contains(attribute, StringComparison.Ordinal))
+				unserialised.Add(fileName);
+		}
+
+		Assert.True(
+			unserialised.Count == 0,
+			"These test files load or save settings, which replaces ErrorLogger's secret "
+				+ "snapshot, but do not carry " + attribute + ": "
+				+ string.Join(", ", unserialised)
+				+ ". Add the attribute, or the redaction tests will flake under parallel runs.");
+	}
+
+	// Walks up from the test binary to the repository root, the same way
+	// ReadmeSettingsCoverageTests finds the README. The solution file is the marker.
+	private static string FindTestSourceDirectory()
+	{
+		var directory = new DirectoryInfo(AppContext.BaseDirectory);
+		while (directory is not null)
+		{
+			string tests = Path.Combine(directory.FullName, "Mutation.Tests");
+			if (File.Exists(Path.Combine(directory.FullName, "Mutation.slnx")) && Directory.Exists(tests))
+				return tests;
+
+			directory = directory.Parent;
+		}
+
+		throw new InvalidOperationException(
+			$"Could not find the Mutation.Tests sources above {AppContext.BaseDirectory}.");
+	}
+}

--- a/Mutation.Tests/LlmPromptFastModeSettingsTests.cs
+++ b/Mutation.Tests/LlmPromptFastModeSettingsTests.cs
@@ -14,6 +14,9 @@ namespace Mutation.Tests;
 /// upgrade step clobbering a saved value, and the settings working copy dropping it on
 /// the way back to the live settings object.
 /// </summary>
+// Loading and saving settings replaces ErrorLogger's process-wide secret snapshot, so
+// this class shares the collection that serialises those statics (issue #250).
+[Collection(ErrorLoggerCollection.Name)]
 public class LlmPromptFastModeSettingsTests : IDisposable
 {
 	private readonly TempSettingsFile _settingsFile = new("fastmode");

--- a/Mutation.Tests/OcrServiceStaticsCollection.cs
+++ b/Mutation.Tests/OcrServiceStaticsCollection.cs
@@ -1,0 +1,16 @@
+using Xunit;
+
+namespace Mutation.Tests;
+
+/// <summary>
+/// Serialises the test classes that reach into <c>OcrService</c>'s private static
+/// <c>SharedRateLimiter</c>. Only one class does today, and it restores the field in a
+/// <c>finally</c> — but a restore is worthless against a class running in parallel, and
+/// those tests assert the real production limit, which a leaked swap breaks. Joining
+/// this collection is what makes the second such class safe to write (issue #250).
+/// </summary>
+[CollectionDefinition(Name)]
+public sealed class OcrServiceStaticsCollection
+{
+	public const string Name = "OcrService statics";
+}

--- a/Mutation.Tests/OcrServiceTests.cs
+++ b/Mutation.Tests/OcrServiceTests.cs
@@ -14,6 +14,9 @@ using PdfSharp.Pdf;
 
 namespace Mutation.Tests;
 
+// Several tests here reflectively swap OcrService's private static SharedRateLimiter.
+// The collection keeps that swap from being visible to another class (issue #250).
+[Collection(OcrServiceStaticsCollection.Name)]
 public class OcrServiceTests
 {
 	[Fact]

--- a/Mutation.Tests/SettingsManagerPromptIdTests.cs
+++ b/Mutation.Tests/SettingsManagerPromptIdTests.cs
@@ -11,6 +11,9 @@ namespace Mutation.Tests;
 /// Loading is where the repair has to happen: the app must never hold two prompts that
 /// look like the same prompt, whatever a hand-edited Mutation.json says.
 /// </summary>
+// Loading and saving settings replaces ErrorLogger's process-wide secret snapshot, so
+// this class shares the collection that serialises those statics (issue #250).
+[Collection(ErrorLoggerCollection.Name)]
 public class SettingsManagerPromptIdTests : IDisposable
 {
 	private readonly TempSettingsFile _settingsFile = new("promptid");

--- a/Mutation.Tests/TranscriptFormatRuleSeedingTests.cs
+++ b/Mutation.Tests/TranscriptFormatRuleSeedingTests.cs
@@ -97,6 +97,63 @@ public class TranscriptFormatRuleSeedingTests
 		Assert.NotEmpty(RulesInFile(file.FilePath)!);
 	}
 
+	// The other half of the issue's acceptance criterion. Once the file has settled, an
+	// empty rule list is not a gap, so a launch that finds one has nothing to repair and
+	// must leave the file alone. A re-seed — or any other needless rewrite — shows up
+	// here as a changed timestamp.
+	[Fact]
+	public void Load_SettledFileWithNoRules_IsNotRewrittenOnTheNextLaunch()
+	{
+		using var file = new TempSettingsFile("rule-seed");
+
+		var manager = new SettingsManager(file.FilePath);
+		var settings = manager.LoadAndEnsureSettings();
+		settings.TranscriptFormatRules.Clear();
+		manager.SaveSettingsToFile(settings);
+		var beforeMtime = System.IO.File.GetLastWriteTimeUtc(file.FilePath);
+
+		new SettingsManager(file.FilePath).LoadAndEnsureSettings();
+
+		Assert.Equal(beforeMtime, System.IO.File.GetLastWriteTimeUtc(file.FilePath));
+		Assert.Empty(RulesInFile(file.FilePath)!);
+	}
+
+	// The upgrade path. Settings.TranscriptFormatRules is declared with a
+	// `= new List<>()` initialiser, so a file written before the feature existed — one
+	// with no TranscriptFormatRules key at all — deserialises to an EMPTY list, not a
+	// null one. Left to the in-memory check alone, those users would silently lose the
+	// starter rules on the upgrade, which is the same disappearing-choice fault as #220
+	// pointing the other way.
+	[Fact]
+	public void Load_FileWithNoRuleKeyAtAll_StillGetsTheStarterRules()
+	{
+		using var file = new TempSettingsFile("rule-seed", """{ "LlmSettings": { "Prompts": [] } }""");
+
+		var settings = new SettingsManager(file.FilePath).LoadAndEnsureSettings();
+
+		Assert.NotEmpty(settings.TranscriptFormatRules);
+		Assert.Contains(settings.TranscriptFormatRules, r => r.Find == "full stop");
+		Assert.NotEmpty(RulesInFile(file.FilePath)!);
+	}
+
+	// ...and having been seeded once, the key is now present, so deleting every rule
+	// still sticks. The upgrade repair must not become a permanent re-seed.
+	[Fact]
+	public void Load_AfterTheUpgradeSeed_DeletingEveryRuleStillSticks()
+	{
+		using var file = new TempSettingsFile("rule-seed", """{ "LlmSettings": { "Prompts": [] } }""");
+
+		var manager = new SettingsManager(file.FilePath);
+		var seeded = manager.LoadAndEnsureSettings();
+		seeded.TranscriptFormatRules.Clear();
+		manager.SaveSettingsToFile(seeded);
+
+		var reloaded = new SettingsManager(file.FilePath).LoadAndEnsureSettings();
+
+		Assert.Empty(reloaded.TranscriptFormatRules);
+		Assert.Empty(RulesInFile(file.FilePath)!);
+	}
+
 	[Fact]
 	public void Load_CustomRules_AreLeftAlone()
 	{

--- a/Mutation.Tests/TranscriptFormatRuleSeedingTests.cs
+++ b/Mutation.Tests/TranscriptFormatRuleSeedingTests.cs
@@ -1,0 +1,116 @@
+using System.Linq;
+using CognitiveSupport;
+using Mutation.Ui.Services;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Mutation.Tests;
+
+// Turning transcript formatting off has to stick. The starter rules used to be
+// re-seeded in memory whenever the list was empty, without marking the settings as
+// changed — so the file kept saying [] while the app kept applying all 16 rules, and
+// the Settings page kept showing them back (issue #220).
+//
+// LoadAndEnsureSettings feeds the loaded keys to ErrorLogger's process-wide redactor,
+// so this class shares the collection that serialises those statics.
+[Collection(ErrorLoggerCollection.Name)]
+public class TranscriptFormatRuleSeedingTests
+{
+	private static JArray? RulesInFile(string path) =>
+		JObject.Parse(System.IO.File.ReadAllText(path))["TranscriptFormatRules"] as JArray;
+
+	[Fact]
+	public void Load_EmptyRuleList_StaysEmptyInMemory()
+	{
+		using var file = new TempSettingsFile("rule-seed", """{ "TranscriptFormatRules": [] }""");
+
+		var settings = new SettingsManager(file.FilePath).LoadAndEnsureSettings();
+
+		Assert.Empty(settings.TranscriptFormatRules);
+	}
+
+	[Fact]
+	public void Load_EmptyRuleList_StaysEmptyOnDisk()
+	{
+		using var file = new TempSettingsFile("rule-seed", """{ "TranscriptFormatRules": [] }""");
+
+		new SettingsManager(file.FilePath).LoadAndEnsureSettings();
+
+		// Other repairs may rewrite the file; what must not happen is the defaults
+		// coming back with it.
+		Assert.Empty(RulesInFile(file.FilePath)!);
+	}
+
+	// The state used to never converge: every launch re-seeded in memory and left the
+	// file alone, so the two could not agree no matter how many times it ran.
+	[Fact]
+	public void Load_EmptyRuleList_ConvergesAcrossLaunches()
+	{
+		using var file = new TempSettingsFile("rule-seed", """{ "TranscriptFormatRules": [] }""");
+
+		new SettingsManager(file.FilePath).LoadAndEnsureSettings();
+		var settings = new SettingsManager(file.FilePath).LoadAndEnsureSettings();
+
+		Assert.Empty(settings.TranscriptFormatRules);
+		Assert.Empty(RulesInFile(file.FilePath)!);
+	}
+
+	// An empty list is a user choice, not a gap — nothing to repair, nothing to save.
+	[Fact]
+	public void EnsureSettings_ExistingFileWithNoRules_ReportsNothingMissing()
+	{
+		var settings = new Settings();
+		var manager = new SettingsManager("unused.json");
+		manager.EnsureSettings(settings, isNewFile: true);
+
+		settings.TranscriptFormatRules!.Clear();
+		bool somethingWasMissing = manager.EnsureSettings(settings, isNewFile: false);
+
+		Assert.False(somethingWasMissing);
+		Assert.Empty(settings.TranscriptFormatRules);
+	}
+
+	// A first run still gets the starter rules, and gets them written to disk so the
+	// Settings page and the file agree from the very beginning.
+	[Fact]
+	public void FirstRun_SeedsTheStarterRulesAndPersistsThem()
+	{
+		using var file = new TempSettingsFile("rule-seed");
+
+		var settings = new SettingsManager(file.FilePath).LoadAndEnsureSettings();
+
+		Assert.NotEmpty(settings.TranscriptFormatRules);
+		Assert.Contains(settings.TranscriptFormatRules, r => r.Find == "full stop");
+		Assert.Equal(settings.TranscriptFormatRules.Count, RulesInFile(file.FilePath)!.Count);
+	}
+
+	// An explicit null is not a choice the UI can produce — the rest of the app expects
+	// a list, so it is still repaired.
+	[Fact]
+	public void Load_NullRuleList_IsRepaired()
+	{
+		using var file = new TempSettingsFile("rule-seed", """{ "TranscriptFormatRules": null }""");
+
+		var settings = new SettingsManager(file.FilePath).LoadAndEnsureSettings();
+
+		Assert.NotEmpty(settings.TranscriptFormatRules);
+		Assert.NotEmpty(RulesInFile(file.FilePath)!);
+	}
+
+	[Fact]
+	public void Load_CustomRules_AreLeftAlone()
+	{
+		using var file = new TempSettingsFile("rule-seed", """
+		{
+			"TranscriptFormatRules": [
+				{ "Find": "widget", "ReplaceWith": "Widget", "CaseSensitive": false, "MatchType": "Plain" }
+			]
+		}
+		""");
+
+		var settings = new SettingsManager(file.FilePath).LoadAndEnsureSettings();
+
+		Assert.Single(settings.TranscriptFormatRules);
+		Assert.Equal("widget", settings.TranscriptFormatRules.Single().Find);
+	}
+}

--- a/Mutation.Ui/Core/ErrorDialogMessage.cs
+++ b/Mutation.Ui/Core/ErrorDialogMessage.cs
@@ -1,0 +1,71 @@
+using System;
+using CognitiveSupport;
+
+namespace Mutation.Ui.Core;
+
+/// <summary>
+/// Composes what an error dialog puts on screen and reads out.
+/// <para>
+/// Two rules, both of them about what leaves the machine. First, the text is run
+/// through the same exact-match redactor the error log uses, so a configured provider
+/// key can never appear in a dialog — dialogs are read aloud and routinely
+/// screenshotted into bug reports, and the redaction seam was previously applied only
+/// when writing the log file. Second, the dialog carries the exception's own message
+/// and a pointer to the log, not the whole <c>ToString()</c> chain: the stack and the
+/// inner-exception detail are what tend to echo request identifiers and header
+/// fragments, and they are no use to a reader anyway (issue #242).
+/// </para>
+/// Pure apart from the redactor, so the wording is testable without a window.
+/// </summary>
+public static class ErrorDialogMessage
+{
+	/// <summary>Lead-in for the log pointer, so tests and callers agree on one wording.</summary>
+	public const string LogPointerLead = "Full technical details are in the log file:";
+
+	/// <param name="exception">The failure being reported; null yields a neutral placeholder.</param>
+	/// <param name="logPath">Where the full detail was written — normally <see cref="ErrorLogger.PrimaryLogPath"/>.</param>
+	public static string ForException(Exception? exception, string? logPath)
+	{
+		string detail = Redact(Describe(exception));
+		string pointer = string.IsNullOrWhiteSpace(logPath)
+			? string.Empty
+			: $"{Environment.NewLine}{Environment.NewLine}{LogPointerLead}{Environment.NewLine}{logPath}";
+
+		return $"An error occurred:{Environment.NewLine}{detail}{pointer}";
+	}
+
+	/// <summary>
+	/// Redacts a message the caller composed itself (a validation failure, say). No log
+	/// pointer: most of these never reach the log, and promising one that is not there
+	/// sends the reader looking for nothing.
+	/// </summary>
+	public static string ForMessage(string? message) => Redact(message ?? string.Empty);
+
+	// The outer message is what names the operation; the innermost one is usually what
+	// actually went wrong, and wrappers like AggregateException say nothing on their own.
+	// Everything between the two is the part a reader cannot use.
+	private static string Describe(Exception? exception)
+	{
+		if (exception is null)
+			return "No further detail is available.";
+
+		string outer = Blank(exception.Message) ? exception.GetType().Name : exception.Message.Trim();
+
+		Exception innermost = exception;
+		while (innermost.InnerException is not null)
+			innermost = innermost.InnerException;
+
+		if (ReferenceEquals(innermost, exception))
+			return outer;
+
+		string inner = Blank(innermost.Message) ? innermost.GetType().Name : innermost.Message.Trim();
+		return string.Equals(inner, outer, StringComparison.Ordinal)
+			? outer
+			: $"{outer}{Environment.NewLine}{inner}";
+	}
+
+	private static bool Blank(string? value) => string.IsNullOrWhiteSpace(value);
+
+	private static string Redact(string text) =>
+		string.IsNullOrEmpty(text) ? text : ErrorLogger.RedactSecrets(text);
+}

--- a/Mutation.Ui/MainWindow.xaml.cs
+++ b/Mutation.Ui/MainWindow.xaml.cs
@@ -2040,7 +2040,7 @@ public sealed partial class MainWindow : Window, IDisposable
 		}
 		catch (Exception ex)
 		{
-			ErrorLogger.LogError("Process with LLM", ex);
+			// ShowErrorDialog logs it; a second call here would duplicate the entry.
 			ShowStatus("Processing", ex.Message, InfoBarSeverity.Error);
 			await ShowErrorDialog("Process with LLM Error", ex);
 		}
@@ -2106,7 +2106,7 @@ public sealed partial class MainWindow : Window, IDisposable
         }
         catch (Exception ex)
         {
-             ErrorLogger.LogError("Process with LLM", ex);
+             // ShowErrorDialog logs it; a second call here would duplicate the entry.
              ShowStatus("Processing Failed", ex.Message, InfoBarSeverity.Error);
              await ShowErrorDialog($"Error executing prompt '{prompt.Name}'", ex);
         }
@@ -2422,6 +2422,12 @@ public sealed partial class MainWindow : Window, IDisposable
 
         private void ShowStatus(string title, string message, InfoBarSeverity severity)
         {
+		// Several callers pass an exception's own message straight through, so the
+		// InfoBar is the same redaction bypass the error dialog was (issue #242).
+		// Redacting once here covers the bar, its HelpText, and the announcement. It
+		// is a no-op for the literal strings most callers pass.
+		message = ErrorLogger.RedactSecrets(message ?? string.Empty);
+
                 void Update()
                 {
 			StatusInfoBar.Title = title;
@@ -2494,7 +2500,13 @@ public sealed partial class MainWindow : Window, IDisposable
 
 	public async Task ShowErrorDialog(string title, Exception ex)
 	{
-		string message = $"An error occurred:\n{ex.Message}\n\n{ex}";
+		// The full exception chain goes to the log and nowhere else. The log is
+		// redacted and stays on the machine; this text is read aloud and pasted into
+		// bug reports, so it gets the exception's own message, redacted, plus where
+		// to find the rest (issue #242). Logging here also means every caller of this
+		// method leaves a record without having to remember to.
+		ErrorLogger.LogError(title, ex);
+		string message = ErrorDialogMessage.ForException(ex, ErrorLogger.PrimaryLogPath);
 		var dialog = new ContentDialog
 		{
 			Title = title,

--- a/Mutation.Ui/Services/SettingsManager.cs
+++ b/Mutation.Ui/Services/SettingsManager.cs
@@ -474,8 +474,17 @@ End of summary.
 		if (PromptIdBackfill.Apply(llmSettings.Prompts))
 			somethingWasMissing = true;
 
-		if (settings.TranscriptFormatRules == null || !settings.TranscriptFormatRules.Any())
+		// Seed the starter rules on a brand-new settings file only — the same
+		// deliberate guard the router mappings use below. An existing file holding an
+		// empty list is a user who deleted every rule on the Transcript formatting
+		// page; re-seeding it put the defaults back in memory on every launch while
+		// the file still said [], so the feature could never be turned off and the
+		// state never converged (issue #220). An explicit null in the file is still
+		// repaired, because the rest of the app expects a list.
+		if (settings.TranscriptFormatRules == null
+			|| (isNewFile && !settings.TranscriptFormatRules.Any()))
 		{
+			somethingWasMissing = true;
 			settings.TranscriptFormatRules = new List<TranscriptFormatRule>
 			{
 				new TranscriptFormatRule

--- a/Mutation.Ui/Services/SettingsManager.cs
+++ b/Mutation.Ui/Services/SettingsManager.cs
@@ -479,8 +479,10 @@ End of summary.
 		// empty list is a user who deleted every rule on the Transcript formatting
 		// page; re-seeding it put the defaults back in memory on every launch while
 		// the file still said [], so the feature could never be turned off and the
-		// state never converged (issue #220). An explicit null in the file is still
-		// repaired, because the rest of the app expects a list.
+		// state never converged (issue #220). A null list is still repaired, because the
+		// rest of the app expects a list — and because that is how LoadAndEnsureSettings
+		// signals a file that has no TranscriptFormatRules key at all, which is a user
+		// upgrading from before the feature rather than one who switched it off.
 		if (settings.TranscriptFormatRules == null
 			|| (isNewFile && !settings.TranscriptFormatRules.Any()))
 		{
@@ -953,6 +955,25 @@ End of summary.
 		}
 	}
 
+	/// <summary>
+	/// True when the settings JSON actually carries a <c>TranscriptFormatRules</c> key —
+	/// including an explicit <c>null</c> or an empty array. False means the file predates
+	/// the feature, which is the one case that still deserves the starter rules.
+	/// Never throws: an unparseable file is reported as declaring the key, so the loaded
+	/// settings are left exactly as they came out of the deserializer.
+	/// </summary>
+	internal static bool DeclaresTranscriptFormatRules(string json)
+	{
+		try
+		{
+			return JObject.Parse(json)["TranscriptFormatRules"] is not null;
+		}
+		catch
+		{
+			return true;
+		}
+	}
+
 	internal static bool IsLegacyTempDirectory(string? tempDirectory)
 	{
 		if (string.IsNullOrWhiteSpace(tempDirectory))
@@ -1022,6 +1043,16 @@ End of summary.
 
         string json = File.ReadAllText(SettingsFileFullPath);
         Settings settings = JsonConvert.DeserializeObject<Settings>(json, _jsonSerializerSettings) ?? new Settings();
+
+        // Settings.TranscriptFormatRules is declared with a `= new List<>()` initialiser,
+        // so a file written before transcript formatting existed — one carrying no
+        // TranscriptFormatRules key at all — deserialises to exactly what a user who
+        // deleted every rule leaves behind: an empty list. Only the JSON can tell those
+        // two apart, and only the first should get the starter rules. Handing the null
+        // to EnsureSettings seeds them once and writes them out, after which the key is
+        // present and an empty list stays empty (issue #220).
+        if (!DeclaresTranscriptFormatRules(json))
+            settings.TranscriptFormatRules = null!;
 
         bool hadLegacyTempDirectory = IsLegacyTempDirectory(settings.SpeechToTextSettings?.TempDirectory);
 

--- a/Mutation.Ui/Views/PromptEditorWindow.xaml.cs
+++ b/Mutation.Ui/Views/PromptEditorWindow.xaml.cs
@@ -1,6 +1,7 @@
 using CognitiveSupport;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Mutation.Ui.Core;
 using Mutation.Ui.Services;
 using System;
 using System.Collections.Generic;
@@ -185,12 +186,19 @@ public sealed partial class PromptEditorWindow : Window
         }
         catch (Exception ex)
         {
-            ShowError($"Test failed: {ex.Message}");
+            // Keep the full chain in the log and show the reader the short form,
+            // for the same reason as MainWindow's error dialog (issue #242).
+            ErrorLogger.LogError("Prompt test", ex);
+            ShowError(ErrorDialogMessage.ForException(ex, ErrorLogger.PrimaryLogPath));
         }
     }
 
     private async void ShowError(string message)
     {
+        // This text is read aloud and pasted into bug reports, so it goes through the
+        // same redactor the error log uses. A no-op for the validation messages above.
+        message = ErrorDialogMessage.ForMessage(message);
+
         var dialog = new ContentDialog
         {
             Title = "Error",


### PR DESCRIPTION
Four Ready-column items, all in the same settings-and-error-logging plumbing.

Closes #244 · Closes #220 · Closes #242 · Closes #250

## What was wrong, and what changed

### #244 — a failed rotation killed logging for the rest of the run

`ErrorLogger.AppendWithRotation` deleted and moved the backup **before**
appending. With `Mutation_Errors.log.old` held open by an editor, `File.Delete`
threw, the throw propagated into `Write`'s catch-all, and the entry was
discarded — for **both** log locations, on every subsequent call. Logging died
silently at exactly the moment a crash log matters most.

Rotation now fails on its own. An over-sized log still tells the user what went
wrong; a missing entry does not.

### #220 — transcript formatting could not be turned off

The default-rules block was the only repair in `EnsureSettings` that did not set
`somethingWasMissing`, so it seeded 16 rules in memory and never wrote them back.
Delete every rule and save: `Mutation.json` correctly held `[]`, and every launch
put the defaults straight back — formatting kept firing, the Settings page kept
showing the rules, and the two could never converge.

An empty list is now a choice that sticks. The starter rules are seeded on a
brand-new file (the same deliberate `isNewFile` guard the router mappings use),
and an explicit `null` is still repaired because the rest of the app expects a
list.

### #242 — error dialogs bypassed the log's redaction

`ShowErrorDialog` composed `"{ex.Message}\n\n{ex}"` — the whole inner-exception
chain — into the dialog body *and* its `AutomationProperties.HelpText`, so a
screen reader read all of it aloud. `SettingsManager` already feeds every
configured provider key to `ErrorLogger`'s exact-match redactor, but that seam
was applied only when writing the log file.

New `ErrorDialogMessage` (pure, so the wording is testable without a window):
redacted text, the exception's own message plus the innermost cause, and a
pointer to the log for the rest. `ShowErrorDialog` now logs the full chain
itself, so no caller can forget to — the two call sites that logged separately
had their duplicate calls removed. `PromptEditorWindow.ShowError` gets the same
redaction.

**Slightly beyond the issue:** the status `InfoBar` was the same bypass — several
callers pass `ex.Message` straight to `ShowStatus`, which also drives the
HelpText and the screen-reader announcement. One redaction at that seam covers
all three, and is a no-op for the literal strings most callers pass.

### #250 — the redaction tests raced the settings tests

`ErrorLoggerRedactionTests` documented an ordering assumption that covered only
*within-class* runs. xunit runs classes in parallel, and every
`LoadAndEnsureSettings`/`SaveSettingsToFile` **replaces** ErrorLogger's secret
snapshot wholesale — a placeholder-keyed file registers an empty one and wipes
the key a redaction test just set.

The three classes that really do that joined the collection. Rather than rely on
remembering, `ErrorLoggerStaticsCollectionTests` scans the test sources and fails
the moment a new class loads or saves settings without the attribute — the fault
was invisible precisely because nothing about writing a settings test suggests
you are touching a logger. `OcrServiceTests` gets a collection of its own for its
reflective static swap (the "worth fixing together" note on the issue).

## Verification

`dotnet test --configuration Release` — **1195 passed, 0 failed.**

Every new assertion was checked for falsifiability: reverting the three
production fixes in turn makes 7 of them fail, and restoring turns them green.

## Documentation

- `transcript-formatting.md` — deleting every rule now turns the feature off and
  stays off.
- `troubleshooting.md` — what an error message contains now, and that keys are
  stripped from what you see and hear, not just from the log.
- HTML regenerated via `Documentation\Build-UserGuide.cmd` and committed
  alongside the Markdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
