### PR TITLE
Send a recording too big for one request in pieces, cut at its pauses

### DIFF
--- a/CognitiveSupport/AudioChunkPlanner.cs
+++ b/CognitiveSupport/AudioChunkPlanner.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Collections.Generic;
+
+namespace CognitiveSupport;
+
+/// <summary>
+/// Decides where to cut a processed recording so every chunk fits inside the upload
+/// limit the transcription service imposes.
+///
+/// Pure arithmetic over a timeline: no files, no codec, no clock. That is deliberate —
+/// boundary selection is the part worth testing exhaustively, and it can be, without
+/// audio hardware or a network.
+///
+/// For each chunk it walks forward to the furthest end position that still encodes
+/// inside the limit, then looks back over the last
+/// <see cref="SilenceSearchWindowFraction"/> of that candidate for a point where the
+/// trimmer removed a silence. The longest removed silence in that window wins, because
+/// the longer the original pause, the more likely the cut falls between sentences
+/// rather than mid-word. With no such point the cut stays at the furthest safe
+/// position — a slightly awkward boundary beats an oversized upload.
+/// </summary>
+public static class AudioChunkPlanner
+{
+	/// <summary>How much of the end of a candidate chunk is searched for a silence cut.</summary>
+	public const double SilenceSearchWindowFraction = 0.2;
+
+	// Floor on a chunk's length. Only reachable with an absurdly small byte limit, and
+	// only there to keep the loop below from planning millions of chunks.
+	private const double MinimumChunkSeconds = 1.0;
+
+	// A leftover tail shorter than this is folded into the chunk before it instead of
+	// being sent on its own: a fraction-of-a-second upload costs a whole round trip and
+	// comes back with nothing worth having. The overshoot that allows — half a second of
+	// audio, under two kilobytes encoded — is well inside the headroom a writer already
+	// reserves for the container.
+	private const double MinimumTrailingChunkSeconds = 0.5;
+
+	/// <param name="totalDuration">Length of the processed audio.</param>
+	/// <param name="maxChunkBytes">Upload limit per chunk. Zero or less means no limit.</param>
+	/// <param name="encodedBytesPerSecond">
+	/// How many bytes a second of audio takes once written as a chunk. This is the
+	/// encoder's own output rate, not the source file's — a chunk is always re-encoded,
+	/// so what the source happens to be compressed at says nothing about the result.
+	/// </param>
+	/// <param name="removalPoints">
+	/// Silences the trimmer removed, positioned on this same processed timeline. May be
+	/// empty (an older recording, or stripping switched off), in which case every cut
+	/// falls at the furthest safe position.
+	/// </param>
+	public static IReadOnlyList<AudioChunkRange> Plan(
+		TimeSpan totalDuration,
+		long maxChunkBytes,
+		double encodedBytesPerSecond,
+		IReadOnlyList<SilenceRemovalPoint>? removalPoints)
+	{
+		if (totalDuration <= TimeSpan.Zero)
+			return Array.Empty<AudioChunkRange>();
+
+		var whole = new[] { new AudioChunkRange(TimeSpan.Zero, totalDuration) };
+
+		if (maxChunkBytes <= 0 || encodedBytesPerSecond <= 0 || double.IsNaN(encodedBytesPerSecond))
+			return whole;
+
+		double maxChunkSeconds = Math.Max(maxChunkBytes / encodedBytesPerSecond, MinimumChunkSeconds);
+		double totalSeconds = totalDuration.TotalSeconds;
+		if (maxChunkSeconds >= totalSeconds)
+			return whole;
+
+		var points = removalPoints ?? Array.Empty<SilenceRemovalPoint>();
+		var chunks = new List<AudioChunkRange>();
+
+		double start = 0;
+		while (true)
+		{
+			double candidateEnd = start + maxChunkSeconds;
+			if (candidateEnd >= totalSeconds - MinimumTrailingChunkSeconds)
+			{
+				chunks.Add(new AudioChunkRange(TimeSpan.FromSeconds(start), totalDuration));
+				break;
+			}
+
+			double end = ChooseCut(points, start, candidateEnd);
+			chunks.Add(new AudioChunkRange(TimeSpan.FromSeconds(start), TimeSpan.FromSeconds(end)));
+			start = end;
+		}
+
+		return chunks;
+	}
+
+	/// <summary>
+	/// Picks the cut for a chunk running from <paramref name="start"/> to at most
+	/// <paramref name="candidateEnd"/>: the longest removed silence inside the trailing
+	/// search window, else <paramref name="candidateEnd"/> itself.
+	/// </summary>
+	private static double ChooseCut(IReadOnlyList<SilenceRemovalPoint> points, double start, double candidateEnd)
+	{
+		double windowStart = candidateEnd - (candidateEnd - start) * SilenceSearchWindowFraction;
+
+		bool found = false;
+		double bestPosition = 0;
+		TimeSpan bestRemoved = TimeSpan.MinValue;
+
+		foreach (var point in points)
+		{
+			double position = point.Position.TotalSeconds;
+
+			// A cut at or before the chunk's own start would not advance, and one at or
+			// past the candidate end would blow the limit the candidate was chosen for.
+			if (position <= start || position <= windowStart || position >= candidateEnd)
+				continue;
+			if (point.RemovedDuration <= TimeSpan.Zero)
+				continue;
+
+			// Ties go to the later point: same-sized pause, fewer chunks overall.
+			if (found && point.RemovedDuration < bestRemoved)
+				continue;
+			if (found && point.RemovedDuration == bestRemoved && position <= bestPosition)
+				continue;
+
+			found = true;
+			bestPosition = position;
+			bestRemoved = point.RemovedDuration;
+		}
+
+		return found ? bestPosition : candidateEnd;
+	}
+}

--- a/CognitiveSupport/AudioChunkRange.cs
+++ b/CognitiveSupport/AudioChunkRange.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace CognitiveSupport;
+
+/// <summary>
+/// A half-open slice of an audio timeline, <c>[Start, End)</c>, to be written out as
+/// one upload-sized chunk. Ranges produced by <see cref="AudioChunkPlanner"/> are
+/// contiguous and in playback order, so concatenating them reproduces the original.
+/// </summary>
+public readonly record struct AudioChunkRange(TimeSpan Start, TimeSpan End)
+{
+	public TimeSpan Duration => End - Start;
+}

--- a/CognitiveSupport/AudioFileConverter.cs
+++ b/CognitiveSupport/AudioFileConverter.cs
@@ -3,7 +3,9 @@ using Concentus.Oggfile;
 using Concentus.Structs;
 using NAudio.Wave;
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 
 namespace CognitiveSupport;
@@ -46,7 +48,12 @@ public static class AudioFileConverter
 	/// </summary>
 	/// <param name="inputPath">Path to the input file (MP4, MP3, OGG/Opus, etc.)</param>
 	/// <param name="outputOggPath">Path where the OGG file will be written.</param>
-	public static void ConvertToOgg(string inputPath, string outputOggPath, SilenceTrimmerOptions? silenceOptions = null)
+	/// <returns>
+	/// Every silence period stripped out, positioned on the written file's own timeline.
+	/// Empty when <paramref name="silenceOptions"/> is null. The chunker uses these to cut
+	/// an oversized file at a pause rather than mid-word.
+	/// </returns>
+	public static IReadOnlyList<SilenceRemovalPoint> ConvertToOgg(string inputPath, string outputOggPath, SilenceTrimmerOptions? silenceOptions = null)
 	{
 		if (string.IsNullOrWhiteSpace(inputPath))
 			throw new ArgumentException("Input path cannot be empty", nameof(inputPath));
@@ -97,6 +104,10 @@ public static class AudioFileConverter
 		trimmer?.Flush(f => oggStream.WriteSamples(f, 0, f.Length));
 
 		oggStream.Finish();
+
+		return trimmer is null
+			? Array.Empty<SilenceRemovalPoint>()
+			: trimmer.RemovedSilences.ToArray();
 	}
 
 	private static void DecodeOggOpus(string inputPath, PcmFrameSplitter splitter, Action<short[]> writeFrame)

--- a/CognitiveSupport/AudioFileConverter.cs
+++ b/CognitiveSupport/AudioFileConverter.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Threading;
 
 namespace CognitiveSupport;
 
@@ -48,12 +49,16 @@ public static class AudioFileConverter
 	/// </summary>
 	/// <param name="inputPath">Path to the input file (MP4, MP3, OGG/Opus, etc.)</param>
 	/// <param name="outputOggPath">Path where the OGG file will be written.</param>
+	/// <param name="cancellationToken">
+	/// Checked per frame. Decoding and re-encoding a long recording takes real time, and a
+	/// caller waiting on it — the chunker, or an import — has to be able to give up.
+	/// </param>
 	/// <returns>
 	/// Every silence period stripped out, positioned on the written file's own timeline.
 	/// Empty when <paramref name="silenceOptions"/> is null. The chunker uses these to cut
 	/// an oversized file at a pause rather than mid-word.
 	/// </returns>
-	public static IReadOnlyList<SilenceRemovalPoint> ConvertToOgg(string inputPath, string outputOggPath, SilenceTrimmerOptions? silenceOptions = null)
+	public static IReadOnlyList<SilenceRemovalPoint> ConvertToOgg(string inputPath, string outputOggPath, SilenceTrimmerOptions? silenceOptions = null, CancellationToken cancellationToken = default)
 	{
 		if (string.IsNullOrWhiteSpace(inputPath))
 			throw new ArgumentException("Input path cannot be empty", nameof(inputPath));
@@ -84,6 +89,8 @@ public static class AudioFileConverter
 
 		void WriteFrame(short[] pcmSamples)
 		{
+			cancellationToken.ThrowIfCancellationRequested();
+
 			if (trimmer is null)
 				oggStream.WriteSamples(pcmSamples, 0, pcmSamples.Length);
 			else

--- a/CognitiveSupport/AudioRecorder.cs
+++ b/CognitiveSupport/AudioRecorder.cs
@@ -3,6 +3,7 @@ using Concentus.Oggfile;
 using Concentus.Structs;
 using NAudio.Wave;
 using System.IO;
+using System.Linq;
 
 namespace CognitiveSupport;
 
@@ -30,6 +31,11 @@ public class AudioRecorder : IAudioRecorder
 	// After StopRecording, the trimmed speech duration in seconds when silence stripping was
 	// active; null when stripping was disabled (so callers leave the recording untouched).
 	public double? TrimmedSpeechSeconds { get; private set; }
+
+	// After StopRecording, the silences the trimmer stripped out, positioned on the
+	// written file's timeline. Captured before the trimmer is dropped so the chunker can
+	// still cut at a pause once the recording is closed.
+	public IReadOnlyList<SilenceRemovalPoint> RemovedSilences { get; private set; } = Array.Empty<SilenceRemovalPoint>();
 
 	// First exception (if any) that occurred while encoding audio on NAudio's capture
 	// thread. Captured rather than thrown there, where it would escape as an unhandled
@@ -74,6 +80,7 @@ public class AudioRecorder : IAudioRecorder
 				: new SilenceTrimmer(SampleRate, SamplesPerFrame, silenceOptions);
 			_pcmFrameSplitter = new PcmFrameSplitter(SamplesPerFrame);
 			TrimmedSpeechSeconds = null;
+			RemovedSilences = Array.Empty<SilenceRemovalPoint>();
 			_captureException = null;
 
 			// A source left over from a previous recording still holds the microphone open, and
@@ -233,6 +240,10 @@ public class AudioRecorder : IAudioRecorder
 					{
 						_silenceTrimmer.Flush(WriteFrame);
 						TrimmedSpeechSeconds = _silenceTrimmer.SpeechFrameCount * SamplesPerFrame / (double)SampleRate;
+
+						// Copied out: the trimmer is dropped in the finally below, and the
+						// list it hands back is the one it keeps appending to.
+						RemovedSilences = _silenceTrimmer.RemovedSilences.ToArray();
 					}
 
 					_oggStream.Finish();

--- a/CognitiveSupport/ChunkedTranscriber.cs
+++ b/CognitiveSupport/ChunkedTranscriber.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CognitiveSupport;
+
+/// <summary>
+/// Sends an audio file for transcription, splitting it first when it is bigger than the
+/// service will accept in one request.
+///
+/// A file inside the limit is sent exactly as before — one request, no decoding, no temp
+/// files. Only an oversized file takes the long road: measure it, plan the cuts with
+/// <see cref="AudioChunkPlanner"/>, write the chunks, check each one really is inside the
+/// limit, then upload them one at a time in order and join what comes back. Sequential
+/// rather than parallel on purpose: transcription endpoints rate-limit hard, and the
+/// order of the transcript is the whole point.
+/// </summary>
+public sealed class ChunkedTranscriber
+{
+	private const string ChunkDirectoryPrefix = "chunks-";
+
+	private readonly IAudioChunkWriter _chunkWriter;
+
+	public ChunkedTranscriber()
+		: this(new OggAudioChunkWriter())
+	{
+	}
+
+	public ChunkedTranscriber(IAudioChunkWriter chunkWriter)
+	{
+		_chunkWriter = chunkWriter ?? throw new ArgumentNullException(nameof(chunkWriter));
+	}
+
+	/// <param name="removalPoints">
+	/// Where silence was removed from this file, on its own (processed) timeline. Empty is
+	/// fine — cuts then fall at the furthest safe position instead of at a pause.
+	/// </param>
+	/// <param name="maxUploadBytes">Per-request size limit. Zero or less disables splitting.</param>
+	/// <param name="workingRootDirectory">Folder under which the temporary chunk folder is created.</param>
+	public async Task<string> TranscribeAsync(
+		ISpeechToTextService service,
+		string prompt,
+		string audioFilePath,
+		IReadOnlyList<SilenceRemovalPoint>? removalPoints,
+		long maxUploadBytes,
+		string workingRootDirectory,
+		int timeoutSeconds,
+		CancellationToken cancellationToken)
+	{
+		if (service is null) throw new ArgumentNullException(nameof(service));
+		if (string.IsNullOrWhiteSpace(audioFilePath))
+			throw new ArgumentException("Audio file path cannot be empty.", nameof(audioFilePath));
+
+		if (maxUploadBytes <= 0 || new FileInfo(audioFilePath).Length <= maxUploadBytes)
+			return await service.ConvertAudioToText(prompt, audioFilePath, cancellationToken, timeoutSeconds).ConfigureAwait(false);
+
+		string workingDirectory = Path.Combine(
+			string.IsNullOrWhiteSpace(workingRootDirectory) ? Path.GetTempPath() : workingRootDirectory,
+			ChunkDirectoryPrefix + Guid.NewGuid().ToString("N"));
+
+		try
+		{
+			IReadOnlyList<string> chunks = await Task.Run(
+				() => _chunkWriter.WriteChunks(audioFilePath, removalPoints, maxUploadBytes, workingDirectory, cancellationToken),
+				cancellationToken).ConfigureAwait(false);
+
+			if (chunks.Count == 0)
+				throw new InvalidOperationException(
+					$"'{Path.GetFileName(audioFilePath)}' is too large to send in one request and contains no audio to split.");
+
+			VerifyWithinLimit(chunks, maxUploadBytes);
+
+			var transcripts = new List<string>(chunks.Count);
+			foreach (string chunk in chunks)
+			{
+				cancellationToken.ThrowIfCancellationRequested();
+
+				string text = await service.ConvertAudioToText(prompt, chunk, cancellationToken, timeoutSeconds).ConfigureAwait(false);
+				if (!string.IsNullOrWhiteSpace(text))
+					transcripts.Add(text.Trim());
+			}
+
+			return string.Join(" ", transcripts);
+		}
+		finally
+		{
+			// Whether this succeeded, failed or was cancelled, the chunks were never
+			// anything but scratch space for one upload.
+			TryDeleteDirectory(workingDirectory);
+		}
+	}
+
+	/// <summary>
+	/// Last line of defence before anything is uploaded. The writer already caps each
+	/// chunk as it encodes, so a failure here means that cap did not hold — better to say
+	/// so than to let the service reject the request with something less specific.
+	/// </summary>
+	private static void VerifyWithinLimit(IReadOnlyList<string> chunks, long maxUploadBytes)
+	{
+		foreach (string chunk in chunks)
+		{
+			long length = new FileInfo(chunk).Length;
+			if (length > maxUploadBytes)
+				throw new InvalidOperationException(
+					$"Audio chunk '{Path.GetFileName(chunk)}' is {length} bytes, over the {maxUploadBytes} byte upload limit.");
+		}
+	}
+
+	private static void TryDeleteDirectory(string directory)
+	{
+		try
+		{
+			if (Directory.Exists(directory))
+				Directory.Delete(directory, recursive: true);
+		}
+		catch (DirectoryNotFoundException)
+		{
+		}
+		catch (UnauthorizedAccessException)
+		{
+		}
+		catch (PathTooLongException)
+		{
+		}
+		catch (IOException)
+		{
+			// Scratch space in the app's temp folder; a file still locked by a failed
+			// upload is not worth failing the transcription the user is waiting on.
+		}
+	}
+}

--- a/CognitiveSupport/IAudioChunkWriter.cs
+++ b/CognitiveSupport/IAudioChunkWriter.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using System.Threading;
+
+namespace CognitiveSupport;
+
+/// <summary>
+/// Splits an audio file into standalone files that each fit inside an upload limit.
+///
+/// Separated from <see cref="ChunkedTranscriber"/> so the "split, then upload in order"
+/// flow can be tested without a codec, and so a different container could be slotted in
+/// without touching that flow. Boundary selection itself lives in
+/// <see cref="AudioChunkPlanner"/>, which an implementation is expected to use.
+/// </summary>
+public interface IAudioChunkWriter
+{
+	/// <summary>
+	/// Writes <paramref name="audioFilePath"/> out as a sequence of playable files inside
+	/// <paramref name="outputDirectory"/>, returned in playback order.
+	///
+	/// <paramref name="maxChunkBytes"/> is a hard ceiling enforced while writing, not just
+	/// a planning input: a chunk growing towards it is closed early and the rest continues
+	/// in the next file. <paramref name="removalPoints"/> says where silence was stripped
+	/// out of this file, so a cut can land at a pause rather than mid-word.
+	/// </summary>
+	IReadOnlyList<string> WriteChunks(
+		string audioFilePath,
+		IReadOnlyList<SilenceRemovalPoint>? removalPoints,
+		long maxChunkBytes,
+		string outputDirectory,
+		CancellationToken cancellationToken);
+}

--- a/CognitiveSupport/IAudioRecorder.cs
+++ b/CognitiveSupport/IAudioRecorder.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace CognitiveSupport;
 
@@ -15,6 +16,14 @@ public interface IAudioRecorder : IDisposable
 	/// when silence stripping was active; null when stripping was disabled.
 	/// </summary>
 	double? TrimmedSpeechSeconds { get; }
+
+	/// <summary>
+	/// After <see cref="StopRecording"/>, every silence period stripped out of the
+	/// recording, positioned on the recorded file's own timeline. Empty when stripping
+	/// was disabled. Used to cut a long recording into upload-sized chunks at a pause
+	/// rather than mid-word.
+	/// </summary>
+	IReadOnlyList<SilenceRemovalPoint> RemovedSilences { get; }
 
 	/// <summary>
 	/// First exception (if any) that occurred while encoding audio on the capture

--- a/CognitiveSupport/OggAudioChunkWriter.cs
+++ b/CognitiveSupport/OggAudioChunkWriter.cs
@@ -1,0 +1,259 @@
+using Concentus.Enums;
+using Concentus.Oggfile;
+using Concentus.Structs;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Threading;
+
+namespace CognitiveSupport;
+
+/// <summary>
+/// Splits an audio file into standalone Ogg/Opus chunks.
+///
+/// The source is decoded once and re-encoded straight into the current chunk, so the
+/// whole recording is never held in memory and each chunk gets its own container,
+/// headers and timeline — every output file is independently playable and uploadable.
+///
+/// Encoder settings match <see cref="AudioFileConverter"/> and <see cref="AudioRecorder"/>
+/// (48 kHz mono, 24 kbps VBR), so a chunk sounds like the recording it came from.
+/// </summary>
+public sealed class OggAudioChunkWriter : IAudioChunkWriter
+{
+	private const string ConvertedSourceFileName = "source.ogg";
+
+	private const int SampleRate = 48000;
+
+	// Opus requires 2.5, 5, 10, 20, 40 or 60ms frames. 20ms at 48kHz = 960 samples.
+	private const int SamplesPerFrame = 960;
+	private const int Bitrate = 24000;
+
+	// Nominal payload is Bitrate/8 = 3000 bytes a second; the rest covers Ogg page
+	// headers and the slack a VBR encoder takes on dense material. Deliberately
+	// pessimistic — overestimating costs one extra chunk, underestimating costs a forced
+	// cut in the middle of a word.
+	private const double EncodedBytesPerSecondEstimate = Bitrate / 8.0 * 1.15;
+
+	// The encoder hands the file whole Ogg pages, so bytes on disk trail the samples
+	// already accepted by up to one page (65307 bytes at the format's maximum, and
+	// Finish() can flush more than one). Closing a chunk this far short of the limit
+	// leaves room for everything still to land. Capped at a quarter of the limit so an
+	// unusually small one is still mostly usable rather than reserved away entirely.
+	private const long PageFlushReserveBytes = 128 * 1024;
+
+	// A chunk is never closed on the byte ceiling before it holds this much audio. Only
+	// reachable with a limit smaller than the reserve above, and only there to stop a
+	// nonsensical setting from producing one file per frame.
+	private const long MinimumChunkSamples = SampleRate;
+
+	/// <summary>Length of the audio in an Ogg/Opus file.</summary>
+	public static TimeSpan MeasureDuration(string audioFilePath)
+	{
+		if (string.IsNullOrWhiteSpace(audioFilePath))
+			throw new ArgumentException("Audio file path cannot be empty.", nameof(audioFilePath));
+
+		long samples = 0;
+		OggOpusPcmDecoder.DecodeToMonoPcm(audioFilePath, decoded => samples += decoded.Length);
+		return TimeSpan.FromSeconds(samples / (double)SampleRate);
+	}
+
+	public IReadOnlyList<string> WriteChunks(
+		string audioFilePath,
+		IReadOnlyList<SilenceRemovalPoint>? removalPoints,
+		long maxChunkBytes,
+		string outputDirectory,
+		CancellationToken cancellationToken)
+	{
+		if (string.IsNullOrWhiteSpace(audioFilePath))
+			throw new ArgumentException("Audio file path cannot be empty.", nameof(audioFilePath));
+		if (string.IsNullOrWhiteSpace(outputDirectory))
+			throw new ArgumentException("Output directory cannot be empty.", nameof(outputDirectory));
+
+		Directory.CreateDirectory(outputDirectory);
+
+		// An uploaded audio file is copied in as-is when silence stripping is off, so what
+		// arrives here is not necessarily Ogg/Opus. Convert first — without trimming, so
+		// the timeline the removal points were measured against is left alone.
+		string source = audioFilePath;
+		if (!OggOpusPcmDecoder.IsOggOpus(source))
+		{
+			string converted = Path.Combine(outputDirectory, ConvertedSourceFileName);
+			AudioFileConverter.ConvertToOgg(source, converted, silenceOptions: null);
+			source = converted;
+		}
+
+		cancellationToken.ThrowIfCancellationRequested();
+
+		var ranges = AudioChunkPlanner.Plan(
+			MeasureDuration(source), maxChunkBytes, EncodedBytesPerSecondEstimate, removalPoints);
+
+		return WritePlannedChunks(source, ranges, maxChunkBytes, outputDirectory, cancellationToken);
+	}
+
+	private static IReadOnlyList<string> WritePlannedChunks(
+		string audioFilePath,
+		IReadOnlyList<AudioChunkRange> ranges,
+		long maxChunkBytes,
+		string outputDirectory,
+		CancellationToken cancellationToken)
+	{
+		var boundaries = ToBoundarySamples(ranges);
+		long byteCeiling = maxChunkBytes > 0
+			? Math.Max(maxChunkBytes - Math.Min(PageFlushReserveBytes, maxChunkBytes / 4), 1)
+			: long.MaxValue;
+
+		var paths = new List<string>();
+		ChunkFile? current = null;
+		long position = 0;      // samples accepted across every chunk so far
+		int boundaryIndex = 0;
+
+		try
+		{
+			var splitter = new PcmFrameSplitter(SamplesPerFrame);
+
+			void WriteFrame(short[] frame)
+			{
+				cancellationToken.ThrowIfCancellationRequested();
+
+				if (current is not null && ShouldCloseChunk(current, position, boundaries, boundaryIndex, byteCeiling))
+				{
+					current.Finish();
+					current.Dispose();
+					current = null;
+				}
+
+				// A cut forced by the byte ceiling can overtake planned boundaries; drop
+				// the ones now behind us so they cannot fire a second, empty cut later.
+				while (boundaryIndex < boundaries.Count && boundaries[boundaryIndex] <= position)
+					boundaryIndex++;
+
+				if (current is null)
+				{
+					current = ChunkFile.Create(outputDirectory, paths.Count);
+					paths.Add(current.Path);
+				}
+
+				current.Write(frame);
+				position += frame.Length;
+			}
+
+			OggOpusPcmDecoder.DecodeToMonoPcm(audioFilePath, decoded => splitter.AppendSamples(decoded, decoded.Length, WriteFrame));
+
+			// Pad the final partial frame rather than dropping it, matching the converter:
+			// the tail of the last chunk is the tail of the recording.
+			splitter.Flush(WriteFrame, padWithSilence: true);
+
+			current?.Finish();
+		}
+		finally
+		{
+			current?.Dispose();
+		}
+
+		return paths;
+	}
+
+	private static bool ShouldCloseChunk(
+		ChunkFile current,
+		long position,
+		IReadOnlyList<long> boundaries,
+		int boundaryIndex,
+		long byteCeiling)
+	{
+		if (boundaryIndex < boundaries.Count && position >= boundaries[boundaryIndex])
+			return true;
+
+		return current.BytesWritten > byteCeiling && current.SamplesWritten >= MinimumChunkSamples;
+	}
+
+	/// <summary>
+	/// Converts the planned ranges into the sample positions at which a new chunk starts.
+	/// The final range's end is left out: it is the end of the recording, and a cut there
+	/// would only ever open an empty trailing file.
+	/// </summary>
+	private static IReadOnlyList<long> ToBoundarySamples(IReadOnlyList<AudioChunkRange> ranges)
+	{
+		var boundaries = new List<long>();
+		long previous = 0;
+
+		for (int i = 0; i < ranges.Count - 1; i++)
+		{
+			long samples = (long)Math.Round(ranges[i].End.TotalSeconds * SampleRate);
+			if (samples <= previous)
+				continue;
+
+			boundaries.Add(samples);
+			previous = samples;
+		}
+
+		return boundaries;
+	}
+
+	/// <summary>
+	/// One chunk file being written. Tracks its own size so the caller can stop short of
+	/// the upload limit; the stream is opened unbuffered so <see cref="BytesWritten"/> is
+	/// what is actually on disk rather than what is on its way there.
+	/// </summary>
+	private sealed class ChunkFile : IDisposable
+	{
+		private readonly FileStream _file;
+		private readonly OpusOggWriteStream _ogg;
+		private bool _finished;
+
+		public string Path { get; }
+		public long BytesWritten => _file.Position;
+		public long SamplesWritten { get; private set; }
+
+		private ChunkFile(string path, FileStream file, OpusOggWriteStream ogg)
+		{
+			Path = path;
+			_file = file;
+			_ogg = ogg;
+		}
+
+		public static ChunkFile Create(string outputDirectory, int index)
+		{
+			string path = System.IO.Path.Combine(
+				outputDirectory,
+				string.Format(CultureInfo.InvariantCulture, "chunk-{0:D3}.ogg", index + 1));
+
+			var file = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None, bufferSize: 1);
+			try
+			{
+#pragma warning disable CS0618 // Concentus.OggFile 1.0.6 still requires the concrete OpusEncoder type.
+				var encoder = new OpusEncoder(SampleRate, 1, OpusApplication.OPUS_APPLICATION_VOIP)
+				{
+					Bitrate = Bitrate,
+					UseVBR = true,
+					UseDTX = false // DTX is not supported in Ogg streams by Concentus.OggFile.
+				};
+#pragma warning restore CS0618
+
+				return new ChunkFile(path, file, new OpusOggWriteStream(encoder, file, new OpusTags()));
+			}
+			catch
+			{
+				file.Dispose();
+				throw;
+			}
+		}
+
+		public void Write(short[] frame)
+		{
+			_ogg.WriteSamples(frame, 0, frame.Length);
+			SamplesWritten += frame.Length;
+		}
+
+		public void Finish()
+		{
+			if (_finished) return;
+			_finished = true;
+			_ogg.Finish();
+		}
+
+		// OpusEncoder and OpusOggWriteStream are not IDisposable in Concentus; the file
+		// stream is the only thing holding an OS handle.
+		public void Dispose() => _file.Dispose();
+	}
+}

--- a/CognitiveSupport/OggAudioChunkWriter.cs
+++ b/CognitiveSupport/OggAudioChunkWriter.cs
@@ -47,14 +47,22 @@ public sealed class OggAudioChunkWriter : IAudioChunkWriter
 	// nonsensical setting from producing one file per frame.
 	private const long MinimumChunkSamples = SampleRate;
 
-	/// <summary>Length of the audio in an Ogg/Opus file.</summary>
-	public static TimeSpan MeasureDuration(string audioFilePath)
+	/// <summary>
+	/// Length of the audio in an Ogg/Opus file. This decodes the whole file, which on the
+	/// multi-hour recordings this class exists for takes real time — hence the token.
+	/// </summary>
+	public static TimeSpan MeasureDuration(string audioFilePath, CancellationToken cancellationToken = default)
 	{
 		if (string.IsNullOrWhiteSpace(audioFilePath))
 			throw new ArgumentException("Audio file path cannot be empty.", nameof(audioFilePath));
 
 		long samples = 0;
-		OggOpusPcmDecoder.DecodeToMonoPcm(audioFilePath, decoded => samples += decoded.Length);
+		OggOpusPcmDecoder.DecodeToMonoPcm(audioFilePath, decoded =>
+		{
+			cancellationToken.ThrowIfCancellationRequested();
+			samples += decoded.Length;
+		});
+
 		return TimeSpan.FromSeconds(samples / (double)SampleRate);
 	}
 
@@ -79,14 +87,12 @@ public sealed class OggAudioChunkWriter : IAudioChunkWriter
 		if (!OggOpusPcmDecoder.IsOggOpus(source))
 		{
 			string converted = Path.Combine(outputDirectory, ConvertedSourceFileName);
-			AudioFileConverter.ConvertToOgg(source, converted, silenceOptions: null);
+			AudioFileConverter.ConvertToOgg(source, converted, silenceOptions: null, cancellationToken);
 			source = converted;
 		}
 
-		cancellationToken.ThrowIfCancellationRequested();
-
 		var ranges = AudioChunkPlanner.Plan(
-			MeasureDuration(source), maxChunkBytes, EncodedBytesPerSecondEstimate, removalPoints);
+			MeasureDuration(source, cancellationToken), maxChunkBytes, EncodedBytesPerSecondEstimate, removalPoints);
 
 		return WritePlannedChunks(source, ranges, maxChunkBytes, outputDirectory, cancellationToken);
 	}

--- a/CognitiveSupport/Settings.cs
+++ b/CognitiveSupport/Settings.cs
@@ -188,6 +188,24 @@ public class SpeechToTextSettings
 
         // Audio preserved on each side of speech to avoid clipping word edges (milliseconds).
         public double SilenceGuardMilliseconds { get; set; } = 200.0;
+
+	// Largest audio file sent in a single transcription request. Anything bigger is
+	// split into chunks that are transcribed in order and stitched back together.
+	//
+	// The default sits just under OpenAI's 25 MB request limit; the margin absorbs the
+	// multipart envelope and leaves room for a chunk that encodes slightly denser than
+	// planned. 0 disables splitting entirely, so the whole file is always sent as-is.
+	public const long DefaultMaxTranscriptionUploadBytes = 24L * 1024 * 1024;
+	public const long MinTranscriptionUploadBytes = 1L * 1024 * 1024;
+	public const long MaxTranscriptionUploadBytesLimit = 1000L * 1024 * 1024;
+
+	public long MaxTranscriptionUploadBytes { get; set; } = DefaultMaxTranscriptionUploadBytes;
+
+	// Clamp an upload limit into the supported range. Applied on load and again before
+	// use so a hand-edited JSON value cannot produce chunks no service would accept.
+	// 0 or less is preserved as "no limit" rather than clamped up, matching the OCR cap.
+	public static long ClampTranscriptionUploadBytes(long value) =>
+		value <= 0 ? 0 : Math.Clamp(value, MinTranscriptionUploadBytes, MaxTranscriptionUploadBytesLimit);
 }
 
 public class SpeechToTextServiceSettings

--- a/CognitiveSupport/SilenceRemovalLog.cs
+++ b/CognitiveSupport/SilenceRemovalLog.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+
+namespace CognitiveSupport;
+
+/// <summary>
+/// Carries the silence-removal points from whichever preprocessing pass produced an
+/// audio file through to whoever later transcribes it.
+///
+/// It remembers one file, because that is all the app ever needs: preprocessing and
+/// transcription are two steps of the same user action (stop recording and transcribe;
+/// import a file and transcribe it), so the file just processed is the file about to be
+/// sent. Anything older — a session picked out of history after a restart — has no
+/// points, and chunking falls back to cutting at the furthest safe position.
+///
+/// Thread-safe: preprocessing finishes on a worker thread and the transcription may be
+/// started from another.
+/// </summary>
+public sealed class SilenceRemovalLog
+{
+	private readonly object _gate = new();
+	private string? _path;
+	private IReadOnlyList<SilenceRemovalPoint> _points = Array.Empty<SilenceRemovalPoint>();
+
+	public void Record(string audioFilePath, IReadOnlyList<SilenceRemovalPoint>? points)
+	{
+		if (string.IsNullOrWhiteSpace(audioFilePath))
+			return;
+
+		lock (_gate)
+		{
+			_path = audioFilePath;
+			_points = points ?? Array.Empty<SilenceRemovalPoint>();
+		}
+	}
+
+	/// <summary>
+	/// The points recorded for this file, or an empty list if the file is not the one
+	/// most recently preprocessed.
+	/// </summary>
+	public IReadOnlyList<SilenceRemovalPoint> PointsFor(string audioFilePath)
+	{
+		if (string.IsNullOrWhiteSpace(audioFilePath))
+			return Array.Empty<SilenceRemovalPoint>();
+
+		lock (_gate)
+		{
+			return string.Equals(_path, audioFilePath, StringComparison.OrdinalIgnoreCase)
+				? _points
+				: Array.Empty<SilenceRemovalPoint>();
+		}
+	}
+}

--- a/CognitiveSupport/SilenceRemovalPoint.cs
+++ b/CognitiveSupport/SilenceRemovalPoint.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace CognitiveSupport;
+
+/// <summary>
+/// One silence period that <see cref="SilenceTrimmer"/> removed.
+///
+/// <paramref name="Position"/> is where the cut landed on the <em>processed</em>
+/// timeline — the audio that is actually written out — not on the source timeline.
+/// That is what makes the value still usable after the fact: every earlier removal
+/// has already shortened the output, so a later point's position already accounts
+/// for the shift, and the value can be handed straight to a seek or a split.
+///
+/// <paramref name="RemovedDuration"/> is how much audio was dropped there, measured
+/// on the original timeline. It is the "how big was the pause" signal used to pick
+/// the most natural place to cut a long recording into chunks.
+/// </summary>
+public readonly record struct SilenceRemovalPoint(TimeSpan Position, TimeSpan RemovedDuration);

--- a/CognitiveSupport/SilenceTrimmer.cs
+++ b/CognitiveSupport/SilenceTrimmer.cs
@@ -18,10 +18,18 @@ namespace CognitiveSupport;
 /// </summary>
 public sealed class SilenceTrimmer
 {
+	// A removal is only ever recorded once per trimmed gap, so a multi-hour recording
+	// produces a few thousand entries at most. The cap is a backstop against a
+	// pathological stream (rapid speech/silence alternation for hours) growing this
+	// list without bound on the audio capture path; past it, later gaps are still
+	// trimmed, they are just not offered as split points.
+	private const int MaxRecordedRemovals = 100_000;
+
 	private readonly int _thresholdFrames;
 	private readonly int _guardFrames;
 	private readonly double _meanSquareThreshold;
 	private readonly int _capFrames;
+	private readonly double _frameSeconds;
 
 	// First and last frames of the current silence gap. Bounded to _capFrames each so a
 	// long pause does not grow memory without bound; we only ever keep frames adjacent to
@@ -32,8 +40,22 @@ public sealed class SilenceTrimmer
 
 	private bool _hasEmittedSpeech;
 
+	// Frames handed to the emit callback so far. This is the processed timeline, which
+	// is what a removal point has to be expressed in: it shortens as gaps are dropped,
+	// so a position taken from it stays correct however much earlier audio was removed.
+	private long _emittedFrameCount;
+
+	private readonly List<SilenceRemovalPoint> _removedSilences = new();
+
 	/// <summary>Number of speech (non-silent) frames seen so far.</summary>
 	public long SpeechFrameCount { get; private set; }
+
+	/// <summary>
+	/// Every silence period removed so far, in output order, positioned on the
+	/// processed timeline. Used to pick natural cut points when a recording has to be
+	/// split into upload-sized chunks.
+	/// </summary>
+	public IReadOnlyList<SilenceRemovalPoint> RemovedSilences => _removedSilences;
 
 	public SilenceTrimmer(int sampleRate, int frameSize, SilenceTrimmerOptions options)
 	{
@@ -42,6 +64,7 @@ public sealed class SilenceTrimmer
 		if (options is null) throw new ArgumentNullException(nameof(options));
 
 		double frameMs = frameSize * 1000.0 / sampleRate;
+		_frameSeconds = frameSize / (double)sampleRate;
 
 		_thresholdFrames = Math.Max(0, (int)Math.Round(options.MinSilenceSeconds * 1000.0 / frameMs));
 		_guardFrames = Math.Max(0, (int)Math.Round(options.GuardMilliseconds / frameMs));
@@ -67,6 +90,7 @@ public sealed class SilenceTrimmer
 			FlushGap(hasLeftSpeech: _hasEmittedSpeech, hasRightSpeech: true, emit);
 
 		emit(frame);
+		_emittedFrameCount++;
 		_hasEmittedSpeech = true;
 		SpeechFrameCount++;
 	}
@@ -137,12 +161,34 @@ public sealed class SilenceTrimmer
 		}
 
 		for (int i = 0; i < keepStart; i++)
+		{
 			emit(_head[i]);
+			_emittedFrameCount++;
+		}
+
+		// Recorded between the two halves of the kept guard, which is exactly where the
+		// dropped audio used to sit — so the position is the seam in the output, and any
+		// later removal is measured against an output that has already lost this much.
+		RecordRemoval(length - keepStart - keepEnd);
+
 		for (int i = _tail.Count - keepEnd; i < _tail.Count; i++)
+		{
 			emit(_tail[i]);
+			_emittedFrameCount++;
+		}
 
 		_head.Clear();
 		_tail.Clear();
 		_silenceCount = 0;
+	}
+
+	private void RecordRemoval(long droppedFrames)
+	{
+		if (droppedFrames <= 0 || _removedSilences.Count >= MaxRecordedRemovals)
+			return;
+
+		_removedSilences.Add(new SilenceRemovalPoint(
+			TimeSpan.FromSeconds(_emittedFrameCount * _frameSeconds),
+			TimeSpan.FromSeconds(droppedFrames * _frameSeconds)));
 	}
 }

--- a/Documentation/UserGuide/html/settings.html
+++ b/Documentation/UserGuide/html/settings.html
@@ -305,7 +305,9 @@ pause was taken out, so a break falls between sentences rather than in the middl
 a word.</p>
 <p>24 is the default and suits OpenAI. Set it to 0 if you never want a recording split,
 for example with a service that accepts larger uploads. Otherwise the box takes
-anything from 1 to 1000.</p>
+anything from 1 to 1000. If you type something smaller than 1, Mutation puts 1 back
+in the box, because a piece any smaller than that is no use to a transcription
+service.</p>
 <h3 id="api-keys">API keys</h3>
 <p>Your keys in one place. An API key is a long password that lets Mutation talk to a
 service on your behalf.</p>

--- a/Documentation/UserGuide/html/settings.html
+++ b/Documentation/UserGuide/html/settings.html
@@ -276,6 +276,10 @@ help. Leave them alone unless something is timing out on you.</p>
 <td>Strip silent gaps from audio</td>
 <td>Removes long silences before the audio is sent, so pauses while you think do not bloat the recording.</td>
 </tr>
+<tr>
+<td>Maximum upload size (MB)</td>
+<td>The biggest audio file Mutation sends in one go. Anything larger is broken into pieces and sent one after the other. 24 by default.</td>
+</tr>
 </tbody>
 </table>
 </div>
@@ -292,6 +296,16 @@ always gives you a full path.</p>
 <p>The three silence numbers underneath (minimum silence, threshold, edge guard) fine
 tune that trimming. The defaults are good; each has hover help if you want to
 experiment.</p>
+<p>Under <strong>Large recordings</strong> is <strong>Maximum upload size (MB)</strong>. Transcription services
+refuse anything over about 25 MB in one request, which a long meeting recording will
+sail past. When a recording is bigger than the number in this box, Mutation splits it
+into pieces, sends them one after the other, and joins the results back together in
+order, so you still get one transcript. It picks the splitting points where a long
+pause was taken out, so a break falls between sentences rather than in the middle of
+a word.</p>
+<p>24 is the default and suits OpenAI. Set it to 0 if you never want a recording split,
+for example with a service that accepts larger uploads. Otherwise the box takes
+anything from 1 to 1000.</p>
 <h3 id="api-keys">API keys</h3>
 <p>Your keys in one place. An API key is a long password that lets Mutation talk to a
 service on your behalf.</p>

--- a/Documentation/UserGuide/html/troubleshooting.html
+++ b/Documentation/UserGuide/html/troubleshooting.html
@@ -201,6 +201,25 @@ twenty-minute one.</li>
 timeouts for live dictation and for transcribing a file, plus a per-attempt timeout
 on each speech service.</li>
 </ol>
+<h3 id="a-long-recording-takes-several-rounds-to-come-back">A long recording takes several rounds to come back</h3>
+<p><strong>What's happening.</strong> Transcription services refuse a file over about 25 MB in one
+request. When a recording is bigger than <strong>Maximum upload size (MB)</strong> in <strong>Settings</strong>,
+Mutation splits it and sends the pieces one after the other, then joins the results
+into a single transcript. That is several trips over the internet instead of one, so a
+long meeting recording takes noticeably longer than a short note. Nothing is lost, and
+the pieces are joined back in the order you recorded them.</p>
+<p><strong>What to do.</strong></p>
+<ol>
+<li>Wait it out — the pieces are sent automatically and you get one transcript at the
+end.</li>
+<li>Leave <strong>Strip silent gaps from audio</strong> switched on. It makes recordings smaller, so
+fewer of them need splitting at all, and it gives Mutation the pauses it uses to
+split between sentences rather than mid-word.</li>
+<li>If a message says a piece is still over the upload limit, lower <strong>Maximum upload
+size (MB)</strong> and try again.</li>
+<li>If your service accepts larger uploads than OpenAI does, raise the number, or set
+it to 0 to never split.</li>
+</ol>
 <h3 id="ocr-returns-nothing-useful-or-the-wrong-reading-order">OCR returns nothing useful, or the wrong reading order</h3>
 <p><strong>What's happening.</strong> OCR reads text out of a picture. If the picture is small,
 blurry, or is light text on a dark background, there may be nothing recognisable in

--- a/Documentation/UserGuide/html/troubleshooting.html
+++ b/Documentation/UserGuide/html/troubleshooting.html
@@ -206,8 +206,8 @@ on each speech service.</li>
 request. When a recording is bigger than <strong>Maximum upload size (MB)</strong> in <strong>Settings</strong>,
 Mutation splits it and sends the pieces one after the other, then joins the results
 into a single transcript. That is several trips over the internet instead of one, so a
-long meeting recording takes noticeably longer than a short note. Nothing is lost, and
-the pieces are joined back in the order you recorded them.</p>
+long meeting recording takes noticeably longer than a short note. No audio is skipped,
+and the pieces are joined back in the order you recorded them.</p>
 <p><strong>What to do.</strong></p>
 <ol>
 <li>Wait it out — the pieces are sent automatically and you get one transcript at the

--- a/Documentation/UserGuide/markdown/settings.md
+++ b/Documentation/UserGuide/markdown/settings.md
@@ -106,7 +106,9 @@ a word.
 
 24 is the default and suits OpenAI. Set it to 0 if you never want a recording split,
 for example with a service that accepts larger uploads. Otherwise the box takes
-anything from 1 to 1000.
+anything from 1 to 1000. If you type something smaller than 1, Mutation puts 1 back
+in the box, because a piece any smaller than that is no use to a transcription
+service.
 
 ### API keys
 

--- a/Documentation/UserGuide/markdown/settings.md
+++ b/Documentation/UserGuide/markdown/settings.md
@@ -80,6 +80,7 @@ Where your dictation gets turned into text.
 | Temp directory | The folder your recordings are written to while they are being made. It has to be a full path that starts with a drive, like `D:\Recordings`. |
 | Send hotkey after transcription | Optional keystrokes sent to the app you are in once your text arrives, for example **Ctrl+V** to paste. |
 | Strip silent gaps from audio | Removes long silences before the audio is sent, so pauses while you think do not bloat the recording. |
+| Maximum upload size (MB) | The biggest audio file Mutation sends in one go. Anything larger is broken into pieces and sent one after the other. 24 by default. |
 
 > Adding, removing, or editing a service definition takes effect after you restart
 > Mutation. The per-service prompt and your choice of active service apply straight
@@ -94,6 +95,18 @@ always gives you a full path.
 The three silence numbers underneath (minimum silence, threshold, edge guard) fine
 tune that trimming. The defaults are good; each has hover help if you want to
 experiment.
+
+Under **Large recordings** is **Maximum upload size (MB)**. Transcription services
+refuse anything over about 25 MB in one request, which a long meeting recording will
+sail past. When a recording is bigger than the number in this box, Mutation splits it
+into pieces, sends them one after the other, and joins the results back together in
+order, so you still get one transcript. It picks the splitting points where a long
+pause was taken out, so a break falls between sentences rather than in the middle of
+a word.
+
+24 is the default and suits OpenAI. Set it to 0 if you never want a recording split,
+for example with a service that accepts larger uploads. Otherwise the box takes
+anything from 1 to 1000.
 
 ### API keys
 

--- a/Documentation/UserGuide/markdown/troubleshooting.md
+++ b/Documentation/UserGuide/markdown/troubleshooting.md
@@ -69,6 +69,27 @@ than short ones.
    timeouts for live dictation and for transcribing a file, plus a per-attempt timeout
    on each speech service.
 
+### A long recording takes several rounds to come back
+
+**What's happening.** Transcription services refuse a file over about 25 MB in one
+request. When a recording is bigger than **Maximum upload size (MB)** in **Settings**,
+Mutation splits it and sends the pieces one after the other, then joins the results
+into a single transcript. That is several trips over the internet instead of one, so a
+long meeting recording takes noticeably longer than a short note. Nothing is lost, and
+the pieces are joined back in the order you recorded them.
+
+**What to do.**
+
+1. Wait it out — the pieces are sent automatically and you get one transcript at the
+   end.
+2. Leave **Strip silent gaps from audio** switched on. It makes recordings smaller, so
+   fewer of them need splitting at all, and it gives Mutation the pauses it uses to
+   split between sentences rather than mid-word.
+3. If a message says a piece is still over the upload limit, lower **Maximum upload
+   size (MB)** and try again.
+4. If your service accepts larger uploads than OpenAI does, raise the number, or set
+   it to 0 to never split.
+
 ### OCR returns nothing useful, or the wrong reading order
 
 **What's happening.** OCR reads text out of a picture. If the picture is small,

--- a/Documentation/UserGuide/markdown/troubleshooting.md
+++ b/Documentation/UserGuide/markdown/troubleshooting.md
@@ -75,8 +75,8 @@ than short ones.
 request. When a recording is bigger than **Maximum upload size (MB)** in **Settings**,
 Mutation splits it and sends the pieces one after the other, then joins the results
 into a single transcript. That is several trips over the internet instead of one, so a
-long meeting recording takes noticeably longer than a short note. Nothing is lost, and
-the pieces are joined back in the order you recorded them.
+long meeting recording takes noticeably longer than a short note. No audio is skipped,
+and the pieces are joined back in the order you recorded them.
 
 **What to do.**
 

--- a/Mutation.Tests/AudioChunkPlannerTests.cs
+++ b/Mutation.Tests/AudioChunkPlannerTests.cs
@@ -1,0 +1,180 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using CognitiveSupport;
+
+namespace Mutation.Tests;
+
+/// <summary>
+/// Boundary selection for splitting an oversized recording. A round 1000 bytes a second
+/// is used throughout so a byte limit reads directly as a duration: 10,000 bytes is ten
+/// seconds of audio.
+/// </summary>
+public class AudioChunkPlannerTests
+{
+	private const double BytesPerSecond = 1000;
+
+	private static SilenceRemovalPoint At(double positionSeconds, double removedSeconds) =>
+		new(TimeSpan.FromSeconds(positionSeconds), TimeSpan.FromSeconds(removedSeconds));
+
+	private static IReadOnlyList<AudioChunkRange> Plan(
+		double totalSeconds,
+		double limitSeconds,
+		params SilenceRemovalPoint[] points) =>
+		AudioChunkPlanner.Plan(
+			TimeSpan.FromSeconds(totalSeconds),
+			(long)(limitSeconds * BytesPerSecond),
+			BytesPerSecond,
+			points);
+
+	private static double[] Ends(IReadOnlyList<AudioChunkRange> chunks) =>
+		chunks.Select(c => Math.Round(c.End.TotalSeconds, 6)).ToArray();
+
+	[Fact]
+	public void AudioInsideTheLimit_IsOneChunk()
+	{
+		var chunks = Plan(totalSeconds: 30, limitSeconds: 60);
+
+		var chunk = Assert.Single(chunks);
+		Assert.Equal(TimeSpan.Zero, chunk.Start);
+		Assert.Equal(TimeSpan.FromSeconds(30), chunk.End);
+	}
+
+	[Fact]
+	public void ZeroLengthAudio_PlansNothing()
+	{
+		Assert.Empty(AudioChunkPlanner.Plan(TimeSpan.Zero, 1000, BytesPerSecond, Array.Empty<SilenceRemovalPoint>()));
+	}
+
+	[Fact]
+	public void NoLimit_IsOneChunk()
+	{
+		var chunks = AudioChunkPlanner.Plan(TimeSpan.FromHours(3), maxChunkBytes: 0, BytesPerSecond, null);
+
+		Assert.Equal(TimeSpan.FromHours(3), Assert.Single(chunks).End);
+	}
+
+	[Fact]
+	public void WithoutRemovalPoints_CutsAtTheFurthestSafePosition()
+	{
+		var chunks = Plan(totalSeconds: 25, limitSeconds: 10);
+
+		Assert.Equal(new[] { 10d, 20d, 25d }, Ends(chunks));
+	}
+
+	[Fact]
+	public void RemovalPointInTheFinalFifth_BecomesTheCut()
+	{
+		// The window for a 10s candidate chunk is (8, 10).
+		var chunks = Plan(totalSeconds: 15, limitSeconds: 10, At(8.5, removedSeconds: 3));
+
+		Assert.Equal(new[] { 8.5, 15d }, Ends(chunks));
+	}
+
+	[Fact]
+	public void RemovalPointBeforeTheFinalFifth_IsIgnored()
+	{
+		var chunks = Plan(totalSeconds: 15, limitSeconds: 10, At(4, removedSeconds: 30));
+
+		Assert.Equal(new[] { 10d, 15d }, Ends(chunks));
+	}
+
+	[Fact]
+	public void LongestRemovedSilenceWins_NotTheNearestOrTheLatest()
+	{
+		var chunks = Plan(
+			totalSeconds: 15,
+			limitSeconds: 10,
+			At(8.2, removedSeconds: 1),
+			At(8.7, removedSeconds: 9),   // the longest pause in the window
+			At(9.6, removedSeconds: 2));
+
+		Assert.Equal(8.7, chunks[0].End.TotalSeconds, 6);
+	}
+
+	[Fact]
+	public void EquallyLongSilences_CutAtTheLaterOne()
+	{
+		// Same-sized pause either way, so take the one that carries more audio per chunk.
+		var chunks = Plan(
+			totalSeconds: 15,
+			limitSeconds: 10,
+			At(8.3, removedSeconds: 4),
+			At(9.4, removedSeconds: 4));
+
+		Assert.Equal(9.4, chunks[0].End.TotalSeconds, 6);
+	}
+
+	[Fact]
+	public void ZeroLengthRemoval_IsNotACandidate()
+	{
+		var chunks = Plan(totalSeconds: 15, limitSeconds: 10, At(8.5, removedSeconds: 0));
+
+		Assert.Equal(10d, chunks[0].End.TotalSeconds, 6);
+	}
+
+	[Fact]
+	public void EachChunkGetsItsOwnSearchWindow_MeasuredFromWhereItStarted()
+	{
+		// First cut lands early at 8.5, so the second candidate runs 8.5 -> 18.5 and its
+		// window is (16.5, 18.5). The point at 15.9 is inside the second *chunk* but
+		// before its window, so it must not be chosen.
+		var chunks = Plan(
+			totalSeconds: 30,
+			limitSeconds: 10,
+			At(8.5, removedSeconds: 5),
+			At(15.9, removedSeconds: 20),
+			At(17.2, removedSeconds: 2));
+
+		Assert.Equal(new[] { 8.5, 17.2, 27.2, 30d }, Ends(chunks));
+	}
+
+	[Fact]
+	public void ChunksAreContiguousAndCoverTheWholeRecording()
+	{
+		var points = new[] { At(9.1, 4), At(18.4, 6), At(26.9, 2), At(35.5, 8) };
+		var chunks = AudioChunkPlanner.Plan(TimeSpan.FromSeconds(47), 10_000, BytesPerSecond, points);
+
+		Assert.True(chunks.Count > 1, "A 47s recording at a 10s limit has to be split.");
+		Assert.Equal(TimeSpan.Zero, chunks[0].Start);
+		Assert.Equal(TimeSpan.FromSeconds(47), chunks[^1].End);
+
+		for (int i = 1; i < chunks.Count; i++)
+			Assert.Equal(chunks[i - 1].End, chunks[i].Start);
+
+		foreach (var chunk in chunks)
+			Assert.True(chunk.Duration > TimeSpan.Zero, "A planned chunk must carry audio.");
+	}
+
+	[Fact]
+	public void NoChunkExceedsTheLimit()
+	{
+		var points = new[] { At(9.5, 3), At(18.9, 7), At(27.5, 1) };
+		var chunks = AudioChunkPlanner.Plan(TimeSpan.FromSeconds(40), 10_000, BytesPerSecond, points);
+
+		foreach (var chunk in chunks)
+			Assert.True(chunk.Duration <= TimeSpan.FromSeconds(10),
+				$"Chunk {chunk.Start}-{chunk.End} is {chunk.Duration}, over the 10s the limit allows.");
+	}
+
+	[Fact]
+	public void AScrapOfAudioLeftOver_IsFoldedIntoTheChunkBeforeIt()
+	{
+		// 20.1s at a 10s limit would otherwise end with a 0.1s chunk: a whole request
+		// for a tenth of a second.
+		var chunks = Plan(totalSeconds: 20.1, limitSeconds: 10);
+
+		Assert.Equal(new[] { 10d, 20.1 }, Ends(chunks));
+	}
+
+	[Fact]
+	public void AnAbsurdlySmallLimit_StillTerminates()
+	{
+		// One byte a chunk cannot be honoured; the floor keeps this from planning
+		// millions of ranges rather than pretending the limit is achievable.
+		var chunks = AudioChunkPlanner.Plan(TimeSpan.FromSeconds(30), maxChunkBytes: 1, BytesPerSecond, null);
+
+		Assert.Equal(30, chunks.Count);
+		Assert.Equal(TimeSpan.FromSeconds(30), chunks[^1].End);
+	}
+}

--- a/Mutation.Tests/ChunkedTranscriberTests.cs
+++ b/Mutation.Tests/ChunkedTranscriberTests.cs
@@ -1,0 +1,250 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using CognitiveSupport;
+
+namespace Mutation.Tests;
+
+/// <summary>
+/// The split-and-upload flow: what gets sent, in what order, what comes back, and what
+/// is left on disk afterwards. The chunk writer is faked, so none of this needs a codec.
+/// </summary>
+public class ChunkedTranscriberTests : IDisposable
+{
+	private const long Limit = 1000;
+
+	private readonly string _workingDirectory = Directory.CreateTempSubdirectory("chunked-transcriber-tests").FullName;
+
+	public void Dispose()
+	{
+		try { Directory.Delete(_workingDirectory, recursive: true); } catch { }
+	}
+
+	private string WriteAudioFile(string name, int bytes)
+	{
+		string path = Path.Combine(_workingDirectory, name);
+		File.WriteAllBytes(path, new byte[bytes]);
+		return path;
+	}
+
+	private static Task<string> Transcribe(
+		ChunkedTranscriber transcriber,
+		ISpeechToTextService service,
+		string audioPath,
+		string workingRoot,
+		CancellationToken token = default) =>
+		transcriber.TranscribeAsync(service, "prompt", audioPath, Array.Empty<SilenceRemovalPoint>(), Limit, workingRoot, timeoutSeconds: 30, token);
+
+	[Fact]
+	public async Task FileInsideTheLimit_IsSentWhole_WithNoChunkingAtAll()
+	{
+		string audio = WriteAudioFile("small.ogg", (int)Limit);
+		var writer = new FakeChunkWriter();
+		var service = new RecordingService("all of it");
+
+		string text = await Transcribe(new ChunkedTranscriber(writer), service, audio, _workingDirectory);
+
+		Assert.Equal("all of it", text);
+		Assert.Equal(new[] { audio }, service.Uploaded);
+		Assert.False(writer.WasCalled);
+	}
+
+	[Fact]
+	public async Task LimitOfZero_NeverSplits_HoweverBigTheFileIs()
+	{
+		string audio = WriteAudioFile("huge.ogg", 8000);
+		var writer = new FakeChunkWriter();
+		var service = new RecordingService("all of it");
+
+		string text = await new ChunkedTranscriber(writer).TranscribeAsync(
+			service, "prompt", audio, null, maxUploadBytes: 0, _workingDirectory, timeoutSeconds: 30, CancellationToken.None);
+
+		Assert.Equal("all of it", text);
+		Assert.Equal(new[] { audio }, service.Uploaded);
+		Assert.False(writer.WasCalled);
+	}
+
+	[Fact]
+	public async Task OversizedFile_IsUploadedChunkByChunk_AndTheTranscriptsJoinInOrder()
+	{
+		string audio = WriteAudioFile("big.ogg", 3000);
+		var writer = new FakeChunkWriter(chunkSizes: new[] { 900, 900, 400 });
+		var service = new RecordingService("first", "second", "third");
+
+		string text = await Transcribe(new ChunkedTranscriber(writer), service, audio, _workingDirectory);
+
+		Assert.Equal("first second third", text);
+		Assert.Equal(3, service.Uploaded.Count);
+		Assert.Equal(writer.WrittenPaths, service.Uploaded);
+	}
+
+	[Fact]
+	public async Task BlankTranscripts_DoNotLeaveGapsInTheJoinedText()
+	{
+		string audio = WriteAudioFile("big.ogg", 3000);
+		var writer = new FakeChunkWriter(chunkSizes: new[] { 900, 900, 400 });
+		var service = new RecordingService("first", "   ", " third ");
+
+		string text = await Transcribe(new ChunkedTranscriber(writer), service, audio, _workingDirectory);
+
+		Assert.Equal("first third", text);
+	}
+
+	[Fact]
+	public async Task TheChunkFolderIsGoneWhenTheUploadSucceeds()
+	{
+		string audio = WriteAudioFile("big.ogg", 3000);
+		var writer = new FakeChunkWriter(chunkSizes: new[] { 900, 900 });
+
+		await Transcribe(new ChunkedTranscriber(writer), new RecordingService("a", "b"), audio, _workingDirectory);
+
+		Assert.False(Directory.Exists(writer.OutputDirectory!), "The chunk folder should not outlive the upload.");
+	}
+
+	[Fact]
+	public async Task TheChunkFolderIsGoneWhenAnUploadFails()
+	{
+		string audio = WriteAudioFile("big.ogg", 3000);
+		var writer = new FakeChunkWriter(chunkSizes: new[] { 900, 900 });
+		var service = new RecordingService("a") { ThrowOnCall = 2 };
+
+		await Assert.ThrowsAsync<HttpRequestFailure>(
+			() => Transcribe(new ChunkedTranscriber(writer), service, audio, _workingDirectory));
+
+		Assert.False(Directory.Exists(writer.OutputDirectory!), "A failed upload must not leave chunks behind.");
+	}
+
+	[Fact]
+	public async Task CancellingPartWayThrough_StopsUploadingAndCleansUp()
+	{
+		string audio = WriteAudioFile("big.ogg", 3000);
+		var writer = new FakeChunkWriter(chunkSizes: new[] { 900, 900, 900 });
+		using var cts = new CancellationTokenSource();
+		var service = new RecordingService("a", "b", "c") { CancelAfterCall = 1, Canceller = cts };
+
+		await Assert.ThrowsAnyAsync<OperationCanceledException>(
+			() => Transcribe(new ChunkedTranscriber(writer), service, audio, _workingDirectory, cts.Token));
+
+		Assert.Single(service.Uploaded);
+		Assert.False(Directory.Exists(writer.OutputDirectory!));
+	}
+
+	[Fact]
+	public async Task AChunkOverTheLimit_IsRefusedBeforeAnythingIsUploaded()
+	{
+		string audio = WriteAudioFile("big.ogg", 3000);
+		var writer = new FakeChunkWriter(chunkSizes: new[] { 900, (int)Limit + 1 });
+		var service = new RecordingService("a", "b");
+
+		var error = await Assert.ThrowsAsync<InvalidOperationException>(
+			() => Transcribe(new ChunkedTranscriber(writer), service, audio, _workingDirectory));
+
+		Assert.Contains("upload limit", error.Message, StringComparison.OrdinalIgnoreCase);
+		Assert.Empty(service.Uploaded);
+	}
+
+	[Fact]
+	public async Task AnOversizedFileThatYieldsNoChunks_SaysSoRatherThanReturningNothing()
+	{
+		string audio = WriteAudioFile("big.ogg", 3000);
+		var writer = new FakeChunkWriter(chunkSizes: Array.Empty<int>());
+		var service = new RecordingService();
+
+		await Assert.ThrowsAsync<InvalidOperationException>(
+			() => Transcribe(new ChunkedTranscriber(writer), service, audio, _workingDirectory));
+
+		Assert.Empty(service.Uploaded);
+	}
+
+	[Fact]
+	public async Task TheRemovalPointsForTheFileAreHandedToTheWriter()
+	{
+		string audio = WriteAudioFile("big.ogg", 3000);
+		var writer = new FakeChunkWriter(chunkSizes: new[] { 900 });
+		var points = new[] { new SilenceRemovalPoint(TimeSpan.FromSeconds(4), TimeSpan.FromSeconds(2)) };
+
+		await new ChunkedTranscriber(writer).TranscribeAsync(
+			new RecordingService("a"), "prompt", audio, points, Limit, _workingDirectory, 30, CancellationToken.None);
+
+		Assert.Equal(points, writer.ReceivedRemovalPoints);
+		Assert.Equal(Limit, writer.ReceivedMaxChunkBytes);
+	}
+
+	private sealed class FakeChunkWriter : IAudioChunkWriter
+	{
+		private readonly int[] _chunkSizes;
+
+		public FakeChunkWriter(int[]? chunkSizes = null) => _chunkSizes = chunkSizes ?? Array.Empty<int>();
+
+		public bool WasCalled { get; private set; }
+		public string? OutputDirectory { get; private set; }
+		public long ReceivedMaxChunkBytes { get; private set; }
+		public IReadOnlyList<SilenceRemovalPoint>? ReceivedRemovalPoints { get; private set; }
+		public List<string> WrittenPaths { get; } = new();
+
+		public IReadOnlyList<string> WriteChunks(
+			string audioFilePath,
+			IReadOnlyList<SilenceRemovalPoint>? removalPoints,
+			long maxChunkBytes,
+			string outputDirectory,
+			CancellationToken cancellationToken)
+		{
+			WasCalled = true;
+			OutputDirectory = outputDirectory;
+			ReceivedMaxChunkBytes = maxChunkBytes;
+			ReceivedRemovalPoints = removalPoints;
+
+			Directory.CreateDirectory(outputDirectory);
+			for (int i = 0; i < _chunkSizes.Length; i++)
+			{
+				string path = Path.Combine(outputDirectory, $"chunk-{i + 1:D3}.ogg");
+				File.WriteAllBytes(path, new byte[_chunkSizes[i]]);
+				WrittenPaths.Add(path);
+			}
+
+			return WrittenPaths.ToArray();
+		}
+	}
+
+	private sealed class RecordingService : ISpeechToTextService
+	{
+		private readonly string[] _responses;
+		private int _calls;
+
+		public RecordingService(params string[] responses) => _responses = responses;
+
+		public string ServiceName { get; init; } = "fake";
+		public List<string> Uploaded { get; } = new();
+
+		/// <summary>1-based call number that should throw instead of answering.</summary>
+		public int ThrowOnCall { get; init; }
+
+		/// <summary>1-based call number after which <see cref="Canceller"/> is tripped.</summary>
+		public int CancelAfterCall { get; init; }
+		public CancellationTokenSource? Canceller { get; init; }
+
+		public Task<string> ConvertAudioToText(string speechToTextPrompt, string audioffilePath, CancellationToken overallCancellationToken, int? timeoutSeconds = null)
+		{
+			overallCancellationToken.ThrowIfCancellationRequested();
+
+			_calls++;
+			if (ThrowOnCall == _calls)
+				throw new HttpRequestFailure();
+
+			Uploaded.Add(audioffilePath);
+
+			if (CancelAfterCall == _calls)
+				Canceller?.Cancel();
+
+			return Task.FromResult(_calls <= _responses.Length ? _responses[_calls - 1] : string.Empty);
+		}
+	}
+
+	private sealed class HttpRequestFailure : Exception
+	{
+		public HttpRequestFailure() : base("the service said no") { }
+	}
+}

--- a/Mutation.Tests/EndOfRecordingNotificationTests.cs
+++ b/Mutation.Tests/EndOfRecordingNotificationTests.cs
@@ -161,6 +161,7 @@ public class EndOfRecordingNotificationTests : IDisposable
 		public RecordingAudioRecorder(List<string> events) => _events = events;
 
 		public double? TrimmedSpeechSeconds => null;
+		public IReadOnlyList<SilenceRemovalPoint> RemovedSilences => Array.Empty<SilenceRemovalPoint>();
 		public Exception? CaptureException => null;
 
 		public void StartRecording(int captureDeviceIndex, string outputFile, SilenceTrimmerOptions? silenceOptions = null)
@@ -194,6 +195,7 @@ public class EndOfRecordingNotificationTests : IDisposable
 		public Action? OnStop { get; init; }
 
 		public double? TrimmedSpeechSeconds => TrimmedSeconds;
+		public IReadOnlyList<SilenceRemovalPoint> RemovedSilences => Array.Empty<SilenceRemovalPoint>();
 		public Exception? CaptureException => CaptureError;
 
 		public void StartRecording(int captureDeviceIndex, string outputFile, SilenceTrimmerOptions? silenceOptions = null)

--- a/Mutation.Tests/OggAudioChunkWriterTests.cs
+++ b/Mutation.Tests/OggAudioChunkWriterTests.cs
@@ -186,4 +186,28 @@ public class OggAudioChunkWriterTests : IDisposable
 			new OggAudioChunkWriter().WriteChunks(
 				source, Array.Empty<SilenceRemovalPoint>(), LimitForSeconds(2), OutputDirectory("cancelled-out"), cts.Token));
 	}
+
+	[Fact]
+	public void MeasureDuration_GivesUpWhenCancelled()
+	{
+		// Measuring decodes the whole file, which on the multi-hour recordings this class
+		// exists for is minutes of work with the recorder lock held. A cancel has to land
+		// here, not only once the chunks start being written.
+		string source = WriteFixture("cancelled-measure.ogg");
+		using var cts = new CancellationTokenSource();
+		cts.Cancel();
+
+		Assert.ThrowsAny<OperationCanceledException>(() => OggAudioChunkWriter.MeasureDuration(source, cts.Token));
+	}
+
+	[Fact]
+	public void ConvertingANonOggSource_GivesUpWhenCancelled()
+	{
+		string source = WriteFixture("cancelled-convert.ogg");
+		using var cts = new CancellationTokenSource();
+		cts.Cancel();
+
+		Assert.ThrowsAny<OperationCanceledException>(() =>
+			AudioFileConverter.ConvertToOgg(source, Path.Combine(OutputDirectory("cancelled-convert-out"), "out.ogg"), null, cts.Token));
+	}
 }

--- a/Mutation.Tests/OggAudioChunkWriterTests.cs
+++ b/Mutation.Tests/OggAudioChunkWriterTests.cs
@@ -1,0 +1,189 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using CognitiveSupport;
+using Concentus.Enums;
+using Concentus.Oggfile;
+using Concentus.Structs;
+
+namespace Mutation.Tests;
+
+/// <summary>
+/// Splitting a real Ogg/Opus recording into upload-sized files. Both ends of the round
+/// trip are pure Concentus, so nothing here needs codec support from the host OS.
+/// </summary>
+public class OggAudioChunkWriterTests : IDisposable
+{
+	private const int SampleRate = 48000;
+	private const int FrameSize = 960; // 20ms
+	private const int FixtureSeconds = 6;
+
+	// Matches the writer's own planning estimate (24 kbps plus container overhead), so a
+	// limit here can be expressed as "about this many seconds of audio".
+	private const double PlanningBytesPerSecond = 24000 / 8.0 * 1.15;
+
+	private readonly string _workingDirectory = Directory.CreateTempSubdirectory("ogg-chunk-tests").FullName;
+
+	public void Dispose()
+	{
+		try { Directory.Delete(_workingDirectory, recursive: true); } catch { }
+	}
+
+	private static long LimitForSeconds(double seconds) => (long)(seconds * PlanningBytesPerSecond);
+
+	private string OutputDirectory(string name)
+	{
+		string path = Path.Combine(_workingDirectory, name);
+		Directory.CreateDirectory(path);
+		return path;
+	}
+
+	/// <summary>Six seconds of 440Hz tone as a single Ogg/Opus file.</summary>
+	private string WriteFixture(string fileName)
+	{
+		string path = Path.Combine(_workingDirectory, fileName);
+
+		using var outStream = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None);
+#pragma warning disable CS0618 // Concentus.OggFile 1.0.6 requires the concrete OpusEncoder type.
+		var encoder = new OpusEncoder(SampleRate, 1, OpusApplication.OPUS_APPLICATION_AUDIO)
+		{
+			Bitrate = 32000,
+			UseDTX = false
+		};
+#pragma warning restore CS0618
+		var oggStream = new OpusOggWriteStream(encoder, outStream, new OpusTags());
+
+		var frame = new short[FrameSize];
+		for (int sample = 0; sample < FrameSize; sample++)
+			frame[sample] = (short)(12000 * Math.Sin(2 * Math.PI * 440 * sample / SampleRate));
+
+		for (int i = 0; i < FixtureSeconds * SampleRate / FrameSize; i++)
+			oggStream.WriteSamples(frame, 0, frame.Length);
+
+		oggStream.Finish();
+		return path;
+	}
+
+	private static double DurationSeconds(string oggPath) =>
+		OggAudioChunkWriter.MeasureDuration(oggPath).TotalSeconds;
+
+	private IReadOnlyList<string> Split(string source, long maxChunkBytes, string outputName, params SilenceRemovalPoint[] points) =>
+		new OggAudioChunkWriter().WriteChunks(source, points, maxChunkBytes, OutputDirectory(outputName), CancellationToken.None);
+
+	[Fact]
+	public void MeasureDuration_ReadsTheLengthOfTheRecording()
+	{
+		Assert.Equal(FixtureSeconds, DurationSeconds(WriteFixture("measure.ogg")), 1);
+	}
+
+	[Fact]
+	public void AudioInsideTheLimit_IsWrittenAsOneChunk()
+	{
+		string source = WriteFixture("small.ogg");
+
+		var chunks = Split(source, LimitForSeconds(60), "small-out");
+
+		string only = Assert.Single(chunks);
+		Assert.Equal(FixtureSeconds, DurationSeconds(only), 1);
+	}
+
+	[Fact]
+	public void OversizedAudio_IsSplitAtThePlannedBoundaries()
+	{
+		string source = WriteFixture("split.ogg");
+
+		var chunks = Split(source, LimitForSeconds(3), "split-out");
+
+		Assert.Equal(2, chunks.Count);
+		Assert.Equal(3, DurationSeconds(chunks[0]), 1);
+		Assert.Equal(3, DurationSeconds(chunks[1]), 1);
+	}
+
+	[Fact]
+	public void ARemovedSilenceInTheFinalFifth_MovesTheCutBackToThePause()
+	{
+		string source = WriteFixture("silence-cut.ogg");
+
+		// The candidate chunk ends at ~4s, so its search window is ~3.2s to 4s.
+		var chunks = Split(
+			source,
+			LimitForSeconds(4),
+			"silence-cut-out",
+			new SilenceRemovalPoint(TimeSpan.FromSeconds(3.5), TimeSpan.FromSeconds(4)));
+
+		Assert.Equal(2, chunks.Count);
+		Assert.Equal(3.5, DurationSeconds(chunks[0]), 1);
+		Assert.Equal(2.5, DurationSeconds(chunks[1]), 1);
+	}
+
+	[Fact]
+	public void EveryChunkIsAPlayableOggOpusFile()
+	{
+		string source = WriteFixture("playable.ogg");
+
+		var chunks = Split(source, LimitForSeconds(2), "playable-out");
+
+		Assert.True(chunks.Count > 1, "A 6s recording at a 2s limit has to be split.");
+		foreach (string chunk in chunks)
+		{
+			Assert.True(OggOpusPcmDecoder.IsOggOpus(chunk), $"{Path.GetFileName(chunk)} is not a readable Ogg/Opus file.");
+			Assert.True(DurationSeconds(chunk) > 0, $"{Path.GetFileName(chunk)} decoded to no audio.");
+		}
+	}
+
+	[Theory]
+	[InlineData(1.0)]
+	[InlineData(2.5)]
+	[InlineData(4.0)]
+	public void NoChunkEverExceedsTheLimit(double limitSeconds)
+	{
+		string source = WriteFixture($"limit-{limitSeconds}.ogg");
+		long limit = LimitForSeconds(limitSeconds);
+
+		var chunks = Split(source, limit, $"limit-{limitSeconds}-out");
+
+		foreach (string chunk in chunks)
+		{
+			long length = new FileInfo(chunk).Length;
+			Assert.True(length <= limit, $"{Path.GetFileName(chunk)} is {length} bytes, over the {limit} byte limit.");
+		}
+	}
+
+	[Fact]
+	public void TheChunksTogetherAreTheWholeRecording()
+	{
+		string source = WriteFixture("whole.ogg");
+
+		var chunks = Split(source, LimitForSeconds(2.5), "whole-out");
+
+		// Each chunk closes on a whole Opus frame, so a few milliseconds of padding is
+		// added per cut. Nothing may go missing; a little silence at a seam is fine.
+		double total = chunks.Sum(DurationSeconds);
+		Assert.InRange(total, FixtureSeconds, FixtureSeconds + 0.25);
+	}
+
+	[Fact]
+	public void ChunksAreNamedInPlaybackOrder()
+	{
+		string source = WriteFixture("ordered.ogg");
+
+		var chunks = Split(source, LimitForSeconds(2), "ordered-out");
+
+		Assert.Equal(chunks.OrderBy(p => p, StringComparer.Ordinal).ToArray(), chunks.ToArray());
+		Assert.Equal("chunk-001.ogg", Path.GetFileName(chunks[0]));
+	}
+
+	[Fact]
+	public void CancellationStopsTheSplitPartWayThrough()
+	{
+		string source = WriteFixture("cancelled.ogg");
+		using var cts = new CancellationTokenSource();
+		cts.Cancel();
+
+		Assert.ThrowsAny<OperationCanceledException>(() =>
+			new OggAudioChunkWriter().WriteChunks(
+				source, Array.Empty<SilenceRemovalPoint>(), LimitForSeconds(2), OutputDirectory("cancelled-out"), cts.Token));
+	}
+}

--- a/Mutation.Tests/SettingsDefaultsParityTests.cs
+++ b/Mutation.Tests/SettingsDefaultsParityTests.cs
@@ -68,6 +68,7 @@ public class SettingsDefaultsParityTests : IDisposable
 		Assert.Equal(SettingsDefaults.Speech.SilenceThresholdDbFs, stt.SilenceThresholdDbFs);
 		Assert.Equal(SettingsDefaults.Speech.MinSilenceSeconds, stt.MinSilenceSeconds);
 		Assert.Equal(SettingsDefaults.Speech.SilenceGuardMilliseconds, stt.SilenceGuardMilliseconds);
+		Assert.Equal(SettingsDefaults.Speech.MaxTranscriptionUploadBytes, stt.MaxTranscriptionUploadBytes);
 
 		Assert.NotNull(stt.Services);
 		Assert.NotEmpty(stt.Services!);

--- a/Mutation.Tests/SilenceTrimmerTests.cs
+++ b/Mutation.Tests/SilenceTrimmerTests.cs
@@ -103,4 +103,98 @@ public class SilenceTrimmerTests
 		Assert.Equal(12, emitted.Count);
 		Assert.Equal(12, trimmer.SpeechFrameCount);
 	}
+
+	// One frame is 20ms, so a frame count reads straight off as milliseconds.
+	private static TimeSpan Frames(int count) => TimeSpan.FromMilliseconds(count * 20);
+
+	[Fact]
+	public void ShortGap_RecordsNoRemoval()
+	{
+		var trimmer = NewTrimmer();
+		var frames = new List<short[]>();
+		frames.AddRange(Repeat(Loud(), 5));
+		frames.AddRange(Repeat(Silent(), 6)); // <= threshold, nothing is dropped
+		frames.AddRange(Repeat(Loud(), 5));
+
+		Run(trimmer, frames);
+
+		Assert.Empty(trimmer.RemovedSilences);
+	}
+
+	[Fact]
+	public void InteriorGap_RecordsWhereItWasCutAndHowMuchWentMissing()
+	{
+		var trimmer = NewTrimmer();
+		var frames = new List<short[]>();
+		frames.AddRange(Repeat(Loud(), 5));
+		frames.AddRange(Repeat(Silent(), 30)); // 10 frames survive, 20 are dropped
+		frames.AddRange(Repeat(Loud(), 5));
+
+		Run(trimmer, frames);
+
+		var removal = Assert.Single(trimmer.RemovedSilences);
+		// 5 speech frames, then the 8 frames of hang-time kept before the cut.
+		Assert.Equal(Frames(13), removal.Position);
+		Assert.Equal(Frames(20), removal.RemovedDuration);
+	}
+
+	[Fact]
+	public void LaterRemovals_ArePositionedOnTheShortenedOutput_NotTheOriginal()
+	{
+		var trimmer = NewTrimmer();
+		var frames = new List<short[]>();
+		frames.AddRange(Repeat(Loud(), 5));
+		frames.AddRange(Repeat(Silent(), 30)); // 20 dropped
+		frames.AddRange(Repeat(Loud(), 5));
+		frames.AddRange(Repeat(Silent(), 40)); // 30 dropped
+		frames.AddRange(Repeat(Loud(), 5));
+
+		var emitted = Run(trimmer, frames);
+
+		Assert.Equal(2, trimmer.RemovedSilences.Count);
+
+		// In the source the second gap begins at frame 40. Twenty frames were already
+		// removed ahead of it, so on the trimmed timeline the cut sits at frame 28.
+		Assert.Equal(Frames(13), trimmer.RemovedSilences[0].Position);
+		Assert.Equal(Frames(28), trimmer.RemovedSilences[1].Position);
+		Assert.Equal(Frames(30), trimmer.RemovedSilences[1].RemovedDuration);
+
+		// Every recorded position has to be somewhere inside the audio actually written.
+		foreach (var removal in trimmer.RemovedSilences)
+			Assert.InRange(removal.Position, TimeSpan.Zero, Frames(emitted.Count));
+	}
+
+	[Fact]
+	public void LeadingAndTrailingSilence_AreRecordedToo()
+	{
+		var trimmer = NewTrimmer();
+		var frames = new List<short[]>();
+		frames.AddRange(Repeat(Silent(), 20));
+		frames.AddRange(Repeat(Loud(), 5));
+		frames.AddRange(Repeat(Silent(), 20));
+
+		Run(trimmer, frames);
+
+		Assert.Equal(2, trimmer.RemovedSilences.Count);
+
+		// Leading silence is cut before anything has been written.
+		Assert.Equal(TimeSpan.Zero, trimmer.RemovedSilences[0].Position);
+		Assert.Equal(Frames(18), trimmer.RemovedSilences[0].RemovedDuration);
+
+		// Trailing: 2 pre-roll + 5 speech + 2 hang-time have been written by then.
+		Assert.Equal(Frames(9), trimmer.RemovedSilences[1].Position);
+		Assert.Equal(Frames(18), trimmer.RemovedSilences[1].RemovedDuration);
+	}
+
+	[Fact]
+	public void AllSilence_IsRecordedAsOneRemovalAtTheStart()
+	{
+		var trimmer = NewTrimmer();
+		Run(trimmer, Repeat(Silent(), 15));
+
+		// Nothing was written, so the only position the cut can sit at is the start.
+		var removal = Assert.Single(trimmer.RemovedSilences);
+		Assert.Equal(TimeSpan.Zero, removal.Position);
+		Assert.Equal(Frames(15), removal.RemovedDuration);
+	}
 }

--- a/Mutation.Tests/SpeechToTextManagerChunkingTests.cs
+++ b/Mutation.Tests/SpeechToTextManagerChunkingTests.cs
@@ -1,0 +1,203 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using CognitiveSupport;
+using Mutation.Ui;
+
+namespace Mutation.Tests;
+
+/// <summary>
+/// The wiring between the manager and the chunker: that the configured upload limit is
+/// the one actually applied, and that the pauses stripped out of a recording reach the
+/// code deciding where to cut it. The chunk writer is faked, so no codec is involved.
+/// </summary>
+public class SpeechToTextManagerChunkingTests : IDisposable
+{
+	// The domain clamps anything under a megabyte up to it, so that is the smallest limit
+	// a test can actually exercise.
+	private const long Limit = SpeechToTextSettings.MinTranscriptionUploadBytes;
+
+	private readonly string _tempDirectory;
+	private readonly Settings _settings;
+
+	public SpeechToTextManagerChunkingTests()
+	{
+		_tempDirectory = Path.Combine(Path.GetTempPath(), "MutationTests_" + Guid.NewGuid().ToString("N"));
+		Directory.CreateDirectory(_tempDirectory);
+		_settings = new Settings
+		{
+			SpeechToTextSettings = new SpeechToTextSettings
+			{
+				TempDirectory = _tempDirectory,
+				MaxTranscriptionUploadBytes = Limit,
+			}
+		};
+	}
+
+	public void Dispose()
+	{
+		try { Directory.Delete(_tempDirectory, recursive: true); } catch { }
+	}
+
+	private SpeechSession WriteSession(string fileName, int bytes)
+	{
+		string directory = Path.Combine(_tempDirectory, Constants.SessionsDirectoryName);
+		Directory.CreateDirectory(directory);
+		string path = Path.Combine(directory, fileName);
+		File.WriteAllBytes(path, new byte[bytes]);
+		return new SpeechSession(path, new DateTime(2024, 1, 1));
+	}
+
+	private static SpeechToTextManager NewManager(Settings settings, IAudioChunkWriter writer, Func<IAudioRecorder>? recorderFactory = null) =>
+		new(settings, recorderFactory ?? (() => new SilentRecorder()), new ChunkedTranscriber(writer));
+
+	[Fact]
+	public async Task ASessionOverTheConfiguredLimit_IsSplitBeforeItIsSent()
+	{
+		var session = WriteSession("session_2024-01-01_00-00-00.ogg", (int)Limit + 1);
+		var writer = new FakeChunkWriter(chunkCount: 2);
+		var service = new StubService("one", "two");
+
+		using var manager = NewManager(_settings, writer);
+		string text = await manager.TranscribeExistingRecordingAsync(service, session, "prompt", CancellationToken.None);
+
+		Assert.Equal("one two", text);
+		Assert.Equal(Limit, writer.ReceivedMaxChunkBytes);
+		Assert.Equal(2, service.Uploaded.Count);
+	}
+
+	[Fact]
+	public async Task ASessionInsideTheConfiguredLimit_IsSentWhole()
+	{
+		var session = WriteSession("session_2024-01-01_00-00-00.ogg", (int)Limit);
+		var writer = new FakeChunkWriter(chunkCount: 2);
+		var service = new StubService("whole thing");
+
+		using var manager = NewManager(_settings, writer);
+		string text = await manager.TranscribeExistingRecordingAsync(service, session, "prompt", CancellationToken.None);
+
+		Assert.Equal("whole thing", text);
+		Assert.False(writer.WasCalled);
+		Assert.Equal(new[] { session.FilePath }, service.Uploaded);
+	}
+
+	[Fact]
+	public async Task AnOutOfRangeLimitInTheSettingsFile_IsClampedRatherThanObeyed()
+	{
+		// 12 bytes would make every chunk unsendable; the domain clamp raises it to 1 MB,
+		// which this session is comfortably inside, so it goes as one request.
+		_settings.SpeechToTextSettings!.MaxTranscriptionUploadBytes = 12;
+		var session = WriteSession("session_2024-01-01_00-00-00.ogg", 4096);
+		var writer = new FakeChunkWriter(chunkCount: 2);
+		var service = new StubService("whole thing");
+
+		using var manager = NewManager(_settings, writer);
+		await manager.TranscribeExistingRecordingAsync(service, session, "prompt", CancellationToken.None);
+
+		Assert.False(writer.WasCalled);
+	}
+
+	[Fact]
+	public async Task ThePausesStrippedOutOfARecording_ReachTheCodeThatChoosesTheCuts()
+	{
+		var removals = new[]
+		{
+			new SilenceRemovalPoint(TimeSpan.FromSeconds(12), TimeSpan.FromSeconds(4)),
+			new SilenceRemovalPoint(TimeSpan.FromSeconds(31), TimeSpan.FromSeconds(9)),
+		};
+		var writer = new FakeChunkWriter(chunkCount: 2);
+
+		using var manager = NewManager(_settings, writer, () => new SilentRecorder(removals, oversizedBytes: (int)Limit + 1));
+		await manager.StartRecordingAsync(0);
+
+		await manager.StopRecordingAndTranscribeAsync(
+			new StubService("one", "two"), "prompt", CancellationToken.None, onRecordingStopped: () => { });
+
+		Assert.Equal(removals, writer.ReceivedRemovalPoints);
+	}
+
+	private sealed class FakeChunkWriter : IAudioChunkWriter
+	{
+		private readonly int _chunkCount;
+
+		public FakeChunkWriter(int chunkCount) => _chunkCount = chunkCount;
+
+		public bool WasCalled { get; private set; }
+		public long ReceivedMaxChunkBytes { get; private set; }
+		public IReadOnlyList<SilenceRemovalPoint>? ReceivedRemovalPoints { get; private set; }
+
+		public IReadOnlyList<string> WriteChunks(
+			string audioFilePath,
+			IReadOnlyList<SilenceRemovalPoint>? removalPoints,
+			long maxChunkBytes,
+			string outputDirectory,
+			CancellationToken cancellationToken)
+		{
+			WasCalled = true;
+			ReceivedMaxChunkBytes = maxChunkBytes;
+			ReceivedRemovalPoints = removalPoints;
+
+			Directory.CreateDirectory(outputDirectory);
+			var paths = new List<string>();
+			for (int i = 0; i < _chunkCount; i++)
+			{
+				string path = Path.Combine(outputDirectory, $"chunk-{i + 1:D3}.ogg");
+				File.WriteAllBytes(path, new byte[8]);
+				paths.Add(path);
+			}
+
+			return paths;
+		}
+	}
+
+	// Writes nothing while "recording"; on stop it fills the session file so the manager
+	// sees a file of the size the test wants.
+	private sealed class SilentRecorder : IAudioRecorder
+	{
+		private readonly int _oversizedBytes;
+		private string? _outputFile;
+
+		public SilentRecorder() : this(Array.Empty<SilenceRemovalPoint>(), oversizedBytes: 0) { }
+
+		public SilentRecorder(IReadOnlyList<SilenceRemovalPoint> removedSilences, int oversizedBytes)
+		{
+			RemovedSilences = removedSilences;
+			_oversizedBytes = oversizedBytes;
+		}
+
+		public double? TrimmedSpeechSeconds => null;
+		public Exception? CaptureException => null;
+		public IReadOnlyList<SilenceRemovalPoint> RemovedSilences { get; }
+
+		public void StartRecording(int captureDeviceIndex, string outputFile, SilenceTrimmerOptions? silenceOptions = null) =>
+			_outputFile = outputFile;
+
+		public void StopRecording()
+		{
+			if (_oversizedBytes > 0 && _outputFile is not null)
+				File.WriteAllBytes(_outputFile, new byte[_oversizedBytes]);
+		}
+
+		public void Dispose() { }
+	}
+
+	private sealed class StubService : ISpeechToTextService
+	{
+		private readonly string[] _responses;
+		private int _calls;
+
+		public StubService(params string[] responses) => _responses = responses;
+
+		public string ServiceName { get; init; } = "fake";
+		public List<string> Uploaded { get; } = new();
+
+		public Task<string> ConvertAudioToText(string speechToTextPrompt, string audioffilePath, CancellationToken overallCancellationToken, int? timeoutSeconds = null)
+		{
+			Uploaded.Add(audioffilePath);
+			_calls++;
+			return Task.FromResult(_calls <= _responses.Length ? _responses[_calls - 1] : string.Empty);
+		}
+	}
+}

--- a/Mutation.Tests/SpeechToTextManagerStartGuardTests.cs
+++ b/Mutation.Tests/SpeechToTextManagerStartGuardTests.cs
@@ -120,6 +120,7 @@ public class SpeechToTextManagerStartGuardTests : IDisposable
 		public bool Disposed { get; private set; }
 
 		public double? TrimmedSpeechSeconds => null;
+		public IReadOnlyList<SilenceRemovalPoint> RemovedSilences => Array.Empty<SilenceRemovalPoint>();
 		public Exception? CaptureException => null;
 
 		public void StartRecording(int captureDeviceIndex, string outputFile, SilenceTrimmerOptions? silenceOptions = null)

--- a/Mutation.Tests/TranscriptionCancellationTests.cs
+++ b/Mutation.Tests/TranscriptionCancellationTests.cs
@@ -148,6 +148,7 @@ public class TranscriptionCancellationTests : IDisposable
 	private sealed class NoopAudioRecorder : IAudioRecorder
 	{
 		public double? TrimmedSpeechSeconds => null;
+		public IReadOnlyList<SilenceRemovalPoint> RemovedSilences => Array.Empty<SilenceRemovalPoint>();
 		public Exception? CaptureException => null;
 
 		public void StartRecording(int captureDeviceIndex, string outputFile, SilenceTrimmerOptions? silenceOptions = null)

--- a/Mutation.Ui/Core/SpeechToTextManager.cs
+++ b/Mutation.Ui/Core/SpeechToTextManager.cs
@@ -420,7 +420,10 @@ public class SpeechToTextManager : IDisposable
 		if (AudioFileConverter.IsVideoFile(sourcePath) || silenceOptions is not null)
 		{
 			string destinationPath = await CreateSessionFileAsync(".ogg").ConfigureAwait(false);
-			var removedSilences = await Task.Run(() => AudioFileConverter.ConvertToOgg(sourcePath, destinationPath, silenceOptions), token).ConfigureAwait(false);
+			// The token goes into the conversion itself, not just Task.Run: a long video
+			// takes minutes to decode, and cancelling only the scheduling would leave the
+			// user watching a job they already gave up on.
+			var removedSilences = await Task.Run(() => AudioFileConverter.ConvertToOgg(sourcePath, destinationPath, silenceOptions, token), token).ConfigureAwait(false);
 
 			// The caller transcribes this session next, so the pauses just stripped out of
 			// it are still the right ones to cut at if it turns out to be too big to send.

--- a/Mutation.Ui/Core/SpeechToTextManager.cs
+++ b/Mutation.Ui/Core/SpeechToTextManager.cs
@@ -23,6 +23,8 @@ public class SpeechToTextManager : IDisposable
 	private readonly Settings _settings;
 	private readonly SpeechToTextState _state;
 	private readonly Func<IAudioRecorder> _recorderFactory;
+	private readonly ChunkedTranscriber _transcriber;
+	private readonly SilenceRemovalLog _silenceRemovalLog = new();
 	private IAudioRecorder? _audioRecorder;
 	private readonly object _sessionLock = new();
 	private SpeechSession? _currentRecordingSession;
@@ -35,9 +37,17 @@ public class SpeechToTextManager : IDisposable
 	// Test seam: injects the recorder so a start can be made to fail on demand
 	// without real NAudio hardware.
 	internal SpeechToTextManager(Settings settings, Func<IAudioRecorder> recorderFactory)
+		: this(settings, recorderFactory, new ChunkedTranscriber())
+	{
+	}
+
+	// Test seam: injects the transcriber so the split-and-upload path can be driven
+	// without a codec or a network.
+	internal SpeechToTextManager(Settings settings, Func<IAudioRecorder> recorderFactory, ChunkedTranscriber transcriber)
 	{
 		_settings = settings ?? throw new ArgumentNullException(nameof(settings));
 		_recorderFactory = recorderFactory ?? throw new ArgumentNullException(nameof(recorderFactory));
+		_transcriber = transcriber ?? throw new ArgumentNullException(nameof(transcriber));
 		_state = new SpeechToTextState(() => _audioRecorder);
 	}
 
@@ -71,6 +81,31 @@ public class SpeechToTextManager : IDisposable
 			stt.MinSilenceSeconds,
 			stt.SilenceGuardMilliseconds);
 	}
+
+	// Read at transcription time (and clamped defensively) so a changed setting takes
+	// effect without an app restart, and a hand-edited out-of-range value cannot ask for
+	// a chunk size the service would reject.
+	private long MaxUploadBytes => SpeechToTextSettings.ClampTranscriptionUploadBytes(
+		_settings.SpeechToTextSettings?.MaxTranscriptionUploadBytes
+		?? SpeechToTextSettings.DefaultMaxTranscriptionUploadBytes);
+
+	private string ChunkWorkingDirectory => _settings.SpeechToTextSettings?.TempDirectory ?? Path.GetTempPath();
+
+	/// <summary>
+	/// Sends a processed recording for transcription, splitting it first if it is over the
+	/// configured upload limit. Cuts prefer the pauses the trimmer removed from this very
+	/// file, so a chunk boundary lands between sentences rather than mid-word.
+	/// </summary>
+	private Task<string> TranscribeAsync(ISpeechToTextService service, string prompt, string audioFilePath, int timeoutSeconds, CancellationToken token) =>
+		_transcriber.TranscribeAsync(
+			service,
+			prompt,
+			audioFilePath,
+			_silenceRemovalLog.PointsFor(audioFilePath),
+			MaxUploadBytes,
+			ChunkWorkingDirectory,
+			timeoutSeconds,
+			token);
 
 	public bool HasRecordedAudio()
 	{
@@ -240,16 +275,21 @@ public class SpeechToTextManager : IDisposable
 				// flushes the encoder to disk. Run off the calling thread so a slow or
 				// wedged audio driver cannot freeze the window — and the screen reader
 				// with it — while the user waits to hear the end-of-recording beep.
-				(double? trimmedSpeechSeconds, Exception? captureError) = await Task.Run(() =>
+				(double? trimmedSpeechSeconds, Exception? captureError, IReadOnlyList<SilenceRemovalPoint> removedSilences) = await Task.Run(() =>
 				{
 					IAudioRecorder? recorder = _audioRecorder;
 					_audioRecorder = null;
 					recorder?.StopRecording();
 					var trimmed = recorder?.TrimmedSpeechSeconds;
 					var error = recorder?.CaptureException;
+					var removed = recorder?.RemovedSilences ?? Array.Empty<SilenceRemovalPoint>();
 					recorder?.Dispose();
-					return (trimmed, error);
+					return (trimmed, error, removed);
 				});
+
+				// Recorded before the checks below so the points are available to the
+				// chunker no matter which way this call goes on from here.
+				_silenceRemovalLog.Record(recordingSession.FilePath, removedSilences);
 
 				// Before the cancellation and capture-error checks below: capture has
 				// ended however this call turns out, so the end-of-recording signal is
@@ -268,7 +308,7 @@ public class SpeechToTextManager : IDisposable
 					throw new NoSpeechDetectedException("No speech detected after trimming silence.");
 
 				int liveTimeout = _settings.SpeechToTextSettings?.LiveTranscriptionTimeoutSeconds ?? 60;
-				return await service.ConvertAudioToText(prompt, recordingSession.FilePath, transcribeToken, liveTimeout).ConfigureAwait(false);
+				return await TranscribeAsync(service, prompt, recordingSession.FilePath, liveTimeout, transcribeToken).ConfigureAwait(false);
 			}
 			finally
 			{
@@ -322,7 +362,7 @@ public class SpeechToTextManager : IDisposable
 			try
 			{
 				int timeout = _settings.SpeechToTextSettings?.FileTranscriptionTimeoutSeconds ?? 300;
-				text = await service.ConvertAudioToText(prompt, session.FilePath, transcribeToken, timeout).ConfigureAwait(false);
+				text = await TranscribeAsync(service, prompt, session.FilePath, timeout, transcribeToken).ConfigureAwait(false);
 			}
 			finally
 			{
@@ -380,7 +420,11 @@ public class SpeechToTextManager : IDisposable
 		if (AudioFileConverter.IsVideoFile(sourcePath) || silenceOptions is not null)
 		{
 			string destinationPath = await CreateSessionFileAsync(".ogg").ConfigureAwait(false);
-			await Task.Run(() => AudioFileConverter.ConvertToOgg(sourcePath, destinationPath, silenceOptions), token).ConfigureAwait(false);
+			var removedSilences = await Task.Run(() => AudioFileConverter.ConvertToOgg(sourcePath, destinationPath, silenceOptions), token).ConfigureAwait(false);
+
+			// The caller transcribes this session next, so the pauses just stripped out of
+			// it are still the right ones to cut at if it turns out to be too big to send.
+			_silenceRemovalLog.Record(destinationPath, removedSilences);
 
 			if (!TryCreateSession(destinationPath, out var convertedSession))
 				throw new InvalidOperationException($"Unable to parse converted session '{Path.GetFileName(destinationPath)}'.");

--- a/Mutation.Ui/Resources/HelpText.xaml
+++ b/Mutation.Ui/Resources/HelpText.xaml
@@ -50,6 +50,7 @@
 	<x:String x:Key="Help.Speech.SilenceThreshold">Loudness floor in dBFS. Audio at or below this level counts as silence. Lower (more negative) values are stricter, treating only quieter sounds as silence. Default -40.</x:String>
 	<x:String x:Key="Help.Speech.MinSilence">Shortest silence to keep, in seconds. Pauses shorter than this are left untouched; longer pauses are trimmed down to this length. Default 1.0.</x:String>
 	<x:String x:Key="Help.Speech.SilenceGuard">Audio kept on each side of speech, in milliseconds, so soft word starts, breaths, and word endings are not clipped. Default 200.</x:String>
+	<x:String x:Key="Help.Speech.MaxUploadSize">Largest audio file sent for transcription in one go, in megabytes. Anything bigger is split into pieces, each transcribed in turn and joined back together in order. Splits are made where a long pause was removed, so a break falls between sentences. Default 24, which stays under OpenAI's 25 MB limit. Set 0 to never split. Range 0, then 1 to 1000.</x:String>
 	<x:String x:Key="Help.Speech.Services">Define the transcription services you can choose from. Adding, removing, or editing a service definition takes effect after you restart the app; the per-service prompt and the active-service selection apply immediately.</x:String>
 	<x:String x:Key="Help.Speech.Service.Name">A label for this service, shown in the active-service list. Must be unique.</x:String>
 	<x:String x:Key="Help.Speech.Service.Provider">Which transcription backend this service talks to: OpenAI (Whisper) or Deepgram.</x:String>

--- a/Mutation.Ui/Services/SettingsManager.cs
+++ b/Mutation.Ui/Services/SettingsManager.cs
@@ -334,6 +334,17 @@ internal class SettingsManager : ISettingsManager
 			somethingWasMissing = true;
 		}
 
+		// Same treatment for the per-request upload cap: a missing field keeps the 24 MB
+		// initializer default, and an explicit value is clamped to [1 MB, 1000 MB] so a
+		// hand-edited file cannot ask for chunks no service would accept. 0 stays 0 and
+		// means "never split".
+		long clampedUpload = SpeechToTextSettings.ClampTranscriptionUploadBytes(speechToTextSettings.MaxTranscriptionUploadBytes);
+		if (clampedUpload != speechToTextSettings.MaxTranscriptionUploadBytes)
+		{
+			speechToTextSettings.MaxTranscriptionUploadBytes = clampedUpload;
+			somethingWasMissing = true;
+		}
+
 		var duplicateGroups = speechToTextSettings.Services
 			 .GroupBy(s => s.Name, StringComparer.OrdinalIgnoreCase)
 			 .Where(g => g.Count() > 1)

--- a/Mutation.Ui/Views/Settings/Pages/SpeechSettingsPage.xaml
+++ b/Mutation.Ui/Views/Settings/Pages/SpeechSettingsPage.xaml
@@ -271,5 +271,27 @@
 				</Button>
 			</StackPanel>
 		</StackPanel>
+
+		<TextBlock Text="Large recordings" Style="{StaticResource SubtitleTextBlockStyle}" />
+
+		<StackPanel Spacing="4">
+			<StackPanel Orientation="Horizontal" Spacing="6">
+				<TextBlock Text="Maximum upload size (MB)" VerticalAlignment="Center" Style="{StaticResource BodyStrongTextBlockStyle}" />
+				<controls:InfoHint Text="{StaticResource Help.Speech.MaxUploadSize}" VerticalAlignment="Center" />
+			</StackPanel>
+			<StackPanel Orientation="Horizontal" Spacing="6">
+				<NumberBox x:Name="NbMaxUploadSizeMb"
+						   AutomationProperties.Name="Maximum upload size (MB)"
+						   AutomationProperties.HelpText="{StaticResource Help.Speech.MaxUploadSize}"
+						   Minimum="0" Maximum="1000"
+						   SmallChange="1" LargeChange="10"
+						   SpinButtonPlacementMode="Inline"
+						   Width="220"
+						   ValueChanged="NbMaxUploadSizeMb_ValueChanged" />
+				<Button Click="BtnResetMaxUploadSize_Click" ToolTipService.ToolTip="Reset to default" AutomationProperties.Name="Reset maximum upload size">
+					<FontIcon Glyph="&#xE72C;" FontFamily="Segoe Fluent Icons" FontSize="12" AutomationProperties.AccessibilityView="Raw" />
+				</Button>
+			</StackPanel>
+		</StackPanel>
 	</StackPanel>
 </UserControl>

--- a/Mutation.Ui/Views/Settings/Pages/SpeechSettingsPage.xaml.cs
+++ b/Mutation.Ui/Views/Settings/Pages/SpeechSettingsPage.xaml.cs
@@ -12,6 +12,8 @@ namespace Mutation.Ui.Views.SettingsUi.Pages;
 
 public sealed partial class SpeechSettingsPage : UserControl
 {
+	private const double BytesPerMb = 1024.0 * 1024.0;
+
 	private readonly Settings _settings;
 	private bool _suppressEvents;
 
@@ -65,6 +67,9 @@ public sealed partial class SpeechSettingsPage : UserControl
 			NbMinSilence.Value = stt.MinSilenceSeconds;
 			NbSilenceThreshold.Value = stt.SilenceThresholdDbFs;
 			NbSilenceGuard.Value = stt.SilenceGuardMilliseconds;
+			NbMaxUploadSizeMb.Value = stt.MaxTranscriptionUploadBytes > 0
+				? Math.Round(stt.MaxTranscriptionUploadBytes / BytesPerMb, 1)
+				: 0;
 		}
 		finally { _suppressEvents = false; }
 	}
@@ -188,6 +193,20 @@ public sealed partial class SpeechSettingsPage : UserControl
 
 	private void BtnResetSilenceGuard_Click(object sender, RoutedEventArgs e) =>
 		NbSilenceGuard.Value = SettingsDefaults.Speech.SilenceGuardMilliseconds;
+
+	private void NbMaxUploadSizeMb_ValueChanged(NumberBox sender, NumberBoxValueChangedEventArgs args)
+	{
+		if (_suppressEvents) return;
+		if (double.IsNaN(args.NewValue)) return;
+		// 0 (or less) stores 0 = "never split"; otherwise convert MB -> bytes and clamp,
+		// so the stored value is always one the chunker can act on.
+		long bytes = args.NewValue <= 0 ? 0 : (long)Math.Round(args.NewValue * BytesPerMb);
+		(_settings.SpeechToTextSettings ??= new SpeechToTextSettings()).MaxTranscriptionUploadBytes =
+			SpeechToTextSettings.ClampTranscriptionUploadBytes(bytes);
+	}
+
+	private void BtnResetMaxUploadSize_Click(object sender, RoutedEventArgs e) =>
+		NbMaxUploadSizeMb.Value = SettingsDefaults.Speech.MaxTranscriptionUploadBytes / BytesPerMb;
 
 	// Puts the stored temp directory back on screen after the dialog has repaired an
 	// unusable one, so the user is looking at the path that will actually be saved

--- a/Mutation.Ui/Views/Settings/Pages/SpeechSettingsPage.xaml.cs
+++ b/Mutation.Ui/Views/Settings/Pages/SpeechSettingsPage.xaml.cs
@@ -201,8 +201,25 @@ public sealed partial class SpeechSettingsPage : UserControl
 		// 0 (or less) stores 0 = "never split"; otherwise convert MB -> bytes and clamp,
 		// so the stored value is always one the chunker can act on.
 		long bytes = args.NewValue <= 0 ? 0 : (long)Math.Round(args.NewValue * BytesPerMb);
-		(_settings.SpeechToTextSettings ??= new SpeechToTextSettings()).MaxTranscriptionUploadBytes =
-			SpeechToTextSettings.ClampTranscriptionUploadBytes(bytes);
+		long clamped = SpeechToTextSettings.ClampTranscriptionUploadBytes(bytes);
+		(_settings.SpeechToTextSettings ??= new SpeechToTextSettings()).MaxTranscriptionUploadBytes = clamped;
+
+		// The box allows 0 as "never split", so it also allows a fraction of a megabyte,
+		// which the clamp raises to 1 MB. Put the value that was actually stored back on
+		// screen rather than leaving the box — and the screen reader — announcing a
+		// number nothing will act on.
+		ShowUploadSize(sender, clamped);
+	}
+
+	private void ShowUploadSize(NumberBox box, long bytes)
+	{
+		double display = bytes > 0 ? Math.Round(bytes / BytesPerMb, 1) : 0;
+		if (Math.Abs(display - box.Value) < 0.0001)
+			return;
+
+		_suppressEvents = true;
+		try { box.Value = display; }
+		finally { _suppressEvents = false; }
 	}
 
 	private void BtnResetMaxUploadSize_Click(object sender, RoutedEventArgs e) =>

--- a/Mutation.Ui/Views/Settings/SettingsDefaults.cs
+++ b/Mutation.Ui/Views/Settings/SettingsDefaults.cs
@@ -62,6 +62,11 @@ internal static class SettingsDefaults
 		public const double SilenceThresholdDbFs = -40.0;
 		public const double MinSilenceSeconds = 1.0;
 		public const double SilenceGuardMilliseconds = 200.0;
+		// Upload size cap: default and UI bounds mirror the domain so the dialog, the
+		// load-time clamp, and the chunker all agree on one source of truth.
+		public const long MaxTranscriptionUploadBytes = SpeechToTextSettings.DefaultMaxTranscriptionUploadBytes;
+		public const long MinTranscriptionUploadBytes = SpeechToTextSettings.MinTranscriptionUploadBytes;
+		public const long MaxTranscriptionUploadBytesLimit = SpeechToTextSettings.MaxTranscriptionUploadBytesLimit;
 	}
 
 	public static class Tts


### PR DESCRIPTION
Closes #286

## What changed

A transcription service refuses a request over about 25 MB, so a long dictation or an
imported meeting recording failed outright at the API. Silence stripping shrinks a
recording but never guarantees a size.

After the existing preprocessing finishes, the processed file is now measured against a
new **Maximum upload size (MB)** setting. Inside the limit nothing changes — one
request, no decoding, no temp files. Over it, the recording is split, the pieces are
uploaded one at a time in order, and the transcripts are joined back together.

### Choosing where to cut

- `SilenceTrimmer` records every silence it removes as a `SilenceRemovalPoint`: how long
  the original pause was, and where the cut landed on the **processed** timeline.
  Positions stay correct as earlier audio is dropped, because they are measured against
  the output as it is written, not the source.
- `AudioChunkPlanner` walks to the furthest end position that still encodes inside the
  limit, then looks back over the final 20% of that candidate and cuts at the point
  where the **longest** original silence was removed. With no candidate in that window
  it cuts at the furthest safe position. Pure arithmetic — no files, no codec, no clock.
- `OggAudioChunkWriter` decodes once and re-encodes each slice straight into its own
  Ogg/Opus file (48 kHz mono, 24 kbps, same as the recorder). The limit is a hard
  ceiling enforced *while writing*, not only a planning input: a chunk growing towards
  it closes early rather than overshooting.
- `ChunkedTranscriber` decides whole-vs-split, verifies every chunk really is inside the
  limit before anything is uploaded, submits sequentially, joins in order, and deletes
  the scratch folder on success, failure and cancellation alike.

Both transcription paths are covered — stop-recording-and-transcribe, and
transcribe-an-existing-session — and a non-Ogg import (copied in as-is when stripping is
off) is converted before splitting.

### Setting

**Speech to Text → Large recordings → Maximum upload size (MB)**, default **24**
(margin under OpenAI's 25 MB). Persisted, defaulted and clamped to [1 MB, 1000 MB] by
`EnsureSettings`, mirrored in `SettingsDefaults.Speech`, covered by the parity test. `0`
means never split. Keyboard reachable, named for the screen reader, with an InfoHint and
a reset button, matching the other numeric settings on the page.

## Testing

`dotnet test --configuration Release` — **1217 passed, 0 failed**.

New coverage:

- `AudioChunkPlannerTests` — 14 cases over boundary selection: longest-pause-wins, ties,
  points outside the window, per-chunk windows measured from where the chunk started,
  contiguity, no chunk over the limit, and the degenerate limits.
- `OggAudioChunkWriterTests` — real Ogg/Opus round trip (pure Concentus, no OS codec):
  planned cuts, a silence-driven cut, every chunk playable, nothing over the limit at
  three different limits, nothing lost, ordering, cancellation.
- `ChunkedTranscriberTests` — sequential upload order, joined output, blank chunks,
  scratch cleanup after success/failure/cancel, refusal of an oversized chunk.
- `SpeechToTextManagerChunkingTests` — the wiring: the configured limit is the one
  applied (and out-of-range values are clamped), and a recording's removal points reach
  the code choosing the cuts.
- `SilenceTrimmerTests` — five cases on removal recording, including that a later point
  is positioned on the shortened output rather than the original.

## Documentation

`settings.md` and `troubleshooting.md` updated, HTML rebuilt and committed alongside.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
