### PR TITLE
Stop four quiet lies: welded words, a casing typo, a lost keyterm, a missing reason

### DIFF
--- a/CognitiveSupport/AnthropicLlmService.cs
+++ b/CognitiveSupport/AnthropicLlmService.cs
@@ -34,7 +34,8 @@ public class AnthropicLlmService : ILlmService
 		int retryCount = 3)
 	{
 		if (string.IsNullOrEmpty(apiKey)) throw new ArgumentNullException(nameof(apiKey));
-		if (models is null) throw new ArgumentNullException(nameof(models));
+
+		var modelList = LlmModelIndex.Validate(models, nameof(models));
 
 		_apiKey = apiKey;
 		_httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
@@ -44,7 +45,7 @@ public class AnthropicLlmService : ILlmService
 		_httpClient.Timeout = Timeout.InfiniteTimeSpan;
 		_timeoutSeconds = timeoutSeconds > 0 ? timeoutSeconds : 60;
 		_retryCount = retryCount < 0 ? 0 : retryCount;
-		_modelConfigs = models.ToDictionary(m => m.Name, m => m, StringComparer.OrdinalIgnoreCase);
+		_modelConfigs = modelList.ToDictionary(m => m.Name, m => m, LlmModelIndex.NameComparer);
 	}
 
 	public async Task<string> CreateChatCompletion(

--- a/CognitiveSupport/DeepgramSpeechToTextService.cs
+++ b/CognitiveSupport/DeepgramSpeechToTextService.cs
@@ -38,7 +38,7 @@ public class DeepgramSpeechToTextService : ISpeechToTextService
 
 		List<string> keyterms = ParseKeyterms(speechToTextPrompt);
 
-		var audioBytes = await File.ReadAllBytesAsync(audioffilePath).ConfigureAwait(false);
+		var audioBytes = await File.ReadAllBytesAsync(audioffilePath, overallCancellationToken).ConfigureAwait(false);
 		const string AttemptKey = "Attempt";
 
 		var delay = Backoff.LinearBackoff(TimeSpan.FromMilliseconds(500), retryCount: 3, factor: 1);
@@ -100,13 +100,25 @@ public class DeepgramSpeechToTextService : ISpeechToTextService
 		return response;
 	}
 
-	private static List<string> ParseKeyterms(string speechToTextPrompt)
+	/// <summary>
+	/// Reads the comma-separated keyterms out of a prompt line beginning <c>keyterms:</c>.
+	/// <para>
+	/// The list runs to the end of its line, with one optional full stop allowed to close it.
+	/// It used to stop at the first period anywhere, which meant "keyterms: Dr. Bosch, Mutation."
+	/// yielded the single term "Dr" — and keyterms exist precisely to help with names and jargon,
+	/// the text most likely to contain an abbreviation period. A prompt with no closing period
+	/// dropped every term instead (issue #245).
+	/// </para>
+	/// </summary>
+	internal static List<string> ParseKeyterms(string speechToTextPrompt)
 	{
 		if (speechToTextPrompt == null)
 			speechToTextPrompt = string.Empty;
 
-		string pattern = @"(?<=\bkeyterms:\s*).*?(?=\.)";
-		Match match = Regex.Match(speechToTextPrompt, pattern, RegexOptions.IgnoreCase);
+		// Multiline `$` matches before the `\n` of a CRLF, so the `\r` has to be spelled out
+		// or the lazy match swallows it — and with it the closing period it was meant to trim.
+		string pattern = @"(?<=\bkeyterms:[ \t]*).*?(?=\.?[ \t]*\r?$)";
+		Match match = Regex.Match(speechToTextPrompt, pattern, RegexOptions.IgnoreCase | RegexOptions.Multiline);
 		if (match.Success)
 		{
 			string keytermsString = match.Value.Trim();

--- a/CognitiveSupport/LlmModelIndex.cs
+++ b/CognitiveSupport/LlmModelIndex.cs
@@ -1,0 +1,53 @@
+namespace CognitiveSupport;
+
+/// <summary>
+/// The one place that decides what a configured LLM model name means, so the OpenAI and
+/// Anthropic services behind <see cref="ILlmService"/> cannot answer that question
+/// differently.
+/// <para>
+/// They used to. OpenAI keyed its lookup ordinally and Anthropic case-insensitively, so
+/// hand-editing <c>Mutation.json</c> to <c>"GPT-4.1"</c> against a configured
+/// <c>"gpt-4.1"</c> failed while the identical typo against an Anthropic model worked.
+/// A repeated name diverged the same way: OpenAI silently kept the last copy, Anthropic
+/// threw an unhelpful framework message (issue #240).
+/// </para>
+/// </summary>
+public static class LlmModelIndex
+{
+	/// <summary>
+	/// Model names come from a hand-edited settings file, where a difference in casing is a
+	/// typo rather than a different model, so both providers match them case-insensitively.
+	/// </summary>
+	public static StringComparer NameComparer => StringComparer.OrdinalIgnoreCase;
+
+	/// <summary>
+	/// Materialises the configured models and rejects the two sets a lookup cannot represent:
+	/// no models at all, and a name that repeats once casing is ignored.
+	/// </summary>
+	/// <param name="models">The models as configured, in file order.</param>
+	/// <param name="parameterName">The caller's parameter name, for the thrown exception.</param>
+	/// <exception cref="ArgumentNullException"><paramref name="models"/> is null.</exception>
+	/// <exception cref="ArgumentException">The set is empty, or a name is configured twice.</exception>
+	public static List<LlmModelConfig> Validate(
+		IEnumerable<LlmModelConfig> models,
+		string parameterName)
+	{
+		if (models is null) throw new ArgumentNullException(parameterName);
+
+		var modelList = models.ToList();
+		if (modelList.Count == 0)
+			throw new ArgumentException("At least one model must be configured.", parameterName);
+
+		var seen = new HashSet<string>(NameComparer);
+		foreach (var model in modelList)
+		{
+			string name = model?.Name ?? string.Empty;
+			if (!seen.Add(name))
+				throw new ArgumentException(
+					$"The model name '{name}' is configured more than once. Model names must be unique, ignoring case.",
+					parameterName);
+		}
+
+		return modelList;
+	}
+}

--- a/CognitiveSupport/LlmService.cs
+++ b/CognitiveSupport/LlmService.cs
@@ -25,14 +25,11 @@ public class LlmService : ILlmService
 		PipelineTransport? transport = null)
 	{
 		if (string.IsNullOrEmpty(apiKey)) throw new ArgumentNullException(nameof(apiKey));
-		if (models is null) throw new ArgumentNullException(nameof(models));
 
-		var modelList = models.ToList();
-		if (modelList.Count == 0)
-			throw new ArgumentException("At least one model must be configured.", nameof(models));
+		var modelList = LlmModelIndex.Validate(models, nameof(models));
 
-		_chatClients = new Dictionary<string, ChatClient>();
-		_modelConfigs = new Dictionary<string, LlmModelConfig>();
+		_chatClients = new Dictionary<string, ChatClient>(LlmModelIndex.NameComparer);
+		_modelConfigs = new Dictionary<string, LlmModelConfig>(LlmModelIndex.NameComparer);
 		_timeoutSeconds = timeoutSeconds > 0 ? timeoutSeconds : 60;
 		_retryCount = retryCount < 0 ? 0 : retryCount;
 

--- a/CognitiveSupport/TextFormatter.cs
+++ b/CognitiveSupport/TextFormatter.cs
@@ -151,12 +151,18 @@ public static class TextFormatter
 	/// the literal text the user typed, not a capture group.
 	/// </para>
 	/// <para>
-	/// The spacing around the match is captured rather than swallowed, so <c>ai</c> → <c>AI</c>
-	/// turns "contain ai also" into "contain AI also" instead of welding it into "containAIalso".
-	/// It is emitted back only where the replacement does not supply its own, because the shipped
-	/// rules are mostly dictated punctuation — "full stop" → ". " — where re-emitting the original
-	/// gap would push the period away from the word it belongs to.
+	/// The match also consumes the spacing either side of it, and what happens to that spacing
+	/// depends on what the replacement is. There are three kinds, and conflating them is what
+	/// the old single rule got wrong.
 	/// </para>
+	/// <list type="bullet">
+	/// <item>A <b>word</b> — "ai" → "AI" — needs the gap back, or the neighbours weld into
+	/// "containAIalso".</item>
+	/// <item>A <b>symbol</b> — "full stop" → ". ", "dash" → "-" — supplies its own spacing or
+	/// deliberately has none, so the gap goes. Every rule Mutation ships is one of these.</item>
+	/// <item>A <b>deletion</b> — "um" → "" — closes the gap to a single space, however many
+	/// copies of the word were said in a row.</item>
+	/// </list>
 	/// </summary>
 	private static string ApplySmartRule(
 		string text,
@@ -166,6 +172,13 @@ public static class TextFormatter
 	{
 		string pattern = $@"(\b|^)([.,]?)([ ]*)({Regex.Escape(find)})([.,]?)([ ]*)(\b|$)";
 
+		// Letters and digits are what makes a replacement a word rather than punctuation. A
+		// replacement without any is spacing-neutral by construction — "dash" → "-" wants
+		// "state-of-the-art", not "state - of - the - art" — and dropping the gap for it is
+		// also exactly what this rule did before it learned to keep spacing at all, so no
+		// existing rule can be made worse by this branch.
+		bool isSymbol = replaceWith.Length > 0 && !replaceWith.Any(char.IsLetterOrDigit);
+		bool isDeletion = replaceWith.Length == 0;
 		bool opensAttached = OpensAttachedToPrecedingWord(replaceWith);
 
 		// A replacement closing with whitespace already separates itself from what follows, and
@@ -174,6 +187,13 @@ public static class TextFormatter
 		bool closesSeparated = replaceWith.Length > 0
 			&& char.IsWhiteSpace(replaceWith[^1]);
 
+		// Deletions are the one branch that has to look outside its own match. Fillers arrive in
+		// runs — "um, um, I think" — and consecutive matches abut, so the second one's preceding
+		// word is whatever the first one left behind, which may be nothing. Regex.Replace
+		// evaluates matches left to right, so carrying that forward is enough.
+		int previousEnd = -1;
+		bool wordPrecedes = false;
+
 		return Regex.Replace(text, pattern, match =>
 		{
 			string leadingPunctuation = match.Groups[2].Value;
@@ -181,21 +201,52 @@ public static class TextFormatter
 			string trailingPunctuation = match.Groups[5].Value;
 			string trailingSpaces = match.Groups[6].Value;
 
-			string head = opensAttached ? string.Empty : leadingSpaces;
-			string tail = closesSeparated ? string.Empty : trailingPunctuation + trailingSpaces;
+			if (isSymbol)
+				return leadingPunctuation + replaceWith;
 
-			return leadingPunctuation + head + replaceWith + tail;
+			if (!isDeletion)
+			{
+				string head = opensAttached ? string.Empty : leadingSpaces;
+				string tail = closesSeparated ? string.Empty : trailingPunctuation + trailingSpaces;
+
+				return leadingPunctuation + head + replaceWith + tail;
+			}
+
+			int end = match.Index + match.Length;
+			bool hasWordBefore = match.Index == previousEnd
+				? wordPrecedes
+				: match.Index > 0 && char.IsLetterOrDigit(text[match.Index - 1]);
+
+			string deleted;
+			if (trailingPunctuation.Length > 0 && hasWordBefore)
+				// The deleted word was carrying the sentence's punctuation. That belongs hard
+				// against the word before it, and takes the place of the gap rather than
+				// following it. With no word before it there is nothing to attach to, so it
+				// goes — which is what keeps a line opening "um, um, I think" from starting
+				// with a stray comma.
+				deleted = trailingPunctuation + trailingSpaces;
+			else if (end < text.Length && char.IsWhiteSpace(text[end]))
+				// The text resumes with a space of its own; ours would double it.
+				deleted = string.Empty;
+			else
+				// Keep the gap that was in front of the deleted word. A second filler straight
+				// after the first has none left to keep, which is how a run of them closes to
+				// one space rather than one space per word.
+				deleted = leadingSpaces;
+
+			string emitted = leadingPunctuation + deleted;
+			previousEnd = end;
+			wordPrecedes = emitted.Length == 0 && hasWordBefore;
+
+			return emitted;
 		}, regexOptions);
 	}
 
 	/// <summary>
-	/// Whether the replacement wants to sit hard against the word before it, rather than after
-	/// the gap the match consumed. That is true of a replacement opening with its own spacing,
-	/// and of one that is nothing but sentence punctuation and the spacing after it — the
-	/// dictated "full stop" → ". ". A replacement that merely starts with punctuation and then
-	/// carries text — "dotnet" → ".NET" — is a word, and still needs the gap.
-	/// An empty replacement deletes a word, and takes the gap on this side with it so the two
-	/// neighbours end up one space apart rather than none.
+	/// Whether a word replacement still wants to sit hard against the word before it. True of
+	/// one opening with its own spacing — "newline plus text" → "\r\nHere". A replacement that
+	/// merely starts with punctuation and then carries text — "dotnet" → ".NET" — is a word,
+	/// and still needs the gap.
 	/// </summary>
 	private static bool OpensAttachedToPrecedingWord(string replaceWith)
 	{

--- a/CognitiveSupport/TextFormatter.cs
+++ b/CognitiveSupport/TextFormatter.cs
@@ -132,10 +132,7 @@ public static class TextFormatter
 				text = Regex.Replace(text, find, replaceWith, regexOptions);
 				break;
 			case MatchTypeEnum.Smart:
-				string pattern = $@"(\b|^)([.,]?)([ ]*{find}[.,]?[ ]*)(\b|$)";
-				string replacement = $"$1$2{replaceWith}$4";
-				text = Regex.Replace(text, pattern, replacement, regexOptions);
-
+				text = ApplySmartRule(text, find, replaceWith, regexOptions);
 				break;
 			default:
 				throw new NotImplementedException($"The MatchType {rule.MatchType}: {(int)rule.MatchType} is not implemented.");
@@ -143,6 +140,74 @@ public static class TextFormatter
 
 		return text;
 	}
+
+	/// <summary>
+	/// Applies a Smart rule: a whole-word match on literal text, unlike the RegEx match type.
+	/// <para>
+	/// "Literal" is the whole point of the mode, so <c>Find</c> is escaped before it reaches
+	/// the engine — a rule finding <c>C++</c> used to compile to a nested quantifier and throw,
+	/// which aborted the entire formatting run, not just that one rule. <c>ReplaceWith</c> goes
+	/// in through a match evaluator for the same reason: a replacement containing <c>$1</c> is
+	/// the literal text the user typed, not a capture group.
+	/// </para>
+	/// <para>
+	/// The spacing around the match is captured rather than swallowed, so <c>ai</c> → <c>AI</c>
+	/// turns "contain ai also" into "contain AI also" instead of welding it into "containAIalso".
+	/// It is emitted back only where the replacement does not supply its own, because the shipped
+	/// rules are mostly dictated punctuation — "full stop" → ". " — where re-emitting the original
+	/// gap would push the period away from the word it belongs to.
+	/// </para>
+	/// </summary>
+	private static string ApplySmartRule(
+		string text,
+		string find,
+		string replaceWith,
+		RegexOptions regexOptions)
+	{
+		string pattern = $@"(\b|^)([.,]?)([ ]*)({Regex.Escape(find)})([.,]?)([ ]*)(\b|$)";
+
+		bool opensAttached = OpensAttachedToPrecedingWord(replaceWith);
+
+		// A replacement closing with whitespace already separates itself from what follows, and
+		// carries its own terminator — so the punctuation the match consumed on that side goes
+		// with the gap rather than being stranded after it.
+		bool closesSeparated = replaceWith.Length > 0
+			&& char.IsWhiteSpace(replaceWith[^1]);
+
+		return Regex.Replace(text, pattern, match =>
+		{
+			string leadingPunctuation = match.Groups[2].Value;
+			string leadingSpaces = match.Groups[3].Value;
+			string trailingPunctuation = match.Groups[5].Value;
+			string trailingSpaces = match.Groups[6].Value;
+
+			string head = opensAttached ? string.Empty : leadingSpaces;
+			string tail = closesSeparated ? string.Empty : trailingPunctuation + trailingSpaces;
+
+			return leadingPunctuation + head + replaceWith + tail;
+		}, regexOptions);
+	}
+
+	/// <summary>
+	/// Whether the replacement wants to sit hard against the word before it, rather than after
+	/// the gap the match consumed. That is true of a replacement opening with its own spacing,
+	/// and of one that is nothing but sentence punctuation and the spacing after it — the
+	/// dictated "full stop" → ". ". A replacement that merely starts with punctuation and then
+	/// carries text — "dotnet" → ".NET" — is a word, and still needs the gap.
+	/// An empty replacement deletes a word, and takes the gap on this side with it so the two
+	/// neighbours end up one space apart rather than none.
+	/// </summary>
+	private static bool OpensAttachedToPrecedingWord(string replaceWith)
+	{
+		int index = 0;
+		while (index < replaceWith.Length && IsSentencePunctuation(replaceWith[index]))
+			index++;
+
+		return index == replaceWith.Length || char.IsWhiteSpace(replaceWith[index]);
+	}
+
+	private static bool IsSentencePunctuation(char value) =>
+		value is '.' or ',' or ';' or ':' or '!' or '?';
 
 	public static string RemoveSubstrings(
 		this string text,

--- a/Documentation/UserGuide/html/settings.html
+++ b/Documentation/UserGuide/html/settings.html
@@ -284,6 +284,13 @@ help. Leave them alone unless something is timing out on you.</p>
 Mutation. The per-service prompt and your choice of active service apply straight
 away. You choose which service is active from the main window.</p>
 </blockquote>
+<p>If the service you are using is Deepgram, the prompt can also carry a list of words you
+want it to listen out for. Put them on a line of their own that starts with <code>keyterms:</code>
+and separate them with commas, like this:</p>
+<pre><code>keyterms: Dr. Bosch, Mutation, WinUI
+</code></pre>
+<p>Everything to the end of that line is the list, so full stops inside a name are safe. A
+full stop at the very end is optional and is not treated as part of the last word.</p>
 <p>If you clear the <strong>Temp directory</strong> box, or type a folder name on its own like
 <code>Recordings</code>, Mutation cannot save yet. It puts its own folder back in the box, plays
 the failure beep, and tells you what it did. Press <strong>Save</strong> again to accept that
@@ -345,6 +352,9 @@ the key here is the one used.</p>
 </tbody>
 </table>
 </div>
+<p>Capital letters in a model name do not matter, so <code>GPT-4.1</code> and <code>gpt-4.1</code> are the same
+model. Each name may only appear once in the list, though — if two rows have the same
+name, Mutation tells you which one is duplicated instead of quietly picking one.</p>
 <p>Your prompts themselves are edited on the main window, not here.</p>
 <h3 id="text-to-speech">Text to Speech</h3>
 <p>How Mutation reads text out loud. Voice, rate and volume live on the main window;

--- a/Documentation/UserGuide/html/transcript-formatting.html
+++ b/Documentation/UserGuide/html/transcript-formatting.html
@@ -162,7 +162,7 @@ footer{margin-top:3rem; padding-top:1rem; border-top:1px solid var(--rule); colo
 <h2 id="the-three-match-types">The three match types</h2>
 <p>Each rule also has a <strong>Match type</strong>, which decides how the Find text is interpreted.</p>
 <p><strong>Plain</strong> swaps the exact text wherever it turns up, including in the middle of longer words.</p>
-<p><strong>Smart</strong> matches the word properly, tidying up the spaces and punctuation around it as it goes. This is the one most people want, and it is especially good for removing a spoken word cleanly without leaving a double space or a stranded comma behind.</p>
+<p><strong>Smart</strong> matches the word properly, tidying up the spaces and punctuation around it as it goes. This is the one most people want, and it is especially good for removing a spoken word cleanly without leaving a double space or a stranded comma behind. Whatever you type in the Find box is taken exactly as you typed it, so symbols are fine — a rule finding <code>C++</code> looks for <code>C++</code>.</p>
 <p><strong>RegEx</strong> treats the Find box as a pattern written in a special pattern language for advanced users. If you do not know what this is, you do not need it. (If a pattern is malformed, Mutation shows the error in red under the row so you can fix it.)</p>
 <hr />
 <h2 id="some-worked-examples">Some worked examples</h2>

--- a/Documentation/UserGuide/html/troubleshooting.html
+++ b/Documentation/UserGuide/html/troubleshooting.html
@@ -416,10 +416,13 @@ while back, check the <code>.old</code> file too.</p>
 share. The same applies to anything Mutation shows you on screen or reads out — an error
 message never contains one of your keys.</p>
 <h3 id="when-an-error-message-appears">When an error message appears</h3>
-<p>An error message tells you what went wrong in a sentence or two, then points at the log
-file. The long technical detail — the part only a developer can use — goes to the log and
-not to the screen, so the message stays short enough to read or listen to. If you are
-reporting the problem, copy the message and then open the log for the rest.</p>
+<p>An error message tells you what went wrong in up to four short lines, then points at the
+log file. The lines run from the thing you were doing down to the underlying cause, so a
+failed dictation might read &quot;Speech to text failed.&quot; and then &quot;401 (Unauthorized)&quot; — the
+second line being the one that tells you to go and check your API key.</p>
+<p>The long technical detail — the part only a developer can use — goes to the log and not to
+the screen, so the message stays short enough to read or listen to. If you are reporting
+the problem, copy the message and then open the log for the rest.</p>
 <h2 id="reporting-a-problem">Reporting a problem</h2>
 <p>If none of the above fixes it, please report it. The project's issues page is at
 <a href="https://github.com/Subverting-complexity/Mutation/issues">github.com/Subverting-complexity/Mutation</a>.</p>

--- a/Documentation/UserGuide/markdown/settings.md
+++ b/Documentation/UserGuide/markdown/settings.md
@@ -85,6 +85,17 @@ Where your dictation gets turned into text.
 > Mutation. The per-service prompt and your choice of active service apply straight
 > away. You choose which service is active from the main window.
 
+If the service you are using is Deepgram, the prompt can also carry a list of words you
+want it to listen out for. Put them on a line of their own that starts with `keyterms:`
+and separate them with commas, like this:
+
+```
+keyterms: Dr. Bosch, Mutation, WinUI
+```
+
+Everything to the end of that line is the list, so full stops inside a name are safe. A
+full stop at the very end is optional and is not treated as part of the last word.
+
 If you clear the **Temp directory** box, or type a folder name on its own like
 `Recordings`, Mutation cannot save yet. It puts its own folder back in the box, plays
 the failure beep, and tells you what it did. Press **Save** again to accept that
@@ -118,6 +129,10 @@ The AI models Mutation can send your text to.
 | Request timeout (seconds) | How long to wait for the model to answer before giving up. |
 | Retries | How many times to try again after a failed request. Retries help the very first request after a reboot succeed while the network warms up. Three by default. |
 | Models | Your list of models. Each row has a name, a provider, and an optional temperature — which controls how random the answers are. Leave temperature empty to use the provider's own setting. |
+
+Capital letters in a model name do not matter, so `GPT-4.1` and `gpt-4.1` are the same
+model. Each name may only appear once in the list, though — if two rows have the same
+name, Mutation tells you which one is duplicated instead of quietly picking one.
 
 Your prompts themselves are edited on the main window, not here.
 

--- a/Documentation/UserGuide/markdown/transcript-formatting.md
+++ b/Documentation/UserGuide/markdown/transcript-formatting.md
@@ -28,7 +28,7 @@ Each rule also has a **Match type**, which decides how the Find text is interpre
 
 **Plain** swaps the exact text wherever it turns up, including in the middle of longer words.
 
-**Smart** matches the word properly, tidying up the spaces and punctuation around it as it goes. This is the one most people want, and it is especially good for removing a spoken word cleanly without leaving a double space or a stranded comma behind.
+**Smart** matches the word properly, tidying up the spaces and punctuation around it as it goes. This is the one most people want, and it is especially good for removing a spoken word cleanly without leaving a double space or a stranded comma behind. Whatever you type in the Find box is taken exactly as you typed it, so symbols are fine — a rule finding `C++` looks for `C++`.
 
 **RegEx** treats the Find box as a pattern written in a special pattern language for advanced users. If you do not know what this is, you do not need it. (If a pattern is malformed, Mutation shows the error in red under the row so you can fix it.)
 

--- a/Documentation/UserGuide/markdown/troubleshooting.md
+++ b/Documentation/UserGuide/markdown/troubleshooting.md
@@ -336,10 +336,14 @@ message never contains one of your keys.
 
 ### When an error message appears
 
-An error message tells you what went wrong in a sentence or two, then points at the log
-file. The long technical detail — the part only a developer can use — goes to the log and
-not to the screen, so the message stays short enough to read or listen to. If you are
-reporting the problem, copy the message and then open the log for the rest.
+An error message tells you what went wrong in up to four short lines, then points at the
+log file. The lines run from the thing you were doing down to the underlying cause, so a
+failed dictation might read "Speech to text failed." and then "401 (Unauthorized)" — the
+second line being the one that tells you to go and check your API key.
+
+The long technical detail — the part only a developer can use — goes to the log and not to
+the screen, so the message stays short enough to read or listen to. If you are reporting
+the problem, copy the message and then open the log for the rest.
 
 ## Reporting a problem
 

--- a/Mutation.Tests/DeepgramKeytermParsingTests.cs
+++ b/Mutation.Tests/DeepgramKeytermParsingTests.cs
@@ -1,0 +1,83 @@
+using CognitiveSupport;
+
+namespace Mutation.Tests;
+
+// Keyterms are how the user teaches Deepgram the names and jargon it would otherwise get
+// wrong — which is exactly the text most likely to contain an abbreviation period. The
+// parser used to stop at the first period anywhere in the prompt, so "Dr. Bosch" reduced
+// the whole list to "Dr", and a prompt with no closing period lost every term (issue #245).
+public class DeepgramKeytermParsingTests
+{
+	[Fact]
+	public void AbbreviationPeriod_DoesNotTruncateTheList()
+	{
+		var keyterms = DeepgramSpeechToTextService.ParseKeyterms("keyterms: Dr. Bosch, Mutation, WinUI.");
+
+		Assert.Equal(new[] { "Dr. Bosch", "Mutation", "WinUI" }, keyterms);
+	}
+
+	[Fact]
+	public void NoClosingPeriod_StillReadsTheList()
+	{
+		var keyterms = DeepgramSpeechToTextService.ParseKeyterms("keyterms: Mutation, WinUI");
+
+		Assert.Equal(new[] { "Mutation", "WinUI" }, keyterms);
+	}
+
+	[Fact]
+	public void ClosingPeriod_IsNotPartOfTheLastTerm()
+	{
+		var keyterms = DeepgramSpeechToTextService.ParseKeyterms("keyterms: Mutation, WinUI.");
+
+		Assert.Equal(new[] { "Mutation", "WinUI" }, keyterms);
+	}
+
+	[Fact]
+	public void TrailingSpacesAfterTheClosingPeriod_AreIgnored()
+	{
+		var keyterms = DeepgramSpeechToTextService.ParseKeyterms("keyterms: Mutation, WinUI.   ");
+
+		Assert.Equal(new[] { "Mutation", "WinUI" }, keyterms);
+	}
+
+	// The list belongs to its own line, so prose on the lines around it is not swept in.
+	[Fact]
+	public void ListEndsAtTheEndOfItsLine()
+	{
+		string prompt = string.Join(Environment.NewLine, new[]
+		{
+			"Transcribe carefully.",
+			"keyterms: Dr. Bosch, Deepgram.",
+			"Ignore background noise.",
+		});
+
+		var keyterms = DeepgramSpeechToTextService.ParseKeyterms(prompt);
+
+		Assert.Equal(new[] { "Dr. Bosch", "Deepgram" }, keyterms);
+	}
+
+	[Fact]
+	public void LabelIsMatchedRegardlessOfCase()
+	{
+		var keyterms = DeepgramSpeechToTextService.ParseKeyterms("KEYTERMS: Mutation");
+
+		Assert.Equal(new[] { "Mutation" }, keyterms);
+	}
+
+	[Theory]
+	[InlineData("")]
+	[InlineData("Transcribe this recording accurately.")]
+	[InlineData(null)]
+	public void NoKeytermsLabel_YieldsNoTerms(string? prompt)
+	{
+		Assert.Empty(DeepgramSpeechToTextService.ParseKeyterms(prompt!));
+	}
+
+	[Fact]
+	public void EmptyEntriesAndSurroundingSpace_AreDropped()
+	{
+		var keyterms = DeepgramSpeechToTextService.ParseKeyterms("keyterms:  Mutation ,, WinUI ,");
+
+		Assert.Equal(new[] { "Mutation", "WinUI" }, keyterms);
+	}
+}

--- a/Mutation.Tests/ErrorDialogMessageTests.cs
+++ b/Mutation.Tests/ErrorDialogMessageTests.cs
@@ -96,6 +96,63 @@ public class ErrorDialogMessageTests
 			result.LastIndexOf("Timed out.", StringComparison.Ordinal));
 	}
 
+	// The outer message names the operation and the innermost is the raw cause, but the
+	// sentence telling the reader what to do is often the one in between. Reporting only the
+	// ends left the user hearing "connection closed" when the real answer was a bad API key
+	// (issue #288).
+	[Fact]
+	public void ForException_ThreeLevelChain_KeepsTheActionableMiddleMessage()
+	{
+		ErrorLogger.RegisterSecretValues(null);
+
+		string result = ErrorDialogMessage.ForException(
+			new InvalidOperationException("Speech to text failed.",
+				new InvalidOperationException("Response status code does not indicate success: 401 (Unauthorized).",
+					new Exception("An existing connection was forcibly closed by the remote host."))),
+			LogPath);
+
+		Assert.Contains("Speech to text failed.", result);
+		Assert.Contains("401 (Unauthorized).", result);
+		Assert.Contains("An existing connection was forcibly closed by the remote host.", result);
+	}
+
+	// A wrapper restating a message from further out adds a line and no information, and
+	// hearing the same sentence twice reads as two failures rather than one.
+	[Fact]
+	public void ForException_MessageRepeatedNonConsecutively_IsSaidOnce()
+	{
+		ErrorLogger.RegisterSecretValues(null);
+
+		string result = ErrorDialogMessage.ForException(
+			new InvalidOperationException("Upload failed.",
+				new Exception("Disk is full.",
+					new Exception("Upload failed."))),
+			LogPath);
+
+		Assert.Equal(result.IndexOf("Upload failed.", StringComparison.Ordinal),
+			result.LastIndexOf("Upload failed.", StringComparison.Ordinal));
+	}
+
+	// The dialog is read aloud, so a pathological chain must not become a wall of speech.
+	// Past the cap the log pointer is the answer.
+	[Fact]
+	public void ForException_ChainDeeperThanTheCap_IsBounded()
+	{
+		ErrorLogger.RegisterSecretValues(null);
+
+		Exception chain = new Exception("Level 7.");
+		for (int level = 6; level >= 1; level--)
+			chain = new Exception($"Level {level}.", chain);
+
+		string result = ErrorDialogMessage.ForException(chain, LogPath);
+
+		for (int level = 1; level <= ErrorDialogMessage.MaxChainMessages; level++)
+			Assert.Contains($"Level {level}.", result);
+
+		Assert.DoesNotContain($"Level {ErrorDialogMessage.MaxChainMessages + 1}.", result);
+		Assert.Contains(ErrorDialogMessage.LogPointerLead, result);
+	}
+
 	[Fact]
 	public void ForException_MessagelessException_NamesTheType()
 	{

--- a/Mutation.Tests/LlmModelLookupParityTests.cs
+++ b/Mutation.Tests/LlmModelLookupParityTests.cs
@@ -1,0 +1,165 @@
+using System.ClientModel.Primitives;
+using System.Net;
+using System.Net.Http;
+using CognitiveSupport;
+
+namespace Mutation.Tests;
+
+// The two ILlmService implementations used to disagree about what a model name means:
+// OpenAI keyed its lookup ordinally, Anthropic case-insensitively, and a name repeated in
+// Mutation.json was silently deduped by one and thrown on by the other with a framework
+// message. Same file, same typo, two outcomes (issue #240).
+//
+// These tests drive both implementations through the same cases so the two cannot drift
+// apart again.
+public class LlmModelLookupParityTests : IDisposable
+{
+	private const string OpenAiModel = "gpt-4.1";
+	private const string AnthropicModel = "claude-opus-5";
+
+	private const string OpenAiSuccessBody =
+		"""{"id":"c1","object":"chat.completion","created":1,"model":"gpt-4.1","choices":[{"index":0,"finish_reason":"stop","message":{"role":"assistant","content":"done"}}]}""";
+	private const string AnthropicSuccessBody = """{"content":[{"type":"text","text":"done"}]}""";
+
+	// One client per test, all released at the end of the class rather than left to the
+	// finalizer. Disposing the client disposes the fake handler with it.
+	private readonly List<HttpClient> _clients = new();
+
+	public void Dispose()
+	{
+		foreach (var client in _clients)
+			client.Dispose();
+	}
+
+	private static LlmModelConfig Model(string name, LlmProvider provider) =>
+		new(name, provider, customTemperature: null);
+
+	private static IList<LlmChatMessage> Messages() =>
+		new List<LlmChatMessage> { new(LlmChatRole.User, "hello") };
+
+	private HttpClient Client(string successBody)
+	{
+		var client = new HttpClient(new FakeHttpMessageHandler().Respond(HttpStatusCode.OK, successBody));
+		_clients.Add(client);
+		return client;
+	}
+
+	private AnthropicLlmService CreateAnthropic(params LlmModelConfig[] models) =>
+		new("test-key", models, Client(AnthropicSuccessBody), timeoutSeconds: 5, retryCount: 0);
+
+	private LlmService CreateOpenAi(params LlmModelConfig[] models) =>
+		new("test-key", models, timeoutSeconds: 5, retryCount: 0,
+			transport: new HttpClientPipelineTransport(Client(OpenAiSuccessBody)));
+
+	// ----- Case-insensitive lookup -----
+
+	[Fact]
+	public async Task OpenAi_ModelNameDifferingOnlyInCase_Resolves()
+	{
+		var service = CreateOpenAi(Model(OpenAiModel, LlmProvider.OpenAI));
+
+		string result = await service.CreateChatCompletion(Messages(), OpenAiModel.ToUpperInvariant());
+
+		Assert.Equal("done", result);
+	}
+
+	[Fact]
+	public async Task Anthropic_ModelNameDifferingOnlyInCase_Resolves()
+	{
+		var service = CreateAnthropic(Model(AnthropicModel, LlmProvider.Anthropic));
+
+		string result = await service.CreateChatCompletion(Messages(), AnthropicModel.ToUpperInvariant());
+
+		Assert.Equal("done", result);
+	}
+
+	[Fact]
+	public async Task OpenAi_UnknownModel_IsStillRejected()
+	{
+		var service = CreateOpenAi(Model(OpenAiModel, LlmProvider.OpenAI));
+
+		var thrown = await Assert.ThrowsAsync<ArgumentException>(
+			() => service.CreateChatCompletion(Messages(), "no-such-model"));
+
+		Assert.Equal("llmModelName", thrown.ParamName);
+	}
+
+	[Fact]
+	public async Task Anthropic_UnknownModel_IsStillRejected()
+	{
+		var service = CreateAnthropic(Model(AnthropicModel, LlmProvider.Anthropic));
+
+		var thrown = await Assert.ThrowsAsync<ArgumentException>(
+			() => service.CreateChatCompletion(Messages(), "no-such-model"));
+
+		Assert.Equal("llmModelName", thrown.ParamName);
+	}
+
+	// ----- Duplicate names -----
+
+	[Fact]
+	public void OpenAi_DuplicateModelName_ThrowsNamingTheDuplicate()
+	{
+		var thrown = Assert.Throws<ArgumentException>(() => CreateOpenAi(
+			Model(OpenAiModel, LlmProvider.OpenAI),
+			Model(OpenAiModel, LlmProvider.OpenAI)));
+
+		Assert.Contains(OpenAiModel, thrown.Message);
+		Assert.Equal("models", thrown.ParamName);
+	}
+
+	[Fact]
+	public void Anthropic_DuplicateModelName_ThrowsNamingTheDuplicate()
+	{
+		var thrown = Assert.Throws<ArgumentException>(() => CreateAnthropic(
+			Model(AnthropicModel, LlmProvider.Anthropic),
+			Model(AnthropicModel, LlmProvider.Anthropic)));
+
+		Assert.Contains(AnthropicModel, thrown.Message);
+		Assert.Equal("models", thrown.ParamName);
+	}
+
+	// A duplicate that differs only in case is the same duplicate, since that is how the
+	// lookup now reads it.
+	[Fact]
+	public void OpenAi_DuplicateDifferingOnlyInCase_Throws()
+	{
+		Assert.Throws<ArgumentException>(() => CreateOpenAi(
+			Model(OpenAiModel, LlmProvider.OpenAI),
+			Model(OpenAiModel.ToUpperInvariant(), LlmProvider.OpenAI)));
+	}
+
+	[Fact]
+	public void Anthropic_DuplicateDifferingOnlyInCase_Throws()
+	{
+		Assert.Throws<ArgumentException>(() => CreateAnthropic(
+			Model(AnthropicModel, LlmProvider.Anthropic),
+			Model(AnthropicModel.ToUpperInvariant(), LlmProvider.Anthropic)));
+	}
+
+	// ----- Empty and null model sets -----
+
+	[Fact]
+	public void OpenAi_NoModels_Throws()
+	{
+		Assert.Equal("models", Assert.Throws<ArgumentException>(() => CreateOpenAi()).ParamName);
+	}
+
+	[Fact]
+	public void Anthropic_NoModels_Throws()
+	{
+		Assert.Equal("models", Assert.Throws<ArgumentException>(() => CreateAnthropic()).ParamName);
+	}
+
+	[Fact]
+	public void OpenAi_NullModels_Throws()
+	{
+		Assert.Equal("models", Assert.Throws<ArgumentNullException>(() => CreateOpenAi(null!)).ParamName);
+	}
+
+	[Fact]
+	public void Anthropic_NullModels_Throws()
+	{
+		Assert.Equal("models", Assert.Throws<ArgumentNullException>(() => CreateAnthropic(null!)).ParamName);
+	}
+}

--- a/Mutation.Tests/TextFormatterTests.cs
+++ b/Mutation.Tests/TextFormatterTests.cs
@@ -61,21 +61,101 @@ public class TextFormatterTests
 			"Please ai is great.",
 			Rule("ai", "AI", MatchTypeEnum.Smart));
 
-		Assert.Contains("AI", result);
-		Assert.DoesNotContain(" ai ", result);
+		Assert.Equal("Please AI is great.", result);
 	}
 
 	[Fact]
 	public void FormatWithRule_Smart_OnlyMatchesAtWordBoundary()
 	{
-		// Pins down current behavior: standalone "ai" is replaced; the "ai"
-		// embedded inside "contain" is not. The Smart pattern consumes adjacent
-		// whitespace as part of the match.
+		// Standalone "ai" is replaced; the "ai" embedded inside "contain" is not.
+		// The spacing either side of the match survives — it used to be swallowed,
+		// welding the neighbours into "containAIalso paint" (issue #222).
 		string result = TextFormatter.FormatWithRule(
 			"contain ai also paint",
 			Rule("ai", "AI", MatchTypeEnum.Smart));
 
-		Assert.Equal("containAIalso paint", result);
+		Assert.Equal("contain AI also paint", result);
+	}
+
+	[Fact]
+	public void FormatWithRule_Smart_KeepsPunctuationFollowingTheMatch()
+	{
+		string result = TextFormatter.FormatWithRule(
+			"I like ai, mostly",
+			Rule("ai", "AI", MatchTypeEnum.Smart));
+
+		Assert.Equal("I like AI, mostly", result);
+	}
+
+	// The shipped default rules are dictated punctuation, and they rely on the replacement
+	// supplying its own spacing: re-emitting the gap the match consumed would push the
+	// period away from the word it closes.
+	[Theory]
+	[InlineData("Hello full stop next word", "full stop", ". ", "Hello. next word")]
+	[InlineData("one comma two", "comma", ", ", "one, two")]
+	[InlineData("done question mark really", "question mark", "? ", "done? really")]
+	public void FormatWithRule_Smart_PunctuationReplacement_AttachesToThePrecedingWord(
+		string input, string find, string replaceWith, string expected)
+	{
+		Assert.Equal(expected, TextFormatter.FormatWithRule(input, Rule(find, replaceWith, MatchTypeEnum.Smart)));
+	}
+
+	[Fact]
+	public void FormatWithRule_Smart_NewLineReplacement_DoesNotStrandTheOriginalSpacing()
+	{
+		string result = TextFormatter.FormatWithRule(
+			"first new line second",
+			Rule("new line", Environment.NewLine, MatchTypeEnum.Smart));
+
+		Assert.Equal("first" + Environment.NewLine + "second", result);
+	}
+
+	// Deleting a word should close the gap to a single space, not to none.
+	[Fact]
+	public void FormatWithRule_Smart_EmptyReplacement_LeavesOneSpace()
+	{
+		string result = TextFormatter.FormatWithRule(
+			"so um yeah",
+			Rule("um", string.Empty, MatchTypeEnum.Smart));
+
+		Assert.Equal("so yeah", result);
+	}
+
+	// Smart is the literal match type. Regex metacharacters in Find used to reach the engine
+	// raw: "C++" compiled to a nested quantifier and threw, aborting the whole formatting run
+	// rather than just that rule (issue #222).
+	[Theory]
+	[InlineData("I know C++ well", "C++", "C plus plus", "I know C plus plus well")]
+	[InlineData("type ( here", "(", "open bracket", "type open bracket here")]
+	[InlineData("type [ here", "[", "left square", "type left square here")]
+	[InlineData(@"a \ b", @"\", "backslash", "a backslash b")]
+	public void FormatWithRule_Smart_RegexMetacharactersInFind_AreMatchedLiterally(
+		string input, string find, string replaceWith, string expected)
+	{
+		Assert.Equal(expected, TextFormatter.FormatWithRule(input, Rule(find, replaceWith, MatchTypeEnum.Smart)));
+	}
+
+	[Fact]
+	public void FormatWithRule_Smart_DollarInReplaceWith_IsInsertedLiterally()
+	{
+		string result = TextFormatter.FormatWithRule(
+			"the cost is amount today",
+			Rule("amount", "$1", MatchTypeEnum.Smart));
+
+		Assert.Equal("the cost is $1 today", result);
+	}
+
+	// One bad rule used to take the whole run down with it, so every later rule was lost too.
+	[Fact]
+	public void FormatWithRules_SmartRuleWithMetacharacters_DoesNotAbortLaterRules()
+	{
+		var rules = new List<TranscriptFormatRule>
+		{
+			Rule("C++", "C plus plus", MatchTypeEnum.Smart),
+			Rule("dotnet", ".NET", MatchTypeEnum.Smart),
+		};
+
+		Assert.Equal("C plus plus and .NET", "C++ and dotnet".FormatWithRules(rules));
 	}
 
 	// ----- FormatWithRule: error paths -----

--- a/Mutation.Tests/TextFormatterTests.cs
+++ b/Mutation.Tests/TextFormatterTests.cs
@@ -110,15 +110,79 @@ public class TextFormatterTests
 		Assert.Equal("first" + Environment.NewLine + "second", result);
 	}
 
-	// Deleting a word should close the gap to a single space, not to none.
+	// A symbol replacement is spacing-neutral: it wants to weld its neighbours, which is the
+	// one case where swallowing the gap was right all along.
+	[Theory]
+	[InlineData("state dash of dash the dash art", "dash", "-", "state-of-the-art")]
+	[InlineData("and slash or", "slash", "/", "and/or")]
+	[InlineData("jacques at sign example", "at sign", "@", "jacques@example")]
+	[InlineData("my underscore var here", "underscore", "_", "my_var here")]
+	public void FormatWithRule_Smart_SymbolReplacement_ClosesTheGap(
+		string input, string find, string replaceWith, string expected)
+	{
+		Assert.Equal(expected, TextFormatter.FormatWithRule(input, Rule(find, replaceWith, MatchTypeEnum.Smart)));
+	}
+
+	// A replacement that opens with punctuation but carries text is a word, not punctuation,
+	// and still needs the gap in front of it.
 	[Fact]
-	public void FormatWithRule_Smart_EmptyReplacement_LeavesOneSpace()
+	public void FormatWithRule_Smart_WordOpeningWithPunctuation_KeepsTheGap()
 	{
 		string result = TextFormatter.FormatWithRule(
-			"so um yeah",
+			"built on dotnet today",
+			Rule("dotnet", ".NET", MatchTypeEnum.Smart));
+
+		Assert.Equal("built on .NET today", result);
+	}
+
+	// Deleting a word should close the gap to a single space, not to none — and not to one
+	// space per copy when the word was said twice in a row.
+	[Theory]
+	[InlineData("so um yeah", "so yeah")]
+	[InlineData("so um um yeah", "so yeah")]
+	[InlineData("so um um um yeah", "so yeah")]
+	[InlineData("so um  yeah", "so yeah")]
+	[InlineData("um yeah", "yeah")]
+	public void FormatWithRule_Smart_EmptyReplacement_ClosesToOneSpace(string input, string expected)
+	{
+		Assert.Equal(expected, TextFormatter.FormatWithRule(input, Rule("um", string.Empty, MatchTypeEnum.Smart)));
+	}
+
+	// The deleted word may be carrying the sentence's full stop. Dropping it as well loses the
+	// sentence break; leaving it after the gap strands it before the next word.
+	[Fact]
+	public void FormatWithRule_Smart_EmptyReplacement_KeepsPunctuationTheDeletedWordCarried()
+	{
+		string result = TextFormatter.FormatWithRule(
+			"I think um. Next one",
 			Rule("um", string.Empty, MatchTypeEnum.Smart));
 
-		Assert.Equal("so yeah", result);
+		Assert.Equal("I think. Next one", result);
+	}
+
+	// ...but with no word in front of it, that punctuation has nothing to attach to. A line
+	// that opens with a run of punctuated fillers must not open with their leftover commas.
+	[Theory]
+	[InlineData("um, um, I think", "um", "I think")]
+	[InlineData("um, um, um, I think", "um", "I think")]
+	[InlineData("um. um. I think", "um", "I think")]
+	[InlineData("you know, you know, I think", "you know", "I think")]
+	[InlineData("so um, um, I think", "um", "so, I think")]
+	public void FormatWithRule_Smart_EmptyReplacement_LeadingFillerRun_LeavesNoStrayPunctuation(
+		string input, string find, string expected)
+	{
+		Assert.Equal(expected, TextFormatter.FormatWithRule(input, Rule(find, string.Empty, MatchTypeEnum.Smart)));
+	}
+
+	// The text after the deleted word may already start with a space of its own.
+	[Fact]
+	public void FormatWithRule_Smart_EmptyReplacement_DoesNotDoubleAnExistingSpace()
+	{
+		string result = TextFormatter.FormatWithRule(
+			"I think um , next",
+			Rule("um", string.Empty, MatchTypeEnum.Smart));
+
+		Assert.Equal("I think , next", result);
 	}
 
 	// Smart is the literal match type. Regex metacharacters in Find used to reach the engine

--- a/Mutation.Ui/Core/ErrorDialogMessage.cs
+++ b/Mutation.Ui/Core/ErrorDialogMessage.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using CognitiveSupport;
 
 namespace Mutation.Ui.Core;
@@ -11,9 +13,9 @@ namespace Mutation.Ui.Core;
 /// key can never appear in a dialog — dialogs are read aloud and routinely
 /// screenshotted into bug reports, and the redaction seam was previously applied only
 /// when writing the log file. Second, the dialog carries the exception's own message
-/// and a pointer to the log, not the whole <c>ToString()</c> chain: the stack and the
-/// inner-exception detail are what tend to echo request identifiers and header
-/// fragments, and they are no use to a reader anyway (issue #242).
+/// and a pointer to the log, not the whole <c>ToString()</c> chain: the stack is what
+/// tends to echo request identifiers and header fragments, and it is no use to a reader
+/// anyway (issue #242).
 /// </para>
 /// Pure apart from the redactor, so the wording is testable without a window.
 /// </summary>
@@ -21,6 +23,16 @@ public static class ErrorDialogMessage
 {
 	/// <summary>Lead-in for the log pointer, so tests and callers agree on one wording.</summary>
 	public const string LogPointerLead = "Full technical details are in the log file:";
+
+	/// <summary>
+	/// How many distinct messages from the exception chain the summary reads out.
+	/// <para>
+	/// The dialog is read aloud, so this is a listening budget rather than a screen one:
+	/// four lines is about as much as stays a headline. Anything past it is covered by the
+	/// log pointer, and chains that deep are rare (issue #288).
+	/// </para>
+	/// </summary>
+	public const int MaxChainMessages = 4;
 
 	/// <param name="exception">The failure being reported; null yields a neutral placeholder.</param>
 	/// <param name="logPath">Where the full detail was written — normally <see cref="ErrorLogger.PrimaryLogPath"/>.</param>
@@ -41,27 +53,33 @@ public static class ErrorDialogMessage
 	/// </summary>
 	public static string ForMessage(string? message) => Redact(message ?? string.Empty);
 
-	// The outer message is what names the operation; the innermost one is usually what
-	// actually went wrong, and wrappers like AggregateException say nothing on their own.
-	// Everything between the two is the part a reader cannot use.
+	// The outer message names the operation and the innermost is usually the raw cause, but
+	// the sentence that tells the reader what to do about it is often neither. A provider call
+	// that fails with a 401 wraps it as "Speech to text failed." over "…401 (Unauthorized)."
+	// over a socket error: report only the ends and the reader hears a dropped connection and
+	// never learns their API key is wrong. So every level speaks, up to the cap.
 	private static string Describe(Exception? exception)
 	{
 		if (exception is null)
 			return "No further detail is available.";
 
-		string outer = Blank(exception.Message) ? exception.GetType().Name : exception.Message.Trim();
+		var messages = new List<string>();
+		for (Exception? level = exception; level is not null; level = level.InnerException)
+		{
+			string message = Blank(level.Message) ? level.GetType().Name : level.Message.Trim();
 
-		Exception innermost = exception;
-		while (innermost.InnerException is not null)
-			innermost = innermost.InnerException;
+			// Wrappers that restate what they wrap are common enough that without this the
+			// summary reads as a stutter — and hearing the same sentence twice suggests two
+			// failures rather than one.
+			if (messages.Contains(message, StringComparer.Ordinal))
+				continue;
 
-		if (ReferenceEquals(innermost, exception))
-			return outer;
+			messages.Add(message);
+			if (messages.Count == MaxChainMessages)
+				break;
+		}
 
-		string inner = Blank(innermost.Message) ? innermost.GetType().Name : innermost.Message.Trim();
-		return string.Equals(inner, outer, StringComparison.Ordinal)
-			? outer
-			: $"{outer}{Environment.NewLine}{inner}";
+		return string.Join(Environment.NewLine, messages);
 	}
 
 	private static bool Blank(string? value) => string.IsNullOrWhiteSpace(value);


### PR DESCRIPTION
Four contained faults from the codebase audit, batched because they all live in
code that composes text a user reads or hears, and none is big enough to be worth
a branch of its own.

Closes #222, closes #240, closes #245, closes #288.

## #222 — Smart transcript rules

Two defects on the same two lines.

**Crash.** `Find` went straight into the pattern, so a Smart rule finding `C++`
compiled to a nested quantifier and threw — out of `FormatWithRules`, taking every
later rule with it, not just that one. `Find` is now `Regex.Escape`d.

`ReplaceWith` goes in through a `MatchEvaluator` rather than as a substitution
string, so `$1` is the two characters the user typed. That is stronger than
escaping `$`: nothing in the replacement is ever interpreted.

**Whitespace loss.** The pattern swallowed the spaces either side of the match and
never gave them back, welding `contain ai also` into `containAIalso`. The spacing
is now captured and re-emitted.

> **Departure from the issue.** The issue prescribed emitting the captured spacing
> unconditionally. That would have regressed every shipped default rule: they are
> dictated punctuation — `full stop` → `". "`, `comma` → `", "`, `new line` →
> newline — where the replacement supplies its own spacing and re-emitting the gap
> would give `Hello .  next word`. So the spacing is emitted only where the
> replacement does not already provide it. A replacement that is punctuation plus
> its spacing attaches to the preceding word; one that merely *starts* with
> punctuation and then carries text (`dotnet` → `.NET`) is a word and keeps its
> gap. Both cases are pinned by tests.

The two tests that enshrined the whitespace loss are updated as the issue asked,
and the weak `Contains`/`DoesNotContain` pair is now a full-string assertion.

## #240 — Model-name lookup parity

OpenAI keyed its lookup ordinally, Anthropic case-insensitively. `"GPT-4.1"`
against a configured `"gpt-4.1"` failed on one provider and worked on the other.
A repeated name was silently deduped by one (last wins) and rejected by the other
with a framework message that did not name the duplicate.

Both now build their lookup through `CognitiveSupport/LlmModelIndex.cs`, which is
the single answer to "what does a model name mean": case-insensitive, unique,
and one exception type with one message.

Also aligned: `AnthropicLlmService` now rejects an empty model set, which
`LlmService` already did.

`LlmModelLookupParityTests` drives both implementations through the same cases so
they cannot drift apart again.

## #245 — Deepgram keyterms and cancellation

The keyterm regex was non-greedy to the *first* period anywhere in the prompt, so
`keyterms: Dr. Bosch, Mutation.` yielded the single term `Dr` — and keyterms exist
for precisely the names and jargon most likely to contain an abbreviation period.
A prompt with no closing period matched nothing and dropped every term.

The list now runs to the end of its own line, with one optional closing full stop.
`ParseKeyterms` is `internal` so the eight new cases can drive it directly; the
class had no test coverage at all before.

`overallCancellationToken` now reaches `File.ReadAllBytesAsync`.

## #288 — Error dialog keeps the middle of the chain

The summary was the outer message plus the innermost one. The actionable sentence
is usually neither: a provider 401 wrapped as `Speech to text failed.` over a
socket error read as a dropped connection, and the user never learned their API
key was wrong.

Every distinct level now speaks. Duplicates are collapsed against everything
already said, not just the previous line, so the existing
`SameMessageBothLevels_IsNotRepeated` behaviour holds and a non-consecutive repeat
is caught too.

> **The human decision the issue flagged.** The cap is **four lines**
> (`ErrorDialogMessage.MaxChainMessages`). The dialog is read aloud, so this is a
> listening budget; four is about as much as stays a headline. Past the cap the
> log pointer covers the rest, as the issue suggested. Chains that deep are rare.

## User guide

Updated in this PR, per the project rule:

- `transcript-formatting.md` — Smart takes Find exactly as typed, so symbols are fine.
- `settings.md` — how to write a Deepgram `keyterms:` line (previously undocumented);
  model names ignore capitals and must be unique.
- `troubleshooting.md` — what an error message now contains, with the 401 example.

HTML regenerated and committed alongside.

## Verification

`dotnet test --configuration Release` — **1235 passed, 0 failed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)