### PR TITLE
Stop the app announcing four things that were not true

### DIFF
--- a/Documentation/UserGuide/html/dictation.html
+++ b/Documentation/UserGuide/html/dictation.html
@@ -229,11 +229,14 @@ or when you are dictating notes into Mutation itself and don't want stray text
 landing in another window.</p>
 <p>One thing worth knowing: if the Mutation window itself is the one in front, nothing
 is inserted anywhere. Mutation won't paste into itself.</p>
-<p>Whichever choice you make, Mutation waits to see whether the text actually arrived
-before it tells you it worked. If Windows refused the keystrokes — which it does
-when the app in front is running as an administrator — you get the failure beep and
-a message saying so, instead of a success beep for text that never landed. The
-transcript stays in the Mutation window either way, so nothing is lost.</p>
+<p>Whichever choice you make, Mutation waits for the typing or pasting to finish before
+it tells you the result, and checks that Windows accepted the keystrokes. If Windows
+turned them down, you get the failure beep and a message saying the text could not be
+sent, instead of a success beep for text that never landed. The transcript stays in
+the Mutation window either way, so nothing is lost.</p>
+<p>Windows does not always admit that it refused, so this catch is not a guarantee. If a
+success beep is ever followed by an empty window in the other app, the text is still
+in Mutation — paste it yourself with <strong>Ctrl+V</strong>.</p>
 <h3 id="sending-a-shortcut-afterwards">Sending a shortcut afterwards</h3>
 <p>In <strong>Settings</strong>, on the <strong>Speech to Text</strong> page, there is an optional box called
 <strong>Send hotkey after transcription</strong>. Whatever shortcut you put there is sent to the

--- a/Documentation/UserGuide/html/dictation.html
+++ b/Documentation/UserGuide/html/dictation.html
@@ -229,6 +229,11 @@ or when you are dictating notes into Mutation itself and don't want stray text
 landing in another window.</p>
 <p>One thing worth knowing: if the Mutation window itself is the one in front, nothing
 is inserted anywhere. Mutation won't paste into itself.</p>
+<p>Whichever choice you make, Mutation waits to see whether the text actually arrived
+before it tells you it worked. If Windows refused the keystrokes — which it does
+when the app in front is running as an administrator — you get the failure beep and
+a message saying so, instead of a success beep for text that never landed. The
+transcript stays in the Mutation window either way, so nothing is lost.</p>
 <h3 id="sending-a-shortcut-afterwards">Sending a shortcut afterwards</h3>
 <p>In <strong>Settings</strong>, on the <strong>Speech to Text</strong> page, there is an optional box called
 <strong>Send hotkey after transcription</strong>. Whatever shortcut you put there is sent to the

--- a/Documentation/UserGuide/html/keyboard-shortcuts.html
+++ b/Documentation/UserGuide/html/keyboard-shortcuts.html
@@ -157,6 +157,10 @@ listens.</p>
 <p>There is one exception, and it is noted in the tables below: <strong>Ctrl+Comma</strong> opens
 Settings, and that one only works when Mutation's own window is in front.</p>
 <p>Every default shortcut listed here can be changed. Nothing is fixed.</p>
+<p>A shortcut fires once per press. Holding the keys down a little too long does
+nothing extra — you will not start a second recording, or flip the mute back and
+forth, just because your fingers lingered. Let go and press again when you want it
+to happen a second time.</p>
 <h2 id="the-full-list">The full list</h2>
 <h3 id="microphone">Microphone</h3>
 <div class="table-wrap"><table>

--- a/Documentation/UserGuide/html/troubleshooting.html
+++ b/Documentation/UserGuide/html/troubleshooting.html
@@ -294,13 +294,16 @@ has its own message: &quot;The transcript could not be sent to the other applica
 be running with higher privileges than Mutation. It is available in the Mutation
 window.&quot; You get a failure beep with it, not the success beep.</p>
 <p>Windows will not let an ordinary program type into a window that is running with
-administrator privileges. It does not warn anybody — it simply throws the keystrokes
-away. Mutation now checks whether Windows accepted them and tells you when it did not,
-rather than announcing success for text that never arrived.</p>
+administrator privileges. It simply throws the keystrokes away. Mutation checks
+whether Windows accepted them and tells you when it did not, rather than announcing
+success for text that never arrived.</p>
 <p><strong>What to do.</strong></p>
 <ol>
-<li>Your text is not lost. It is in the main window and, unless the clipboard also
-failed, on your clipboard — so you can paste it yourself with <strong>Ctrl+V</strong>.</li>
+<li>Check the other app first. Once in a while Mutation gets the text through on a
+second route and the warning turns out to be a false alarm, so look before you
+paste again — otherwise you may end up with it twice.</li>
+<li>If it really is missing, your text is not lost. It is in the main window and,
+unless the clipboard also failed, on your clipboard — paste it with <strong>Ctrl+V</strong>.</li>
 <li>The usual cause is an app started with &quot;Run as administrator&quot;, or a system dialog
 that has taken the foreground. Close it, or click into an ordinary window, and
 dictate again.</li>

--- a/Documentation/UserGuide/html/troubleshooting.html
+++ b/Documentation/UserGuide/html/troubleshooting.html
@@ -288,6 +288,33 @@ or pausing one often fixes it for good.</li>
 <li>If you rely on the text landing in another app automatically, set the &quot;send keys
 after&quot; option to <strong>Ctrl+V</strong> so Mutation pastes for you once the copy succeeds.</li>
 </ol>
+<h3 id="mutation-says-it-could-not-send-the-text-to-the-other-app">Mutation says it could not send the text to the other app</h3>
+<p><strong>What's happening.</strong> This is a different problem from the clipboard one above, and it
+has its own message: &quot;The transcript could not be sent to the other application; it may
+be running with higher privileges than Mutation. It is available in the Mutation
+window.&quot; You get a failure beep with it, not the success beep.</p>
+<p>Windows will not let an ordinary program type into a window that is running with
+administrator privileges. It does not warn anybody — it simply throws the keystrokes
+away. Mutation now checks whether Windows accepted them and tells you when it did not,
+rather than announcing success for text that never arrived.</p>
+<p><strong>What to do.</strong></p>
+<ol>
+<li>Your text is not lost. It is in the main window and, unless the clipboard also
+failed, on your clipboard — so you can paste it yourself with <strong>Ctrl+V</strong>.</li>
+<li>The usual cause is an app started with &quot;Run as administrator&quot;, or a system dialog
+that has taken the foreground. Close it, or click into an ordinary window, and
+dictate again.</li>
+<li>Task Manager, the Windows security prompt, and some installer windows behave this
+way too. Nothing is wrong with Mutation or your microphone.</li>
+</ol>
+<h3 id="something-went-wrong-while-delivering-the-transcript">Something went wrong while delivering the transcript</h3>
+<p><strong>What's happening.</strong> Very occasionally the delivery itself fails in a way Mutation did
+not expect — a beep that cannot play, for instance. You hear the failure beep and read
+&quot;Something went wrong while delivering the transcript. It is available in the Mutation
+window.&quot;</p>
+<p><strong>What to do.</strong> Copy the text from the main window. The transcript box goes back to
+being editable straight away, so you can carry on dictating. If it keeps happening,
+the log file has the details — see <strong>Finding the log file</strong> below.</p>
 <h3 id="fast-mode-didnt-actually-run-fast">Fast mode didn't actually run fast</h3>
 <p><strong>What's happening.</strong> Fast mode is a faster setting for AI prompts. If it is not
 available, Mutation does not throw your text away — it quietly runs the prompt again at

--- a/Documentation/UserGuide/markdown/dictation.md
+++ b/Documentation/UserGuide/markdown/dictation.md
@@ -82,11 +82,15 @@ landing in another window.
 One thing worth knowing: if the Mutation window itself is the one in front, nothing
 is inserted anywhere. Mutation won't paste into itself.
 
-Whichever choice you make, Mutation waits to see whether the text actually arrived
-before it tells you it worked. If Windows refused the keystrokes — which it does
-when the app in front is running as an administrator — you get the failure beep and
-a message saying so, instead of a success beep for text that never landed. The
-transcript stays in the Mutation window either way, so nothing is lost.
+Whichever choice you make, Mutation waits for the typing or pasting to finish before
+it tells you the result, and checks that Windows accepted the keystrokes. If Windows
+turned them down, you get the failure beep and a message saying the text could not be
+sent, instead of a success beep for text that never landed. The transcript stays in
+the Mutation window either way, so nothing is lost.
+
+Windows does not always admit that it refused, so this catch is not a guarantee. If a
+success beep is ever followed by an empty window in the other app, the text is still
+in Mutation — paste it yourself with **Ctrl+V**.
 
 ### Sending a shortcut afterwards
 

--- a/Documentation/UserGuide/markdown/dictation.md
+++ b/Documentation/UserGuide/markdown/dictation.md
@@ -82,6 +82,12 @@ landing in another window.
 One thing worth knowing: if the Mutation window itself is the one in front, nothing
 is inserted anywhere. Mutation won't paste into itself.
 
+Whichever choice you make, Mutation waits to see whether the text actually arrived
+before it tells you it worked. If Windows refused the keystrokes — which it does
+when the app in front is running as an administrator — you get the failure beep and
+a message saying so, instead of a success beep for text that never landed. The
+transcript stays in the Mutation window either way, so nothing is lost.
+
 ### Sending a shortcut afterwards
 
 In **Settings**, on the **Speech to Text** page, there is an optional box called

--- a/Documentation/UserGuide/markdown/keyboard-shortcuts.md
+++ b/Documentation/UserGuide/markdown/keyboard-shortcuts.md
@@ -17,6 +17,11 @@ Settings, and that one only works when Mutation's own window is in front.
 
 Every default shortcut listed here can be changed. Nothing is fixed.
 
+A shortcut fires once per press. Holding the keys down a little too long does
+nothing extra — you will not start a second recording, or flip the mute back and
+forth, just because your fingers lingered. Let go and press again when you want it
+to happen a second time.
+
 ## The full list
 
 ### Microphone

--- a/Documentation/UserGuide/markdown/troubleshooting.md
+++ b/Documentation/UserGuide/markdown/troubleshooting.md
@@ -176,6 +176,39 @@ window."
 3. If you rely on the text landing in another app automatically, set the "send keys
    after" option to **Ctrl+V** so Mutation pastes for you once the copy succeeds.
 
+### Mutation says it could not send the text to the other app
+
+**What's happening.** This is a different problem from the clipboard one above, and it
+has its own message: "The transcript could not be sent to the other application; it may
+be running with higher privileges than Mutation. It is available in the Mutation
+window." You get a failure beep with it, not the success beep.
+
+Windows will not let an ordinary program type into a window that is running with
+administrator privileges. It does not warn anybody — it simply throws the keystrokes
+away. Mutation now checks whether Windows accepted them and tells you when it did not,
+rather than announcing success for text that never arrived.
+
+**What to do.**
+
+1. Your text is not lost. It is in the main window and, unless the clipboard also
+   failed, on your clipboard — so you can paste it yourself with **Ctrl+V**.
+2. The usual cause is an app started with "Run as administrator", or a system dialog
+   that has taken the foreground. Close it, or click into an ordinary window, and
+   dictate again.
+3. Task Manager, the Windows security prompt, and some installer windows behave this
+   way too. Nothing is wrong with Mutation or your microphone.
+
+### Something went wrong while delivering the transcript
+
+**What's happening.** Very occasionally the delivery itself fails in a way Mutation did
+not expect — a beep that cannot play, for instance. You hear the failure beep and read
+"Something went wrong while delivering the transcript. It is available in the Mutation
+window."
+
+**What to do.** Copy the text from the main window. The transcript box goes back to
+being editable straight away, so you can carry on dictating. If it keeps happening,
+the log file has the details — see **Finding the log file** below.
+
 ### Fast mode didn't actually run fast
 
 **What's happening.** Fast mode is a faster setting for AI prompts. If it is not

--- a/Documentation/UserGuide/markdown/troubleshooting.md
+++ b/Documentation/UserGuide/markdown/troubleshooting.md
@@ -184,18 +184,21 @@ be running with higher privileges than Mutation. It is available in the Mutation
 window." You get a failure beep with it, not the success beep.
 
 Windows will not let an ordinary program type into a window that is running with
-administrator privileges. It does not warn anybody — it simply throws the keystrokes
-away. Mutation now checks whether Windows accepted them and tells you when it did not,
-rather than announcing success for text that never arrived.
+administrator privileges. It simply throws the keystrokes away. Mutation checks
+whether Windows accepted them and tells you when it did not, rather than announcing
+success for text that never arrived.
 
 **What to do.**
 
-1. Your text is not lost. It is in the main window and, unless the clipboard also
-   failed, on your clipboard — so you can paste it yourself with **Ctrl+V**.
-2. The usual cause is an app started with "Run as administrator", or a system dialog
+1. Check the other app first. Once in a while Mutation gets the text through on a
+   second route and the warning turns out to be a false alarm, so look before you
+   paste again — otherwise you may end up with it twice.
+2. If it really is missing, your text is not lost. It is in the main window and,
+   unless the clipboard also failed, on your clipboard — paste it with **Ctrl+V**.
+3. The usual cause is an app started with "Run as administrator", or a system dialog
    that has taken the foreground. Close it, or click into an ordinary window, and
    dictate again.
-3. Task Manager, the Windows security prompt, and some installer windows behave this
+4. Task Manager, the Windows security prompt, and some installer windows behave this
    way too. Nothing is wrong with Mutation or your microphone.
 
 ### Something went wrong while delivering the transcript

--- a/Mutation.Tests/GuardedUiOperationTests.cs
+++ b/Mutation.Tests/GuardedUiOperationTests.cs
@@ -109,6 +109,47 @@ public class GuardedUiOperationTests
 		Assert.True(run.IsCompletedSuccessfully);
 	}
 
+	// Restoration touches the window too, so it can fail for the same reasons the work
+	// did. Letting it escape would fault the task and hand the async void caller's
+	// exception to the global handler — the very route out of the app this guard exists
+	// to close.
+	[Fact]
+	public async Task DoesNotPropagate_WhenRestoreItselfThrows()
+	{
+		Exception? reported = null;
+
+		var run = GuardedUiOperation.RunAsync(
+			work: () => Task.CompletedTask,
+			onFailure: _ => { },
+			restore: () => throw new InvalidOperationException("the window is being torn down"),
+			onReportFailed: ex => reported = ex);
+
+		await run;
+
+		Assert.True(run.IsCompletedSuccessfully);
+		Assert.Equal("the window is being torn down", reported?.Message);
+	}
+
+	// A restore that gives the user their text box back and then fails on the tidying
+	// after it still has to leave the box usable.
+	[Fact]
+	public async Task RestorePartlyDone_KeepsWhatItManagedBeforeThrowing()
+	{
+		bool readOnlyCleared = false;
+
+		await GuardedUiOperation.RunAsync(
+			work: () => throw new InvalidOperationException("delivery failed"),
+			onFailure: _ => { },
+			restore: () =>
+			{
+				readOnlyCleared = true;
+				throw new InvalidOperationException("session cleanup failed");
+			},
+			onReportFailed: _ => { });
+
+		Assert.True(readOnlyCleared);
+	}
+
 	[Fact]
 	public async Task RestoresExactlyOnce()
 	{

--- a/Mutation.Tests/GuardedUiOperationTests.cs
+++ b/Mutation.Tests/GuardedUiOperationTests.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Mutation.Ui.Core;
+
+namespace Mutation.Tests;
+
+// Covers issue #234: FinalizeTranscript restored the transcript box and the auto-action
+// suppression in its last two statements, after three awaits and two beeps, with no
+// try/finally. Any throw on the delivery path skipped both — and because the method is
+// async void the exception went to the global handler, so the user simply found that
+// the transcript box no longer accepted typing, for the rest of the session, with
+// nothing said about why.
+public class GuardedUiOperationTests
+{
+	[Fact]
+	public async Task Restores_WhenTheWorkSucceeds()
+	{
+		bool restored = false;
+
+		await GuardedUiOperation.RunAsync(
+			work: () => Task.CompletedTask,
+			onFailure: _ => Assert.Fail("The work succeeded; nothing to report."),
+			restore: () => restored = true);
+
+		Assert.True(restored);
+	}
+
+	[Fact]
+	public async Task Restores_WhenTheWorkThrows()
+	{
+		bool restored = false;
+
+		await GuardedUiOperation.RunAsync(
+			work: () => throw new InvalidOperationException("beep player is gone"),
+			onFailure: _ => { },
+			restore: () => restored = true);
+
+		Assert.True(restored);
+	}
+
+	// The throw can land after an await, on the continuation rather than synchronously.
+	[Fact]
+	public async Task Restores_WhenTheWorkThrowsAfterAnAwait()
+	{
+		bool restored = false;
+
+		await GuardedUiOperation.RunAsync(
+			work: async () =>
+			{
+				await Task.Yield();
+				throw new InvalidOperationException("automation peer failed inside ShowStatus");
+			},
+			onFailure: _ => { },
+			restore: () => restored = true);
+
+		Assert.True(restored);
+	}
+
+	// A failure the user is never told about is the thing that made #234 baffling
+	// rather than merely annoying.
+	[Fact]
+	public async Task ReportsTheFailure_BeforeRestoring()
+	{
+		var order = new List<string>();
+		var thrown = new InvalidOperationException("delivery failed");
+		Exception? reported = null;
+
+		await GuardedUiOperation.RunAsync(
+			work: () => throw thrown,
+			onFailure: ex => { reported = ex; order.Add("report"); },
+			restore: () => order.Add("restore"));
+
+		Assert.Same(thrown, reported);
+		Assert.Equal(new[] { "report", "restore" }, order);
+	}
+
+	// The reporting path is beeps and automation peers — exactly what was failing in the
+	// first place. It must not be able to take the restoration down with it.
+	[Fact]
+	public async Task Restores_WhenTheFailureReportItselfThrows()
+	{
+		bool restored = false;
+		Exception? secondary = null;
+
+		await GuardedUiOperation.RunAsync(
+			work: () => throw new InvalidOperationException("delivery failed"),
+			onFailure: _ => throw new InvalidOperationException("no audio device for the failure beep"),
+			restore: () => restored = true,
+			onReportFailed: ex => secondary = ex);
+
+		Assert.True(restored);
+		Assert.NotNull(secondary);
+		Assert.Equal("no audio device for the failure beep", secondary!.Message);
+	}
+
+	// The whole point is that the async void caller never sees an exception, so the
+	// global handler is never what tells the user something went wrong.
+	[Fact]
+	public async Task DoesNotPropagateTheFailure()
+	{
+		var run = GuardedUiOperation.RunAsync(
+			work: () => throw new InvalidOperationException("delivery failed"),
+			onFailure: _ => { },
+			restore: () => { });
+
+		await run;
+
+		Assert.True(run.IsCompletedSuccessfully);
+	}
+
+	[Fact]
+	public async Task RestoresExactlyOnce()
+	{
+		int restores = 0;
+
+		await GuardedUiOperation.RunAsync(
+			work: () => throw new InvalidOperationException("delivery failed"),
+			onFailure: _ => { },
+			restore: () => restores++);
+
+		Assert.Equal(1, restores);
+	}
+}

--- a/Mutation.Tests/HotkeyModifiersTests.cs
+++ b/Mutation.Tests/HotkeyModifiersTests.cs
@@ -1,0 +1,71 @@
+using Mutation.Ui.Services;
+using Windows.System;
+
+namespace Mutation.Tests;
+
+// Covers issue #226: MOD_NOREPEAT was declared but never OR'd into the modifier word,
+// so Windows repeated WM_HOTKEY at the keyboard auto-repeat rate while a hotkey was
+// held. Holding the dictation shortcut a moment too long started a recording, stopped
+// and transcribed it, and started another — with a RecorderBusy failure beep per round.
+public class HotkeyModifiersTests
+{
+	[Fact]
+	public void Compose_AlwaysSetsNoRepeat()
+	{
+		uint mods = HotkeyModifiers.Compose(new Hotkey { Key = VirtualKey.U });
+
+		Assert.Equal(HotkeyModifiers.MOD_NOREPEAT, mods & HotkeyModifiers.MOD_NOREPEAT);
+	}
+
+	[Fact]
+	public void Compose_SetsNoRepeat_ForEveryModifierCombination()
+	{
+		for (int bits = 0; bits < 16; bits++)
+		{
+			var hotkey = new Hotkey
+			{
+				Alt = (bits & 1) != 0,
+				Control = (bits & 2) != 0,
+				Shift = (bits & 4) != 0,
+				Win = (bits & 8) != 0,
+				Key = VirtualKey.U,
+			};
+
+			uint mods = HotkeyModifiers.Compose(hotkey);
+
+			Assert.Equal(HotkeyModifiers.MOD_NOREPEAT, mods & HotkeyModifiers.MOD_NOREPEAT);
+		}
+	}
+
+	[Fact]
+	public void Compose_KeepsTheRequestedModifiers()
+	{
+		uint mods = HotkeyModifiers.Compose(Hotkey.Parse("Shift+Alt+U"));
+
+		Assert.Equal(
+			HotkeyModifiers.MOD_SHIFT | HotkeyModifiers.MOD_ALT | HotkeyModifiers.MOD_NOREPEAT,
+			mods);
+	}
+
+	[Fact]
+	public void Compose_DoesNotSetModifiersThatWereNotAsked_For()
+	{
+		uint mods = HotkeyModifiers.Compose(Hotkey.Parse("Ctrl+M"));
+
+		Assert.Equal(HotkeyModifiers.MOD_CONTROL | HotkeyModifiers.MOD_NOREPEAT, mods);
+		Assert.Equal(0u, mods & HotkeyModifiers.MOD_ALT);
+		Assert.Equal(0u, mods & HotkeyModifiers.MOD_SHIFT);
+		Assert.Equal(0u, mods & HotkeyModifiers.MOD_WIN);
+	}
+
+	[Fact]
+	public void Compose_MapsWin()
+	{
+		uint mods = HotkeyModifiers.Compose(Hotkey.Parse("Win+Ctrl+Shift+Alt+F1"));
+
+		Assert.Equal(
+			HotkeyModifiers.MOD_WIN | HotkeyModifiers.MOD_CONTROL | HotkeyModifiers.MOD_SHIFT
+				| HotkeyModifiers.MOD_ALT | HotkeyModifiers.MOD_NOREPEAT,
+			mods);
+	}
+}

--- a/Mutation.Tests/RecordingUiPlannerTests.cs
+++ b/Mutation.Tests/RecordingUiPlannerTests.cs
@@ -1,0 +1,76 @@
+using Mutation.Ui.Core;
+
+namespace Mutation.Tests;
+
+// Covers issue #271: the state-changed handler branched on the recorder's IsRecording
+// flag, which it read after the dispatcher had handed it back to the UI thread. When
+// the stop path had not finished stopping by then, the handler took the *start* branch
+// on a stop — start beep, Stop button, "Recording..." — telling a screen-reader user
+// that recording had just begun a moment after they ended it.
+//
+// The activity now travels with the event, and this planner is what turns it into what
+// the user sees and hears. Nothing here reads recorder state, so a stop cannot be
+// announced as a start no matter how the threads interleave.
+public class RecordingUiPlannerTests
+{
+	[Fact]
+	public void Recording_StartsWithTheStartBeep()
+	{
+		var plan = RecordingUiPlanner.For(RecordingActivity.Recording);
+
+		Assert.True(plan.PlayStartBeep);
+		Assert.Equal("Stop", plan.ButtonLabel);
+		Assert.True(plan.ButtonEnabled);
+		Assert.True(plan.TranscriptReadOnly);
+		Assert.Equal("Recording...", plan.TranscriptText);
+	}
+
+	// The heart of #271: whatever the recorder's flags happen to say while a stop is
+	// still unwinding, the transcribing activity never sounds the start beep and never
+	// puts the button into its Stop state.
+	[Fact]
+	public void Transcribing_NeverSoundsTheStartBeep_AndNeverReadsAsRecording()
+	{
+		var plan = RecordingUiPlanner.For(RecordingActivity.Transcribing);
+
+		Assert.False(plan.PlayStartBeep);
+		Assert.Equal("Transcribing...", plan.ButtonLabel);
+		Assert.NotEqual("Stop", plan.ButtonLabel);
+		Assert.Equal("Transcribing...", plan.TranscriptText);
+		Assert.True(plan.TranscriptReadOnly);
+	}
+
+	// The buttons go dead while the audio is being turned into text, so a second press
+	// cannot queue another operation behind the one already running.
+	[Fact]
+	public void Transcribing_DisablesTheRecordButtons()
+	{
+		Assert.False(RecordingUiPlanner.For(RecordingActivity.Transcribing).ButtonEnabled);
+	}
+
+	[Fact]
+	public void Idle_HandsTheTranscriptBoxBack_AndIsSilent()
+	{
+		var plan = RecordingUiPlanner.For(RecordingActivity.Idle);
+
+		Assert.False(plan.PlayStartBeep);
+		Assert.Equal("Record", plan.ButtonLabel);
+		Assert.True(plan.ButtonEnabled);
+		Assert.False(plan.TranscriptReadOnly);
+	}
+
+	// Going idle must not wipe the transcript that has just been delivered into the box.
+	[Fact]
+	public void Idle_LeavesTheTranscriptTextAlone()
+	{
+		Assert.Null(RecordingUiPlanner.For(RecordingActivity.Idle).TranscriptText);
+	}
+
+	[Fact]
+	public void OnlyRecording_SoundsTheStartBeep()
+	{
+		Assert.Single(
+			new[] { RecordingActivity.Idle, RecordingActivity.Recording, RecordingActivity.Transcribing },
+			a => RecordingUiPlanner.For(a).PlayStartBeep);
+	}
+}

--- a/Mutation.Tests/TranscriptDeliveryMessagesTests.cs
+++ b/Mutation.Tests/TranscriptDeliveryMessagesTests.cs
@@ -1,0 +1,98 @@
+using Mutation.Ui.Core;
+
+namespace Mutation.Tests;
+
+// Covers issue #232: both delivery branches fired the injection and returned success
+// immediately, and SendInput's return count was thrown away. With an elevated app in
+// front, Windows drops the injected input silently — and Mutation still played the
+// success beep and announced "Transcript ready." A blind user had no way to discover
+// that nothing had been typed.
+public class TranscriptDeliveryMessagesTests
+{
+	[Fact]
+	public void EverythingLanded_HasNothingToReport()
+	{
+		Assert.Null(TranscriptDeliveryMessages.Failure(
+			clipboardCopied: true, TranscriptDeliveryOutcome.Delivered, "transcript"));
+	}
+
+	[Fact]
+	public void InjectionFailure_IsReported_EvenThoughTheClipboardCopyWorked()
+	{
+		string? failure = TranscriptDeliveryMessages.Failure(
+			clipboardCopied: true, TranscriptDeliveryOutcome.InjectionFailed, "transcript");
+
+		Assert.NotNull(failure);
+		Assert.Contains("could not be sent to the other application", failure);
+		Assert.Contains(TranscriptDeliveryMessages.StillAvailable, failure);
+	}
+
+	// The two failures have different causes and different remedies, so they must not
+	// read the same: blaming the clipboard for a privilege problem sends the user
+	// hunting for a clipboard manager that was never involved.
+	[Fact]
+	public void InjectionFailure_DoesNotBlameTheClipboard()
+	{
+		string? failure = TranscriptDeliveryMessages.Failure(
+			clipboardCopied: true, TranscriptDeliveryOutcome.InjectionFailed, "transcript");
+
+		Assert.DoesNotContain("clipboard", failure!, System.StringComparison.OrdinalIgnoreCase);
+	}
+
+	// An injection failure is the one the user cannot otherwise notice, so it wins when
+	// both went wrong.
+	[Fact]
+	public void InjectionFailure_IsReportedAheadOfAClipboardFailure()
+	{
+		string? failure = TranscriptDeliveryMessages.Failure(
+			clipboardCopied: false, TranscriptDeliveryOutcome.InjectionFailed, "transcript");
+
+		Assert.Contains("could not be sent to the other application", failure);
+	}
+
+	[Fact]
+	public void ClipboardFailure_IsStillReported()
+	{
+		string? failure = TranscriptDeliveryMessages.Failure(
+			clipboardCopied: false, TranscriptDeliveryOutcome.Delivered, "transcript");
+
+		Assert.NotNull(failure);
+		Assert.Contains("clipboard is in use by another application", failure);
+		Assert.Contains(TranscriptDeliveryMessages.StillAvailable, failure);
+	}
+
+	[Fact]
+	public void PasteWithNoClipboard_IsReportedAsAClipboardFailure()
+	{
+		string? failure = TranscriptDeliveryMessages.Failure(
+			clipboardCopied: true, TranscriptDeliveryOutcome.ClipboardBlocked, "transcript");
+
+		Assert.Contains("clipboard is in use by another application", failure);
+	}
+
+	// Every failure has to end by saying where the text still is — that is the whole
+	// point of telling the user.
+	[Theory]
+	[InlineData(false, TranscriptDeliveryOutcome.Delivered)]
+	[InlineData(true, TranscriptDeliveryOutcome.ClipboardBlocked)]
+	[InlineData(true, TranscriptDeliveryOutcome.InjectionFailed)]
+	public void EveryFailure_SaysWhereTheTextIs(bool copied, TranscriptDeliveryOutcome outcome)
+	{
+		string? failure = TranscriptDeliveryMessages.Failure(copied, outcome, "transcript");
+
+		Assert.NotNull(failure);
+		Assert.EndsWith(TranscriptDeliveryMessages.StillAvailable, failure);
+	}
+
+	[Theory]
+	[InlineData("transcript")]
+	[InlineData("formatted transcript")]
+	[InlineData("processed text")]
+	public void TheMessageNamesWhatCouldNotBeDelivered(string subject)
+	{
+		Assert.Contains(subject, TranscriptDeliveryMessages.Failure(
+			clipboardCopied: false, TranscriptDeliveryOutcome.Delivered, subject));
+		Assert.Contains(subject, TranscriptDeliveryMessages.Failure(
+			clipboardCopied: true, TranscriptDeliveryOutcome.InjectionFailed, subject));
+	}
+}

--- a/Mutation.Ui/Core/AudioSessionManager.cs
+++ b/Mutation.Ui/Core/AudioSessionManager.cs
@@ -60,6 +60,15 @@ public class AudioSessionManager : IDisposable
     public bool IsRecording => _speechManager.Recording;
     public bool IsTranscribing => _speechManager.Transcribing;
 
+    // The recorder's own view of what it is doing. Used only where a failure has left
+    // the session in a state this class cannot name from where it stands — everywhere
+    // else the raising code states the activity it is entering, so a change that is
+    // still in flight cannot be announced as its opposite.
+    private RecordingActivity CurrentActivity =>
+        IsRecording ? RecordingActivity.Recording
+        : IsTranscribing ? RecordingActivity.Transcribing
+        : RecordingActivity.Idle;
+
     /// <summary>
     /// Playback speed for the recorded-audio player (1.0 = normal). Setting it
     /// retunes audio that is already playing, without restarting. The value is
@@ -74,8 +83,14 @@ public class AudioSessionManager : IDisposable
     public event EventHandler? SelectedSessionChanged;
     public event EventHandler? PlaybackStarted;
     public event EventHandler? PlaybackStopped;
-    public event EventHandler? StateChanged;
-    
+    /// <summary>
+    /// Raised with the activity the session is entering. The activity is carried on the
+    /// event rather than read back off <see cref="IsRecording"/> by the handler: the
+    /// handler runs on the UI thread via the dispatcher, so by then the recorder's flags
+    /// may not have caught up, and a stop could be announced as a start (issue #271).
+    /// </summary>
+    public event EventHandler<RecordingActivity>? StateChanged;
+
     public event EventHandler<TranscriptResult>? TranscriptReady;
     public event EventHandler<string>? ErrorOccurred;
     public event EventHandler<string>? StatusMessage;
@@ -163,7 +178,9 @@ public class AudioSessionManager : IDisposable
             {
                 _speechManager.CancelTranscription();
                 BeepPlayer.Play(BeepType.Failure);
-                StateChanged?.Invoke(this, EventArgs.Empty);
+                // Cancellation has only been requested; the in-flight transcription is
+                // still unwinding and raises its own Idle from its finally.
+                StateChanged?.Invoke(this, RecordingActivity.Transcribing);
                 StatusMessage?.Invoke(this, "Transcription cancelled.");
                 return;
             }
@@ -197,14 +214,17 @@ public class AudioSessionManager : IDisposable
                     ? "Listening — but the pinned microphone level could not be applied; recording at the current level."
                     : "Listening for audio...");
                 RefreshSessions(session);
-                StateChanged?.Invoke(this, EventArgs.Empty); // Notify UI to update buttons (Stop)
+                StateChanged?.Invoke(this, RecordingActivity.Recording);
             }
             else
             {
                 _currentRecordingUsesLlmProcessing = useLlmProcessing;
                 StopPlayback();
                 StatusMessage?.Invoke(this, "Transcribing your recording...");
-                StateChanged?.Invoke(this, EventArgs.Empty); // Notify UI to update buttons (Transcribing...)
+                // Transcribing, stated outright. The recorder has not been asked to stop
+                // yet, so a handler reading IsRecording here would see a live recording
+                // and greet a stop with the start beep and "Recording..." (issue #271).
+                StateChanged?.Invoke(this, RecordingActivity.Transcribing);
 
                 try
                 {
@@ -230,7 +250,7 @@ public class AudioSessionManager : IDisposable
                 }
                 finally
                 {
-                    StateChanged?.Invoke(this, EventArgs.Empty);
+                    StateChanged?.Invoke(this, RecordingActivity.Idle);
                 }
             }
         }
@@ -238,12 +258,12 @@ public class AudioSessionManager : IDisposable
         {
             BeepPlayer.Play(BeepType.Failure);
             StatusMessage?.Invoke(this, "Still finishing the previous operation — try again shortly.");
-            StateChanged?.Invoke(this, EventArgs.Empty);
+            StateChanged?.Invoke(this, CurrentActivity);
         }
         catch (Exception ex)
         {
             ErrorOccurred?.Invoke(this, ex.Message);
-            StateChanged?.Invoke(this, EventArgs.Empty);
+            StateChanged?.Invoke(this, CurrentActivity);
         }
     }
 
@@ -280,7 +300,7 @@ public class AudioSessionManager : IDisposable
         {
             StopPlayback();
             StatusMessage?.Invoke(this, "Transcribing your recording...");
-            StateChanged?.Invoke(this, EventArgs.Empty);
+            StateChanged?.Invoke(this, RecordingActivity.Transcribing);
 
             string text = await _speechManager.TranscribeExistingRecordingAsync(activeService, SelectedSession, prompt, cancellationToken);
             // Retry doesn't apply LLM processing — pass raw text only so
@@ -298,7 +318,7 @@ public class AudioSessionManager : IDisposable
         }
         finally
         {
-            StateChanged?.Invoke(this, EventArgs.Empty);
+            StateChanged?.Invoke(this, RecordingActivity.Idle);
         }
     }
 
@@ -314,7 +334,7 @@ public class AudioSessionManager : IDisposable
         {
             StopPlayback();
             StatusMessage?.Invoke(this, $"Transcribing {file.Name}...");
-            StateChanged?.Invoke(this, EventArgs.Empty);
+            StateChanged?.Invoke(this, RecordingActivity.Transcribing);
 
             var session = await _speechManager.ImportUploadedAudioAsync(file.Path, cancellationToken);
             RefreshSessions(session);
@@ -333,7 +353,7 @@ public class AudioSessionManager : IDisposable
         }
         finally
         {
-            StateChanged?.Invoke(this, EventArgs.Empty);
+            StateChanged?.Invoke(this, RecordingActivity.Idle);
         }
     }
 

--- a/Mutation.Ui/Core/AudioSessionManager.cs
+++ b/Mutation.Ui/Core/AudioSessionManager.cs
@@ -178,9 +178,14 @@ public class AudioSessionManager : IDisposable
             {
                 _speechManager.CancelTranscription();
                 BeepPlayer.Play(BeepType.Failure);
-                // Cancellation has only been requested; the in-flight transcription is
-                // still unwinding and raises its own Idle from its finally.
-                StateChanged?.Invoke(this, RecordingActivity.Transcribing);
+                // No state change is raised here. Nothing has changed yet — only a
+                // cancellation has been asked for — and the transcription that owns the
+                // state raises its own Idle from its finally when it unwinds. Raising a
+                // Transcribing here would race that Idle: both are delivered through the
+                // dispatcher, and if the Idle landed first the window would settle on a
+                // stale Transcribing with nothing left to correct it, leaving the buttons
+                // disabled and the transcript box read-only for the rest of the session.
+                // The beep and the status message are this branch's whole signal.
                 StatusMessage?.Invoke(this, "Transcription cancelled.");
                 return;
             }
@@ -256,12 +261,18 @@ public class AudioSessionManager : IDisposable
         }
         catch (RecorderBusyException)
         {
+            // Busy means a *different* operation owns the recorder and the session state.
+            // This one changed nothing, so it raises nothing: the owner will announce its
+            // own Idle when it finishes, and a state change from here would race it.
             BeepPlayer.Play(BeepType.Failure);
             StatusMessage?.Invoke(this, "Still finishing the previous operation — try again shortly.");
-            StateChanged?.Invoke(this, CurrentActivity);
         }
         catch (Exception ex)
         {
+            // Any other failure belongs to this operation — the busy case, the only one
+            // where another operation could be running concurrently, is caught above — so
+            // there is no competing raise to race with and the recorder's own flags are
+            // the best account of where the failure left things.
             ErrorOccurred?.Invoke(this, ex.Message);
             StateChanged?.Invoke(this, CurrentActivity);
         }

--- a/Mutation.Ui/Core/GuardedUiOperation.cs
+++ b/Mutation.Ui/Core/GuardedUiOperation.cs
@@ -23,13 +23,17 @@ public static class GuardedUiOperation
 	/// thread.
 	/// </param>
 	/// <param name="restore">
-	/// Gives the window back. Runs exactly once, whether or not anything threw.
+	/// Gives the window back. Runs exactly once, whether or not anything threw. Put the
+	/// state the user needs back first: a failure part-way through is reported through
+	/// <paramref name="onReportFailed"/> and swallowed, so the statements before it have
+	/// still taken effect.
 	/// </param>
 	/// <param name="onReportFailed">
-	/// Receives a failure raised by <paramref name="onFailure"/> itself — the beep
-	/// player or an automation peer failing while reporting the first failure. It is
-	/// logged rather than rethrown, because restoring the window still has to happen
-	/// and a second exception here would take the whole guard down with it.
+	/// Receives a failure raised by <paramref name="onFailure"/> or by
+	/// <paramref name="restore"/> itself — the beep player or an automation peer failing
+	/// while reporting or clearing up. It is logged rather than rethrown. Nothing at all
+	/// escapes this method: the callers are <c>async void</c>, so an escaping exception
+	/// would go straight back to the global handler this exists to keep them out of.
 	/// </param>
 	public static async Task RunAsync(
 		Func<Task> work,
@@ -58,7 +62,14 @@ public static class GuardedUiOperation
 		}
 		finally
 		{
-			restore();
+			try
+			{
+				restore();
+			}
+			catch (Exception restoreFailure)
+			{
+				onReportFailed?.Invoke(restoreFailure);
+			}
 		}
 	}
 }

--- a/Mutation.Ui/Core/GuardedUiOperation.cs
+++ b/Mutation.Ui/Core/GuardedUiOperation.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Mutation.Ui.Core;
+
+/// <summary>
+/// Runs UI work that has taken something away from the user — a text box put into
+/// read-only, suppressed auto-actions — and must give it back however the work ends.
+/// </summary>
+/// <remarks>
+/// The callers are <c>async void</c> handlers, so an escaping exception is swallowed by
+/// the global handler and the window is simply left crippled with no explanation: the
+/// transcript box stops accepting typing for the rest of the session (issue #234).
+/// Restoration therefore runs in a <c>finally</c>, and the failure is reported where
+/// the user will actually meet it rather than only in the log.
+/// </remarks>
+public static class GuardedUiOperation
+{
+	/// <param name="work">The operation. Its failure is caught, not propagated.</param>
+	/// <param name="onFailure">
+	/// Tells the user the operation failed — status text and a beep. Called on the same
+	/// thread as <paramref name="work"/> finished on, which for UI callers is the UI
+	/// thread.
+	/// </param>
+	/// <param name="restore">
+	/// Gives the window back. Runs exactly once, whether or not anything threw.
+	/// </param>
+	/// <param name="onReportFailed">
+	/// Receives a failure raised by <paramref name="onFailure"/> itself — the beep
+	/// player or an automation peer failing while reporting the first failure. It is
+	/// logged rather than rethrown, because restoring the window still has to happen
+	/// and a second exception here would take the whole guard down with it.
+	/// </param>
+	public static async Task RunAsync(
+		Func<Task> work,
+		Action<Exception> onFailure,
+		Action restore,
+		Action<Exception>? onReportFailed = null)
+	{
+		ArgumentNullException.ThrowIfNull(work);
+		ArgumentNullException.ThrowIfNull(onFailure);
+		ArgumentNullException.ThrowIfNull(restore);
+
+		try
+		{
+			await work();
+		}
+		catch (Exception ex)
+		{
+			try
+			{
+				onFailure(ex);
+			}
+			catch (Exception reportFailure)
+			{
+				onReportFailed?.Invoke(reportFailure);
+			}
+		}
+		finally
+		{
+			restore();
+		}
+	}
+}

--- a/Mutation.Ui/Core/RecordingActivity.cs
+++ b/Mutation.Ui/Core/RecordingActivity.cs
@@ -1,0 +1,25 @@
+namespace Mutation.Ui.Core;
+
+/// <summary>
+/// What the audio session is doing, as the code that raises the change intends it —
+/// not as a later reader of the recorder's own flags would see it.
+/// </summary>
+/// <remarks>
+/// The distinction matters. The state change is delivered to the UI thread through the
+/// dispatcher, so it arrives after the raising code has moved on. A handler that
+/// re-read the recorder's flags could see a recording that had not finished stopping
+/// yet and announce "Recording..." on a stop — telling a screen-reader user the exact
+/// opposite of what they just did (issue #271). Carrying the intended activity with
+/// the event removes the race: what was meant is what is announced.
+/// </remarks>
+public enum RecordingActivity
+{
+	/// <summary>Nothing in flight; the transcript box is the user's to edit.</summary>
+	Idle,
+
+	/// <summary>The microphone is live.</summary>
+	Recording,
+
+	/// <summary>Capture is over and the audio is being turned into text.</summary>
+	Transcribing,
+}

--- a/Mutation.Ui/Core/RecordingUiPlan.cs
+++ b/Mutation.Ui/Core/RecordingUiPlan.cs
@@ -1,0 +1,21 @@
+namespace Mutation.Ui.Core;
+
+/// <summary>
+/// What the main window should look like, and sound like, for one recording activity.
+/// </summary>
+/// <param name="ButtonLabel">Accessible label for the record/stop buttons.</param>
+/// <param name="ButtonEnabled">Whether those buttons can be pressed.</param>
+/// <param name="TranscriptReadOnly">Whether the raw transcript box accepts typing.</param>
+/// <param name="TranscriptText">
+/// Placeholder to show in the raw transcript box, or null to leave whatever is there.
+/// </param>
+/// <param name="PlayStartBeep">
+/// Whether to sound the start beep. Only a genuine start does — the beep is the blind
+/// user's confirmation that the microphone is live, so it must never accompany a stop.
+/// </param>
+public sealed record RecordingUiPlan(
+	string ButtonLabel,
+	bool ButtonEnabled,
+	bool TranscriptReadOnly,
+	string? TranscriptText,
+	bool PlayStartBeep);

--- a/Mutation.Ui/Core/RecordingUiPlanner.cs
+++ b/Mutation.Ui/Core/RecordingUiPlanner.cs
@@ -1,0 +1,36 @@
+namespace Mutation.Ui.Core;
+
+/// <summary>
+/// Turns a <see cref="RecordingActivity"/> into the window state it calls for. Pure, so
+/// the announcement a screen-reader user gets for each activity can be asserted without
+/// a window.
+/// </summary>
+public static class RecordingUiPlanner
+{
+	public const string RecordingPlaceholder = "Recording...";
+	public const string TranscribingPlaceholder = "Transcribing...";
+
+	public static RecordingUiPlan For(RecordingActivity activity) => activity switch
+	{
+		RecordingActivity.Recording => new RecordingUiPlan(
+			ButtonLabel: "Stop",
+			ButtonEnabled: true,
+			TranscriptReadOnly: true,
+			TranscriptText: RecordingPlaceholder,
+			PlayStartBeep: true),
+
+		RecordingActivity.Transcribing => new RecordingUiPlan(
+			ButtonLabel: TranscribingPlaceholder,
+			ButtonEnabled: false,
+			TranscriptReadOnly: true,
+			TranscriptText: TranscribingPlaceholder,
+			PlayStartBeep: false),
+
+		_ => new RecordingUiPlan(
+			ButtonLabel: "Record",
+			ButtonEnabled: true,
+			TranscriptReadOnly: false,
+			TranscriptText: null,
+			PlayStartBeep: false),
+	};
+}

--- a/Mutation.Ui/Core/TranscriptDeliveryMessages.cs
+++ b/Mutation.Ui/Core/TranscriptDeliveryMessages.cs
@@ -1,0 +1,36 @@
+namespace Mutation.Ui.Core;
+
+/// <summary>
+/// What to tell the user about a delivery that did not fully land. Every message ends
+/// by saying where the text still is, because the point of telling them is that they
+/// can retrieve it.
+/// </summary>
+public static class TranscriptDeliveryMessages
+{
+	public const string StillAvailable = "It is available in the Mutation window.";
+
+	/// <summary>
+	/// The failure to announce, or null when there is nothing to report.
+	/// </summary>
+	/// <param name="clipboardCopied">Whether the text reached the clipboard.</param>
+	/// <param name="outcome">How far the insert into the other application got.</param>
+	/// <param name="subject">
+	/// Names the text in the message — "transcript", "formatted transcript",
+	/// "processed text".
+	/// </param>
+	/// <remarks>
+	/// An injection failure is reported ahead of a clipboard failure: it is the one the
+	/// user cannot otherwise discover. A blind user who is told "Transcript ready" has
+	/// no way to notice that nothing was typed into the other window.
+	/// </remarks>
+	public static string? Failure(bool clipboardCopied, TranscriptDeliveryOutcome outcome, string subject)
+	{
+		if (outcome == TranscriptDeliveryOutcome.InjectionFailed)
+			return $"The {subject} could not be sent to the other application; it may be running with higher privileges than Mutation. {StillAvailable}";
+
+		if (!clipboardCopied || outcome == TranscriptDeliveryOutcome.ClipboardBlocked)
+			return $"The clipboard is in use by another application; the {subject} could not be delivered. {StillAvailable}";
+
+		return null;
+	}
+}

--- a/Mutation.Ui/Core/TranscriptDeliveryOutcome.cs
+++ b/Mutation.Ui/Core/TranscriptDeliveryOutcome.cs
@@ -1,0 +1,23 @@
+namespace Mutation.Ui.Core;
+
+/// <summary>
+/// How far text got on its way into the application the user was working in.
+/// </summary>
+public enum TranscriptDeliveryOutcome
+{
+	/// <summary>
+	/// Everything the chosen insert option asked for was carried out — including the
+	/// case where nothing had to be inserted at all.
+	/// </summary>
+	Delivered,
+
+	/// <summary>The clipboard could not be written, so there was nothing to paste.</summary>
+	ClipboardBlocked,
+
+	/// <summary>
+	/// The keystrokes were submitted but Windows did not accept them all. The usual
+	/// cause is a foreground application running with higher privileges than Mutation,
+	/// which makes Windows drop injected input silently (issue #232).
+	/// </summary>
+	InjectionFailed,
+}

--- a/Mutation.Ui/MainWindow.xaml.cs
+++ b/Mutation.Ui/MainWindow.xaml.cs
@@ -2005,8 +2005,9 @@ public sealed partial class MainWindow : Window, IDisposable
 		string formatted = _transcriptFormatter.ApplyRules(raw, false);
 		TxtFormatTranscript.Text = formatted;
 		bool copied = await _clipboard.TrySetTextAsync(formatted);
-		bool inserted = await TryInsertIntoActiveApplicationAsync(formatted, clipboardAvailable: copied);
-		if (copied && inserted)
+		var outcome = await TryInsertIntoActiveApplicationAsync(formatted, clipboardAvailable: copied);
+		string? failure = TranscriptDeliveryMessages.Failure(copied, outcome, "formatted transcript");
+		if (failure is null)
 		{
 			BeepPlayer.Play(BeepType.Success);
 			ShowStatus("Formatting", "Transcript formatted and copied.", InfoBarSeverity.Success);
@@ -2014,9 +2015,7 @@ public sealed partial class MainWindow : Window, IDisposable
 		else
 		{
 			BeepPlayer.Play(BeepType.Failure);
-			ShowStatus("Formatting",
-				"The clipboard is in use by another application; the formatted transcript could not be copied. It is available in the Mutation window.",
-				InfoBarSeverity.Error);
+			ShowStatus("Formatting", failure, InfoBarSeverity.Error);
 		}
 	}
 
@@ -2078,7 +2077,8 @@ public sealed partial class MainWindow : Window, IDisposable
 
 			TxtFormatTranscript.Text = processed;
 			bool copied = await _clipboard.TrySetTextAsync(processed);
-			bool inserted = await TryInsertIntoActiveApplicationAsync(processed, clipboardAvailable: copied);
+			var outcome = await TryInsertIntoActiveApplicationAsync(processed, clipboardAvailable: copied);
+			string? failure = TranscriptDeliveryMessages.Failure(copied, outcome, "processed text");
 
 			// Claimed after everything that can throw and just before the announcement,
 			// so a failure on the delivery path cannot burn the one notice the user gets
@@ -2086,7 +2086,7 @@ public sealed partial class MainWindow : Window, IDisposable
 			// once however the delivery turns out.
 			FastModeFallbackReason? fastModeNotice = ClaimFastModeNotice(prompt.Id, fastModeFallback);
 
-			if (copied && inserted)
+			if (failure is null)
 			{
 				BeepPlayer.Play(BeepType.Success);
 				ShowStatus("Processing",
@@ -2098,9 +2098,7 @@ public sealed partial class MainWindow : Window, IDisposable
 			{
 				BeepPlayer.Play(BeepType.Failure);
 				ShowStatus("Processing",
-					FastModeMessages.AppendTo(
-						"The clipboard is in use by another application; the processed text could not be delivered. It is available in the Mutation window.",
-						fastModeNotice),
+					FastModeMessages.AppendTo(failure, fastModeNotice),
 					InfoBarSeverity.Error);
 			}
         }
@@ -2258,61 +2256,81 @@ public sealed partial class MainWindow : Window, IDisposable
 		string? formattedText = null,
 		FastModeFallbackReason? fastModeNotice = null)
 	{
-		string formatted = formattedText ?? _transcriptFormatter.ApplyRules(rawText, false);
+		// The restoration below is what gives the user their transcript box back. It ran
+		// last, unguarded, so any throw on the delivery path — a beep, an automation peer
+		// inside ShowStatus — left the box read-only and auto-formatting suppressed for
+		// the rest of the session, with nothing said about why (#234). It now runs in a
+		// finally, and the failure is announced rather than left to the global handler.
+		await GuardedUiOperation.RunAsync(
+			work: async () =>
+			{
+				string formatted = formattedText ?? _transcriptFormatter.ApplyRules(rawText, false);
 
-		TxtRawTranscript.Text = rawText;
-		TxtFormatTranscript.Text = formatted;
+				TxtRawTranscript.Text = rawText;
+				TxtFormatTranscript.Text = formatted;
 
-		bool copied = await _clipboard.TrySetTextAsync(formatted);
-		bool inserted = await TryInsertIntoActiveApplicationAsync(formatted, clipboardAvailable: copied);
+				bool copied = await _clipboard.TrySetTextAsync(formatted);
+				var outcome = await TryInsertIntoActiveApplicationAsync(formatted, clipboardAvailable: copied);
+				string? failure = TranscriptDeliveryMessages.Failure(copied, outcome, "transcript");
 
-		if (copied && inserted)
-		{
-			BeepPlayer.Play(BeepType.Success);
-			ShowStatus("Speech to Text", FastModeMessages.AppendTo(successMessage, fastModeNotice), InfoBarSeverity.Success);
-			HotkeyManager.SendHotkeyAfterDelay(_settings.SpeechToTextSettings?.SendHotkeyAfterTranscriptionOperation, Constants.SendHotkeyDelay);
-		}
-		else
-		{
-			BeepPlayer.Play(BeepType.Failure);
-			ShowStatus("Speech to Text",
-				FastModeMessages.AppendTo(
-					"The clipboard is in use by another application; the transcript could not be delivered. It is available in the Mutation window.",
-					fastModeNotice),
-				InfoBarSeverity.Error);
-		}
-
-		TxtRawTranscript.IsReadOnly = false;
-		_suppressAutoActions = false;
-		UpdateRecordingActionAvailability();
-		ScheduleSessionCleanup();
+				if (failure is null)
+				{
+					BeepPlayer.Play(BeepType.Success);
+					ShowStatus("Speech to Text", FastModeMessages.AppendTo(successMessage, fastModeNotice), InfoBarSeverity.Success);
+					HotkeyManager.SendHotkeyAfterDelay(_settings.SpeechToTextSettings?.SendHotkeyAfterTranscriptionOperation, Constants.SendHotkeyDelay);
+				}
+				else
+				{
+					BeepPlayer.Play(BeepType.Failure);
+					ShowStatus("Speech to Text",
+						FastModeMessages.AppendTo(failure, fastModeNotice),
+						InfoBarSeverity.Error);
+				}
+			},
+			onFailure: ex =>
+			{
+				ErrorLogger.LogError("FinalizeTranscript", ex);
+				BeepPlayer.Play(BeepType.Failure);
+				ShowStatus("Speech to Text",
+					"Something went wrong while delivering the transcript. It is available in the Mutation window.",
+					InfoBarSeverity.Error);
+			},
+			restore: () =>
+			{
+				TxtRawTranscript.IsReadOnly = false;
+				_suppressAutoActions = false;
+				UpdateRecordingActionAvailability();
+				ScheduleSessionCleanup();
+			},
+			onReportFailed: ex => ErrorLogger.LogError("FinalizeTranscript failure report", ex));
 	}
 
-    private void AudioSessionManager_StateChanged(object? sender, EventArgs e)
+    // Driven by the activity the session says it is entering, never by re-reading the
+    // recorder's flags. This handler is dispatched, so it runs after the raising code
+    // has moved on: reading IsRecording here once let a stop be greeted with the start
+    // beep and "Recording..." — the opposite of what the user had just done (#271).
+    private void AudioSessionManager_StateChanged(object? sender, RecordingActivity activity)
     {
         DispatcherQueue.TryEnqueue(() =>
         {
             UpdateRecordingActionAvailability();
-            if (_audioSessionManager.IsRecording)
-            {
-                UpdateSpeechButtonVisuals("Stop", StopGlyph);
-                TxtRawTranscript.IsReadOnly = true;
-                TxtRawTranscript.Text = "Recording...";
+
+            var plan = RecordingUiPlanner.For(activity);
+            UpdateSpeechButtonVisuals(plan.ButtonLabel, GlyphFor(activity), plan.ButtonEnabled);
+            TxtRawTranscript.IsReadOnly = plan.TranscriptReadOnly;
+            if (plan.TranscriptText is string placeholder)
+                TxtRawTranscript.Text = placeholder;
+            if (plan.PlayStartBeep)
                 BeepPlayer.Play(BeepType.Start);
-            }
-            else if (_audioSessionManager.IsTranscribing)
-            {
-                UpdateSpeechButtonVisuals("Transcribing...", ProcessingGlyph, false);
-                TxtRawTranscript.IsReadOnly = true;
-                TxtRawTranscript.Text = "Transcribing...";
-            }
-            else
-            {
-                UpdateSpeechButtonVisuals("Record", RecordGlyph);
-                TxtRawTranscript.IsReadOnly = false;
-            }
         });
     }
+
+    private static string GlyphFor(RecordingActivity activity) => activity switch
+    {
+        RecordingActivity.Recording => StopGlyph,
+        RecordingActivity.Transcribing => ProcessingGlyph,
+        _ => RecordGlyph,
+    };
 
     private void AudioSessionManager_TranscriptReady(object? sender, TranscriptResult result)
     {
@@ -2739,41 +2757,49 @@ public sealed partial class MainWindow : Window, IDisposable
 		ThirdPartyExplanationText.Text = explanation;
 	}
 
-	// Returns false only when a paste-mode insert could not proceed because the
-	// clipboard stayed unavailable; every path that needs no insert returns true.
-	private async Task<bool> TryInsertIntoActiveApplicationAsync(string text, bool clipboardAvailable = true)
+	// Reports how far the text actually got. Every path that needs no insert — an empty
+	// transcript, Mutation itself in front, the "do not insert" option — is Delivered.
+	//
+	// The injection is awaited rather than fired and forgotten (#232). Windows drops
+	// injected input silently when the foreground application runs with higher
+	// privileges, so the only moment the failure can be seen is when SendInput returns
+	// a short count; a caller that had already announced success by then would have
+	// told a blind user their dictation landed in a window that never received it. The
+	// await keeps the work off the UI thread — it runs on the thread pool and the UI
+	// thread returns to its message pump — and it is bounded: SendInput is synchronous,
+	// and the hotkey path waits at most ModifierReleaseTimeoutMs for the user to let go
+	// of the chord they triggered this with.
+	private async Task<TranscriptDeliveryOutcome> TryInsertIntoActiveApplicationAsync(string text, bool clipboardAvailable = true)
 	{
 		if (string.IsNullOrWhiteSpace(text))
-			return true;
+			return TranscriptDeliveryOutcome.Delivered;
 
 		var windowHandle = WindowNative.GetWindowHandle(this);
 		if (windowHandle != IntPtr.Zero)
 		{
 			var foregroundWindow = GetForegroundWindow();
 			if (foregroundWindow == windowHandle)
-				return true;
+				return TranscriptDeliveryOutcome.Delivered;
 		}
 
 		switch (_insertOption)
 		{
 			case DictationInsertOption.SendKeys:
 				BeepPlayer.Play(BeepType.Start);
-				// Off the UI thread: SendInput can stall on the foreground app
-				// and must never block or pump messages mid-finalization.
-				_ = Task.Run(() => HotkeyManager.SendText(text));
-				return true;
+				bool typed = await Task.Run(() => HotkeyManager.SendText(text));
+				return typed ? TranscriptDeliveryOutcome.Delivered : TranscriptDeliveryOutcome.InjectionFailed;
 			case DictationInsertOption.Paste:
 				// Pasting sends Ctrl+V, so the text must actually be on the
 				// clipboard; retry the write here if the earlier copy failed.
 				if (!clipboardAvailable && !await _clipboard.TrySetTextAsync(text))
-					return false;
+					return TranscriptDeliveryOutcome.ClipboardBlocked;
 				// "Ctrl+V" (not "^v"): Hotkey.Parse has no caret syntax, so the
 				// literal would throw and drop to the SendKeys.SendWait fallback.
-				_ = Task.Run(() => HotkeyManager.SendHotkey("Ctrl+V"));
-				return true;
+				bool pasted = await Task.Run(() => HotkeyManager.SendHotkey("Ctrl+V"));
+				return pasted ? TranscriptDeliveryOutcome.Delivered : TranscriptDeliveryOutcome.InjectionFailed;
 		}
 
-		return true;
+		return TranscriptDeliveryOutcome.Delivered;
 	}
 
 	private async void TxtSpeechToText_TextChanged(object sender, TextChangedEventArgs e)

--- a/Mutation.Ui/MainWindow.xaml.cs
+++ b/Mutation.Ui/MainWindow.xaml.cs
@@ -2152,26 +2152,29 @@ public sealed partial class MainWindow : Window, IDisposable
 
 	private void UpdateSpeechButtonVisuals(string label, string glyph, bool isEnabled = true)
 	{
+		// isEnabled is honoured in every branch. It used to be read only by the last
+		// one, which made the caller's choice silently inert for the Record and Stop
+		// states — a plan could say "disabled" and the window would not agree.
 		if (label == "Record")
 		{
 			// Idle state
 			BtnSpeechToTextIcon.Glyph = RecordGlyph;
-			BtnSpeechToText.IsEnabled = true;
+			BtnSpeechToText.IsEnabled = isEnabled;
 			ConfigureButtonHotkey(BtnSpeechToText, null, _settings.SpeechToTextSettings?.SpeechToTextHotKey, "Record", "Record");
 
 			BtnSpeechToTextWithFormatIcon.Glyph = MagicGlyph;
-			BtnSpeechToTextWithFormat.IsEnabled = true;
+			BtnSpeechToTextWithFormat.IsEnabled = isEnabled;
 			ConfigureButtonHotkey(BtnSpeechToTextWithFormat, null, _settings.SpeechToTextSettings?.SpeechToTextWithLlmProcessingHotKey, "Record and Format", "Record and Format");
 		}
 		else if (label == "Stop")
 		{
 			// Recording state
 			BtnSpeechToTextIcon.Glyph = StopGlyph;
-			BtnSpeechToText.IsEnabled = true;
+			BtnSpeechToText.IsEnabled = isEnabled;
 			ConfigureButtonHotkey(BtnSpeechToText, null, _settings.SpeechToTextSettings?.SpeechToTextHotKey, "Stop", "Stop");
 
 			BtnSpeechToTextWithFormatIcon.Glyph = StopGlyph;
-			BtnSpeechToTextWithFormat.IsEnabled = true;
+			BtnSpeechToTextWithFormat.IsEnabled = isEnabled;
 			ConfigureButtonHotkey(BtnSpeechToTextWithFormat, null, _settings.SpeechToTextSettings?.SpeechToTextWithLlmProcessingHotKey, "Stop and Format", "Stop and Format");
 		}
 		else

--- a/Mutation.Ui/Services/HotkeyManager.cs
+++ b/Mutation.Ui/Services/HotkeyManager.cs
@@ -110,11 +110,8 @@ public class HotkeyManager : IDisposable
 	private const int WM_HOTKEY = 0x0312;
 	private const int GWLP_WNDPROC = -4;
 
-	private const uint MOD_ALT = 0x1;
-	private const uint MOD_CONTROL = 0x2;
-	private const uint MOD_SHIFT = 0x4;
-	private const uint MOD_WIN = 0x8;
-	private const uint MOD_NOREPEAT = 0x4000;
+	// Modifier flags live in HotkeyModifiers so their composition — including
+	// MOD_NOREPEAT — can be tested without a window handle.
 
         [DllImport("user32.dll", SetLastError = true)] static extern bool RegisterHotKey(IntPtr hWnd, int id, uint fsModifiers, uint vk);
 	[DllImport("user32.dll")] static extern bool UnregisterHotKey(IntPtr hWnd, int id);
@@ -205,10 +202,7 @@ public class HotkeyManager : IDisposable
                 }
 
                 int id = Interlocked.Increment(ref _id);
-                uint mods = (hotkey.Alt ? MOD_ALT : 0) |
-                                                                                          (hotkey.Control ? MOD_CONTROL : 0) |
-                                                                                          (hotkey.Shift ? MOD_SHIFT : 0) |
-                                                                                          (hotkey.Win ? MOD_WIN : 0);
+                uint mods = HotkeyModifiers.Compose(hotkey);
 				bool success = RegisterHotKey(_hwnd, id, mods, (uint)hotkey.Key);
                 if (success)
                 {
@@ -428,10 +422,22 @@ public class HotkeyManager : IDisposable
 		});
 	}
 
-	public static void SendHotkey(string hotkey)
+	/// <summary>
+	/// Sends <paramref name="hotkey"/> — one chord, or a comma-separated sequence — to
+	/// whatever window has the keyboard focus.
+	/// </summary>
+	/// <returns>
+	/// True only when every chord was confirmed delivered through SendInput. The
+	/// WinForms SendKeys fallback still runs as a best effort, but it cannot report
+	/// whether the target window took the keystrokes, so a run that needed it returns
+	/// false. Callers that announce the result must treat that as "could not confirm
+	/// delivery": for a blind user a false success is worse than a false alarm, because
+	/// nothing else in the session will ever contradict it (issue #232).
+	/// </returns>
+	public static bool SendHotkey(string hotkey)
 	{
 		if (string.IsNullOrWhiteSpace(hotkey))
-			return;
+			return true;
 
 		// Quick override for diagnostics: set MUTATION_FORCE_SENDKEYS=1 to bypass SendInput
 		if (Environment.GetEnvironmentVariable("MUTATION_FORCE_SENDKEYS") == "1")
@@ -441,7 +447,7 @@ public class HotkeyManager : IDisposable
 				string mappedHotkey = SendKeysMapper.Map(hotkey);
 				Log($"ENV override: Fallback SendKeys: '{mappedHotkey}' (from '{hotkey}')");
 				SendKeysOnUiThread(mappedHotkey);
-				return;
+				return false;
 			}
 			catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"SendKeys env override failed: {ex.Message}"); }
 		}
@@ -449,7 +455,7 @@ public class HotkeyManager : IDisposable
 		// Support sequences like "Ctrl+C, Ctrl+V"
 		var parts = hotkey.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
 		if (parts.Length == 0)
-			return;
+			return true;
 
 		bool allSentViaInput = true;
 		foreach (var part in parts)
@@ -490,6 +496,8 @@ public class HotkeyManager : IDisposable
 			}
 			catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"SendKeys fallback failed: {ex.Message}"); }
 		}
+
+		return allSentViaInput;
 	}
 
 	private static void SendKeysOnUiThread(string mapped)
@@ -536,10 +544,20 @@ public class HotkeyManager : IDisposable
 		return tcs.Task;
 	}
 
-	public static void SendText(string text)
+	/// <summary>
+	/// Types <paramref name="text"/> into whatever window has the keyboard focus.
+	/// </summary>
+	/// <returns>
+	/// True when Windows accepted every keystroke. False when it accepted fewer than
+	/// were submitted — which is what happens when the foreground application runs with
+	/// higher privileges than Mutation and Windows drops the input silently. The caller
+	/// has to tell the user, or they are left believing their dictation landed in an
+	/// application that never received a character (issue #232).
+	/// </returns>
+	public static bool SendText(string text)
 	{
 		if (string.IsNullOrEmpty(text))
-			return;
+			return true;
 
 		List<INPUT> inputs = new();
 		foreach (char c in text)
@@ -555,7 +573,13 @@ public class HotkeyManager : IDisposable
 				U = new INPUTUNION { ki = new KEYBDINPUT { wScan = c, dwFlags = KEYEVENTF_UNICODE | KEYEVENTF_KEYUP } }
 			});
 		}
-		SendInput((uint)inputs.Count, inputs.ToArray(), Marshal.SizeOf<INPUT>());
+		uint submitted = (uint)inputs.Count;
+		uint sent = SendInput(submitted, inputs.ToArray(), Marshal.SizeOf<INPUT>());
+		if (sent == submitted)
+			return true;
+
+		Log($"SendText delivered {sent}/{submitted} keystrokes, GetLastError={Marshal.GetLastWin32Error()}");
+		return false;
 	}
 
 	private static bool SendHotkeyViaSendInput(Hotkey hotkey)

--- a/Mutation.Ui/Services/HotkeyModifiers.cs
+++ b/Mutation.Ui/Services/HotkeyModifiers.cs
@@ -1,0 +1,41 @@
+using System;
+
+namespace Mutation.Ui.Services;
+
+/// <summary>
+/// Builds the <c>fsModifiers</c> word that <c>RegisterHotKey</c> takes. Kept apart
+/// from <see cref="HotkeyManager"/> so the composition is testable without a window
+/// handle or a P/Invoke.
+/// </summary>
+public static class HotkeyModifiers
+{
+	public const uint MOD_ALT = 0x1;
+	public const uint MOD_CONTROL = 0x2;
+	public const uint MOD_SHIFT = 0x4;
+	public const uint MOD_WIN = 0x8;
+
+	/// <summary>
+	/// Windows repeats WM_HOTKEY at the keyboard auto-repeat rate for as long as the
+	/// combination is held unless this flag is set. Every hotkey here starts an
+	/// operation — record, mute, read aloud — so a repeat is never what the user meant:
+	/// holding the dictation shortcut a moment too long would start a recording, stop
+	/// and transcribe it, and start another (issue #226).
+	/// </summary>
+	public const uint MOD_NOREPEAT = 0x4000;
+
+	/// <summary>
+	/// Modifier flags for <paramref name="hotkey"/>, always including
+	/// <see cref="MOD_NOREPEAT"/> so a held combination activates exactly once.
+	/// </summary>
+	public static uint Compose(Hotkey hotkey)
+	{
+		ArgumentNullException.ThrowIfNull(hotkey);
+
+		uint mods = MOD_NOREPEAT;
+		if (hotkey.Alt) mods |= MOD_ALT;
+		if (hotkey.Control) mods |= MOD_CONTROL;
+		if (hotkey.Shift) mods |= MOD_SHIFT;
+		if (hotkey.Win) mods |= MOD_WIN;
+		return mods;
+	}
+}


### PR DESCRIPTION
Closes #226
Closes #232
Closes #234
Closes #271

Four small defects around the dictation round trip, taken together because they
sit in the same three files. Each one had the app telling a blind user something
it had not actually done.

## A held hotkey auto-repeated (#226)

`MOD_NOREPEAT` was declared in `HotkeyManager` and referenced nowhere else, so
Windows re-delivered `WM_HOTKEY` at the keyboard auto-repeat rate for as long as
the combination was held. Holding the dictation shortcut a moment too long
started a recording, stopped and transcribed it, and started another — with a
`RecorderBusyException` failure beep per round. The mute hotkey flip-flopped the
same way.

Modifier composition moves out to `HotkeyModifiers.Compose`, which always sets
the flag and can be tested without a window handle or a P/Invoke.

## SendKeys and paste reported success when the injection failed (#232)

Both delivery branches did `_ = Task.Run(...)` and returned true immediately, and
`HotkeyManager.SendText` discarded `SendInput`'s return value. When the
foreground application runs with higher privileges, Windows drops the injected
input silently — so Mutation played the success beep and announced "Transcript
ready" for text that never arrived, with no way for the user to find out.

- `SendText` and `SendHotkey` now return whether Windows accepted the keystrokes.
- `TryInsertIntoActiveApplicationAsync` awaits the injection and returns a
  `TranscriptDeliveryOutcome` instead of a bool.
- A delivery failure gets its own beep and its own message, distinct from the
  clipboard one — the causes and the remedies are different, and blaming the
  clipboard for a privilege problem sends the user hunting for the wrong thing.

Awaiting keeps the work off the UI thread (it runs on the thread pool; the UI
thread returns to its message pump) and is bounded — `SendInput` is synchronous,
and the hotkey path waits at most `ModifierReleaseTimeoutMs` for the user to
release the chord.

One judgement call worth flagging: `SendHotkey` returns false when it had to use
the WinForms `SendKeys` fallback, because that path cannot confirm the target
took the keystrokes. The fallback still runs as a best effort; it just does not
get to claim success. For a blind user a false alarm is recoverable and a false
success is not.

## FinalizeTranscript could leave the transcript box read-only forever (#234)

The two statements that gave the user their transcript box back ran last, after
three awaits and two beeps, with no `try`/`finally`. Any throw on the delivery
path skipped both, and because the method is `async void` the exception went to
the global handler — so the box simply stopped accepting typing for the rest of
the session, with nothing said about why.

Restoration moves into a `finally` through the new `GuardedUiOperation`, and the
failure is announced with status and beep rather than left to the log. The guard
also survives its own failure report throwing, which matters here because the
reporting path is beeps and automation peers — exactly what tends to be failing.

## Stopping a recording could announce and beep "recording started" (#271)

`StartStopRecordingAsync` raised `StateChanged` on the stop path before the
recorder had stopped, and the handler — dispatched to the UI thread, so running
after the raiser had moved on — branched on `IsRecording`. With the recorder
semaphore contended it took the *start* branch on a stop: "Recording..." in the
transcript box, the button into its Stop state, and `BeepType.Start`.

Fixed at the source. `StateChanged` is now `EventHandler<RecordingActivity>` and
each raise site states the activity it is entering; the handler never re-reads
recorder flags. `RecordingUiPlanner` turns the activity into what the user sees
and hears, so the mapping is assertable without a window.

**Behaviour change beyond the reported bug**, called out deliberately: the retry
and upload paths also raised a state change before their transcription began, so
they said "Transcribing your recording..." and then showed the *idle* state.
They now declare `Transcribing` like the record path does, which disables the
record buttons for the duration and shows the placeholder. This is the same
defect the issue describes and the fix falls out of it, but it is a visible
change and the reviewer should agree with it.

The two `catch` blocks still read the recorder's flags, because a failure can
leave the session either way and its own flags are the best information
available there. That is commented in place.

## Tests

30 new tests across four files; the whole suite is 1274 passing on Release.

- `HotkeyModifiersTests` — `MOD_NOREPEAT` set for all 16 modifier combinations,
  requested modifiers preserved, unrequested ones absent.
- `TranscriptDeliveryMessagesTests` — an injection failure is reported, does not
  mention the clipboard, wins over a simultaneous clipboard failure, and every
  failure ends by saying where the text still is.
- `GuardedUiOperationTests` — state restored when the work throws synchronously,
  when it throws after an await, and when the failure report itself throws;
  restored exactly once; nothing propagates to the `async void` caller.
- `RecordingUiPlannerTests` — transcribing never sounds the start beep and never
  reads as recording; only recording does; idle leaves the delivered transcript
  in place.

## Documentation

- `troubleshooting.md` — two new entries: the delivery-refused message with its
  causes and remedies, and the unexpected-delivery-failure message.
- `dictation.md` — Mutation waits to see whether the text arrived before saying
  it worked.
- `keyboard-shortcuts.md` — a shortcut fires once per press; holding it does
  nothing extra.
- HTML regenerated with `Documentation\Build-UserGuide.cmd` and committed
  alongside.

## Not done

Verifying #226 against a physically held hotkey needs a real keyboard and a real
window — that one is for manual acceptance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
