### PR TITLE
Say the option out loud, decode off the UI thread, and know which side a symbol leans on

### DIFF
--- a/CognitiveSupport/AudioPlayer.cs
+++ b/CognitiveSupport/AudioPlayer.cs
@@ -107,16 +107,22 @@ public class AudioPlayer : IDisposable
         }
         catch (Exception ex)
         {
-            prepared?.Dispose();
-
-            // A superseded request stays quiet and touches nothing. The player belongs to a
-            // newer file by now, and Stop here would cut off audio that is already playing
-            // while PlaybackFailed pops an error dialog about a file the user has moved on
-            // from — the failing decode is seconds behind the request that replaced it.
+            // A superseded request stays quiet and touches nothing but its own work. The
+            // player belongs to a newer file by now, and Stop here would cut off audio that is
+            // already playing while PlaybackFailed pops an error dialog about a file the user
+            // moved on from — the failing decode is seconds behind the request that replaced
+            // it.
             if (!IsCurrent(generation))
+            {
+                prepared?.Dispose();
                 return;
+            }
 
+            // Stop first, then release the buffers. StartPlayback can throw after it has
+            // published the source and attached the output device, and disposing the stream
+            // the device is reading from before detaching the device is the wrong order.
             Stop();
+            prepared?.Dispose();
             PlaybackFailed?.Invoke(this, $"Playback failed: {ex.Message}");
         }
     }

--- a/CognitiveSupport/AudioPlayer.cs
+++ b/CognitiveSupport/AudioPlayer.cs
@@ -24,6 +24,13 @@ public class AudioPlayer : IDisposable
     private double _speed = PlaybackSpeedOptions.Default;
     private bool _disposed;
 
+    // Bumped by every request to play and by every Stop. A decode that finishes holding a
+    // stale number has been superseded — the user pressed Stop, or asked for a different
+    // file — and throws its work away instead of starting audio nobody is waiting for any
+    // more. Only meaningful once decoding moved off the calling thread and a request could
+    // outlive the answer.
+    private int _playGeneration;
+
     // Opus parameters matching AudioRecorder
     private const int SampleRate = 48000;
     private const int Channels = 1;
@@ -65,10 +72,12 @@ public class AudioPlayer : IDisposable
     public event EventHandler<string>? PlaybackFailed;
 
     /// <summary>
-    /// Plays an audio file. Supports OGG/Opus, WAV, and MP3 formats.
+    /// Plays an audio file, decoding it on the calling thread. Supports OGG/Opus, WAV, and
+    /// MP3 formats. Prefer <see cref="PlayAsync"/> anywhere the caller is the UI thread.
     /// </summary>
     public void Play(string filePath)
     {
+        int generation = NextGeneration();
         PreparedSource? prepared = null;
         try
         {
@@ -76,33 +85,82 @@ public class AudioPlayer : IDisposable
             // seconds, and doing it under _playLock blocked every Speed change made from the
             // UI thread for that whole window, freezing the window.
             prepared = Prepare(filePath);
-            if (prepared is null)
-            {
-                PlaybackFailed?.Invoke(this, "No audio data found in file.");
-                return;
-            }
-
-            lock (_playLock)
-            {
-                // Stopping and publishing happen under one lock, so two overlapping Play calls
-                // cannot leave the loser's output device attached with nothing to release it.
-                StopCore();
-
-                if (_disposed)
-                {
-                    prepared.Dispose();
-                    return;
-                }
-
-                _pcmStream = prepared.Pcm;
-                StartPlayback(prepared.Stream);
-            }
+            Launch(prepared, generation);
         }
         catch (Exception ex)
         {
             Stop();
             prepared?.Dispose();
             PlaybackFailed?.Invoke(this, $"Playback failed: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Plays an audio file, decoding it on the thread pool. A whole-file Opus decode takes
+    /// seconds to tens of seconds for a long recording, and on the UI thread that is a frozen
+    /// window and a silent screen reader for the duration (issue #281).
+    /// <para>
+    /// Only the decode moves. The output device is still constructed where the caller was,
+    /// because NAudio's <c>WaveOutEvent</c> captures <c>SynchronizationContext.Current</c> at
+    /// construction and posts <c>PlaybackStopped</c> back to it — build it on a pool thread
+    /// with no context and <see cref="PlaybackEnded"/> would start arriving on NAudio's own
+    /// playback thread, where its listeners touch the UI. Starting is microseconds of work;
+    /// decoding is the part that had to move.
+    /// </para>
+    /// </summary>
+    public async Task PlayAsync(string filePath)
+    {
+        int generation = NextGeneration();
+        PreparedSource? prepared = null;
+        try
+        {
+            // ConfigureAwait(true) is the point of the method, not an oversight: the
+            // continuation has to resume where the caller was so the device is built there.
+            prepared = await Task.Run(() => Prepare(filePath)).ConfigureAwait(true);
+            Launch(prepared, generation);
+        }
+        catch (Exception ex)
+        {
+            Stop();
+            prepared?.Dispose();
+            PlaybackFailed?.Invoke(this, $"Playback failed: {ex.Message}");
+        }
+    }
+
+    private int NextGeneration()
+    {
+        lock (_playLock)
+        {
+            return ++_playGeneration;
+        }
+    }
+
+    /// <summary>
+    /// Publishes a decoded source and starts it, unless something newer has happened since the
+    /// decode began.
+    /// </summary>
+    private void Launch(PreparedSource? prepared, int generation)
+    {
+        if (prepared is null)
+        {
+            PlaybackFailed?.Invoke(this, "No audio data found in file.");
+            return;
+        }
+
+        lock (_playLock)
+        {
+            // Stopping and publishing happen under one lock, so two overlapping Play calls
+            // cannot leave the loser's output device attached with nothing to release it.
+            if (_disposed || generation != _playGeneration)
+            {
+                prepared.Dispose();
+                return;
+            }
+
+            StopCore();
+
+            _pcmStream = prepared.Pcm;
+            StartPlayback(prepared.Stream);
         }
     }
 
@@ -216,6 +274,9 @@ public class AudioPlayer : IDisposable
     {
         lock (_playLock)
         {
+            // Supersede any decode still running, so a file the user has already stopped
+            // does not start playing the moment its decode lands.
+            _playGeneration++;
             StopCore();
         }
     }

--- a/CognitiveSupport/AudioPlayer.cs
+++ b/CognitiveSupport/AudioPlayer.cs
@@ -16,6 +16,7 @@ namespace CognitiveSupport;
 public class AudioPlayer : IDisposable
 {
     private readonly Func<IAudioOutputDevice> _outputDeviceFactory;
+    private readonly Action<string>? _beforePrepare;
     private IAudioOutputDevice? _waveOut;
     private MemoryStream? _pcmStream;
     private WaveStream? _sourceStream;
@@ -40,9 +41,16 @@ public class AudioPlayer : IDisposable
     {
     }
 
-    internal AudioPlayer(Func<IAudioOutputDevice> outputDeviceFactory)
+    /// <param name="beforePrepare">
+    /// Test seam. Runs on the decoding thread, before the file is opened, so a test can hold a
+    /// decode open and act while it is in flight — which is the only way to reach the
+    /// superseded and failed-decode paths deterministically rather than by racing the thread
+    /// pool. Null in production.
+    /// </param>
+    internal AudioPlayer(Func<IAudioOutputDevice> outputDeviceFactory, Action<string>? beforePrepare = null)
     {
         _outputDeviceFactory = outputDeviceFactory ?? throw new ArgumentNullException(nameof(outputDeviceFactory));
+        _beforePrepare = beforePrepare;
     }
 
     public bool IsPlaying => _waveOut?.PlaybackState == PlaybackState.Playing;
@@ -72,33 +80,10 @@ public class AudioPlayer : IDisposable
     public event EventHandler<string>? PlaybackFailed;
 
     /// <summary>
-    /// Plays an audio file, decoding it on the calling thread. Supports OGG/Opus, WAV, and
-    /// MP3 formats. Prefer <see cref="PlayAsync"/> anywhere the caller is the UI thread.
-    /// </summary>
-    public void Play(string filePath)
-    {
-        int generation = NextGeneration();
-        PreparedSource? prepared = null;
-        try
-        {
-            // Reading and decoding happen outside the lock. Decoding a long recording takes
-            // seconds, and doing it under _playLock blocked every Speed change made from the
-            // UI thread for that whole window, freezing the window.
-            prepared = Prepare(filePath);
-            Launch(prepared, generation);
-        }
-        catch (Exception ex)
-        {
-            Stop();
-            prepared?.Dispose();
-            PlaybackFailed?.Invoke(this, $"Playback failed: {ex.Message}");
-        }
-    }
-
-    /// <summary>
-    /// Plays an audio file, decoding it on the thread pool. A whole-file Opus decode takes
-    /// seconds to tens of seconds for a long recording, and on the UI thread that is a frozen
-    /// window and a silent screen reader for the duration (issue #281).
+    /// Plays an audio file, decoding it on the thread pool. Supports OGG/Opus, WAV, and MP3.
+    /// A whole-file Opus decode takes seconds to tens of seconds for a long recording, and on
+    /// the UI thread that is a frozen window and a silent screen reader for the duration
+    /// (issue #281).
     /// <para>
     /// Only the decode moves. The output device is still constructed where the caller was,
     /// because NAudio's <c>WaveOutEvent</c> captures <c>SynchronizationContext.Current</c> at
@@ -114,15 +99,24 @@ public class AudioPlayer : IDisposable
         PreparedSource? prepared = null;
         try
         {
-            // ConfigureAwait(true) is the point of the method, not an oversight: the
+            // Reading and decoding happen outside the lock, so a decode never blocks a Speed
+            // change. ConfigureAwait(true) is the point of the method, not an oversight: the
             // continuation has to resume where the caller was so the device is built there.
             prepared = await Task.Run(() => Prepare(filePath)).ConfigureAwait(true);
             Launch(prepared, generation);
         }
         catch (Exception ex)
         {
-            Stop();
             prepared?.Dispose();
+
+            // A superseded request stays quiet and touches nothing. The player belongs to a
+            // newer file by now, and Stop here would cut off audio that is already playing
+            // while PlaybackFailed pops an error dialog about a file the user has moved on
+            // from — the failing decode is seconds behind the request that replaced it.
+            if (!IsCurrent(generation))
+                return;
+
+            Stop();
             PlaybackFailed?.Invoke(this, $"Playback failed: {ex.Message}");
         }
     }
@@ -135,41 +129,59 @@ public class AudioPlayer : IDisposable
         }
     }
 
+    /// <summary>Whether this request is still the one the player is answering.</summary>
+    private bool IsCurrent(int generation)
+    {
+        lock (_playLock)
+        {
+            return !_disposed && generation == _playGeneration;
+        }
+    }
+
     /// <summary>
     /// Publishes a decoded source and starts it, unless something newer has happened since the
-    /// decode began.
+    /// decode began. A null source means the file held no audio.
     /// </summary>
     private void Launch(PreparedSource? prepared, int generation)
     {
-        if (prepared is null)
-        {
-            PlaybackFailed?.Invoke(this, "No audio data found in file.");
-            return;
-        }
+        bool nothingToPlay;
 
         lock (_playLock)
         {
-            // Stopping and publishing happen under one lock, so two overlapping Play calls
-            // cannot leave the loser's output device attached with nothing to release it.
+            // Checked before anything is touched: a stale decode owns nothing here, so it
+            // neither tears the current playback down nor reports anything about itself.
             if (_disposed || generation != _playGeneration)
             {
-                prepared.Dispose();
+                prepared?.Dispose();
                 return;
             }
 
-            StopCore();
+            nothingToPlay = prepared is null;
+            if (!nothingToPlay)
+            {
+                // Stopping and publishing happen under one lock, so two overlapping requests
+                // cannot leave the loser's output device attached with nothing to release it.
+                StopCore();
 
-            _pcmStream = prepared.Pcm;
-            StartPlayback(prepared.Stream);
+                _pcmStream = prepared!.Pcm;
+                StartPlayback(prepared.Stream);
+            }
         }
+
+        // Raised outside the lock: it runs listener code, which is free to call straight back
+        // into PlayAsync or Stop.
+        if (nothingToPlay)
+            PlaybackFailed?.Invoke(this, "No audio data found in file.");
     }
 
     /// <summary>
     /// Opens or decodes the file into a source ready to play, without touching any of the
     /// player's own state. Returns null when the file holds no audio.
     /// </summary>
-    private static PreparedSource? Prepare(string filePath)
+    private PreparedSource? Prepare(string filePath)
     {
+        _beforePrepare?.Invoke(filePath);
+
         string extension = Path.GetExtension(filePath).ToLowerInvariant();
 
         // Ogg/Opus is decoded in managed code: Windows Media Foundation has no demuxer for it,

--- a/CognitiveSupport/SymbolAttachment.cs
+++ b/CognitiveSupport/SymbolAttachment.cs
@@ -1,0 +1,76 @@
+namespace CognitiveSupport;
+
+/// <summary>
+/// Which side of a dictated symbol the words around it close up against.
+/// </summary>
+public enum SymbolAttachment
+{
+	/// <summary>
+	/// Hugs the word on its left and leaves the gap on its right — "fifty percent last year"
+	/// wants "fifty% last year", not "fifty %last year".
+	/// </summary>
+	Left,
+
+	/// <summary>
+	/// Hugs the word on its right and leaves the gap on its left — "issue hash 42" wants
+	/// "issue #42", not "issue# 42".
+	/// </summary>
+	Right,
+
+	/// <summary>
+	/// Hugs both, welding its neighbours together — "state dash of dash the dash art" wants
+	/// "state-of-the-art". Also the answer for anything unrecognised, because closing both
+	/// sides is what a Smart rule has always done with a symbol.
+	/// </summary>
+	Both,
+}
+
+/// <summary>
+/// Works out which side a symbol replacement attaches to, from the symbol itself.
+/// <para>
+/// Kept separate from the formatter because it is a question about punctuation rather than
+/// about matching, and because the classes are the part worth reading and testing on their
+/// own: get a symbol into the wrong class and the spacing is wrong in every transcript that
+/// uses that rule.
+/// </para>
+/// </summary>
+public static class SymbolAttachments
+{
+	/// <summary>
+	/// Punctuation that finishes something and so sits hard against the word it finishes.
+	/// The curly quotes are here because they say which end they are; the straight
+	/// <c>"</c> and <c>'</c> do not, so they are deliberately left out and fall through to
+	/// <see cref="SymbolAttachment.Both"/> — their existing behaviour.
+	/// </summary>
+	private const string ClosingSymbols = ".,;:!?)]}%’”»";
+
+	/// <summary>Punctuation that starts something and so leans onto what follows it.</summary>
+	private const string OpeningSymbols = "([{$#‘“«";
+
+	/// <summary>
+	/// Classifies a replacement by its first meaningful character. Leading whitespace is
+	/// skipped so a replacement that supplies its own spacing — "\r\n- " — is still judged
+	/// on the punctuation it carries.
+	/// </summary>
+	public static SymbolAttachment Classify(string? replaceWith)
+	{
+		if (string.IsNullOrEmpty(replaceWith))
+			return SymbolAttachment.Both;
+
+		foreach (char candidate in replaceWith)
+		{
+			if (char.IsWhiteSpace(candidate))
+				continue;
+
+			if (ClosingSymbols.Contains(candidate))
+				return SymbolAttachment.Left;
+
+			if (OpeningSymbols.Contains(candidate))
+				return SymbolAttachment.Right;
+
+			return SymbolAttachment.Both;
+		}
+
+		return SymbolAttachment.Both;
+	}
+}

--- a/CognitiveSupport/SymbolAttachment.cs
+++ b/CognitiveSupport/SymbolAttachment.cs
@@ -38,11 +38,16 @@ public static class SymbolAttachments
 {
 	/// <summary>
 	/// Punctuation that finishes something and so sits hard against the word it finishes.
-	/// The curly quotes are here because they say which end they are; the straight
-	/// <c>"</c> and <c>'</c> do not, so they are deliberately left out and fall through to
-	/// <see cref="SymbolAttachment.Both"/> — their existing behaviour.
+	/// <para>
+	/// The quote characters that are left out are left out on purpose. The straight <c>"</c>
+	/// and <c>'</c> do not say which end of a quotation they are. Neither, in practice, does
+	/// the curly <c>’</c>: it is the right single quotation mark and the typographic
+	/// apostrophe, the same character, so classifying it as closing would turn a perfectly
+	/// ordinary <c>apostrophe</c> → <c>’</c> rule into "John’ s". All three fall through to
+	/// <see cref="SymbolAttachment.Both"/>, which is the behaviour they have always had.
+	/// </para>
 	/// </summary>
-	private const string ClosingSymbols = ".,;:!?)]}%’”»";
+	private const string ClosingSymbols = ".,;:!?)]}%”»";
 
 	/// <summary>Punctuation that starts something and so leans onto what follows it.</summary>
 	private const string OpeningSymbols = "([{$#‘“«";

--- a/CognitiveSupport/TextFormatter.cs
+++ b/CognitiveSupport/TextFormatter.cs
@@ -271,7 +271,7 @@ public static class TextFormatter
 	/// </summary>
 	private static bool OpensAttachedToPrecedingWord(string replaceWith)
 	{
-		if (replaceWith.Length > 0 && IsSuffixMark(replaceWith[0]))
+		if (IsWordSuffix(replaceWith))
 			return true;
 
 		int index = 0;
@@ -282,11 +282,29 @@ public static class TextFormatter
 	}
 
 	/// <summary>
-	/// An apostrophe opening a replacement makes the whole thing a suffix — "apostrophe s" →
-	/// "'s" — and a possessive belongs against the thing it possesses: "Jacques's", never
-	/// "Jacques 's".
+	/// Whether the replacement is an English suffix: an apostrophe and the one or two letters
+	/// that follow it, and nothing else — "'s", "'re", "'ll", "'ve". A possessive belongs
+	/// against the thing it possesses ("Jacques's", never "Jacques 's").
+	/// <para>
+	/// Deliberately narrow. "Starts with an apostrophe" would catch a decade — "nineties" →
+	/// "'90s" — and weld it to the word before, and it would catch a quoting rule such as
+	/// "'quoted'" too. Those are words, and words keep their gap.
+	/// </para>
 	/// </summary>
-	private static bool IsSuffixMark(char value) => value is '\'' or '’';
+	private static bool IsWordSuffix(string replaceWith)
+	{
+		if (replaceWith.Length is < 2 or > 3)
+			return false;
+
+		if (replaceWith[0] is not ('\'' or '’'))
+			return false;
+
+		for (int index = 1; index < replaceWith.Length; index++)
+			if (!char.IsLetter(replaceWith[index]))
+				return false;
+
+		return true;
+	}
 
 	private static bool IsSentencePunctuation(char value) =>
 		value is '.' or ',' or ';' or ':' or '!' or '?';

--- a/CognitiveSupport/TextFormatter.cs
+++ b/CognitiveSupport/TextFormatter.cs
@@ -159,7 +159,8 @@ public static class TextFormatter
 	/// <item>A <b>word</b> — "ai" → "AI" — needs the gap back, or the neighbours weld into
 	/// "containAIalso".</item>
 	/// <item>A <b>symbol</b> — "full stop" → ". ", "dash" → "-" — supplies its own spacing or
-	/// deliberately has none, so the gap goes. Every rule Mutation ships is one of these.</item>
+	/// deliberately has none, so the gap goes. Every rule Mutation ships is one of these.
+	/// Which gap goes depends on the symbol: see <see cref="SymbolAttachments"/>.</item>
 	/// <item>A <b>deletion</b> — "um" → "" — closes the gap to a single space, however many
 	/// copies of the word were said in a row.</item>
 	/// </list>
@@ -180,12 +181,16 @@ public static class TextFormatter
 		bool isSymbol = replaceWith.Length > 0 && !replaceWith.Any(char.IsLetterOrDigit);
 		bool isDeletion = replaceWith.Length == 0;
 		bool opensAttached = OpensAttachedToPrecedingWord(replaceWith);
+		SymbolAttachment attachment = SymbolAttachments.Classify(replaceWith);
 
 		// A replacement closing with whitespace already separates itself from what follows, and
 		// carries its own terminator — so the punctuation the match consumed on that side goes
-		// with the gap rather than being stranded after it.
+		// with the gap rather than being stranded after it. Its mirror image is a replacement
+		// that opens with whitespace; re-emitting the gap in front of that one doubles it.
 		bool closesSeparated = replaceWith.Length > 0
 			&& char.IsWhiteSpace(replaceWith[^1]);
+		bool opensSeparated = replaceWith.Length > 0
+			&& char.IsWhiteSpace(replaceWith[0]);
 
 		// Deletions are the one branch that has to look outside its own match. Fillers arrive in
 		// runs — "um, um, I think" — and consecutive matches abut, so the second one's preceding
@@ -202,7 +207,22 @@ public static class TextFormatter
 			string trailingSpaces = match.Groups[6].Value;
 
 			if (isSymbol)
-				return leadingPunctuation + replaceWith;
+			{
+				// A left-attaching symbol closes the gap in front of it and gives back the one
+				// behind it, so "fifty percent last year" ends up "fifty% last year" rather
+				// than welded into "fifty%last year". A right-attaching one is the mirror
+				// image. Connectors — and every symbol the classifier does not recognise —
+				// close both, which is what a symbol rule has always done, so no rule that
+				// works today can be made worse here.
+				string symbolHead = attachment == SymbolAttachment.Right && !opensSeparated
+					? leadingSpaces
+					: string.Empty;
+				string symbolTail = attachment == SymbolAttachment.Left && !closesSeparated
+					? trailingPunctuation + trailingSpaces
+					: string.Empty;
+
+				return leadingPunctuation + symbolHead + replaceWith + symbolTail;
+			}
 
 			if (!isDeletion)
 			{
@@ -244,18 +264,29 @@ public static class TextFormatter
 
 	/// <summary>
 	/// Whether a word replacement still wants to sit hard against the word before it. True of
-	/// one opening with its own spacing — "newline plus text" → "\r\nHere". A replacement that
-	/// merely starts with punctuation and then carries text — "dotnet" → ".NET" — is a word,
-	/// and still needs the gap.
+	/// one opening with its own spacing — "newline plus text" → "\r\nHere" — and of a suffix,
+	/// which belongs to the word in front of it rather than a space away from it. A
+	/// replacement that merely starts with punctuation and then carries text — "dotnet" →
+	/// ".NET" — is a word, and still needs the gap.
 	/// </summary>
 	private static bool OpensAttachedToPrecedingWord(string replaceWith)
 	{
+		if (replaceWith.Length > 0 && IsSuffixMark(replaceWith[0]))
+			return true;
+
 		int index = 0;
 		while (index < replaceWith.Length && IsSentencePunctuation(replaceWith[index]))
 			index++;
 
 		return index == replaceWith.Length || char.IsWhiteSpace(replaceWith[index]);
 	}
+
+	/// <summary>
+	/// An apostrophe opening a replacement makes the whole thing a suffix — "apostrophe s" →
+	/// "'s" — and a possessive belongs against the thing it possesses: "Jacques's", never
+	/// "Jacques 's".
+	/// </summary>
+	private static bool IsSuffixMark(char value) => value is '\'' or '’';
 
 	private static bool IsSentencePunctuation(char value) =>
 		value is '.' or ',' or ';' or ':' or '!' or '?';

--- a/CognitiveSupport/TextFormatter.cs
+++ b/CognitiveSupport/TextFormatter.cs
@@ -282,28 +282,25 @@ public static class TextFormatter
 	}
 
 	/// <summary>
-	/// Whether the replacement is an English suffix: an apostrophe and the one or two letters
-	/// that follow it, and nothing else — "'s", "'re", "'ll", "'ve". A possessive belongs
-	/// against the thing it possesses ("Jacques's", never "Jacques 's").
+	/// The endings that belong to the word in front of them rather than a space away from it:
+	/// the possessive and the English contractions. "Jacques's", never "Jacques 's".
 	/// <para>
-	/// Deliberately narrow. "Starts with an apostrophe" would catch a decade — "nineties" →
-	/// "'90s" — and weld it to the word before, and it would catch a quoting rule such as
-	/// "'quoted'" too. Those are words, and words keep their gap.
+	/// Spelled out rather than described as "an apostrophe and a letter or two", because that
+	/// description also covers "'em" and "'n", which are whole words and want their gap. And
+	/// "starts with an apostrophe" — the first attempt — covered a decade ("nineties" →
+	/// "'90s") and any quoted phrase as well.
 	/// </para>
 	/// </summary>
+	private static readonly string[] WordSuffixes = { "s", "d", "m", "t", "ll", "re", "ve" };
+
 	private static bool IsWordSuffix(string replaceWith)
 	{
-		if (replaceWith.Length is < 2 or > 3)
+		if (replaceWith.Length < 2 || replaceWith[0] is not ('\'' or '’'))
 			return false;
 
-		if (replaceWith[0] is not ('\'' or '’'))
-			return false;
+		string ending = replaceWith[1..];
 
-		for (int index = 1; index < replaceWith.Length; index++)
-			if (!char.IsLetter(replaceWith[index]))
-				return false;
-
-		return true;
+		return WordSuffixes.Contains(ending, StringComparer.OrdinalIgnoreCase);
 	}
 
 	private static bool IsSentencePunctuation(char value) =>

--- a/Documentation/UserGuide/html/accessibility.html
+++ b/Documentation/UserGuide/html/accessibility.html
@@ -161,6 +161,12 @@ attached announce the shortcut as part of their name, so you hear something like
 &quot;Mute, Ctrl+Shift+M&quot;. When a button changes state, the announced name changes with it
 — a button that becomes Unmute announces itself as Unmute, not as the name it had at
 startup.</p>
+<p>Where a list repeats the same buttons on every row, the announced name says which row
+it belongs to. In the <strong>LLM Prompts</strong> list you hear &quot;Delete prompt 'Summarise'&quot; rather
+than just &quot;Delete&quot;, so you know what you are about to remove before you press it.</p>
+<p>Dropdowns read out proper wording, not shorthand. The <strong>Third-party interaction</strong>
+dropdown announces &quot;Paste into 3rd party application&quot;, and when you pick a different
+one, the line of explanation underneath is read out straight after.</p>
 <p>The help text for settings is written once and used twice. The sentence your screen
 reader reads out for a setting is exactly the sentence that appears in the tooltip
 when you hover it with the mouse. There is no short visual label with a longer hidden

--- a/Documentation/UserGuide/html/dictation.html
+++ b/Documentation/UserGuide/html/dictation.html
@@ -199,34 +199,34 @@ clipboard. There are three choices:</p>
 </thead>
 <tbody>
 <tr>
-<td><strong>Paste</strong></td>
+<td><strong>Paste into 3rd party application</strong></td>
 <td>Mutation copies the text and then presses <strong>Ctrl+V</strong> for you, so it appears in whatever app was in front.</td>
 </tr>
 <tr>
-<td><strong>SendKeys</strong></td>
+<td><strong>Send keys to 3rd party application</strong></td>
 <td>Mutation types the text out, one keystroke at a time, as if you had typed it yourself.</td>
 </tr>
 <tr>
-<td><strong>DoNotInsert</strong></td>
+<td><strong>Don't insert into 3rd party application</strong></td>
 <td>Mutation does nothing further. The text stays in the Mutation window and on the clipboard, and you paste it yourself.</td>
 </tr>
 </tbody>
 </table>
 </div>
 <blockquote>
-<p>The three choices are shown using their short internal names — <strong>Paste</strong>,
-<strong>SendKeys</strong> and <strong>DoNotInsert</strong>. They are not the friendliest labels, but a line of
-explanation appears underneath the dropdown as soon as you pick one.</p>
+<p>A line of explanation appears underneath the dropdown as soon as you pick one, and
+your screen reader reads it out.</p>
 </blockquote>
 <p><strong>Which should you pick?</strong></p>
-<p>Start with <strong>Paste</strong>. It is the fastest and it handles long text without trouble.</p>
-<p>Switch to <strong>SendKeys</strong> when an app refuses to accept a paste, or mangles it. Some
-older apps, some remote-desktop sessions, and some web forms behave that way. Typing
-is slower and you will see the letters appear one by one, but it works almost
-everywhere.</p>
-<p>Choose <strong>DoNotInsert</strong> when you want to look at the text before it goes anywhere —
-or when you are dictating notes into Mutation itself and don't want stray text
-landing in another window.</p>
+<p>Start with <strong>Paste into 3rd party application</strong>. It is the fastest and it handles
+long text without trouble.</p>
+<p>Switch to <strong>Send keys to 3rd party application</strong> when an app refuses to accept a
+paste, or mangles it. Some older apps, some remote-desktop sessions, and some web
+forms behave that way. Typing is slower and you will see the letters appear one by
+one, but it works almost everywhere.</p>
+<p>Choose <strong>Don't insert into 3rd party application</strong> when you want to look at the text
+before it goes anywhere — or when you are dictating notes into Mutation itself and
+don't want stray text landing in another window.</p>
 <p>One thing worth knowing: if the Mutation window itself is the one in front, nothing
 is inserted anywhere. Mutation won't paste into itself.</p>
 <p>Whichever choice you make, Mutation waits for the typing or pasting to finish before
@@ -286,7 +286,10 @@ a different list of terms for each one. It saves itself as you type.</p>
 <li>The <strong>older</strong> and <strong>newer</strong> arrow buttons step back and forward through your
 recent sessions.</li>
 <li><strong>Play selected session</strong> plays the one you've landed on, so you can hear what
-you actually said.</li>
+you actually said. A long recording takes a moment to get ready before the sound
+starts; if it takes more than a blink, Mutation says &quot;Decoding&quot; and the name of
+the file, so you know it is working on it. The window stays usable throughout, and
+pressing the button again stops it — even while it is still getting ready.</li>
 <li>The <strong>Speed</strong> dropdown changes how fast it plays back, from half speed up to
 three times normal. Voices stay at their natural pitch at every speed — nobody
 turns into a chipmunk.</li>

--- a/Documentation/UserGuide/html/main-window.html
+++ b/Documentation/UserGuide/html/main-window.html
@@ -360,9 +360,9 @@ with no internet connection.</p>
 </div>
 <p>There are three choices, and the line of text underneath the dropdown explains whichever one you have picked:</p>
 <ul>
-<li><strong>Paste</strong> — copies the transcript and pastes it into the active application.</li>
-<li><strong>SendKeys</strong> — types the transcript into the active app as if you entered it yourself.</li>
-<li><strong>DoNotInsert</strong> — keeps the transcript inside Mutation without sending it anywhere.</li>
+<li><strong>Paste into 3rd party application</strong> — copies the transcript and pastes it into the active application.</li>
+<li><strong>Send keys to 3rd party application</strong> — types the transcript into the active app as if you entered it yourself.</li>
+<li><strong>Don't insert into 3rd party application</strong> — keeps the transcript inside Mutation without sending it anywhere.</li>
 </ul>
 <p>Full details: <a href="dictation.html">Dictation: turning speech into text</a>.</p>
 <hr />

--- a/Documentation/UserGuide/html/settings.html
+++ b/Documentation/UserGuide/html/settings.html
@@ -452,7 +452,7 @@ move them.</p>
 </tr>
 <tr>
 <td>Dictation insert preference</td>
-<td>How your text reaches the app you are in. <strong>Paste</strong> puts it in via the clipboard, <strong>SendKeys</strong> types it out one key at a time, and <strong>DoNotInsert</strong> leaves the text in Mutation only.</td>
+<td>How your text reaches the app you are in. <strong>Paste into 3rd party application</strong> puts it in via the clipboard, <strong>Send keys to 3rd party application</strong> types it out one key at a time, and <strong>Don't insert into 3rd party application</strong> leaves the text in Mutation only.</td>
 </tr>
 <tr>
 <td>Reset window position</td>

--- a/Documentation/UserGuide/html/transcript-formatting.html
+++ b/Documentation/UserGuide/html/transcript-formatting.html
@@ -191,7 +191,7 @@ footer{margin-top:3rem; padding-top:1rem; border-top:1px solid var(--rule); colo
 </tbody>
 </table>
 </div>
-<p>Anything it does not recognise joins both sides, which is the safe answer for a symbol. Straight quote marks (<code>&quot;</code> and <code>'</code>) are left alone on purpose, because they do not say whether they open or close.</p>
+<p>Anything it does not recognise joins both sides, which is the safe answer for a symbol. Quote marks are left alone on purpose. A straight <code>&quot;</code> or <code>'</code> does not say whether it opens or closes, and the curly <code>’</code> is also the apostrophe in &quot;John’s&quot;, so guessing would get it wrong as often as right.</p>
 <p>An ending like <code>'s</code> or <code>'re</code> also goes tight against the word before it, so a rule replacing &quot;apostrophe s&quot; with <code>'s</code> gives you &quot;Jacques's&quot; rather than &quot;Jacques 's&quot;. Longer replacements that happen to start with an apostrophe — <code>'90s</code>, or a quoted phrase — are treated as ordinary words and keep their space.</p>
 <p><strong>RegEx</strong> treats the Find box as a pattern written in a special pattern language for advanced users. If you do not know what this is, you do not need it. (If a pattern is malformed, Mutation shows the error in red under the row so you can fix it.)</p>
 <hr />

--- a/Documentation/UserGuide/html/transcript-formatting.html
+++ b/Documentation/UserGuide/html/transcript-formatting.html
@@ -191,7 +191,8 @@ footer{margin-top:3rem; padding-top:1rem; border-top:1px solid var(--rule); colo
 </tbody>
 </table>
 </div>
-<p>Anything it does not recognise joins both sides, which is the safe answer for a symbol.</p>
+<p>Anything it does not recognise joins both sides, which is the safe answer for a symbol. Straight quote marks (<code>&quot;</code> and <code>'</code>) are left alone on purpose, because they do not say whether they open or close.</p>
+<p>An ending like <code>'s</code> or <code>'re</code> also goes tight against the word before it, so a rule replacing &quot;apostrophe s&quot; with <code>'s</code> gives you &quot;Jacques's&quot; rather than &quot;Jacques 's&quot;. Longer replacements that happen to start with an apostrophe — <code>'90s</code>, or a quoted phrase — are treated as ordinary words and keep their space.</p>
 <p><strong>RegEx</strong> treats the Find box as a pattern written in a special pattern language for advanced users. If you do not know what this is, you do not need it. (If a pattern is malformed, Mutation shows the error in red under the row so you can fix it.)</p>
 <hr />
 <h2 id="some-worked-examples">Some worked examples</h2>

--- a/Documentation/UserGuide/html/transcript-formatting.html
+++ b/Documentation/UserGuide/html/transcript-formatting.html
@@ -163,6 +163,35 @@ footer{margin-top:3rem; padding-top:1rem; border-top:1px solid var(--rule); colo
 <p>Each rule also has a <strong>Match type</strong>, which decides how the Find text is interpreted.</p>
 <p><strong>Plain</strong> swaps the exact text wherever it turns up, including in the middle of longer words.</p>
 <p><strong>Smart</strong> matches the word properly, tidying up the spaces and punctuation around it as it goes. This is the one most people want, and it is especially good for removing a spoken word cleanly without leaving a double space or a stranded comma behind. Whatever you type in the Find box is taken exactly as you typed it, so symbols are fine — a rule finding <code>C++</code> looks for <code>C++</code>.</p>
+<p>Smart also knows that different symbols sit differently in a sentence. If you replace a spoken word with a symbol, it works out which side the symbol belongs on.</p>
+<div class="table-wrap"><table>
+<thead>
+<tr>
+<th scope="col">You replace with</th>
+<th scope="col">Where it sits</th>
+<th scope="col">Example</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>A closing symbol, like <code>%</code> <code>)</code> <code>]</code> <code>.</code> <code>?</code></td>
+<td>Tight against the word before it</td>
+<td>&quot;fifty percent last year&quot; becomes &quot;fifty% last year&quot;</td>
+</tr>
+<tr>
+<td>An opening symbol, like <code>#</code> <code>(</code> <code>[</code> <code>$</code></td>
+<td>Tight against the word after it</td>
+<td>&quot;issue hash 42&quot; becomes &quot;issue #42&quot;</td>
+</tr>
+<tr>
+<td>A joining symbol, like <code>-</code> <code>/</code> <code>_</code> <code>@</code></td>
+<td>Tight against both</td>
+<td>&quot;and slash or&quot; becomes &quot;and/or&quot;</td>
+</tr>
+</tbody>
+</table>
+</div>
+<p>Anything it does not recognise joins both sides, which is the safe answer for a symbol.</p>
 <p><strong>RegEx</strong> treats the Find box as a pattern written in a special pattern language for advanced users. If you do not know what this is, you do not need it. (If a pattern is malformed, Mutation shows the error in red under the row so you can fix it.)</p>
 <hr />
 <h2 id="some-worked-examples">Some worked examples</h2>

--- a/Documentation/UserGuide/markdown/accessibility.md
+++ b/Documentation/UserGuide/markdown/accessibility.md
@@ -22,6 +22,14 @@ attached announce the shortcut as part of their name, so you hear something like
 — a button that becomes Unmute announces itself as Unmute, not as the name it had at
 startup.
 
+Where a list repeats the same buttons on every row, the announced name says which row
+it belongs to. In the **LLM Prompts** list you hear "Delete prompt 'Summarise'" rather
+than just "Delete", so you know what you are about to remove before you press it.
+
+Dropdowns read out proper wording, not shorthand. The **Third-party interaction**
+dropdown announces "Paste into 3rd party application", and when you pick a different
+one, the line of explanation underneath is read out straight after.
+
 The help text for settings is written once and used twice. The sentence your screen
 reader reads out for a setting is exactly the sentence that appears in the tooltip
 when you hover it with the mouse. There is no short visual label with a longer hidden

--- a/Documentation/UserGuide/markdown/dictation.md
+++ b/Documentation/UserGuide/markdown/dictation.md
@@ -58,26 +58,26 @@ clipboard. There are three choices:
 
 | Choice in the list | What happens |
 |---|---|
-| **Paste** | Mutation copies the text and then presses **Ctrl+V** for you, so it appears in whatever app was in front. |
-| **SendKeys** | Mutation types the text out, one keystroke at a time, as if you had typed it yourself. |
-| **DoNotInsert** | Mutation does nothing further. The text stays in the Mutation window and on the clipboard, and you paste it yourself. |
+| **Paste into 3rd party application** | Mutation copies the text and then presses **Ctrl+V** for you, so it appears in whatever app was in front. |
+| **Send keys to 3rd party application** | Mutation types the text out, one keystroke at a time, as if you had typed it yourself. |
+| **Don't insert into 3rd party application** | Mutation does nothing further. The text stays in the Mutation window and on the clipboard, and you paste it yourself. |
 
-> The three choices are shown using their short internal names — **Paste**,
-> **SendKeys** and **DoNotInsert**. They are not the friendliest labels, but a line of
-> explanation appears underneath the dropdown as soon as you pick one.
+> A line of explanation appears underneath the dropdown as soon as you pick one, and
+> your screen reader reads it out.
 
 **Which should you pick?**
 
-Start with **Paste**. It is the fastest and it handles long text without trouble.
+Start with **Paste into 3rd party application**. It is the fastest and it handles
+long text without trouble.
 
-Switch to **SendKeys** when an app refuses to accept a paste, or mangles it. Some
-older apps, some remote-desktop sessions, and some web forms behave that way. Typing
-is slower and you will see the letters appear one by one, but it works almost
-everywhere.
+Switch to **Send keys to 3rd party application** when an app refuses to accept a
+paste, or mangles it. Some older apps, some remote-desktop sessions, and some web
+forms behave that way. Typing is slower and you will see the letters appear one by
+one, but it works almost everywhere.
 
-Choose **DoNotInsert** when you want to look at the text before it goes anywhere —
-or when you are dictating notes into Mutation itself and don't want stray text
-landing in another window.
+Choose **Don't insert into 3rd party application** when you want to look at the text
+before it goes anywhere — or when you are dictating notes into Mutation itself and
+don't want stray text landing in another window.
 
 One thing worth knowing: if the Mutation window itself is the one in front, nothing
 is inserted anywhere. Mutation won't paste into itself.
@@ -155,7 +155,10 @@ Mutation keeps your recent recordings so you can go back to them.
 - The **older** and **newer** arrow buttons step back and forward through your
   recent sessions.
 - **Play selected session** plays the one you've landed on, so you can hear what
-  you actually said.
+  you actually said. A long recording takes a moment to get ready before the sound
+  starts; if it takes more than a blink, Mutation says "Decoding" and the name of
+  the file, so you know it is working on it. The window stays usable throughout, and
+  pressing the button again stops it — even while it is still getting ready.
 - The **Speed** dropdown changes how fast it plays back, from half speed up to
   three times normal. Voices stay at their natural pitch at every speed — nobody
   turns into a chipmunk.

--- a/Documentation/UserGuide/markdown/main-window.md
+++ b/Documentation/UserGuide/markdown/main-window.md
@@ -111,9 +111,9 @@ One small but important setting: it controls where your finished transcripts are
 
 There are three choices, and the line of text underneath the dropdown explains whichever one you have picked:
 
-- **Paste** — copies the transcript and pastes it into the active application.
-- **SendKeys** — types the transcript into the active app as if you entered it yourself.
-- **DoNotInsert** — keeps the transcript inside Mutation without sending it anywhere.
+- **Paste into 3rd party application** — copies the transcript and pastes it into the active application.
+- **Send keys to 3rd party application** — types the transcript into the active app as if you entered it yourself.
+- **Don't insert into 3rd party application** — keeps the transcript inside Mutation without sending it anywhere.
 
 Full details: [Dictation: turning speech into text](dictation.md).
 

--- a/Documentation/UserGuide/markdown/settings.md
+++ b/Documentation/UserGuide/markdown/settings.md
@@ -188,7 +188,7 @@ Small comforts for the main window.
 | Setting | What it does |
 |---|---|
 | Max text-box visible lines | Caps how tall the transcript and OCR boxes grow on the main window. |
-| Dictation insert preference | How your text reaches the app you are in. **Paste** puts it in via the clipboard, **SendKeys** types it out one key at a time, and **DoNotInsert** leaves the text in Mutation only. |
+| Dictation insert preference | How your text reaches the app you are in. **Paste into 3rd party application** puts it in via the clipboard, **Send keys to 3rd party application** types it out one key at a time, and **Don't insert into 3rd party application** leaves the text in Mutation only. |
 | Reset window position | Puts Mutation's window back to its starting position and size. Handy if it has ended up off-screen. |
 
 ### Hotkeys

--- a/Documentation/UserGuide/markdown/transcript-formatting.md
+++ b/Documentation/UserGuide/markdown/transcript-formatting.md
@@ -38,7 +38,7 @@ Smart also knows that different symbols sit differently in a sentence. If you re
 | An opening symbol, like `#` `(` `[` `$` | Tight against the word after it | "issue hash 42" becomes "issue #42" |
 | A joining symbol, like `-` `/` `_` `@` | Tight against both | "and slash or" becomes "and/or" |
 
-Anything it does not recognise joins both sides, which is the safe answer for a symbol. Straight quote marks (`"` and `'`) are left alone on purpose, because they do not say whether they open or close.
+Anything it does not recognise joins both sides, which is the safe answer for a symbol. Quote marks are left alone on purpose. A straight `"` or `'` does not say whether it opens or closes, and the curly `’` is also the apostrophe in "John’s", so guessing would get it wrong as often as right.
 
 An ending like `'s` or `'re` also goes tight against the word before it, so a rule replacing "apostrophe s" with `'s` gives you "Jacques's" rather than "Jacques 's". Longer replacements that happen to start with an apostrophe — `'90s`, or a quoted phrase — are treated as ordinary words and keep their space.
 

--- a/Documentation/UserGuide/markdown/transcript-formatting.md
+++ b/Documentation/UserGuide/markdown/transcript-formatting.md
@@ -38,7 +38,9 @@ Smart also knows that different symbols sit differently in a sentence. If you re
 | An opening symbol, like `#` `(` `[` `$` | Tight against the word after it | "issue hash 42" becomes "issue #42" |
 | A joining symbol, like `-` `/` `_` `@` | Tight against both | "and slash or" becomes "and/or" |
 
-Anything it does not recognise joins both sides, which is the safe answer for a symbol.
+Anything it does not recognise joins both sides, which is the safe answer for a symbol. Straight quote marks (`"` and `'`) are left alone on purpose, because they do not say whether they open or close.
+
+An ending like `'s` or `'re` also goes tight against the word before it, so a rule replacing "apostrophe s" with `'s` gives you "Jacques's" rather than "Jacques 's". Longer replacements that happen to start with an apostrophe — `'90s`, or a quoted phrase — are treated as ordinary words and keep their space.
 
 **RegEx** treats the Find box as a pattern written in a special pattern language for advanced users. If you do not know what this is, you do not need it. (If a pattern is malformed, Mutation shows the error in red under the row so you can fix it.)
 

--- a/Documentation/UserGuide/markdown/transcript-formatting.md
+++ b/Documentation/UserGuide/markdown/transcript-formatting.md
@@ -30,6 +30,16 @@ Each rule also has a **Match type**, which decides how the Find text is interpre
 
 **Smart** matches the word properly, tidying up the spaces and punctuation around it as it goes. This is the one most people want, and it is especially good for removing a spoken word cleanly without leaving a double space or a stranded comma behind. Whatever you type in the Find box is taken exactly as you typed it, so symbols are fine — a rule finding `C++` looks for `C++`.
 
+Smart also knows that different symbols sit differently in a sentence. If you replace a spoken word with a symbol, it works out which side the symbol belongs on.
+
+| You replace with | Where it sits | Example |
+|---|---|---|
+| A closing symbol, like `%` `)` `]` `.` `?` | Tight against the word before it | "fifty percent last year" becomes "fifty% last year" |
+| An opening symbol, like `#` `(` `[` `$` | Tight against the word after it | "issue hash 42" becomes "issue #42" |
+| A joining symbol, like `-` `/` `_` `@` | Tight against both | "and slash or" becomes "and/or" |
+
+Anything it does not recognise joins both sides, which is the safe answer for a symbol.
+
 **RegEx** treats the Find box as a pattern written in a special pattern language for advanced users. If you do not know what this is, you do not need it. (If a pattern is malformed, Mutation shows the error in red under the row so you can fix it.)
 
 ---

--- a/Mutation.Tests/AudioPlayerAsyncPlaybackTests.cs
+++ b/Mutation.Tests/AudioPlayerAsyncPlaybackTests.cs
@@ -1,9 +1,13 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using CognitiveSupport;
+using Concentus.Enums;
+using Concentus.Oggfile;
+using Concentus.Structs;
 
 namespace Mutation.Tests;
 
@@ -39,6 +43,39 @@ public class AudioPlayerAsyncPlaybackTests : IDisposable
 		string path = Path.Combine(_workingDirectory, fileName);
 		File.WriteAllBytes(path, BeepToneSynthesizer.SynthesizeWav(new[] { (440, 200) }));
 		return path;
+	}
+
+	/// <summary>
+	/// A real Ogg/Opus file carrying its two header pages and no audio — what a recording
+	/// interrupted before it captured anything leaves on disk. It decodes to zero samples,
+	/// which is the only way to reach the "no audio data" branch that decides what a
+	/// superseded empty decode is allowed to say.
+	/// </summary>
+	private string WriteHeadersOnlyOgg(string fileName)
+	{
+		using var complete = new MemoryStream();
+#pragma warning disable CS0618 // Concentus.OggFile 1.0.6 requires the concrete OpusEncoder type.
+		var encoder = new OpusEncoder(48000, 1, OpusApplication.OPUS_APPLICATION_AUDIO);
+#pragma warning restore CS0618
+		// Finish pads the part-filled buffer out and encodes it, so even a stream nothing was
+		// written to ends up with one frame of silence. The audio starts at the third page.
+		new OpusOggWriteStream(encoder, complete, new OpusTags()).Finish();
+
+		byte[] bytes = complete.ToArray();
+		int audioPage = PageOffsets(bytes).Skip(2).First();
+
+		string path = Path.Combine(_workingDirectory, fileName);
+		File.WriteAllBytes(path, bytes[..audioPage]);
+		return path;
+	}
+
+	/// <summary>Where each Ogg page starts: every "OggS" capture pattern in the file.</summary>
+	private static IEnumerable<int> PageOffsets(byte[] bytes)
+	{
+		for (int index = 0; index + 3 < bytes.Length; index++)
+			if (bytes[index] == (byte)'O' && bytes[index + 1] == (byte)'g'
+				&& bytes[index + 2] == (byte)'g' && bytes[index + 3] == (byte)'S')
+				yield return index;
 	}
 
 	private AudioPlayer NewPlayer(Action<string>? beforePrepare = null)
@@ -136,6 +173,45 @@ public class AudioPlayerAsyncPlaybackTests : IDisposable
 		Assert.Equal(0, current.DisposeCount);
 		Assert.True(player.IsPlaying);
 		Assert.Null(failure);
+	}
+
+	// A file that decodes to nothing is reported, not started.
+	[Fact]
+	public async Task PlayAsync_reports_a_file_that_holds_no_audio()
+	{
+		using var player = NewPlayer();
+		string? failure = null;
+		player.PlaybackFailed += (_, message) => failure = message;
+
+		await player.PlayAsync(WriteHeadersOnlyOgg("empty.ogg"));
+
+		Assert.Equal("No audio data found in file.", failure);
+		Assert.Empty(_devices);
+	}
+
+	// ...and once superseded it is not reported either, for the same reason a failing stale
+	// decode is not: the message would stop the recording that is playing now.
+	[Fact]
+	public async Task A_stale_decode_that_holds_no_audio_says_nothing()
+	{
+		using var gate = new DecodeGate();
+		using var player = NewPlayer(gate.Wait);
+		string? failure = null;
+		player.PlaybackFailed += (_, message) => failure = message;
+
+		Task stale = player.PlayAsync(WriteHeadersOnlyOgg("stale-empty.ogg"));
+		gate.WaitUntilDecodeStarted();
+
+		gate.LetTheNextOneThrough();
+		await player.PlayAsync(WriteWav("current.wav"));
+		FakeAudioOutputDevice current = Assert.Single(_devices);
+
+		gate.Release();
+		await stale;
+
+		Assert.Null(failure);
+		Assert.True(current.IsPlaying);
+		Assert.Equal(0, current.DisposeCount);
 	}
 
 	// Superseding is per-request, not a latch: the next Play after a Stop still plays.

--- a/Mutation.Tests/AudioPlayerAsyncPlaybackTests.cs
+++ b/Mutation.Tests/AudioPlayerAsyncPlaybackTests.cs
@@ -14,8 +14,14 @@ namespace Mutation.Tests;
 /// <para>
 /// Two things had to stay true through that move. The output device must still be built where
 /// the caller was, since NAudio captures that thread's synchronization context to post
-/// playback notifications back to. And a recording the user has already stopped must not
-/// start playing when its decode finally lands.
+/// playback notifications back to. And a request that has been superseded — the user pressed
+/// Stop, or picked another file — must do nothing at all when it finally lands, whether it
+/// succeeded or failed.
+/// </para>
+/// <para>
+/// The superseded cases are driven through the player's <c>beforePrepare</c> seam rather than
+/// by racing the thread pool: a test that only wins by scheduling luck is a test that passes
+/// when the fix is reverted.
 /// </para>
 /// </summary>
 public class AudioPlayerAsyncPlaybackTests : IDisposable
@@ -28,21 +34,23 @@ public class AudioPlayerAsyncPlaybackTests : IDisposable
 		try { Directory.Delete(_workingDirectory, recursive: true); } catch { }
 	}
 
-	private string WriteWav(string fileName, int milliseconds = 200)
+	private string WriteWav(string fileName)
 	{
 		string path = Path.Combine(_workingDirectory, fileName);
-		File.WriteAllBytes(path, BeepToneSynthesizer.SynthesizeWav(new[] { (440, milliseconds) }));
+		File.WriteAllBytes(path, BeepToneSynthesizer.SynthesizeWav(new[] { (440, 200) }));
 		return path;
 	}
 
-	private AudioPlayer NewPlayer()
+	private AudioPlayer NewPlayer(Action<string>? beforePrepare = null)
 	{
-		return new AudioPlayer(() =>
-		{
-			var device = new FakeAudioOutputDevice();
-			_devices.Add(device);
-			return device;
-		});
+		return new AudioPlayer(
+			() =>
+			{
+				var device = new FakeAudioOutputDevice();
+				_devices.Add(device);
+				return device;
+			},
+			beforePrepare);
 	}
 
 	[Fact]
@@ -82,18 +90,52 @@ public class AudioPlayerAsyncPlaybackTests : IDisposable
 
 	// Pressing Play and then Stop while a long recording is still decoding used to be
 	// impossible, because the window was frozen for the whole decode. Now that it is not, the
-	// stop has to win: without it the audio starts anyway, seconds after the user stopped it,
-	// with the button already reading "Play".
+	// stop has to win: without this the audio starts anyway, seconds after the user stopped
+	// it, with the button already reading "Play".
 	[Fact]
 	public async Task Stopping_while_a_file_is_still_decoding_keeps_it_silent()
 	{
-		using var player = NewPlayer();
+		using var gate = new DecodeGate();
+		using var player = NewPlayer(gate.Wait);
 
-		Task playback = player.PlayAsync(WriteWav("stopped-mid-decode.wav", milliseconds: 3000));
+		Task playback = player.PlayAsync(WriteWav("stopped-mid-decode.wav"));
+		gate.WaitUntilDecodeStarted();
+
 		player.Stop();
+		gate.Release();
 		await playback;
 
+		Assert.Empty(_devices);
 		Assert.False(player.IsPlaying);
+	}
+
+	// A decode that fails after it has been superseded belongs to nobody. Reporting it stops
+	// whatever is playing now and puts a modal error dialog in front of the user about a file
+	// they moved on from seconds ago.
+	[Fact]
+	public async Task A_stale_decode_that_fails_leaves_the_current_recording_playing()
+	{
+		using var gate = new DecodeGate();
+		using var player = NewPlayer(gate.Wait);
+		string? failure = null;
+		player.PlaybackFailed += (_, message) => failure = message;
+
+		// The stale request: held at the gate, and rigged to throw when it is let go.
+		Task stale = player.PlayAsync(Path.Combine(_workingDirectory, "deleted-mid-decode.wav"));
+		gate.WaitUntilDecodeStarted();
+
+		// The user moves on. This one is not gated, so it decodes and starts normally.
+		gate.LetTheNextOneThrough();
+		await player.PlayAsync(WriteWav("current.wav"));
+		FakeAudioOutputDevice current = Assert.Single(_devices);
+
+		gate.Release();
+		await stale;
+
+		Assert.True(current.IsPlaying);
+		Assert.Equal(0, current.DisposeCount);
+		Assert.True(player.IsPlaying);
+		Assert.Null(failure);
 	}
 
 	// Superseding is per-request, not a latch: the next Play after a Stop still plays.
@@ -124,21 +166,63 @@ public class AudioPlayerAsyncPlaybackTests : IDisposable
 		Assert.Empty(_devices);
 	}
 
-	// Two overlapping requests: the newer one owns the player, and the older one throws its
-	// decoded audio away instead of stealing the device back.
+	// Two overlapping requests. Exactly one device is ever opened — the older request throws
+	// its decoded audio away rather than opening a second one and stealing the player back.
 	[Fact]
 	public async Task The_last_file_asked_for_is_the_one_that_plays()
 	{
-		using var player = NewPlayer();
+		using var gate = new DecodeGate();
+		using var player = NewPlayer(gate.Wait);
 
-		Task first = player.PlayAsync(WriteWav("older.wav", milliseconds: 3000));
-		Task second = player.PlayAsync(WriteWav("newer.wav"));
-		await Task.WhenAll(first, second);
+		Task older = player.PlayAsync(WriteWav("older.wav"));
+		gate.WaitUntilDecodeStarted();
 
+		gate.LetTheNextOneThrough();
+		Task newer = player.PlayAsync(WriteWav("newer.wav"));
+		await newer;
+
+		gate.Release();
+		await older;
+
+		FakeAudioOutputDevice only = Assert.Single(_devices);
+		Assert.True(only.IsPlaying);
+		Assert.Equal(0, only.DisposeCount);
 		Assert.True(player.IsPlaying);
-		FakeAudioOutputDevice last = _devices[^1];
-		Assert.True(last.IsPlaying);
-		Assert.Equal(0, last.DisposeCount);
+	}
+
+	/// <summary>
+	/// Holds the first decode open until the test says otherwise, so the test can act while a
+	/// request is genuinely in flight instead of hoping the thread pool is slow enough.
+	/// </summary>
+	private sealed class DecodeGate : IDisposable
+	{
+		private readonly ManualResetEventSlim _started = new(false);
+		private readonly ManualResetEventSlim _released = new(false);
+		private int _passThrough;
+
+		/// <summary>Runs on the decoding thread. Blocks unless it has been waved past.</summary>
+		public void Wait(string filePath)
+		{
+			if (Interlocked.Exchange(ref _passThrough, 0) != 0)
+				return;
+
+			_started.Set();
+			_released.Wait(TimeSpan.FromSeconds(10));
+		}
+
+		public void WaitUntilDecodeStarted() => Assert.True(_started.Wait(TimeSpan.FromSeconds(10)));
+
+		/// <summary>The next decode is not held — used for the request that supersedes.</summary>
+		public void LetTheNextOneThrough() => Interlocked.Exchange(ref _passThrough, 1);
+
+		public void Release() => _released.Set();
+
+		public void Dispose()
+		{
+			_released.Set();
+			_started.Dispose();
+			_released.Dispose();
+		}
 	}
 
 	/// <summary>

--- a/Mutation.Tests/AudioPlayerAsyncPlaybackTests.cs
+++ b/Mutation.Tests/AudioPlayerAsyncPlaybackTests.cs
@@ -1,0 +1,165 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using CognitiveSupport;
+
+namespace Mutation.Tests;
+
+/// <summary>
+/// Covers <see cref="AudioPlayer.PlayAsync"/>: decoding a recording moved off the calling
+/// thread, because a 30-minute voice note took seconds to tens of seconds to decode and on
+/// the UI thread that was a frozen window and a silent screen reader (issue #281).
+/// <para>
+/// Two things had to stay true through that move. The output device must still be built where
+/// the caller was, since NAudio captures that thread's synchronization context to post
+/// playback notifications back to. And a recording the user has already stopped must not
+/// start playing when its decode finally lands.
+/// </para>
+/// </summary>
+public class AudioPlayerAsyncPlaybackTests : IDisposable
+{
+	private readonly string _workingDirectory = Directory.CreateTempSubdirectory("audio-player-async-tests").FullName;
+	private readonly List<FakeAudioOutputDevice> _devices = new();
+
+	public void Dispose()
+	{
+		try { Directory.Delete(_workingDirectory, recursive: true); } catch { }
+	}
+
+	private string WriteWav(string fileName, int milliseconds = 200)
+	{
+		string path = Path.Combine(_workingDirectory, fileName);
+		File.WriteAllBytes(path, BeepToneSynthesizer.SynthesizeWav(new[] { (440, milliseconds) }));
+		return path;
+	}
+
+	private AudioPlayer NewPlayer()
+	{
+		return new AudioPlayer(() =>
+		{
+			var device = new FakeAudioOutputDevice();
+			_devices.Add(device);
+			return device;
+		});
+	}
+
+	[Fact]
+	public async Task PlayAsync_starts_the_file()
+	{
+		using var player = NewPlayer();
+
+		await player.PlayAsync(WriteWav("plays.wav"));
+
+		FakeAudioOutputDevice device = Assert.Single(_devices);
+		Assert.True(device.IsPlaying);
+		Assert.True(player.IsPlaying);
+	}
+
+	// The whole reason only the decode moved to the thread pool. Built without a context, the
+	// real device raises PlaybackEnded on NAudio's playback thread, and every listener of that
+	// event touches the UI.
+	[Fact]
+	public async Task PlayAsync_opens_the_device_back_on_the_callers_context()
+	{
+		var context = new InlineSynchronizationContext();
+		SynchronizationContext? original = SynchronizationContext.Current;
+		SynchronizationContext.SetSynchronizationContext(context);
+		try
+		{
+			using var player = NewPlayer();
+
+			await player.PlayAsync(WriteWav("context.wav"));
+
+			Assert.Same(context, Assert.Single(_devices).CreatedOnContext);
+		}
+		finally
+		{
+			SynchronizationContext.SetSynchronizationContext(original);
+		}
+	}
+
+	// Pressing Play and then Stop while a long recording is still decoding used to be
+	// impossible, because the window was frozen for the whole decode. Now that it is not, the
+	// stop has to win: without it the audio starts anyway, seconds after the user stopped it,
+	// with the button already reading "Play".
+	[Fact]
+	public async Task Stopping_while_a_file_is_still_decoding_keeps_it_silent()
+	{
+		using var player = NewPlayer();
+
+		Task playback = player.PlayAsync(WriteWav("stopped-mid-decode.wav", milliseconds: 3000));
+		player.Stop();
+		await playback;
+
+		Assert.False(player.IsPlaying);
+	}
+
+	// Superseding is per-request, not a latch: the next Play after a Stop still plays.
+	[Fact]
+	public async Task Playing_again_after_a_stop_still_starts()
+	{
+		using var player = NewPlayer();
+
+		await player.PlayAsync(WriteWav("first.wav"));
+		player.Stop();
+		await player.PlayAsync(WriteWav("second.wav"));
+
+		Assert.True(player.IsPlaying);
+		Assert.Equal(2, _devices.Count);
+		Assert.True(_devices[1].IsPlaying);
+	}
+
+	[Fact]
+	public async Task PlayAsync_reports_a_missing_file_rather_than_throwing()
+	{
+		using var player = NewPlayer();
+		string? failure = null;
+		player.PlaybackFailed += (_, message) => failure = message;
+
+		await player.PlayAsync(Path.Combine(_workingDirectory, "not-there.wav"));
+
+		Assert.NotNull(failure);
+		Assert.Empty(_devices);
+	}
+
+	// Two overlapping requests: the newer one owns the player, and the older one throws its
+	// decoded audio away instead of stealing the device back.
+	[Fact]
+	public async Task The_last_file_asked_for_is_the_one_that_plays()
+	{
+		using var player = NewPlayer();
+
+		Task first = player.PlayAsync(WriteWav("older.wav", milliseconds: 3000));
+		Task second = player.PlayAsync(WriteWav("newer.wav"));
+		await Task.WhenAll(first, second);
+
+		Assert.True(player.IsPlaying);
+		FakeAudioOutputDevice last = _devices[^1];
+		Assert.True(last.IsPlaying);
+		Assert.Equal(0, last.DisposeCount);
+	}
+
+	/// <summary>
+	/// Stands in for a UI thread's context: it runs the continuation immediately, but with
+	/// itself installed as <c>SynchronizationContext.Current</c>, which is what lets a test
+	/// see where the continuation actually resumed.
+	/// </summary>
+	private sealed class InlineSynchronizationContext : SynchronizationContext
+	{
+		public override void Post(SendOrPostCallback d, object? state)
+		{
+			SynchronizationContext? previous = Current;
+			SetSynchronizationContext(this);
+			try
+			{
+				d(state);
+			}
+			finally
+			{
+				SetSynchronizationContext(previous);
+			}
+		}
+	}
+}

--- a/Mutation.Tests/AudioPlayerTeardownTests.cs
+++ b/Mutation.Tests/AudioPlayerTeardownTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.IO;
 using CognitiveSupport;
@@ -42,13 +43,13 @@ public class AudioPlayerTeardownTests : IDisposable
 	}
 
 	[Fact]
-	public void Reaching_the_end_of_a_file_releases_the_device()
+	public async Task Reaching_the_end_of_a_file_releases_the_device()
 	{
 		using var player = NewPlayer();
 		bool ended = false;
 		player.PlaybackEnded += (_, _) => ended = true;
 
-		player.Play(WriteWav("ends.wav"));
+		await player.PlayAsync(WriteWav("ends.wav"));
 		FakeAudioOutputDevice device = Assert.Single(_devices);
 		Assert.True(device.IsPlaying);
 
@@ -60,13 +61,13 @@ public class AudioPlayerTeardownTests : IDisposable
 	}
 
 	[Fact]
-	public void A_failed_playback_reports_the_error_and_still_releases_the_device()
+	public async Task A_failed_playback_reports_the_error_and_still_releases_the_device()
 	{
 		using var player = NewPlayer();
 		string? failure = null;
 		player.PlaybackFailed += (_, message) => failure = message;
 
-		player.Play(WriteWav("fails.wav"));
+		await player.PlayAsync(WriteWav("fails.wav"));
 		FakeAudioOutputDevice device = Assert.Single(_devices);
 
 		device.RaisePlaybackStopped(new InvalidOperationException("device lost"));
@@ -79,21 +80,26 @@ public class AudioPlayerTeardownTests : IDisposable
 	// A PlaybackEnded listener that queues up the next file is the normal "play the whole
 	// list" pattern. The finishing device must not tear down the one that just started.
 	[Fact]
-	public void Starting_the_next_file_from_the_ended_handler_leaves_the_new_device_alone()
+	public async Task Starting_the_next_file_from_the_ended_handler_leaves_the_new_device_alone()
 	{
 		using var player = NewPlayer();
-		string next = WriteWav("next.wav");
+		string nextPath = WriteWav("next.wav");
 
+		// The listener cannot await, so it hands the task out to be awaited here. That is the
+		// shape a real handler has too: the next file starts decoding while the finishing
+		// device is still tidying itself up.
+		Task? next = null;
 		player.PlaybackEnded += (_, _) =>
 		{
 			if (_devices.Count == 1)
-				player.Play(next);
+				next = player.PlayAsync(nextPath);
 		};
 
-		player.Play(WriteWav("first.wav"));
+		await player.PlayAsync(WriteWav("first.wav"));
 		FakeAudioOutputDevice first = _devices[0];
 
 		first.RaisePlaybackStopped();
+		await next!;
 
 		Assert.Equal(2, _devices.Count);
 		Assert.Equal(1, first.DisposeCount);
@@ -104,16 +110,16 @@ public class AudioPlayerTeardownTests : IDisposable
 		Assert.True(player.IsPlaying);
 	}
 
-	// Two overlapping Play calls must not strand the loser's device: the file is decoded
-	// outside the playback lock now, so the second call can arrive while the first is
-	// still preparing.
+	// One file after another: the first file's device must be released rather than left
+	// attached with nothing to close it. Overlapping requests are covered separately, in
+	// AudioPlayerAsyncPlaybackTests.
 	[Fact]
-	public void Playing_a_second_file_releases_the_first_files_device()
+	public async Task Playing_a_second_file_releases_the_first_files_device()
 	{
 		using var player = NewPlayer();
 
-		player.Play(WriteWav("one.wav"));
-		player.Play(WriteWav("two.wav"));
+		await player.PlayAsync(WriteWav("one.wav"));
+		await player.PlayAsync(WriteWav("two.wav"));
 
 		Assert.Equal(2, _devices.Count);
 		Assert.Equal(1, _devices[0].DisposeCount);
@@ -121,15 +127,15 @@ public class AudioPlayerTeardownTests : IDisposable
 	}
 
 	[Fact]
-	public void A_stopped_notification_from_a_superseded_device_is_ignored()
+	public async Task A_stopped_notification_from_a_superseded_device_is_ignored()
 	{
 		using var player = NewPlayer();
 		int endedCount = 0;
 		player.PlaybackEnded += (_, _) => endedCount++;
 
-		player.Play(WriteWav("stale.wav"));
+		await player.PlayAsync(WriteWav("stale.wav"));
 		FakeAudioOutputDevice stale = _devices[0];
-		player.Play(WriteWav("current.wav"));
+		await player.PlayAsync(WriteWav("current.wav"));
 		FakeAudioOutputDevice current = _devices[1];
 
 		// The old device's PlaybackStopped, delivered late.
@@ -141,10 +147,10 @@ public class AudioPlayerTeardownTests : IDisposable
 	}
 
 	[Fact]
-	public void Dispose_releases_the_device()
+	public async Task Dispose_releases_the_device()
 	{
 		var player = NewPlayer();
-		player.Play(WriteWav("disposed.wav"));
+		await player.PlayAsync(WriteWav("disposed.wav"));
 
 		player.Dispose();
 

--- a/Mutation.Tests/AudioPlayerTeardownTests.cs
+++ b/Mutation.Tests/AudioPlayerTeardownTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using CognitiveSupport;
@@ -16,7 +16,7 @@ namespace Mutation.Tests;
 public class AudioPlayerTeardownTests : IDisposable
 {
 	private readonly string _workingDirectory = Directory.CreateTempSubdirectory("audio-player-tests").FullName;
-	private readonly List<FakeOutputDevice> _devices = new();
+	private readonly List<FakeAudioOutputDevice> _devices = new();
 
 	public void Dispose()
 	{
@@ -35,7 +35,7 @@ public class AudioPlayerTeardownTests : IDisposable
 	{
 		return new AudioPlayer(() =>
 		{
-			var device = new FakeOutputDevice();
+			var device = new FakeAudioOutputDevice();
 			_devices.Add(device);
 			return device;
 		});
@@ -49,7 +49,7 @@ public class AudioPlayerTeardownTests : IDisposable
 		player.PlaybackEnded += (_, _) => ended = true;
 
 		player.Play(WriteWav("ends.wav"));
-		FakeOutputDevice device = Assert.Single(_devices);
+		FakeAudioOutputDevice device = Assert.Single(_devices);
 		Assert.True(device.IsPlaying);
 
 		device.RaisePlaybackStopped();
@@ -67,7 +67,7 @@ public class AudioPlayerTeardownTests : IDisposable
 		player.PlaybackFailed += (_, message) => failure = message;
 
 		player.Play(WriteWav("fails.wav"));
-		FakeOutputDevice device = Assert.Single(_devices);
+		FakeAudioOutputDevice device = Assert.Single(_devices);
 
 		device.RaisePlaybackStopped(new InvalidOperationException("device lost"));
 
@@ -91,14 +91,14 @@ public class AudioPlayerTeardownTests : IDisposable
 		};
 
 		player.Play(WriteWav("first.wav"));
-		FakeOutputDevice first = _devices[0];
+		FakeAudioOutputDevice first = _devices[0];
 
 		first.RaisePlaybackStopped();
 
 		Assert.Equal(2, _devices.Count);
 		Assert.Equal(1, first.DisposeCount);
 
-		FakeOutputDevice second = _devices[1];
+		FakeAudioOutputDevice second = _devices[1];
 		Assert.Equal(0, second.DisposeCount);
 		Assert.True(second.IsPlaying);
 		Assert.True(player.IsPlaying);
@@ -128,9 +128,9 @@ public class AudioPlayerTeardownTests : IDisposable
 		player.PlaybackEnded += (_, _) => endedCount++;
 
 		player.Play(WriteWav("stale.wav"));
-		FakeOutputDevice stale = _devices[0];
+		FakeAudioOutputDevice stale = _devices[0];
 		player.Play(WriteWav("current.wav"));
-		FakeOutputDevice current = _devices[1];
+		FakeAudioOutputDevice current = _devices[1];
 
 		// The old device's PlaybackStopped, delivered late.
 		stale.RaisePlaybackStopped();
@@ -150,37 +150,5 @@ public class AudioPlayerTeardownTests : IDisposable
 
 		Assert.Equal(1, _devices[0].DisposeCount);
 		Assert.False(player.IsPlaying);
-	}
-
-	private sealed class FakeOutputDevice : IAudioOutputDevice
-	{
-		public int DisposeCount { get; private set; }
-
-		public bool IsPlaying => PlaybackState == PlaybackState.Playing;
-
-		public PlaybackState PlaybackState { get; private set; } = PlaybackState.Stopped;
-
-		public event EventHandler<StoppedEventArgs>? PlaybackStopped;
-
-		public void Init(IWaveProvider waveProvider)
-		{
-		}
-
-		public void Play() => PlaybackState = PlaybackState.Playing;
-
-		public void Stop() => PlaybackState = PlaybackState.Stopped;
-
-		/// <summary>Stands in for the device reporting that the audio ran out, or failed.</summary>
-		public void RaisePlaybackStopped(Exception? exception = null)
-		{
-			PlaybackState = PlaybackState.Stopped;
-			PlaybackStopped?.Invoke(this, new StoppedEventArgs(exception));
-		}
-
-		public void Dispose()
-		{
-			DisposeCount++;
-			PlaybackState = PlaybackState.Stopped;
-		}
 	}
 }

--- a/Mutation.Tests/DictationInsertOptionItemTests.cs
+++ b/Mutation.Tests/DictationInsertOptionItemTests.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Linq;
+using Mutation.Ui;
+
+namespace Mutation.Tests;
+
+/// <summary>
+/// The third-party interaction dropdown is bound to these. A screen reader reads whatever is
+/// in them, so an entry that falls back to the identifier is a blind user hearing
+/// "DoNotInsert" (issue #243).
+/// </summary>
+public class DictationInsertOptionItemTests
+{
+	[Theory]
+	[InlineData(DictationInsertOption.DoNotInsert, "Don't insert into 3rd party application")]
+	[InlineData(DictationInsertOption.SendKeys, "Send keys to 3rd party application")]
+	[InlineData(DictationInsertOption.Paste, "Paste into 3rd party application")]
+	public void Describe_reads_the_human_wording(DictationInsertOption option, string expected)
+	{
+		Assert.Equal(expected, DictationInsertOptionItem.Describe(option));
+	}
+
+	// The point of the type: no entry may read out as its identifier.
+	[Fact]
+	public void No_option_is_left_reading_as_its_identifier()
+	{
+		foreach (DictationInsertOptionItem item in DictationInsertOptionItem.All())
+		{
+			Assert.NotEqual(item.Option.ToString(), item.Description);
+			Assert.False(string.IsNullOrWhiteSpace(item.Description));
+		}
+	}
+
+	[Fact]
+	public void All_lists_every_option_once_in_declaration_order()
+	{
+		DictationInsertOption[] expected = Enum.GetValues<DictationInsertOption>();
+
+		Assert.Equal(expected, DictationInsertOptionItem.All().Select(item => item.Option));
+	}
+
+	// The ComboBox displays the bound property, but anything that asks the item itself — an
+	// automation client walking the list, a debugger, a log line — must not get the identifier.
+	[Fact]
+	public void ToString_gives_the_description_rather_than_the_record_shape()
+	{
+		var item = new DictationInsertOptionItem(DictationInsertOption.Paste, "Paste into 3rd party application");
+
+		Assert.Equal("Paste into 3rd party application", item.ToString());
+	}
+}

--- a/Mutation.Tests/FakeAudioOutputDevice.cs
+++ b/Mutation.Tests/FakeAudioOutputDevice.cs
@@ -1,0 +1,51 @@
+using System;
+using CognitiveSupport;
+using NAudio.Wave;
+
+namespace Mutation.Tests;
+
+/// <summary>
+/// A speaker that makes no sound. The build machine has no audio hardware, and the rules
+/// worth testing around <see cref="AudioPlayer"/> are about ownership and threading rather
+/// than about what comes out.
+/// </summary>
+internal sealed class FakeAudioOutputDevice : IAudioOutputDevice
+{
+	public int DisposeCount { get; private set; }
+
+	public bool IsPlaying => PlaybackState == PlaybackState.Playing;
+
+	public PlaybackState PlaybackState { get; private set; } = PlaybackState.Stopped;
+
+	/// <summary>
+	/// The synchronization context in force where this device was constructed. NAudio's real
+	/// <c>WaveOutEvent</c> captures exactly this to post <c>PlaybackStopped</c> back to, so a
+	/// device built with no context raises its events on the playback thread instead of the
+	/// UI one.
+	/// </summary>
+	public System.Threading.SynchronizationContext? CreatedOnContext { get; } =
+		System.Threading.SynchronizationContext.Current;
+
+	public event EventHandler<StoppedEventArgs>? PlaybackStopped;
+
+	public void Init(IWaveProvider waveProvider)
+	{
+	}
+
+	public void Play() => PlaybackState = PlaybackState.Playing;
+
+	public void Stop() => PlaybackState = PlaybackState.Stopped;
+
+	/// <summary>Stands in for the device reporting that the audio ran out, or failed.</summary>
+	public void RaisePlaybackStopped(Exception? exception = null)
+	{
+		PlaybackState = PlaybackState.Stopped;
+		PlaybackStopped?.Invoke(this, new StoppedEventArgs(exception));
+	}
+
+	public void Dispose()
+	{
+		DisposeCount++;
+		PlaybackState = PlaybackState.Stopped;
+	}
+}

--- a/Mutation.Tests/PromptActionNamesTests.cs
+++ b/Mutation.Tests/PromptActionNamesTests.cs
@@ -1,0 +1,56 @@
+using Mutation.Ui.Services;
+
+namespace Mutation.Tests;
+
+/// <summary>
+/// The accessible names on the Run / Edit / Delete buttons in the prompt list. Every row shows
+/// the same three words, so the name is the only thing that tells a screen-reader user which
+/// prompt the button in front of them belongs to (issue #243).
+/// </summary>
+public class PromptActionNamesTests
+{
+	[Theory]
+	[InlineData("Run", "Run prompt 'Summarise'")]
+	[InlineData("Edit", "Edit prompt 'Summarise'")]
+	[InlineData("Delete", "Delete prompt 'Summarise'")]
+	public void Build_names_the_prompt_the_button_belongs_to(string verb, string expected)
+	{
+		Assert.Equal(expected, PromptActionNames.Build(verb, "Summarise"));
+	}
+
+	[Fact]
+	public void Build_trims_the_name_the_way_the_confirmation_dialog_does()
+	{
+		Assert.Equal("Delete prompt 'Summarise'", PromptActionNames.Build("Delete", "  Summarise  "));
+	}
+
+	// A row can exist before it has been named. It still needs a whole sentence, not a
+	// dangling verb.
+	[Theory]
+	[InlineData(null)]
+	[InlineData("")]
+	[InlineData("   ")]
+	public void Build_falls_back_to_a_neutral_label_for_an_unnamed_prompt(string? name)
+	{
+		Assert.Equal("Delete this prompt", PromptActionNames.Build("Delete", name));
+	}
+
+	[Fact]
+	public void Build_without_a_verb_still_names_the_prompt()
+	{
+		Assert.Equal("prompt 'Summarise'", PromptActionNames.Build(" ", "Summarise"));
+	}
+
+	// The button and the dialog it opens have to name the prompt identically — hearing
+	// "Delete prompt 'Summarise'" and then a question about something else is disorienting.
+	[Fact]
+	public void Build_agrees_with_the_deletion_confirmation()
+	{
+		Assert.Contains(
+			PromptActionNames.Build("Delete", "Summarise"),
+			"Delete prompt 'Summarise'? This cannot be undone.");
+		Assert.Equal(
+			"Delete prompt 'Summarise'? This cannot be undone.",
+			PromptDeletionMessages.BuildConfirmation("Summarise"));
+	}
+}

--- a/Mutation.Tests/SmartRuleShippedDefaultsTests.cs
+++ b/Mutation.Tests/SmartRuleShippedDefaultsTests.cs
@@ -1,0 +1,64 @@
+using System;
+using CognitiveSupport;
+using static CognitiveSupport.TranscriptFormatRule;
+
+namespace Mutation.Tests;
+
+/// <summary>
+/// Pins the output of every Smart rule Mutation seeds into a new settings file. Issue #293
+/// required that teaching the formatter which side a symbol attaches to leave these
+/// byte-identical, and they are the rules almost every user is actually running.
+/// <para>
+/// The expectations here were taken from the behaviour before the change, so a future edit to
+/// the classification that shifts one of them fails here rather than in someone's transcript.
+/// Keep this list in step with the seeding in <c>SettingsManager</c>.
+/// </para>
+/// </summary>
+public class SmartRuleShippedDefaultsTests
+{
+	private static string Apply(string input, string find, string replaceWith)
+		=> TextFormatter.FormatWithRule(input, new TranscriptFormatRule(find, replaceWith, false, MatchTypeEnum.Smart));
+
+	private static readonly string NewLine = Environment.NewLine;
+
+	[Theory]
+	[InlineData("new colon", ": ", "one new colon two", "one: two")]
+	[InlineData("semicolon", "; ", "one semicolon two", "one; two")]
+	[InlineData("full stop", ". ", "one full stop two", "one. two")]
+	[InlineData("comma", ", ", "one comma two", "one, two")]
+	[InlineData("exclamation mark", "! ", "one exclamation mark two", "one! two")]
+	[InlineData("question mark", "? ", "one question mark two", "one? two")]
+	[InlineData("ellipsis", "... ", "one ellipsis two", "one... two")]
+	[InlineData("dot dot dot", "... ", "one dot dot dot two", "one... two")]
+	public void Punctuation_defaults_attach_to_the_word_before_and_supply_their_own_space(
+		string find, string replaceWith, string input, string expected)
+	{
+		Assert.Equal(expected, Apply(input, find, replaceWith));
+	}
+
+	[Theory]
+	[InlineData("new line", "one new line two")]
+	[InlineData("newline", "one newline two")]
+	[InlineData("next line", "one next line two")]
+	public void Line_break_defaults_swallow_the_spacing_either_side(string find, string input)
+	{
+		Assert.Equal($"one{NewLine}two", Apply(input, find, NewLine));
+	}
+
+	[Theory]
+	[InlineData("new paragraph", "one new paragraph two")]
+	[InlineData("new paragraphs", "one new paragraphs two")]
+	[InlineData("next paragraph", "one next paragraph two")]
+	public void Paragraph_defaults_swallow_the_spacing_either_side(string find, string input)
+	{
+		Assert.Equal($"one{NewLine}{NewLine}two", Apply(input, find, NewLine + NewLine));
+	}
+
+	[Theory]
+	[InlineData("new bullet", "one new bullet two")]
+	[InlineData("next bullet", "one next bullet two")]
+	public void Bullet_defaults_swallow_the_spacing_either_side(string find, string input)
+	{
+		Assert.Equal($"one{NewLine}- two", Apply(input, find, NewLine + "- "));
+	}
+}

--- a/Mutation.Tests/SmartRuleShippedDefaultsTests.cs
+++ b/Mutation.Tests/SmartRuleShippedDefaultsTests.cs
@@ -5,13 +5,20 @@ using static CognitiveSupport.TranscriptFormatRule;
 namespace Mutation.Tests;
 
 /// <summary>
-/// Pins the output of every Smart rule Mutation seeds into a new settings file. Issue #293
-/// required that teaching the formatter which side a symbol attaches to leave these
+/// A before-and-after pin on the Smart rules Mutation seeds into a new settings file. Issue
+/// #293 required that teaching the formatter which side a symbol attaches to leave these
 /// byte-identical, and they are the rules almost every user is actually running.
 /// <para>
-/// The expectations here were taken from the behaviour before the change, so a future edit to
-/// the classification that shifts one of them fails here rather than in someone's transcript.
-/// Keep this list in step with the seeding in <c>SettingsManager</c>.
+/// This is a pin, not a check of the classification: every one of these rules falls into a
+/// shape the classes cannot move — either it carries no classifiable punctuation at all, or it
+/// supplies its own trailing space, which suppresses the side that changed. That is exactly
+/// why they are safe, and why emptying the class lists would not fail anything here.
+/// <see cref="SymbolAttachmentsTests"/> and the symbol cases in <see cref="TextFormatterTests"/>
+/// are what cover the classification itself.
+/// </para>
+/// <para>
+/// The find/replace pairs are copied from the seeding in <c>SettingsManager</c> rather than
+/// read from it, so a rule added there needs a line added here.
 /// </para>
 /// </summary>
 public class SmartRuleShippedDefaultsTests

--- a/Mutation.Tests/SymbolAttachmentsTests.cs
+++ b/Mutation.Tests/SymbolAttachmentsTests.cs
@@ -1,0 +1,83 @@
+using CognitiveSupport;
+
+namespace Mutation.Tests;
+
+/// <summary>
+/// Covers which side a dictated symbol closes up against. The formatter asks this once per
+/// rule and then trusts it, so a symbol in the wrong class is wrong in every transcript that
+/// uses that rule.
+/// </summary>
+public class SymbolAttachmentsTests
+{
+	[Theory]
+	[InlineData(".")]
+	[InlineData(",")]
+	[InlineData(";")]
+	[InlineData(":")]
+	[InlineData("!")]
+	[InlineData("?")]
+	[InlineData(")")]
+	[InlineData("]")]
+	[InlineData("}")]
+	[InlineData("%")]
+	[InlineData("’")]
+	[InlineData("”")]
+	public void Closing_punctuation_attaches_on_the_left(string replaceWith)
+	{
+		Assert.Equal(SymbolAttachment.Left, SymbolAttachments.Classify(replaceWith));
+	}
+
+	[Theory]
+	[InlineData("(")]
+	[InlineData("[")]
+	[InlineData("{")]
+	[InlineData("$")]
+	[InlineData("#")]
+	[InlineData("‘")]
+	[InlineData("“")]
+	public void Opening_punctuation_attaches_on_the_right(string replaceWith)
+	{
+		Assert.Equal(SymbolAttachment.Right, SymbolAttachments.Classify(replaceWith));
+	}
+
+	[Theory]
+	[InlineData("-")]
+	[InlineData("/")]
+	[InlineData("_")]
+	[InlineData("&")]
+	[InlineData("@")]
+	[InlineData("+")]
+	public void Connectors_attach_on_both_sides(string replaceWith)
+	{
+		Assert.Equal(SymbolAttachment.Both, SymbolAttachments.Classify(replaceWith));
+	}
+
+	// A straight quote does not say which end of the quotation it is. Guessing would be wrong
+	// half the time, so it keeps the behaviour every symbol had before there were classes.
+	[Theory]
+	[InlineData("\"")]
+	[InlineData("'")]
+	public void Straight_quotes_are_left_alone(string replaceWith)
+	{
+		Assert.Equal(SymbolAttachment.Both, SymbolAttachments.Classify(replaceWith));
+	}
+
+	// The shipped defaults carry their own spacing. Classification has to look past it,
+	// otherwise the punctuation that matters is never reached.
+	[Fact]
+	public void Leading_whitespace_is_skipped()
+	{
+		Assert.Equal(SymbolAttachment.Left, SymbolAttachments.Classify(". "));
+		Assert.Equal(SymbolAttachment.Both, SymbolAttachments.Classify("\r\n- "));
+	}
+
+	[Theory]
+	[InlineData(null)]
+	[InlineData("")]
+	[InlineData("   ")]
+	[InlineData("\r\n")]
+	public void Nothing_to_classify_falls_back_to_both(string? replaceWith)
+	{
+		Assert.Equal(SymbolAttachment.Both, SymbolAttachments.Classify(replaceWith));
+	}
+}

--- a/Mutation.Tests/SymbolAttachmentsTests.cs
+++ b/Mutation.Tests/SymbolAttachmentsTests.cs
@@ -20,7 +20,6 @@ public class SymbolAttachmentsTests
 	[InlineData("]")]
 	[InlineData("}")]
 	[InlineData("%")]
-	[InlineData("’")]
 	[InlineData("”")]
 	public void Closing_punctuation_attaches_on_the_left(string replaceWith)
 	{
@@ -52,12 +51,15 @@ public class SymbolAttachmentsTests
 		Assert.Equal(SymbolAttachment.Both, SymbolAttachments.Classify(replaceWith));
 	}
 
-	// A straight quote does not say which end of the quotation it is. Guessing would be wrong
-	// half the time, so it keeps the behaviour every symbol had before there were classes.
+	// A straight quote does not say which end of the quotation it is, and the curly single
+	// quote is also the typographic apostrophe — "John’s" is far more common than a quotation.
+	// Guessing would be wrong at least half the time, so all three keep the behaviour every
+	// symbol had before there were classes.
 	[Theory]
 	[InlineData("\"")]
 	[InlineData("'")]
-	public void Straight_quotes_are_left_alone(string replaceWith)
+	[InlineData("’")]
+	public void Ambiguous_quotes_are_left_alone(string replaceWith)
 	{
 		Assert.Equal(SymbolAttachment.Both, SymbolAttachments.Classify(replaceWith));
 	}

--- a/Mutation.Tests/TextFormatterTests.cs
+++ b/Mutation.Tests/TextFormatterTests.cs
@@ -189,6 +189,10 @@ public class TextFormatterTests
 	[Theory]
 	[InlineData("back in the nineties we did", "nineties", "'90s", "back in the '90s we did")]
 	[InlineData("he said quoted thing today", "quoted thing", "'quoted thing'", "he said 'quoted thing' today")]
+	// "'em" and "'n" open with an apostrophe and are two letters long, but they are whole
+	// words — "give it to 'em", not "give it to'em".
+	[InlineData("give it to them today", "them", "'em", "give it to 'em today")]
+	[InlineData("fish and chips please", "and", "'n", "fish 'n chips please")]
 	public void FormatWithRule_Smart_WordOpeningWithAnApostrophe_KeepsTheGap(
 		string input, string find, string replaceWith, string expected)
 	{

--- a/Mutation.Tests/TextFormatterTests.cs
+++ b/Mutation.Tests/TextFormatterTests.cs
@@ -123,6 +123,67 @@ public class TextFormatterTests
 		Assert.Equal(expected, TextFormatter.FormatWithRule(input, Rule(find, replaceWith, MatchTypeEnum.Smart)));
 	}
 
+	// Closing punctuation finishes the word in front of it and lets the next word start
+	// normally. Welding both sides — which is what every symbol used to get — ran the
+	// following word straight into the mark (issue #293).
+	[Theory]
+	[InlineData("fifty percent last year", "percent", "%", "fifty% last year")]
+	[InlineData("the total close bracket then", "close bracket", ")", "the total) then")]
+	[InlineData("item close square then", "close square", "]", "item] then")]
+	public void FormatWithRule_Smart_ClosingSymbol_HugsTheWordOnItsLeft(
+		string input, string find, string replaceWith, string expected)
+	{
+		Assert.Equal(expected, TextFormatter.FormatWithRule(input, Rule(find, replaceWith, MatchTypeEnum.Smart)));
+	}
+
+	// Opening punctuation is the mirror image: it leans onto what follows and leaves the
+	// gap in front of it alone.
+	[Theory]
+	[InlineData("issue hash 42 is open", "hash", "#", "issue #42 is open")]
+	[InlineData("type open bracket here", "open bracket", "(", "type (here")]
+	[InlineData("costs dollar 40 today", "dollar", "$", "costs $40 today")]
+	public void FormatWithRule_Smart_OpeningSymbol_HugsTheWordOnItsRight(
+		string input, string find, string replaceWith, string expected)
+	{
+		Assert.Equal(expected, TextFormatter.FormatWithRule(input, Rule(find, replaceWith, MatchTypeEnum.Smart)));
+	}
+
+	// A closing symbol at the end of a sentence still takes the punctuation that followed it,
+	// so the mark it closes with is not stranded a space away.
+	[Fact]
+	public void FormatWithRule_Smart_ClosingSymbol_KeepsTrailingPunctuationAttached()
+	{
+		string result = TextFormatter.FormatWithRule(
+			"we hit fifty percent. Then more",
+			Rule("percent", "%", MatchTypeEnum.Smart));
+
+		Assert.Equal("we hit fifty%. Then more", result);
+	}
+
+	// The shipped defaults are all left-attaching and all supply their own trailing space.
+	// Handing them back the gap the match consumed as well would double it.
+	[Theory]
+	[InlineData("Hello full stop next word", "full stop", ". ", "Hello. next word")]
+	[InlineData("one new colon two", "new colon", ": ", "one: two")]
+	[InlineData("wait ellipsis then", "ellipsis", "... ", "wait... then")]
+	public void FormatWithRule_Smart_ClosingSymbolSupplyingItsOwnSpace_DoesNotDoubleIt(
+		string input, string find, string replaceWith, string expected)
+	{
+		Assert.Equal(expected, TextFormatter.FormatWithRule(input, Rule(find, replaceWith, MatchTypeEnum.Smart)));
+	}
+
+	// A possessive belongs to the word it possesses. It carries a letter, so it is a word
+	// replacement rather than a symbol, but it still has to close the gap on its left.
+	[Fact]
+	public void FormatWithRule_Smart_ApostropheSuffix_AttachesToThePrecedingWord()
+	{
+		string result = TextFormatter.FormatWithRule(
+			"that is Jacques apostrophe s laptop",
+			Rule("apostrophe s", "'s", MatchTypeEnum.Smart));
+
+		Assert.Equal("that is Jacques's laptop", result);
+	}
+
 	// A replacement that opens with punctuation but carries text is a word, not punctuation,
 	// and still needs the gap in front of it.
 	[Fact]

--- a/Mutation.Tests/TextFormatterTests.cs
+++ b/Mutation.Tests/TextFormatterTests.cs
@@ -174,14 +174,38 @@ public class TextFormatterTests
 
 	// A possessive belongs to the word it possesses. It carries a letter, so it is a word
 	// replacement rather than a symbol, but it still has to close the gap on its left.
+	[Theory]
+	[InlineData("that is Jacques apostrophe s laptop", "apostrophe s", "'s", "that is Jacques's laptop")]
+	[InlineData("they are they apostrophe re here", "apostrophe re", "'re", "they are they're here")]
+	[InlineData("we curly apostrophe s done", "curly apostrophe s", "’s", "we’s done")]
+	public void FormatWithRule_Smart_ApostropheSuffix_AttachesToThePrecedingWord(
+		string input, string find, string replaceWith, string expected)
+	{
+		Assert.Equal(expected, TextFormatter.FormatWithRule(input, Rule(find, replaceWith, MatchTypeEnum.Smart)));
+	}
+
+	// "Starts with an apostrophe" is not the same thing as "is a suffix". A decade and a
+	// quotation both open with one and are both ordinary words that keep their gap.
+	[Theory]
+	[InlineData("back in the nineties we did", "nineties", "'90s", "back in the '90s we did")]
+	[InlineData("he said quoted thing today", "quoted thing", "'quoted thing'", "he said 'quoted thing' today")]
+	public void FormatWithRule_Smart_WordOpeningWithAnApostrophe_KeepsTheGap(
+		string input, string find, string replaceWith, string expected)
+	{
+		Assert.Equal(expected, TextFormatter.FormatWithRule(input, Rule(find, replaceWith, MatchTypeEnum.Smart)));
+	}
+
+	// U+2019 is the right single quote and the typographic apostrophe at the same time.
+	// Treating it as closing punctuation would break the far more common of the two uses,
+	// so it keeps the both-sides behaviour it has always had.
 	[Fact]
-	public void FormatWithRule_Smart_ApostropheSuffix_AttachesToThePrecedingWord()
+	public void FormatWithRule_Smart_CurlyApostropheSymbol_StillWeldsBothSides()
 	{
 		string result = TextFormatter.FormatWithRule(
-			"that is Jacques apostrophe s laptop",
-			Rule("apostrophe s", "'s", MatchTypeEnum.Smart));
+			"that is John apostrophe s laptop",
+			Rule("apostrophe", "’", MatchTypeEnum.Smart));
 
-		Assert.Equal("that is Jacques's laptop", result);
+		Assert.Equal("that is John’s laptop", result);
 	}
 
 	// A replacement that opens with punctuation but carries text is a word, not punctuation,

--- a/Mutation.Ui/Converters/PromptActionNameConverter.cs
+++ b/Mutation.Ui/Converters/PromptActionNameConverter.cs
@@ -1,0 +1,20 @@
+using Microsoft.UI.Xaml.Data;
+using Mutation.Ui.Services;
+using System;
+
+namespace Mutation.Ui.Converters;
+
+/// <summary>
+/// Turns a prompt's name into the accessible name for one of its action buttons. The verb
+/// comes from the binding's <c>ConverterParameter</c>, so one converter serves Run, Edit and
+/// Delete: <c>{Binding Name, Converter={StaticResource PromptActionNameConverter},
+/// ConverterParameter='Delete'}</c> reads out as "Delete prompt 'Summarise'".
+/// </summary>
+public class PromptActionNameConverter : IValueConverter
+{
+	public object Convert(object value, Type targetType, object parameter, string language)
+		=> PromptActionNames.Build(parameter as string, value as string);
+
+	public object ConvertBack(object value, Type targetType, object parameter, string language)
+		=> throw new NotSupportedException("Accessible names are display-only.");
+}

--- a/Mutation.Ui/Core/AudioSessionManager.cs
+++ b/Mutation.Ui/Core/AudioSessionManager.cs
@@ -460,10 +460,29 @@ public class AudioSessionManager : IDisposable
             // to stop a decode that is taking too long.
             PlaybackStarted?.Invoke(this, EventArgs.Empty);
 
-            if (await Task.WhenAny(playback, Task.Delay(DecodeAnnouncementDelay)).ConfigureAwait(true) != playback)
-                StatusMessage?.Invoke(this, $"Decoding {session.FileName}...");
+            using (var announcement = new CancellationTokenSource())
+            {
+                Task waited = await Task.WhenAny(playback, Task.Delay(DecodeAnnouncementDelay, announcement.Token))
+                    .ConfigureAwait(true);
+                // Cancelled either way: a decode that beat the delay leaves a timer running
+                // for every recording ever played otherwise.
+                announcement.Cancel();
+
+                // Only speak for a decode that is still the one the user is waiting for. Stop,
+                // or a jump to another session, can land inside the delay — and announcing
+                // then names a file that was cancelled, over the top of the one now playing.
+                if (waited != playback && !playback.IsCompleted && IsStillPlaying(session))
+                    StatusMessage?.Invoke(this, $"Decoding {session.FileName}...");
+            }
 
             await playback.ConfigureAwait(true);
+
+            // The same state, re-asserted now that the audio is actually running. The handler
+            // reads IsPlaying to decide what stays enabled while a recording plays, and at the
+            // point PlaybackStarted was first raised the decode had not finished, so it read
+            // false and left Retry and Upload enabled for the whole of playback.
+            if (IsStillPlaying(session))
+                PlaybackStarted?.Invoke(this, EventArgs.Empty);
         }
         catch (Exception ex)
         {
@@ -471,6 +490,13 @@ public class AudioSessionManager : IDisposable
             ErrorOccurred?.Invoke(this, $"Playback failed: {ex.Message}");
         }
     }
+
+    /// <summary>
+    /// Whether the request that started this session is still the live one. False once Stop,
+    /// a jump to another session, or the file reaching its end has cleared it.
+    /// </summary>
+    private bool IsStillPlaying(SpeechSession session) =>
+        ReferenceEquals(_playingSession, session);
 
     public void StopPlayback()
     {

--- a/Mutation.Ui/Core/AudioSessionManager.cs
+++ b/Mutation.Ui/Core/AudioSessionManager.cs
@@ -413,42 +413,63 @@ public class AudioSessionManager : IDisposable
         StatusMessage?.Invoke(this, "Transcript ready and copied.");
     }
 
-    public Task PlaySelectedSessionAsync()
-    {
-        if (SelectedSession == null) return Task.CompletedTask;
+    /// <summary>
+    /// How long a recording may take to decode before the user is told it is happening. A
+    /// short recording is ready well inside this, so the common case stays quiet; a long one
+    /// would otherwise be silence with no explanation, which for a screen-reader user is
+    /// indistinguishable from a dead button.
+    /// </summary>
+    private static readonly TimeSpan DecodeAnnouncementDelay = TimeSpan.FromMilliseconds(400);
 
-        if (IsPlaying && _playingSession != null && PathsEqual(_playingSession.FilePath, SelectedSession.FilePath))
+    public async Task PlaySelectedSessionAsync()
+    {
+        // Captured once. The method now awaits, so the selection is free to move underneath
+        // it, and every line below has to be talking about the same recording.
+        SpeechSession? session = SelectedSession;
+        if (session == null) return;
+
+        // Asked against the session this class chose to play rather than against the player's
+        // IsPlaying: decoding now happens off the UI thread, so there is a window where a file
+        // is on its way to the speakers without being audible yet. Pressing the button in that
+        // window has to stop it, not queue up a second copy of the same recording.
+        if (_playingSession != null && PathsEqual(_playingSession.FilePath, session.FilePath))
         {
             StopPlayback();
-            return Task.CompletedTask;
+            return;
         }
 
         try
         {
             StopPlayback();
 
-            if (!File.Exists(SelectedSession.FilePath))
+            if (!File.Exists(session.FilePath))
             {
                 StatusMessage?.Invoke(this, "Audio file not found.");
                 RefreshSessions();
-                return Task.CompletedTask;
+                return;
             }
 
-            _playingSession = SelectedSession;
+            _playingSession = session;
             // Start each playback at the persisted speed so a saved preference is
             // honoured on launch and after navigating between sessions.
             _playbackPlayer.Speed = _settings.AudioSettings?.PlaybackSpeed ?? PlaybackSpeedOptions.Default;
-            _playbackPlayer.Play(SelectedSession.FilePath);
-            
+
+            Task playback = _playbackPlayer.PlayAsync(session.FilePath);
+
+            // Raised before the file is audible, because the button it drives is now the way
+            // to stop a decode that is taking too long.
             PlaybackStarted?.Invoke(this, EventArgs.Empty);
+
+            if (await Task.WhenAny(playback, Task.Delay(DecodeAnnouncementDelay)).ConfigureAwait(true) != playback)
+                StatusMessage?.Invoke(this, $"Decoding {session.FileName}...");
+
+            await playback.ConfigureAwait(true);
         }
         catch (Exception ex)
         {
             StopPlayback();
             ErrorOccurred?.Invoke(this, $"Playback failed: {ex.Message}");
         }
-
-        return Task.CompletedTask;
     }
 
     public void StopPlayback()

--- a/Mutation.Ui/Core/AudioSessionManager.cs
+++ b/Mutation.Ui/Core/AudioSessionManager.cs
@@ -56,7 +56,15 @@ public class AudioSessionManager : IDisposable
         }
     }
 
-    public bool IsPlaying => _playbackPlayer.IsPlaying;
+    /// <summary>
+    /// Whether a recording is playing <em>or on its way there</em>. Decoding happens off the
+    /// UI thread now, so there are seconds between the user pressing Play and
+    /// <see cref="IsPlaying"/> becoming true — and for that whole window the session is
+    /// committed and the Play button is a Stop button. Anything deciding what to enable
+    /// during playback wants this, not <see cref="IsPlaying"/>, or it leaves controls live
+    /// for exactly the stretch this feature exists to make usable.
+    /// </summary>
+    public bool IsPlaybackActive => _playingSession != null;
     public bool IsRecording => _speechManager.Recording;
     public bool IsTranscribing => _speechManager.Transcribing;
 
@@ -476,13 +484,6 @@ public class AudioSessionManager : IDisposable
             }
 
             await playback.ConfigureAwait(true);
-
-            // The same state, re-asserted now that the audio is actually running. The handler
-            // reads IsPlaying to decide what stays enabled while a recording plays, and at the
-            // point PlaybackStarted was first raised the decode had not finished, so it read
-            // false and left Retry and Upload enabled for the whole of playback.
-            if (IsStillPlaying(session))
-                PlaybackStarted?.Invoke(this, EventArgs.Empty);
         }
         catch (Exception ex)
         {

--- a/Mutation.Ui/Core/DictationInsertOptionItem.cs
+++ b/Mutation.Ui/Core/DictationInsertOptionItem.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Reflection;
+
+namespace Mutation.Ui;
+
+/// <summary>
+/// One entry in the third-party interaction dropdown: the option, paired with the human
+/// wording for it.
+/// <para>
+/// The dropdown used to be bound to the bare enum, so a screen reader read the identifier out
+/// — "DoNotInsert", "SendKeys" — while the sentence that actually explains each choice sat
+/// unread in a <see cref="DescriptionAttribute"/> nothing looked at (issue #243).
+/// </para>
+/// </summary>
+public sealed record DictationInsertOptionItem(DictationInsertOption Option, string Description)
+{
+	/// <summary>
+	/// What a reader falls back to if it is ever handed the item rather than the bound
+	/// display property, which is the failure this type exists to prevent.
+	/// </summary>
+	public override string ToString() => Description;
+
+	/// <summary>Every option, in declaration order, ready to bind.</summary>
+	public static IReadOnlyList<DictationInsertOptionItem> All() =>
+		Enum.GetValues<DictationInsertOption>()
+			.Select(option => new DictationInsertOptionItem(option, Describe(option)))
+			.ToList();
+
+	/// <summary>
+	/// The option's description, falling back to its identifier. An option added later
+	/// without a description reads badly, but it still reads — which beats an empty row in
+	/// a list a blind user is navigating by ear.
+	/// </summary>
+	public static string Describe(DictationInsertOption option)
+	{
+		FieldInfo? field = typeof(DictationInsertOption).GetField(option.ToString());
+		string? description = field?.GetCustomAttribute<DescriptionAttribute>()?.Description;
+
+		return string.IsNullOrWhiteSpace(description)
+			? option.ToString()
+			: description;
+	}
+}

--- a/Mutation.Ui/MainWindow.xaml
+++ b/Mutation.Ui/MainWindow.xaml
@@ -20,6 +20,7 @@
     <Grid Background="{ThemeResource AppBackgroundBrush}">
         <Grid.Resources>
             <converters:BooleanToVisibilityConverter x:Key="BoolToVisConverter" />
+            <converters:PromptActionNameConverter x:Key="PromptActionNameConverter" />
         </Grid.Resources>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
@@ -507,9 +508,15 @@
                                                 <TextBlock Text="{Binding ModelName}" FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
                                             </StackPanel>
 
-                                            <Button Grid.Column="1" Content="Run" Click="BtnRunPrompt_Click" Tag="{Binding}" Style="{StaticResource OutlinedButtonStyle}" />
-                                            <Button Grid.Column="2" Content="Edit" Click="BtnEditPrompt_Click" Tag="{Binding}" />
-                                            <Button Grid.Column="3" Content="Delete" Click="BtnDeletePrompt_Click" Tag="{Binding}" />
+                                            <!-- The accessible names carry the row's prompt name. The visible
+                                                 Content is the same three words on every row, so without this a
+                                                 screen reader says "Delete" all the way down the list. -->
+                                            <Button Grid.Column="1" Content="Run" Click="BtnRunPrompt_Click" Tag="{Binding}" Style="{StaticResource OutlinedButtonStyle}"
+                                                    AutomationProperties.Name="{Binding Name, Converter={StaticResource PromptActionNameConverter}, ConverterParameter='Run'}" />
+                                            <Button Grid.Column="2" Content="Edit" Click="BtnEditPrompt_Click" Tag="{Binding}"
+                                                    AutomationProperties.Name="{Binding Name, Converter={StaticResource PromptActionNameConverter}, ConverterParameter='Edit'}" />
+                                            <Button Grid.Column="3" Content="Delete" Click="BtnDeletePrompt_Click" Tag="{Binding}"
+                                                    AutomationProperties.Name="{Binding Name, Converter={StaticResource PromptActionNameConverter}, ConverterParameter='Delete'}" />
                                         </Grid>
                                     </DataTemplate>
                                 </ListView.ItemTemplate>
@@ -602,9 +609,12 @@
                                     AutomationProperties.HelpText="{StaticResource Help.Main.ThirdPartyInteraction}"
                                     ToolTipService.ToolTip="Choose how formatted text is inserted"
                                     SelectionChanged="CmbInsertOption_SelectionChanged" />
+                                <!-- A live region: picking a different mode changes this line, and the
+                                     change is the only feedback there is that the choice took effect. -->
                                 <TextBlock
                                     x:Name="ThirdPartyExplanationText"
                                     TextWrapping="Wrap"
+                                    AutomationProperties.LiveSetting="Polite"
                                     Style="{StaticResource CaptionTextStyle}"
                                     Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
                             </StackPanel>

--- a/Mutation.Ui/MainWindow.xaml.cs
+++ b/Mutation.Ui/MainWindow.xaml.cs
@@ -2,6 +2,7 @@
 using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Automation;
+using Microsoft.UI.Xaml.Automation.Peers;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Input;
@@ -255,8 +256,11 @@ public sealed partial class MainWindow : Window, IDisposable
 		var tooltipManager = new TooltipManager(_settings);
 		tooltipManager.SetupTooltips(TxtRawTranscript, TxtFormatTranscript);
 
-		var insertOptions = Enum.GetValues(typeof(DictationInsertOption)).Cast<DictationInsertOption>().ToList();
+		// Bound to the described options rather than the bare enum, so the reader announces
+		// "Paste into 3rd party application" instead of the identifier "Paste" (issue #243).
+		var insertOptions = DictationInsertOptionItem.All();
 		CmbInsertOption.ItemsSource = insertOptions;
+		CmbInsertOption.DisplayMemberPath = nameof(DictationInsertOptionItem.Description);
 		var persistedInsertPreference = _settings.MainWindowUiSettings?.DictationInsertPreference;
 		if (!string.IsNullOrWhiteSpace(persistedInsertPreference) && Enum.TryParse(persistedInsertPreference, true, out DictationInsertOption persistedOption))
 		{
@@ -266,8 +270,13 @@ public sealed partial class MainWindow : Window, IDisposable
 		{
 			_insertOption = DictationInsertOption.Paste;
 		}
-		CmbInsertOption.SelectedItem = _insertOption;
+		CmbInsertOption.SelectedItem = insertOptions.FirstOrDefault(item => item.Option == _insertOption);
 		UpdateThirdPartyExplanation(_insertOption);
+
+		// Only from here on is a change to the explanation something the user did. Restoring
+		// the saved preference is not news, and announcing it would talk over whatever the
+		// screen reader says as the window opens.
+		_announceThirdPartyExplanation = true;
 
 		// After initializing and restoring the active microphone, play a sound
 		// representing the current state (mute/unmute) to reflect actual status.
@@ -2734,8 +2743,9 @@ public sealed partial class MainWindow : Window, IDisposable
 
 	private void CmbInsertOption_SelectionChanged(object sender, SelectionChangedEventArgs e)
 	{
-		if (CmbInsertOption.SelectedItem is DictationInsertOption opt)
+		if (CmbInsertOption.SelectedItem is DictationInsertOptionItem selected)
 		{
+			DictationInsertOption opt = selected.Option;
 			_insertOption = opt;
 			UpdateThirdPartyExplanation(opt);
 			var persistedValue = opt.ToString();
@@ -2747,6 +2757,9 @@ public sealed partial class MainWindow : Window, IDisposable
 		}
 	}
 
+	// False until the saved preference has been restored. See where it is set.
+	private bool _announceThirdPartyExplanation;
+
 	private void UpdateThirdPartyExplanation(DictationInsertOption option)
 	{
 		string explanation = option switch
@@ -2757,7 +2770,21 @@ public sealed partial class MainWindow : Window, IDisposable
 			_ => string.Empty
 		};
 
+		if (ThirdPartyExplanationText.Text == explanation)
+			return;
+
 		ThirdPartyExplanationText.Text = explanation;
+
+		if (!_announceThirdPartyExplanation)
+			return;
+
+		// The live setting on the TextBlock says the text is worth announcing; it does not
+		// announce it. WinUI raises nothing of its own when a TextBlock's Text changes, so
+		// without this the explanation for the newly chosen mode is silent and the selection
+		// change is the last thing the user hears (issue #243).
+		AutomationPeer? peer = FrameworkElementAutomationPeer.FromElement(ThirdPartyExplanationText)
+			?? FrameworkElementAutomationPeer.CreatePeerForElement(ThirdPartyExplanationText);
+		peer?.RaiseAutomationEvent(AutomationEvents.LiveRegionChanged);
 	}
 
 	// Reports how far the text actually got. Every path that needs no insert — an empty

--- a/Mutation.Ui/MainWindow.xaml.cs
+++ b/Mutation.Ui/MainWindow.xaml.cs
@@ -2235,7 +2235,11 @@ public sealed partial class MainWindow : Window, IDisposable
         var session = _audioSessionManager.SelectedSession;
         bool hasRecording = session != null && File.Exists(session.FilePath);
         bool busy = _audioSessionManager.IsRecording || _audioSessionManager.IsTranscribing;
-        bool isPlaying = _audioSessionManager.IsPlaying;
+        // Asked of the session rather than the speakers: a long recording spends seconds
+        // decoding before it is audible, and during that window the Play button is already a
+        // Stop button. Reading IsPlaying here left Retry and Upload announced as available for
+        // the whole of that stretch.
+        bool isPlaying = _audioSessionManager.IsPlaybackActive;
 
         BtnPlayLatestRecording.IsEnabled = isPlaying || (hasRecording && !busy);
         BtnRetrySpeechToText.IsEnabled = session != null && _activeSpeechService != null && !busy && !isPlaying;

--- a/Mutation.Ui/Services/PromptActionNames.cs
+++ b/Mutation.Ui/Services/PromptActionNames.cs
@@ -1,0 +1,25 @@
+namespace Mutation.Ui.Services;
+
+/// <summary>
+/// Builds the accessible name for a per-prompt action button.
+/// <para>
+/// The Run, Edit and Delete buttons in the prompt list carry the same three words on every
+/// row, so arrowing down the list a screen reader said "Delete" over and over with nothing to
+/// say which prompt it belonged to (issue #243). The name has to carry the row.
+/// </para>
+/// </summary>
+internal static class PromptActionNames
+{
+	/// <summary>
+	/// For example <c>Build("Delete", "Summarise")</c> → "Delete prompt 'Summarise'". A row
+	/// whose prompt has no name still gets a whole sentence: "Delete this prompt".
+	/// </summary>
+	internal static string Build(string? verb, string? promptName)
+	{
+		string subject = PromptLabel.Describe(promptName);
+
+		return string.IsNullOrWhiteSpace(verb)
+			? subject
+			: $"{verb.Trim()} {subject}";
+	}
+}

--- a/Mutation.Ui/Services/PromptDeletionMessages.cs
+++ b/Mutation.Ui/Services/PromptDeletionMessages.cs
@@ -11,7 +11,7 @@ namespace Mutation.Ui.Services;
 internal static class PromptDeletionMessages
 {
 	/// <summary>Fallback label when a prompt has no usable name.</summary>
-	internal const string UnnamedPrompt = "this prompt";
+	internal const string UnnamedPrompt = PromptLabel.Unnamed;
 
 	internal const string ConfirmationTitle = "Delete prompt";
 
@@ -35,10 +35,8 @@ internal static class PromptDeletionMessages
 
 	/// <summary>
 	/// Renders a prompt reference for a sentence: a quoted name when one is
-	/// present, or a neutral fallback when the name is missing or blank.
+	/// present, or a neutral fallback when the name is missing or blank. Shared with the
+	/// buttons that act on a row, so the dialog and the button that opened it agree.
 	/// </summary>
-	private static string Describe(string? name) =>
-		string.IsNullOrWhiteSpace(name)
-			? UnnamedPrompt
-			: $"prompt '{name.Trim()}'";
+	private static string Describe(string? name) => PromptLabel.Describe(name);
 }

--- a/Mutation.Ui/Services/PromptLabel.cs
+++ b/Mutation.Ui/Services/PromptLabel.cs
@@ -1,0 +1,22 @@
+namespace Mutation.Ui.Services;
+
+/// <summary>
+/// How a prompt is referred to inside a sentence a screen reader will read out: a quoted name
+/// when there is one, a neutral fallback when there is not.
+/// <para>
+/// Shared so the confirmation dialog, the outcome announcements, and the accessible names on
+/// the per-row buttons all name the same prompt the same way. Hearing "Delete prompt
+/// 'Summarise'" and then "Delete this prompt?" for the same row is a small thing to read and
+/// a confusing thing to hear.
+/// </para>
+/// </summary>
+internal static class PromptLabel
+{
+	/// <summary>Fallback label when a prompt has no usable name.</summary>
+	internal const string Unnamed = "this prompt";
+
+	internal static string Describe(string? name) =>
+		string.IsNullOrWhiteSpace(name)
+			? Unnamed
+			: $"prompt '{name.Trim()}'";
+}

--- a/Mutation.Ui/Views/Settings/Pages/InterfaceSettingsPage.xaml
+++ b/Mutation.Ui/Views/Settings/Pages/InterfaceSettingsPage.xaml
@@ -44,7 +44,7 @@
 				<ComboBox x:Name="CmbDictationInsert"
 						  AutomationProperties.Name="Dictation insert preference"
 						  AutomationProperties.HelpText="{StaticResource Help.Interface.DictationInsert}"
-						  Width="220"
+						  MinWidth="220"
 						  SelectionChanged="CmbDictationInsert_SelectionChanged" />
 				<Button x:Name="BtnResetDictation" Click="BtnResetDictation_Click"
 						AutomationProperties.Name="Reset dictation insert preference">

--- a/Mutation.Ui/Views/Settings/Pages/InterfaceSettingsPage.xaml
+++ b/Mutation.Ui/Views/Settings/Pages/InterfaceSettingsPage.xaml
@@ -45,11 +45,7 @@
 						  AutomationProperties.Name="Dictation insert preference"
 						  AutomationProperties.HelpText="{StaticResource Help.Interface.DictationInsert}"
 						  Width="220"
-						  SelectionChanged="CmbDictationInsert_SelectionChanged">
-					<x:String>Paste</x:String>
-					<x:String>Type</x:String>
-					<x:String>DoNotInsert</x:String>
-				</ComboBox>
+						  SelectionChanged="CmbDictationInsert_SelectionChanged" />
 				<Button x:Name="BtnResetDictation" Click="BtnResetDictation_Click"
 						AutomationProperties.Name="Reset dictation insert preference">
 					<FontIcon Glyph="&#xE72C;" FontFamily="Segoe Fluent Icons" FontSize="12"

--- a/Mutation.Ui/Views/Settings/Pages/InterfaceSettingsPage.xaml.cs
+++ b/Mutation.Ui/Views/Settings/Pages/InterfaceSettingsPage.xaml.cs
@@ -42,9 +42,16 @@ public sealed partial class InterfaceSettingsPage : UserControl
 	}
 
 	/// <summary>
-	/// Selects the entry a stored preference names. A file written by an older build can hold
-	/// something no option matches — "Type" was offered here for years — so an unrecognised
-	/// value falls back to the default rather than leaving the dropdown blank.
+	/// Selects the entry a stored preference names, and writes the value back. A file written
+	/// by an older build can hold something no option matches — "Type" was offered here for
+	/// years — so an unrecognised value falls back to the default rather than leaving the
+	/// dropdown blank, and the file is corrected rather than left holding a value nothing can
+	/// read.
+	/// <para>
+	/// The write is explicit rather than left to <c>SelectionChanged</c>: selecting the item
+	/// that is already selected raises nothing, which is exactly the case a Reset lands in
+	/// after a fallback, and it would have made the button do nothing at all.
+	/// </para>
 	/// </summary>
 	private void SelectStoredOption(string? storedValue)
 	{
@@ -52,8 +59,21 @@ public sealed partial class InterfaceSettingsPage : UserControl
 			? _insertOptions.FirstOrDefault(item => item.Option == stored)
 			: null;
 
-		CmbDictationInsert.SelectedItem = match ?? _insertOptions.FirstOrDefault(
+		match ??= _insertOptions.FirstOrDefault(
 			item => item.Option.ToString() == SettingsDefaults.MainWindowUi.DictationInsertPreference);
+
+		CmbDictationInsert.SelectedItem = match;
+		StorePreference(match);
+	}
+
+	private void StorePreference(DictationInsertOptionItem? selected)
+	{
+		_settings.MainWindowUiSettings ??= new MainWindowUiSettings();
+		// The identifier, not the description: that is what is persisted and what the main
+		// window parses back.
+		_settings.MainWindowUiSettings.DictationInsertPreference = selected is null
+			? SettingsDefaults.MainWindowUi.DictationInsertPreference
+			: selected.Option.ToString();
 	}
 
 	private void NbMaxLines_ValueChanged(NumberBox sender, NumberBoxValueChangedEventArgs args)
@@ -67,13 +87,7 @@ public sealed partial class InterfaceSettingsPage : UserControl
 	private void CmbDictationInsert_SelectionChanged(object sender, SelectionChangedEventArgs e)
 	{
 		if (_suppressEvents) return;
-		var selected = CmbDictationInsert.SelectedItem as DictationInsertOptionItem;
-		_settings.MainWindowUiSettings ??= new MainWindowUiSettings();
-		// The identifier, not the description: that is what is persisted and what the main
-		// window parses back.
-		_settings.MainWindowUiSettings.DictationInsertPreference = selected is null
-			? SettingsDefaults.MainWindowUi.DictationInsertPreference
-			: selected.Option.ToString();
+		StorePreference(CmbDictationInsert.SelectedItem as DictationInsertOptionItem);
 	}
 
 	private void BtnResetMaxLines_Click(object sender, RoutedEventArgs e)

--- a/Mutation.Ui/Views/Settings/Pages/InterfaceSettingsPage.xaml.cs
+++ b/Mutation.Ui/Views/Settings/Pages/InterfaceSettingsPage.xaml.cs
@@ -1,6 +1,9 @@
 using System;
+using System.Collections.Generic;
 using System.Drawing;
+using System.Linq;
 using CognitiveSupport;
+using Mutation.Ui;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 
@@ -11,10 +14,18 @@ public sealed partial class InterfaceSettingsPage : UserControl
 	private readonly Settings _settings;
 	private bool _suppressEvents;
 
+	// The same described options the main window's dropdown binds, for the same two reasons:
+	// a screen reader was reading out identifiers, and this list's middle entry said "Type",
+	// which is not a DictationInsertOption at all — choosing it wrote a value the main window
+	// could not parse, so the preference silently reverted to Paste (issue #243).
+	private readonly IReadOnlyList<DictationInsertOptionItem> _insertOptions = DictationInsertOptionItem.All();
+
 	public InterfaceSettingsPage(Settings settings)
 	{
 		_settings = settings;
 		InitializeComponent();
+		CmbDictationInsert.ItemsSource = _insertOptions;
+		CmbDictationInsert.DisplayMemberPath = nameof(DictationInsertOptionItem.Description);
 		LoadValues();
 	}
 
@@ -25,9 +36,24 @@ public sealed partial class InterfaceSettingsPage : UserControl
 		{
 			var ui = _settings.MainWindowUiSettings ?? new MainWindowUiSettings();
 			NbMaxLines.Value = ui.MaxTextBoxLineCount > 0 ? ui.MaxTextBoxLineCount : SettingsDefaults.MainWindowUi.MaxTextBoxLineCount;
-			CmbDictationInsert.SelectedItem = ui.DictationInsertPreference ?? SettingsDefaults.MainWindowUi.DictationInsertPreference;
+			SelectStoredOption(ui.DictationInsertPreference);
 		}
 		finally { _suppressEvents = false; }
+	}
+
+	/// <summary>
+	/// Selects the entry a stored preference names. A file written by an older build can hold
+	/// something no option matches — "Type" was offered here for years — so an unrecognised
+	/// value falls back to the default rather than leaving the dropdown blank.
+	/// </summary>
+	private void SelectStoredOption(string? storedValue)
+	{
+		DictationInsertOptionItem? match = Enum.TryParse(storedValue, ignoreCase: true, out DictationInsertOption stored)
+			? _insertOptions.FirstOrDefault(item => item.Option == stored)
+			: null;
+
+		CmbDictationInsert.SelectedItem = match ?? _insertOptions.FirstOrDefault(
+			item => item.Option.ToString() == SettingsDefaults.MainWindowUi.DictationInsertPreference);
 	}
 
 	private void NbMaxLines_ValueChanged(NumberBox sender, NumberBoxValueChangedEventArgs args)
@@ -41,11 +67,13 @@ public sealed partial class InterfaceSettingsPage : UserControl
 	private void CmbDictationInsert_SelectionChanged(object sender, SelectionChangedEventArgs e)
 	{
 		if (_suppressEvents) return;
-		string? selected = CmbDictationInsert.SelectedItem as string;
+		var selected = CmbDictationInsert.SelectedItem as DictationInsertOptionItem;
 		_settings.MainWindowUiSettings ??= new MainWindowUiSettings();
-		_settings.MainWindowUiSettings.DictationInsertPreference = string.IsNullOrWhiteSpace(selected)
+		// The identifier, not the description: that is what is persisted and what the main
+		// window parses back.
+		_settings.MainWindowUiSettings.DictationInsertPreference = selected is null
 			? SettingsDefaults.MainWindowUi.DictationInsertPreference
-			: selected;
+			: selected.Option.ToString();
 	}
 
 	private void BtnResetMaxLines_Click(object sender, RoutedEventArgs e)
@@ -55,7 +83,7 @@ public sealed partial class InterfaceSettingsPage : UserControl
 
 	private void BtnResetDictation_Click(object sender, RoutedEventArgs e)
 	{
-		CmbDictationInsert.SelectedItem = SettingsDefaults.MainWindowUi.DictationInsertPreference;
+		SelectStoredOption(SettingsDefaults.MainWindowUi.DictationInsertPreference);
 	}
 
 	private void BtnResetWindow_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
Three small Ready-column items, done together because two of them live in the same
part of the main window.

Closes #243
Closes #281
Closes #293

## #243 — the dropdown said "DoNotInsert" and every Delete button sounded the same

`CmbInsertOption` was bound to the bare `DictationInsertOption` enum with no
`DisplayMemberPath`, so a screen reader read out the identifiers — "DoNotInsert",
"SendKeys" — while the sentence that explains each choice sat unread in a
`[Description]` attribute nothing looked at.

It is now bound to `DictationInsertOptionItem`, which pairs each option with its
description. The item's `ToString` returns the description too, so anything that asks
the item rather than the bound property still gets human wording.

`ThirdPartyExplanationText` is a polite live region, and raises the announcement
itself — WinUI raises nothing of its own when a `TextBlock`'s `Text` changes, so the
attribute alone would have been decoration. It stays quiet while the saved preference
is being restored at startup, which is not news.

The Run / Edit / Delete buttons in the prompt list carry the row's prompt in their
accessible name: "Delete prompt 'Summarise'". The wording comes from the same
describer the confirmation dialog uses, so the button and the question it opens name
the prompt identically.

## #281 — playing a long recording froze the window

`PlaySelectedSessionAsync` was `async` in name only. `AudioPlayer.Play` ran a
whole-file managed Opus decode on the WinUI dispatcher thread, so a 30-minute voice
note left the window and the screen reader dead for seconds to tens of seconds with
nothing said about it.

`AudioPlayer.PlayAsync` decodes on the thread pool and comes back to the caller to
open the output device. **Only the decode moves**, deliberately: NAudio's
`WaveOutEvent` captures `SynchronizationContext.Current` at construction to post
`PlaybackStopped` back to, and a device built on a pool thread would start raising
`PlaybackEnded` on NAudio's playback thread, where every listener touches the UI.
Building it back on the caller's context is the cheap half; decoding was the part
that had to move. There is a test that asserts exactly that.

Two things fall out of the window now being usable during a decode:

- A decode that has been superseded — Stop pressed, or a different file chosen —
  throws its work away instead of starting audio nobody is waiting for. Without it,
  Stop during a decode leaves the button reading "Play" while sound comes out.
- The Play/Stop toggle asks which session this class chose to play rather than
  whether the player is audible yet, so pressing the button during a decode stops it
  instead of queueing a second copy of the same recording.

A decode still running after 400 ms announces "Decoding <file>...". Short recordings
are ready well inside that, so the common case stays quiet.

## #293 — a symbol could only attach to both sides

`ApplySmartRule` treated every symbol replacement as "attaches to both", so `percent`
→ `%` produced `fifty%last year` and `hash` → `#` produced `issue#42`.

Symbols are now classified by the side they attach to. Closing punctuation
(`. , ; : ! ? ) ] } %` and the closing curly quotes) hugs the word on its left and
gives back the gap on its right; opening punctuation (`( [ { $ #` and the opening
curly quotes) is the mirror image; connectors and **everything unrecognised** hug
both, which is what a symbol rule has always done — so no rule that works today can
be made worse. The straight `"` and `'` are deliberately unclassified: they do not say
which end of a quotation they are.

A possessive is handled alongside it: `'s` carries a letter, so it is a word
replacement rather than a symbol, but it still has to close the gap on its left —
"Jacques's", not "Jacques 's".

All sixteen shipped default rules are byte-identical. They are all left-attaching and
all supply their own trailing space, and there is a test covering that they do not
gain a doubled one.

## Testing

`dotnet test --configuration Release` — 1383 passing, 0 failing.

New coverage: symbol classification per class, the three attachment behaviours through
the formatter, the shipped-default shape, the apostrophe suffix, `PlayAsync` opening
the device back on the caller's context, stop-during-decode, last-request-wins, the
insert-option descriptions, and the per-row button names.

`FakeOutputDevice` moved out of `AudioPlayerTeardownTests` into a shared
`FakeAudioOutputDevice` so the new async tests use the same one rather than a copy.

## Documentation

`dictation.md`, `main-window.md` and `settings.md` listed the old identifiers as the
on-screen labels, including a note explaining that they were "short internal names" —
all now wrong, all updated. `transcript-formatting.md` gains a short table of the
three symbol classes with an example each, `accessibility.md` covers the per-row
button names and the dropdown wording, and `dictation.md` says what a long recording
does before the sound starts. HTML rebuilt and committed alongside.

## Not done here

#281's note about `DecodeToPcmStream` still materialising the whole file in a
`MemoryStream` is untouched — that is #237's third bullet, a separate change with its
own risk, and this PR is about where the decode runs rather than how much it costs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)