### PR TITLE
Stop a cancel lying, a settings upgrade breaking its own file, and a decode nobody needed (#295, #283, #290)

### DIFF
--- a/CognitiveSupport/OggAudioChunkWriter.cs
+++ b/CognitiveSupport/OggAudioChunkWriter.cs
@@ -48,14 +48,27 @@ public sealed class OggAudioChunkWriter : IAudioChunkWriter
 	private const long MinimumChunkSamples = SampleRate;
 
 	/// <summary>
-	/// Length of the audio in an Ogg/Opus file. This decodes the whole file, which on the
-	/// multi-hour recordings this class exists for takes real time — hence the token.
+	/// Length of the audio in an Ogg/Opus file.
+	///
+	/// The container states this outright, so that is where it is read from. Only a file
+	/// whose tail cannot be trusted to answer falls back to decoding the whole thing —
+	/// which on the multi-hour recordings this class exists for takes real time, hence
+	/// the token.
 	/// </summary>
 	public static TimeSpan MeasureDuration(string audioFilePath, CancellationToken cancellationToken = default)
 	{
 		if (string.IsNullOrWhiteSpace(audioFilePath))
 			throw new ArgumentException("Audio file path cannot be empty.", nameof(audioFilePath));
 
+		// Checked before the fast path too: a caller that has already been cancelled must
+		// stop here whether or not this happens to be cheap now (see #289).
+		cancellationToken.ThrowIfCancellationRequested();
+
+		return OggStreamDuration.TryRead(audioFilePath) ?? MeasureDurationByDecoding(audioFilePath, cancellationToken);
+	}
+
+	private static TimeSpan MeasureDurationByDecoding(string audioFilePath, CancellationToken cancellationToken)
+	{
 		long samples = 0;
 		OggOpusPcmDecoder.DecodeToMonoPcm(audioFilePath, decoded =>
 		{

--- a/CognitiveSupport/OggStreamDuration.cs
+++ b/CognitiveSupport/OggStreamDuration.cs
@@ -1,0 +1,206 @@
+using System;
+using System.Buffers.Binary;
+using System.IO;
+
+namespace CognitiveSupport;
+
+/// <summary>
+/// Reads how long an Ogg/Opus file plays for out of its container, without decoding a
+/// single sample.
+///
+/// RFC 7845 §4 puts a granule position — the count of 48 kHz samples the stream has
+/// produced up to and including that page — in every Ogg page header. The final page of
+/// the audio stream therefore already states the length, and the <c>OpusHead</c>
+/// pre-skip (§5.1) is the priming the decoder throws away. Length is the one minus the
+/// other, from two small reads rather than a pass over the whole file.
+///
+/// This exists because splitting an oversized recording used to decode it twice — once
+/// only to learn its length — and that only happens on files big enough to be worth
+/// hours of audio (issue #290). Everything here is best-effort: an unreadable or
+/// unconvincing tail returns null so the caller can fall back to decoding.
+/// </summary>
+public static class OggStreamDuration
+{
+	// RFC 3533 §6: capture pattern, version, header type, granule position, serial.
+	private const int PageHeaderBytes = 27;
+	private const int VersionOffset = 4;
+	private const int HeaderTypeOffset = 5;
+	private const int GranuleOffset = 6;
+	private const int SerialNumberOffset = 14;
+	private const int SegmentCountOffset = 26;
+
+	// Only the three lowest bits of the header type are defined (continued, BOS, EOS).
+	// Anything else set means these bytes are not a page header.
+	private const int DefinedHeaderTypeBits = 0x07;
+
+	// An Ogg page is at most 27 + 255 + 255*255 = 65307 bytes, so a tail this size always
+	// contains the whole of the last page however large it is.
+	private const int TailScanBytes = 128 * 1024;
+
+	// OpusHead has to be alone in the first page of its logical stream, so it is found
+	// immediately unless the container multiplexes several streams ahead of the audio.
+	// A cap keeps a file that is not really Ogg from being walked end to end.
+	private const int MaxPagesScannedForOpusHead = 64;
+
+	private static readonly byte[] OggMagic = "OggS"u8.ToArray();
+	private static readonly byte[] OpusHeadMagic = "OpusHead"u8.ToArray();
+
+	/// <summary>
+	/// Length of the Opus stream in <paramref name="audioFilePath"/>, or null when the
+	/// container cannot be trusted to answer — no readable <c>OpusHead</c>, no final page
+	/// carrying a granule position, or a granule that does not exceed the pre-skip.
+	/// A null is an instruction to measure some other way, not a claim the file is broken.
+	/// </summary>
+	public static TimeSpan? TryRead(string audioFilePath)
+	{
+		if (string.IsNullOrWhiteSpace(audioFilePath))
+			return null;
+
+		try
+		{
+			using var stream = File.OpenRead(audioFilePath);
+
+			if (!TryReadOpusHeadPage(stream, out uint serialNumber, out int preSkipSamples))
+				return null;
+
+			if (!TryReadFinalGranule(stream, serialNumber, out long granule))
+				return null;
+
+			long samples = granule - preSkipSamples;
+			return samples > 0
+				? TimeSpan.FromSeconds(samples / (double)OggOpusPcmDecoder.SampleRate)
+				: null;
+		}
+		catch (IOException)
+		{
+			return null;
+		}
+		catch (UnauthorizedAccessException)
+		{
+			return null;
+		}
+	}
+
+	/// <summary>
+	/// Walks pages from the start until one begins with an <c>OpusHead</c> packet, and
+	/// reads the logical stream it belongs to along with its pre-skip. Walking rather
+	/// than scanning raw bytes is what keeps an "OpusHead" that happens to sit inside a
+	/// comment string from being mistaken for the identification header.
+	/// </summary>
+	private static bool TryReadOpusHeadPage(Stream stream, out uint serialNumber, out int preSkipSamples)
+	{
+		serialNumber = 0;
+		preSkipSamples = 0;
+
+		var header = new byte[PageHeaderBytes];
+
+		for (int page = 0; page < MaxPagesScannedForOpusHead; page++)
+		{
+			if (stream.ReadAtLeast(header, header.Length, throwOnEndOfStream: false) < header.Length)
+				return false;
+			if (!IsPageHeader(header, 0))
+				return false;
+
+			int segmentCount = header[SegmentCountOffset];
+			var segmentTable = new byte[segmentCount];
+			if (stream.ReadAtLeast(segmentTable, segmentCount, throwOnEndOfStream: false) < segmentCount)
+				return false;
+
+			int payloadBytes = 0;
+			foreach (byte segment in segmentTable)
+				payloadBytes += segment;
+
+			var payload = new byte[payloadBytes];
+			if (stream.ReadAtLeast(payload, payloadBytes, throwOnEndOfStream: false) < payloadBytes)
+				return false;
+
+			// RFC 7845 §5.1: "OpusHead", version, channel count, then the 16-bit pre-skip.
+			if (StartsWith(payload, OpusHeadMagic) && payload.Length >= OpusHeadMagic.Length + 4)
+			{
+				serialNumber = BinaryPrimitives.ReadUInt32LittleEndian(header.AsSpan(SerialNumberOffset));
+				preSkipSamples = BinaryPrimitives.ReadUInt16LittleEndian(
+					payload.AsSpan(OpusHeadMagic.Length + 2));
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/// <summary>
+	/// Finds the last page of the given logical stream by scanning the tail of the file
+	/// backwards, and reads its granule position. Scanning back from the end rather than
+	/// forward from the start is the whole point: it costs one small read regardless of
+	/// how many hours of audio sit in between.
+	/// </summary>
+	private static bool TryReadFinalGranule(Stream stream, uint serialNumber, out long granule)
+	{
+		granule = 0;
+
+		int tailBytes = (int)Math.Min(stream.Length, TailScanBytes);
+		if (tailBytes < PageHeaderBytes)
+			return false;
+
+		var tail = new byte[tailBytes];
+		stream.Position = stream.Length - tailBytes;
+		if (stream.ReadAtLeast(tail, tailBytes, throwOnEndOfStream: false) < tailBytes)
+			return false;
+
+		for (int offset = tailBytes - PageHeaderBytes; offset >= 0; offset--)
+		{
+			if (!IsPageHeader(tail, offset))
+				continue;
+			if (BinaryPrimitives.ReadUInt32LittleEndian(tail.AsSpan(offset + SerialNumberOffset)) != serialNumber)
+				continue;
+
+			ulong stated = BinaryPrimitives.ReadUInt64LittleEndian(tail.AsSpan(offset + GranuleOffset));
+
+			// -1 means no packet finishes on this page, so it states no position at all,
+			// and 0 is what the header pages carry. Keep walking back to a page that
+			// actually reports progress. Anything past long.MaxValue is not a sample
+			// count, it is a misread.
+			if (stated == 0 || stated > long.MaxValue)
+				continue;
+
+			granule = (long)stated;
+			return true;
+		}
+
+		return false;
+	}
+
+	/// <summary>
+	/// Whether the bytes at <paramref name="offset"/> plausibly start a page header:
+	/// the capture pattern, the only stream structure version there has ever been, and
+	/// no undefined header-type bits. Cheap checks, but enough that a stray "OggS" in
+	/// compressed audio is very unlikely to be read as the end of the recording.
+	/// </summary>
+	private static bool IsPageHeader(byte[] buffer, int offset)
+	{
+		if (offset + PageHeaderBytes > buffer.Length)
+			return false;
+
+		for (int i = 0; i < OggMagic.Length; i++)
+		{
+			if (buffer[offset + i] != OggMagic[i])
+				return false;
+		}
+
+		return buffer[offset + VersionOffset] == 0
+			&& (buffer[offset + HeaderTypeOffset] & ~DefinedHeaderTypeBits) == 0;
+	}
+
+	private static bool StartsWith(byte[] buffer, byte[] prefix)
+	{
+		if (buffer.Length < prefix.Length)
+			return false;
+
+		for (int i = 0; i < prefix.Length; i++)
+		{
+			if (buffer[i] != prefix[i])
+				return false;
+		}
+
+		return true;
+	}
+}

--- a/Documentation/UserGuide/html/dictation.html
+++ b/Documentation/UserGuide/html/dictation.html
@@ -169,8 +169,9 @@ Open <strong>Settings</strong> with <strong>Ctrl+Comma</strong> and look on the 
 reads &quot;Transcribing...&quot; and the buttons are greyed out. Press <strong>Shift+Alt+U</strong> once
 more and it gives up on that recording. You hear the failure beep and &quot;Transcription
 cancelled.&quot;, the box empties itself, and everything is yours to use again.</p>
-<p>Your recording is not lost. It is still in the list of recent sessions, so you can
-select it and press <strong>Retry transcription</strong> whenever you like.</p>
+<p>Your recording is not lost. It is still the session Mutation has selected, so you
+can press <strong>Retry transcription</strong> to send it off again — or step back to it later
+with the <strong>older</strong> and <strong>newer</strong> arrow buttons.</p>
 <h2 id="recording-and-cleaning-up-in-one-step">Recording and cleaning up in one step</h2>
 <p>There is a second shortcut, <strong>Shift+Alt+I</strong> by default, that records <em>and</em> then
 runs your chosen AI prompt on the result — all from the one press. So you can

--- a/Documentation/UserGuide/html/dictation.html
+++ b/Documentation/UserGuide/html/dictation.html
@@ -164,6 +164,13 @@ never have to switch to Mutation first.</p>
 <p><strong>Shift+Alt+U</strong> is just the default. Every shortcut in Mutation can be changed.
 Open <strong>Settings</strong> with <strong>Ctrl+Comma</strong> and look on the <strong>Hotkeys</strong> tab.</p>
 </blockquote>
+<h2 id="changed-your-mind-while-it-is-transcribing">Changed your mind while it is transcribing</h2>
+<p>While Mutation is turning your recording into text, the <strong>Raw Transcript</strong> box
+reads &quot;Transcribing...&quot; and the buttons are greyed out. Press <strong>Shift+Alt+U</strong> once
+more and it gives up on that recording. You hear the failure beep and &quot;Transcription
+cancelled.&quot;, the box empties itself, and everything is yours to use again.</p>
+<p>Your recording is not lost. It is still in the list of recent sessions, so you can
+select it and press <strong>Retry transcription</strong> whenever you like.</p>
 <h2 id="recording-and-cleaning-up-in-one-step">Recording and cleaning up in one step</h2>
 <p>There is a second shortcut, <strong>Shift+Alt+I</strong> by default, that records <em>and</em> then
 runs your chosen AI prompt on the result — all from the one press. So you can

--- a/Documentation/UserGuide/html/troubleshooting.html
+++ b/Documentation/UserGuide/html/troubleshooting.html
@@ -419,6 +419,17 @@ naming the mapping.</p>
 <p><strong>What to do.</strong> Open <strong>Settings</strong> with <strong>Ctrl+Comma</strong>, go to <strong>Hotkeys</strong>, and either
 fill in the missing shortcut or delete the row. A mapping with a blank side simply
 does nothing until you finish it.</p>
+<h3 id="a-speech-service-came-back-set-to-openai">A speech service came back set to OpenAI</h3>
+<p><strong>What's happening.</strong> Every speech service in the settings file records which company
+does the transcribing — OpenAI or Deepgram. If that entry is missing, blank, or
+misspelt, Mutation cannot tell which one you meant. Rather than refuse to start, it
+sets that service to OpenAI while starting up and keeps everything else you had
+configured. This normally only happens after editing the file by hand — the
+<strong>Advanced</strong> switch in <strong>Settings</strong> reveals an <strong>Open Mutation.json</strong> button that
+opens it.</p>
+<p><strong>What to do.</strong> Open <strong>Settings</strong> with <strong>Ctrl+Comma</strong>, go to <strong>Speech to Text</strong>, and
+pick the service you actually wanted from the list. If you use Deepgram, check the
+service is set back to Deepgram before you dictate again.</p>
 <h3 id="screen-capture-appears-to-be-blocked">Screen capture appears to be blocked</h3>
 <p><strong>What's happening.</strong> Some managed work PCs disable screen capture by policy, and some
 privacy and DRM-protected windows cannot be captured at all. Mutation tests this before

--- a/Documentation/UserGuide/markdown/dictation.md
+++ b/Documentation/UserGuide/markdown/dictation.md
@@ -21,6 +21,16 @@ If you prefer clicking, the **Speech to Text** card on the main window has a
 > **Shift+Alt+U** is just the default. Every shortcut in Mutation can be changed.
 > Open **Settings** with **Ctrl+Comma** and look on the **Hotkeys** tab.
 
+## Changed your mind while it is transcribing
+
+While Mutation is turning your recording into text, the **Raw Transcript** box
+reads "Transcribing..." and the buttons are greyed out. Press **Shift+Alt+U** once
+more and it gives up on that recording. You hear the failure beep and "Transcription
+cancelled.", the box empties itself, and everything is yours to use again.
+
+Your recording is not lost. It is still in the list of recent sessions, so you can
+select it and press **Retry transcription** whenever you like.
+
 ## Recording and cleaning up in one step
 
 There is a second shortcut, **Shift+Alt+I** by default, that records *and* then

--- a/Documentation/UserGuide/markdown/dictation.md
+++ b/Documentation/UserGuide/markdown/dictation.md
@@ -28,8 +28,9 @@ reads "Transcribing..." and the buttons are greyed out. Press **Shift+Alt+U** on
 more and it gives up on that recording. You hear the failure beep and "Transcription
 cancelled.", the box empties itself, and everything is yours to use again.
 
-Your recording is not lost. It is still in the list of recent sessions, so you can
-select it and press **Retry transcription** whenever you like.
+Your recording is not lost. It is still the session Mutation has selected, so you
+can press **Retry transcription** to send it off again — or step back to it later
+with the **older** and **newer** arrow buttons.
 
 ## Recording and cleaning up in one step
 

--- a/Documentation/UserGuide/markdown/troubleshooting.md
+++ b/Documentation/UserGuide/markdown/troubleshooting.md
@@ -334,6 +334,20 @@ naming the mapping.
 fill in the missing shortcut or delete the row. A mapping with a blank side simply
 does nothing until you finish it.
 
+### A speech service came back set to OpenAI
+
+**What's happening.** Every speech service in the settings file records which company
+does the transcribing — OpenAI or Deepgram. If that entry is missing, blank, or
+misspelt, Mutation cannot tell which one you meant. Rather than refuse to start, it
+sets that service to OpenAI while starting up and keeps everything else you had
+configured. This normally only happens after editing the file by hand — the
+**Advanced** switch in **Settings** reveals an **Open Mutation.json** button that
+opens it.
+
+**What to do.** Open **Settings** with **Ctrl+Comma**, go to **Speech to Text**, and
+pick the service you actually wanted from the list. If you use Deepgram, check the
+service is set back to Deepgram before you dictate again.
+
 ### Screen capture appears to be blocked
 
 **What's happening.** Some managed work PCs disable screen capture by policy, and some

--- a/Mutation.Tests/OggStreamDurationTests.cs
+++ b/Mutation.Tests/OggStreamDurationTests.cs
@@ -1,0 +1,197 @@
+using System;
+using System.Buffers.Binary;
+using System.IO;
+using System.Threading;
+using CognitiveSupport;
+using Concentus.Enums;
+using Concentus.Oggfile;
+using Concentus.Structs;
+
+namespace Mutation.Tests;
+
+/// <summary>
+/// Issue #290: splitting an oversized recording decoded it twice, the first pass only to
+/// learn how long it was. The Ogg container states the length in every page header, so
+/// the answer is two small reads away — and these tests hold that answer to the one the
+/// decode gives, because a wrong length moves every chunk boundary.
+/// </summary>
+public class OggStreamDurationTests : IDisposable
+{
+	private const int SampleRate = 48000;
+	private const int FrameSize = 960; // 20ms
+
+	// RFC 3533 §6 page header layout, as far as this fixture needs it.
+	private const int PageHeaderBytes = 27;
+	private const int GranuleOffset = 6;
+	private const int SegmentCountOffset = 26;
+
+	private readonly string _workingDirectory = Directory.CreateTempSubdirectory("ogg-duration-tests").FullName;
+
+	public void Dispose()
+	{
+		try { Directory.Delete(_workingDirectory, recursive: true); } catch { }
+	}
+
+	/// <summary>A 440Hz tone of the requested length as a single Ogg/Opus file.</summary>
+	private string WriteFixture(string fileName, double seconds)
+	{
+		string path = Path.Combine(_workingDirectory, fileName);
+
+		using (var outStream = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None))
+		{
+#pragma warning disable CS0618 // Concentus.OggFile 1.0.6 requires the concrete OpusEncoder type.
+			var encoder = new OpusEncoder(SampleRate, 1, OpusApplication.OPUS_APPLICATION_AUDIO)
+			{
+				Bitrate = 32000,
+				UseDTX = false
+			};
+#pragma warning restore CS0618
+			var oggStream = new OpusOggWriteStream(encoder, outStream, new OpusTags());
+
+			var frame = new short[FrameSize];
+			for (int sample = 0; sample < FrameSize; sample++)
+				frame[sample] = (short)(12000 * Math.Sin(2 * Math.PI * 440 * sample / SampleRate));
+
+			for (int i = 0; i < seconds * SampleRate / FrameSize; i++)
+				oggStream.WriteSamples(frame, 0, frame.Length);
+
+			oggStream.Finish();
+		}
+
+		return path;
+	}
+
+	/// <summary>
+	/// What the file decodes to, counted the long way round. This is the number the
+	/// container reading has to agree with.
+	/// </summary>
+	private static double DecodedSeconds(string path)
+	{
+		long samples = 0;
+		OggOpusPcmDecoder.DecodeToMonoPcm(path, decoded => samples += decoded.Length);
+		return samples / (double)SampleRate;
+	}
+
+	/// <summary>
+	/// Rewrites every page's granule position to -1 — the legal "no packet finishes on
+	/// this page" value. The audio is untouched and still decodes; the container simply
+	/// stops stating where it has got to, which is the condition the fallback exists for.
+	/// </summary>
+	private static void EraseGranulePositions(string path)
+	{
+		byte[] file = File.ReadAllBytes(path);
+		int offset = 0;
+
+		while (offset + PageHeaderBytes <= file.Length)
+		{
+			if (file[offset] != (byte)'O' || file[offset + 1] != (byte)'g'
+				|| file[offset + 2] != (byte)'g' || file[offset + 3] != (byte)'S')
+				break;
+
+			BinaryPrimitives.WriteUInt64LittleEndian(file.AsSpan(offset + GranuleOffset), ulong.MaxValue);
+
+			int segmentCount = file[offset + SegmentCountOffset];
+			int payload = 0;
+			for (int i = 0; i < segmentCount; i++)
+				payload += file[offset + PageHeaderBytes + i];
+
+			offset += PageHeaderBytes + segmentCount + payload;
+		}
+
+		File.WriteAllBytes(path, file);
+	}
+
+	[Theory]
+	[InlineData(1.0)]
+	[InlineData(6.0)]
+	[InlineData(12.5)]
+	public void TryRead_AgreesWithTheDecodedDuration(double seconds)
+	{
+		string path = WriteFixture($"agree-{seconds}.ogg", seconds);
+
+		TimeSpan? fromContainer = OggStreamDuration.TryRead(path);
+
+		Assert.NotNull(fromContainer);
+		// The container states the exact stream length; the decode can only ever land on
+		// a whole 20ms frame boundary, so it may overshoot by up to one frame.
+		Assert.InRange(fromContainer.Value.TotalSeconds, DecodedSeconds(path) - 0.02, DecodedSeconds(path));
+	}
+
+	// The whole point of the change: the fast path has to be the one that answers, or the
+	// second decode is still there and nothing has been saved.
+	[Fact]
+	public void MeasureDuration_TakesTheContainerReading()
+	{
+		string path = WriteFixture("fast-path.ogg", 6);
+
+		Assert.Equal(OggStreamDuration.TryRead(path), OggAudioChunkWriter.MeasureDuration(path));
+	}
+
+	[Fact]
+	public void TryRead_GivesUp_WhenNoPageStatesAPosition()
+	{
+		string path = WriteFixture("no-granule.ogg", 6);
+		EraseGranulePositions(path);
+
+		Assert.Null(OggStreamDuration.TryRead(path));
+	}
+
+	// AC: a file whose trailing page cannot answer still measures correctly, by decoding.
+	[Fact]
+	public void MeasureDuration_FallsBackToDecoding_WhenTheContainerCannotAnswer()
+	{
+		string path = WriteFixture("fallback.ogg", 6);
+		EraseGranulePositions(path);
+
+		Assert.Equal(DecodedSeconds(path), OggAudioChunkWriter.MeasureDuration(path).TotalSeconds, 3);
+	}
+
+	// The fallback decodes the whole file, so the token still has to be honoured — the
+	// cancellation #289 added must not have been quietly bypassed by the fast path.
+	[Fact]
+	public void MeasureDuration_GivesUpWhenCancelled_EvenOnTheFastPath()
+	{
+		string path = WriteFixture("cancelled-fast.ogg", 1);
+		using var cts = new CancellationTokenSource();
+		cts.Cancel();
+
+		Assert.ThrowsAny<OperationCanceledException>(() => OggAudioChunkWriter.MeasureDuration(path, cts.Token));
+	}
+
+	[Fact]
+	public void TryRead_GivesUp_OnAFileThatIsNotOgg()
+	{
+		string path = Path.Combine(_workingDirectory, "not-ogg.bin");
+		File.WriteAllBytes(path, new byte[4096]);
+
+		Assert.Null(OggStreamDuration.TryRead(path));
+	}
+
+	[Fact]
+	public void TryRead_GivesUp_OnAMissingFile()
+	{
+		Assert.Null(OggStreamDuration.TryRead(Path.Combine(_workingDirectory, "absent.ogg")));
+	}
+
+	// Each chunk the splitter writes is measured again to plan the upload, so the reading
+	// has to hold for the files this app produces, not only for the source it was handed.
+	[Fact]
+	public void TryRead_AgreesWithTheDecodedDuration_ForEveryWrittenChunk()
+	{
+		string source = WriteFixture("chunked.ogg", 6);
+		string outputDirectory = Path.Combine(_workingDirectory, "chunked-out");
+
+		var chunks = new OggAudioChunkWriter().WriteChunks(
+			source, Array.Empty<SilenceRemovalPoint>(), (long)(2 * 24000 / 8.0 * 1.15), outputDirectory, CancellationToken.None);
+
+		Assert.True(chunks.Count > 1, "A 6s recording at a 2s limit has to be split.");
+		foreach (string chunk in chunks)
+		{
+			TimeSpan? fromContainer = OggStreamDuration.TryRead(chunk);
+
+			Assert.NotNull(fromContainer);
+			double decoded = DecodedSeconds(chunk);
+			Assert.InRange(fromContainer.Value.TotalSeconds, decoded - 0.02, decoded);
+		}
+	}
+}

--- a/Mutation.Tests/RecordingUiPlannerTests.cs
+++ b/Mutation.Tests/RecordingUiPlannerTests.cs
@@ -1,3 +1,4 @@
+using System;
 using Mutation.Ui.Core;
 
 namespace Mutation.Tests;
@@ -66,11 +67,45 @@ public class RecordingUiPlannerTests
 		Assert.Null(RecordingUiPlanner.For(RecordingActivity.Idle).TranscriptText);
 	}
 
+	// Issue #295. Cancelling has no transcript to put in the box, so the box kept the
+	// "Transcribing..." the run had set — a screen reader read work as still running
+	// long after the user had heard "Transcription cancelled."
+	[Fact]
+	public void Cancelled_TakesTheTranscribingPlaceholderBackOut()
+	{
+		var plan = RecordingUiPlanner.For(RecordingActivity.Cancelled);
+
+		Assert.Equal(string.Empty, plan.TranscriptText);
+		Assert.NotEqual(RecordingUiPlanner.TranscribingPlaceholder, plan.TranscriptText);
+	}
+
+	// Clearing the box is the only thing that separates a cancel from going idle: the
+	// user is back where they started and everything must be theirs to drive again.
+	[Fact]
+	public void Cancelled_OtherwiseLooksExactlyLikeIdle()
+	{
+		var cancelled = RecordingUiPlanner.For(RecordingActivity.Cancelled);
+		var idle = RecordingUiPlanner.For(RecordingActivity.Idle);
+
+		Assert.Equal(idle.ButtonLabel, cancelled.ButtonLabel);
+		Assert.Equal(idle.ButtonEnabled, cancelled.ButtonEnabled);
+		Assert.Equal(idle.TranscriptReadOnly, cancelled.TranscriptReadOnly);
+		Assert.Equal(idle.PlayStartBeep, cancelled.PlayStartBeep);
+	}
+
+	// Guards the other half of #295: clearing on a cancel must not turn into clearing on
+	// the ordinary idle, which would wipe the transcript FinalizeTranscript just delivered.
+	[Fact]
+	public void OnlyCancelled_ClearsTheTranscriptBox()
+	{
+		Assert.Single(
+			Enum.GetValues<RecordingActivity>(),
+			a => RecordingUiPlanner.For(a).TranscriptText == string.Empty);
+	}
+
 	[Fact]
 	public void OnlyRecording_SoundsTheStartBeep()
 	{
-		Assert.Single(
-			new[] { RecordingActivity.Idle, RecordingActivity.Recording, RecordingActivity.Transcribing },
-			a => RecordingUiPlanner.For(a).PlayStartBeep);
+		Assert.Single(Enum.GetValues<RecordingActivity>(), a => RecordingUiPlanner.For(a).PlayStartBeep);
 	}
 }

--- a/Mutation.Tests/SettingsLoadRepairTests.cs
+++ b/Mutation.Tests/SettingsLoadRepairTests.cs
@@ -176,6 +176,69 @@ public class SettingsLoadRepairTests
 		Assert.All(manager.HotKeyRouterIssues, issue => Assert.Contains("mapping 1", issue));
 	}
 
+	// Issue #283. A SpeechToTextSettings section with no Services array was read as a
+	// pre-Services legacy file and collapsed into one synthesized service — and with no
+	// legacy Service name to carry over, the synthesized Provider was "". The very next
+	// deserialize threw on that empty enum value, so a file the upgrade had just written
+	// could not be loaded at all. Reachable from the dialog's own "Open JSON" button.
+	[Fact]
+	public void Load_SpeechSectionWithNoServicesArray_StillLoads()
+	{
+		var settings = Load("""
+		{
+			"SpeechToTextSettings": { "TempDirectory": "D:\\MyRecordings" },
+			"MainWindowUiSettings": { "MaxTextBoxLineCount": 7 }
+		}
+		""");
+
+		// Nothing legacy to migrate, so the section is left for EnsureSettings to seed
+		// with the ordinary OpenAI Whisper default — and the rest of the file survives.
+		Assert.Equal(7, settings.MainWindowUiSettings!.MaxTextBoxLineCount);
+		Assert.Equal(@"D:\MyRecordings", settings.SpeechToTextSettings!.TempDirectory);
+		var service = Assert.Single(settings.SpeechToTextSettings.Services!);
+		Assert.Equal(SpeechToTextProviders.OpenAi, service.Provider);
+		Assert.Equal(SettingsDefaults.Speech.DefaultServiceName, service.Name);
+	}
+
+	// The other half of #283: a Provider the enum does not recognise, however it got
+	// there, must cost that one service its stored value — not the whole settings file.
+	[Theory]
+	[InlineData("\"\"")]
+	[InlineData("\"   \"")]
+	[InlineData("\"Whisper\"")]
+	[InlineData("\"None\"")]
+	[InlineData("null")]
+	public void Load_UnusableProvider_IsRepairedRatherThanFatal(string jsonValue)
+	{
+		var settings = Load($$"""
+		{
+			"SpeechToTextSettings": {
+				"Services": [ { "Name": "My service", "Provider": {{jsonValue}}, "ModelId": "whisper-1" } ]
+			}
+		}
+		""");
+
+		var service = Assert.Single(settings.SpeechToTextSettings!.Services!);
+		Assert.Equal(SpeechToTextProviders.OpenAi, service.Provider);
+		// Only the provider is repaired; everything the user did configure is kept.
+		Assert.Equal("My service", service.Name);
+		Assert.Equal("whisper-1", service.ModelId);
+	}
+
+	[Fact]
+	public void Load_RecognisedProvider_IsKeptAsIs()
+	{
+		var settings = Load("""
+		{
+			"SpeechToTextSettings": {
+				"Services": [ { "Name": "Deepgram Nova", "Provider": "Deepgram" } ]
+			}
+		}
+		""");
+
+		Assert.Equal(SpeechToTextProviders.Deepgram, settings.SpeechToTextSettings!.Services!.Single().Provider);
+	}
+
 	[Fact]
 	public void Load_WellFormedRouterMappings_ReportNothing()
 	{

--- a/Mutation.Tests/SettingsLoadRepairTests.cs
+++ b/Mutation.Tests/SettingsLoadRepairTests.cs
@@ -202,12 +202,20 @@ public class SettingsLoadRepairTests
 
 	// The other half of #283: a Provider the enum does not recognise, however it got
 	// there, must cost that one service its stored value — not the whole settings file.
+	// Numbers and comma-lists are the nastier half of this: Enum.TryParse accepts them
+	// and hands back a value the enum never declared, so they survive deserialization
+	// and only blow up later, at the switch that builds the service — past the recovery
+	// App.OnLaunched wraps the load in, so the user gets a bare crash and no backup offer.
 	[Theory]
 	[InlineData("\"\"")]
 	[InlineData("\"   \"")]
 	[InlineData("\"Whisper\"")]
 	[InlineData("\"None\"")]
 	[InlineData("null")]
+	[InlineData("5")]
+	[InlineData("-1")]
+	[InlineData("\"5\"")]
+	[InlineData("\"OpenAi, Deepgram\"")]
 	public void Load_UnusableProvider_IsRepairedRatherThanFatal(string jsonValue)
 	{
 		var settings = Load($$"""
@@ -222,6 +230,44 @@ public class SettingsLoadRepairTests
 		Assert.Equal(SpeechToTextProviders.OpenAi, service.Provider);
 		// Only the provider is repaired; everything the user did configure is kept.
 		Assert.Equal("My service", service.Name);
+		Assert.Equal("whisper-1", service.ModelId);
+	}
+
+	// Half-deleting the Services array by hand leaves something that is neither an array
+	// nor absent, and the deserializer cannot make a service list out of it either.
+	[Theory]
+	[InlineData("{}")]
+	[InlineData("\"OpenAi\"")]
+	[InlineData("7")]
+	public void Load_ServicesThatIsNotAnArray_StillLoads(string jsonValue)
+	{
+		var settings = Load($$"""
+		{
+			"SpeechToTextSettings": { "Services": {{jsonValue}} },
+			"MainWindowUiSettings": { "MaxTextBoxLineCount": 7 }
+		}
+		""");
+
+		Assert.Equal(7, settings.MainWindowUiSettings!.MaxTextBoxLineCount);
+		var service = Assert.Single(settings.SpeechToTextSettings!.Services!);
+		Assert.Equal(SpeechToTextProviders.OpenAi, service.Provider);
+		Assert.Equal(SettingsDefaults.Speech.DefaultServiceName, service.Name);
+	}
+
+	// The loose legacy fields still have to be carried over when the malformed Services
+	// is cleared out of the way — a real pre-Services file must not lose its API key.
+	[Fact]
+	public void Load_ServicesThatIsNotAnArray_StillCarriesTheLegacyFieldsOver()
+	{
+		var settings = Load("""
+		{
+			"SpeechToTextSettings": { "Services": {}, "ApiKey": "stt-key", "ModelId": "whisper-1" }
+		}
+		""");
+
+		var service = Assert.Single(settings.SpeechToTextSettings!.Services!);
+		Assert.Equal(SpeechToTextProviders.OpenAi, service.Provider);
+		Assert.Equal("stt-key", service.ApiKey);
 		Assert.Equal("whisper-1", service.ModelId);
 	}
 

--- a/Mutation.Tests/SettingsManagerMigrationTests.cs
+++ b/Mutation.Tests/SettingsManagerMigrationTests.cs
@@ -483,6 +483,64 @@ public class SettingsManagerMigrationTests : IDisposable
 		Assert.Equal("llm-key", result["ApiKeys"]?["OpenAiApiKey"]?.ToString());
 	}
 
+	// Issue #283. A section with no Services array and none of the loose legacy fields
+	// beside it is not a pre-Services file — it is just a short one. Collapsing it wrote
+	// a service with a blank Name and a blank Provider, and the blank Provider then threw
+	// on deserialize, so the upgrade broke the file it had just written.
+	[Fact]
+	public void UpgradeSettings_SpeechSectionWithNothingLegacy_SynthesizesNoService()
+	{
+		JObject result = UpgradeAndReload("""
+			{
+				"SpeechToTextSettings": { "TempDirectory": "D:\\MyRecordings" }
+			}
+			""");
+
+		Assert.Null(result["SpeechToTextSettings"]?["Services"]);
+		Assert.Equal(@"D:\MyRecordings", result["SpeechToTextSettings"]?["TempDirectory"]?.ToString());
+	}
+
+	// Loose legacy fields but no Service naming the provider: there is something to
+	// carry over, so the collapse still runs — with the OpenAI default standing in for
+	// the provider nobody recorded, rather than an empty string no enum can parse.
+	[Fact]
+	public void UpgradeSettings_LegacyFieldsWithNoServiceName_DefaultsTheProviderToOpenAi()
+	{
+		JObject result = UpgradeAndReload("""
+			{
+				"SpeechToTextSettings": {
+					"ApiKey": "stt-key",
+					"ModelId": "whisper-1"
+				}
+			}
+			""");
+
+		var services = (JArray)result["SpeechToTextSettings"]!["Services"]!;
+		var service = Assert.Single(services);
+		Assert.Equal(nameof(SpeechToTextProviders.OpenAi), service["Provider"]?.ToString());
+		Assert.Equal("stt-key", service["ApiKey"]?.ToString());
+		Assert.Equal("whisper-1", service["ModelId"]?.ToString());
+	}
+
+	[Theory]
+	[InlineData("\"\"")]
+	[InlineData("\"Whisper\"")]
+	[InlineData("null")]
+	public void UpgradeSettings_UnrecognisedProvider_IsRewrittenToOpenAi(string jsonValue)
+	{
+		JObject result = UpgradeAndReload($$"""
+			{
+				"SpeechToTextSettings": {
+					"Services": [ { "Name": "My service", "Provider": {{jsonValue}} } ]
+				}
+			}
+			""");
+
+		var services = (JArray)result["SpeechToTextSettings"]!["Services"]!;
+		Assert.Equal(nameof(SpeechToTextProviders.OpenAi), services[0]?["Provider"]?.ToString());
+		Assert.Equal("My service", services[0]?["Name"]?.ToString());
+	}
+
 	// Chain test: a JSON containing every legacy key still recognised by UpgradeSettings.
 	// Verifies that all migrations run in one pass without interfering with each other,
 	// and (critically) that ordering produces correct A->B->C chains where one block reads

--- a/Mutation.Ui/Core/AudioSessionManager.cs
+++ b/Mutation.Ui/Core/AudioSessionManager.cs
@@ -239,6 +239,7 @@ public class AudioSessionManager : IDisposable
                 // and greet a stop with the start beep and "Recording..." (issue #271).
                 StateChanged?.Invoke(this, RecordingActivity.Transcribing);
 
+                bool cancelled = false;
                 try
                 {
                     // The end beep is raised from inside the stop, not from here: it has to
@@ -254,6 +255,7 @@ public class AudioSessionManager : IDisposable
                 }
                 catch (OperationCanceledException)
                 {
+                    cancelled = true;
                     StatusMessage?.Invoke(this, "Transcription cancelled.");
                 }
                 catch (NoSpeechDetectedException)
@@ -263,7 +265,11 @@ public class AudioSessionManager : IDisposable
                 }
                 finally
                 {
-                    StateChanged?.Invoke(this, RecordingActivity.Idle);
+                    // Cancelled rather than Idle when nothing was delivered, so the
+                    // "Transcribing..." placeholder is cleared instead of left standing
+                    // (issue #295). Still raised from the finally, and still exactly one
+                    // state change, so the ordering guarantees above are untouched.
+                    StateChanged?.Invoke(this, cancelled ? RecordingActivity.Cancelled : RecordingActivity.Idle);
                 }
             }
         }
@@ -315,6 +321,7 @@ public class AudioSessionManager : IDisposable
             return;
         }
 
+        bool cancelled = false;
         try
         {
             StopPlayback();
@@ -329,6 +336,7 @@ public class AudioSessionManager : IDisposable
         }
         catch (OperationCanceledException)
         {
+            cancelled = true;
             StatusMessage?.Invoke(this, "Transcription cancelled.");
         }
         catch (Exception ex)
@@ -337,7 +345,7 @@ public class AudioSessionManager : IDisposable
         }
         finally
         {
-            StateChanged?.Invoke(this, RecordingActivity.Idle);
+            StateChanged?.Invoke(this, cancelled ? RecordingActivity.Cancelled : RecordingActivity.Idle);
         }
     }
 
@@ -349,6 +357,7 @@ public class AudioSessionManager : IDisposable
             return;
         }
 
+        bool cancelled = false;
         try
         {
             StopPlayback();
@@ -364,6 +373,7 @@ public class AudioSessionManager : IDisposable
         }
         catch (OperationCanceledException)
         {
+            cancelled = true;
             StatusMessage?.Invoke(this, "Transcription cancelled.");
         }
         catch (Exception ex)
@@ -372,7 +382,7 @@ public class AudioSessionManager : IDisposable
         }
         finally
         {
-            StateChanged?.Invoke(this, RecordingActivity.Idle);
+            StateChanged?.Invoke(this, cancelled ? RecordingActivity.Cancelled : RecordingActivity.Idle);
         }
     }
 

--- a/Mutation.Ui/Core/RecordingActivity.cs
+++ b/Mutation.Ui/Core/RecordingActivity.cs
@@ -22,4 +22,14 @@ public enum RecordingActivity
 
 	/// <summary>Capture is over and the audio is being turned into text.</summary>
 	Transcribing,
+
+	/// <summary>
+	/// A transcription was abandoned before it produced anything. Everything
+	/// <see cref="Idle"/> means, plus the one thing it deliberately does not do: the
+	/// "Transcribing..." placeholder is taken back out of the transcript box. Idle
+	/// leaves the box alone because the normal path has just delivered a transcript
+	/// into it — a cancel has nothing to deliver, so leaving it alone left the box
+	/// telling a screen-reader user work was still running (issue #295).
+	/// </summary>
+	Cancelled,
 }

--- a/Mutation.Ui/Core/RecordingUiPlanner.cs
+++ b/Mutation.Ui/Core/RecordingUiPlanner.cs
@@ -26,6 +26,16 @@ public static class RecordingUiPlanner
 			TranscriptText: TranscribingPlaceholder,
 			PlayStartBeep: false),
 
+		// Idle in every respect, except that the placeholder is cleared. Nothing was
+		// delivered into the box, so what is in it is the "Transcribing..." this run
+		// put there — and a screen reader would read that back as work still running.
+		RecordingActivity.Cancelled => new RecordingUiPlan(
+			ButtonLabel: "Record",
+			ButtonEnabled: true,
+			TranscriptReadOnly: false,
+			TranscriptText: string.Empty,
+			PlayStartBeep: false),
+
 		_ => new RecordingUiPlan(
 			ButtonLabel: "Record",
 			ButtonEnabled: true,

--- a/Mutation.Ui/MainWindow.xaml.cs
+++ b/Mutation.Ui/MainWindow.xaml.cs
@@ -2334,8 +2334,10 @@ public sealed partial class MainWindow : Window, IDisposable
             var plan = RecordingUiPlanner.For(activity);
             UpdateSpeechButtonVisuals(plan.ButtonLabel, GlyphFor(activity), plan.ButtonEnabled);
             TxtRawTranscript.IsReadOnly = plan.TranscriptReadOnly;
-            if (plan.TranscriptText is string placeholder)
-                TxtRawTranscript.Text = placeholder;
+            // Null means "leave whatever is in the box"; empty means "clear it", which is
+            // how a cancelled run takes its own "Transcribing..." back out (#295).
+            if (plan.TranscriptText is string transcriptText)
+                TxtRawTranscript.Text = transcriptText;
             if (plan.PlayStartBeep)
                 BeepPlayer.Play(BeepType.Start);
         });

--- a/Mutation.Ui/Services/SettingsManager.cs
+++ b/Mutation.Ui/Services/SettingsManager.cs
@@ -265,7 +265,11 @@ internal class SettingsManager : ISettingsManager
 		}
 		foreach (var s in speechToTextSettings.Services)
 		{
-			if (s.Provider == SpeechToTextProviders.None)
+			// Undefined as well as None. A number the enum never declared reaches the
+			// switch that builds the service and throws there — outside the recovery
+			// App.OnLaunched wraps the load in, so the user gets a bare startup crash
+			// with no offer to restore their backup (issue #283).
+			if (!Enum.IsDefined(s.Provider) || s.Provider == SpeechToTextProviders.None)
 				s.Provider = SpeechToTextProviders.OpenAi;
 			// A service's ApiKey is an optional override of the root-level ApiKeys.
 			// Leave it blank by default so the central key is used unless the user
@@ -750,8 +754,22 @@ End of summary.
 			// a blank Name and a blank Provider — which the very next deserialize then
 			// threw on, taking the whole settings file down with it (issue #283). Left
 			// alone, EnsureSettings seeds the proper OpenAI Whisper default instead.
-			if ((speechSettings["Services"] is not JToken servicesToken || servicesToken.Type != JTokenType.Array)
-				&& LegacyServiceFieldNames.Any(name => speechSettings[name] is not null))
+			bool hasServicesArray = speechSettings["Services"] is JToken servicesToken
+				&& servicesToken.Type == JTokenType.Array;
+
+			// A Services that is present but is neither an array nor null — an object left
+			// behind by half-deleting the array, say — cannot be deserialized into one
+			// either, and the throw takes the whole file with it. Drop it and let
+			// EnsureSettings seed the default, the same outcome an absent key gets.
+			if (!hasServicesArray
+				&& speechSettings["Services"] is JToken malformedServices
+				&& malformedServices.Type != JTokenType.Null)
+			{
+				speechSettings.Remove("Services");
+				saveRequired = true;
+			}
+
+			if (!hasServicesArray && LegacyServiceFieldNames.Any(name => speechSettings[name] is not null))
 			{
 				// No legacy Service to carry over means the provider is unknown, not blank.
 				// Name it what EnsureSettings would have: the OpenAI default.
@@ -803,22 +821,16 @@ End of summary.
 						? provider.ToString()
 						: string.Empty;
 
-					// The enum was renamed; carry the old name across.
-					if (providerText == "OpenAiWhisper")
-					{
-						service["Provider"] = nameof(SpeechToTextProviders.OpenAi);
+					// Written back as the one spelling the enum actually has. That covers
+					// three faults at once: the old "OpenAiWhisper" name, a value the enum
+					// does not know (blank, null, a hand-typed name), and a value it parses
+					// but never defined — a bare number, or a comma-list, both of which
+					// Enum.TryParse accepts. The first is fatal inside the deserializer and
+					// the last is fatal later, at the switch that builds the service, past
+					// the recovery App.OnLaunched wraps the load in (issue #283).
+					service["Provider"] = NormalizeProviderName(providerText);
+					if (service["Provider"]!.ToString() != providerText)
 						saveRequired = true;
-					}
-					// Anything the enum does not recognise — blank, null, or a hand-typed
-					// name — throws inside the deserializer, and a throw there is fatal to
-					// the whole file rather than to one service. Repair it here, the same
-					// way EnsureSettings repairs a stored None (issue #283).
-					else if (!Enum.TryParse<SpeechToTextProviders>(providerText, ignoreCase: true, out var parsed)
-						|| parsed == SpeechToTextProviders.None)
-					{
-						service["Provider"] = nameof(SpeechToTextProviders.OpenAi);
-						saveRequired = true;
-					}
 				}
 			}
 		}
@@ -1021,6 +1033,20 @@ End of summary.
 			return true;
 		}
 	}
+
+	/// <summary>
+	/// The stored provider spelled the way <see cref="SpeechToTextProviders"/> spells it,
+	/// or the OpenAI default when it names no provider the app can actually build.
+	/// <see cref="Enum.TryParse{TEnum}(string, bool, out TEnum)"/> alone is not enough:
+	/// it happily returns a value of 5 for "5" and 3 for "OpenAi, Deepgram", neither of
+	/// which is defined, so <see cref="Enum.IsDefined{TEnum}(TEnum)"/> has to gate it too.
+	/// </summary>
+	internal static string NormalizeProviderName(string? storedProvider) =>
+		Enum.TryParse<SpeechToTextProviders>(storedProvider, ignoreCase: true, out var provider)
+		&& Enum.IsDefined(provider)
+		&& provider != SpeechToTextProviders.None
+			? provider.ToString()
+			: nameof(SpeechToTextProviders.OpenAi);
 
 	internal static bool IsLegacyTempDirectory(string? tempDirectory)
 	{

--- a/Mutation.Ui/Services/SettingsManager.cs
+++ b/Mutation.Ui/Services/SettingsManager.cs
@@ -19,6 +19,15 @@ internal class SettingsManager : ISettingsManager
 		Converters = new List<JsonConverter> { new StringEnumConverter() }
 	};
 
+	/// <summary>
+	/// The fields a pre-<c>Services</c> settings file kept loose on the
+	/// <c>SpeechToTextSettings</c> section, one set per single configured provider.
+	/// Their presence is what identifies such a file; <see cref="UpgradeSettings"/>
+	/// collapses them into <c>Services[0]</c> and removes them.
+	/// </summary>
+	private static readonly string[] LegacyServiceFieldNames =
+		{ "Service", "ApiKey", "BaseDomain", "ModelId", "SpeechToTextPrompt" };
+
 	public string SettingsFilePath { get; }
 	private string SettingsFileFullPath => Path.GetFullPath(SettingsFilePath);
 
@@ -734,9 +743,22 @@ End of summary.
 				saveRequired = true;
 			}
 
-			if (speechSettings["Services"] is not JToken servicesToken || servicesToken.Type != JTokenType.Array)
+			// A section with no Services array predates the array, so the loose fields
+			// beside it are collapsed into a single synthesized service. Only do that when
+			// at least one of them is actually there: a section carrying none of them is
+			// not a legacy file at all, and synthesizing from nothing wrote a service with
+			// a blank Name and a blank Provider — which the very next deserialize then
+			// threw on, taking the whole settings file down with it (issue #283). Left
+			// alone, EnsureSettings seeds the proper OpenAI Whisper default instead.
+			if ((speechSettings["Services"] is not JToken servicesToken || servicesToken.Type != JTokenType.Array)
+				&& LegacyServiceFieldNames.Any(name => speechSettings[name] is not null))
 			{
-				string providerName = speechSettings.Value<string>("Service") ?? string.Empty;
+				// No legacy Service to carry over means the provider is unknown, not blank.
+				// Name it what EnsureSettings would have: the OpenAI default.
+				string legacyService = speechSettings.Value<string>("Service") ?? string.Empty;
+				string providerName = string.IsNullOrWhiteSpace(legacyService)
+					? nameof(SpeechToTextProviders.OpenAi)
+					: legacyService;
 
 				JObject serviceObj = new JObject
 				{
@@ -750,11 +772,8 @@ End of summary.
 
 				JArray createdServicesArray = new JArray { serviceObj };
 
-				speechSettings.Remove("Service");
-				speechSettings.Remove("ApiKey");
-				speechSettings.Remove("BaseDomain");
-				speechSettings.Remove("ModelId");
-				speechSettings.Remove("SpeechToTextPrompt");
+				foreach (string name in LegacyServiceFieldNames)
+					speechSettings.Remove(name);
 
 				// Only seed ActiveSpeechToTextService if the typo-fix above didn't already
 				// populate it from a legacy ActiveSpeetchToTextService.
@@ -777,9 +796,27 @@ End of summary.
 			{
 				foreach (var service in servicesArray)
 				{
-					if (service["Provider"]?.ToString() == "OpenAiWhisper")
+					if (service["Provider"] is not JToken provider)
+						continue;
+
+					string providerText = provider.Type is JTokenType.String or JTokenType.Integer
+						? provider.ToString()
+						: string.Empty;
+
+					// The enum was renamed; carry the old name across.
+					if (providerText == "OpenAiWhisper")
 					{
-						service["Provider"] = "OpenAi";
+						service["Provider"] = nameof(SpeechToTextProviders.OpenAi);
+						saveRequired = true;
+					}
+					// Anything the enum does not recognise — blank, null, or a hand-typed
+					// name — throws inside the deserializer, and a throw there is fatal to
+					// the whole file rather than to one service. Repair it here, the same
+					// way EnsureSettings repairs a stored None (issue #283).
+					else if (!Enum.TryParse<SpeechToTextProviders>(providerText, ignoreCase: true, out var parsed)
+						|| parsed == SpeechToTextProviders.None)
+					{
+						service["Provider"] = nameof(SpeechToTextProviders.OpenAi);
 						saveRequired = true;
 					}
 				}


### PR DESCRIPTION
Three small, independent fixes from the board.

Closes #295
Closes #283
Closes #290

## #295 — Cancelling a transcription left "Transcribing..." in the box

Going idle deliberately does not touch the transcript box: on the normal path
`FinalizeTranscript` has just delivered a transcript into it, and clearing would wipe
it. A cancel has nothing to deliver, so the "Transcribing..." the run had set stayed
put — and a screen reader read work as still running long after the user had heard
"Transcription cancelled."

- New `RecordingActivity.Cancelled`: identical to `Idle` except that it clears the box.
- The three `OperationCanceledException` paths in `AudioSessionManager` (dictation,
  retry, upload) raise it from their existing `finally`, so it is still exactly one
  state change and the ordering guarantees from #271 are untouched.
- `RecordingUiPlannerTests` covers it, including that `Idle` still leaves the box alone.

## #283 — UpgradeSettings wrote a blank Provider, then the file would not load

`UpgradeSettings` treated any `SpeechToTextSettings` section without a `Services` array
as a pre-`Services` legacy file and collapsed the loose fields into one synthesized
service. When the legacy `Service` field was absent too, it wrote `"Provider": ""` —
and `StringEnumConverter` threw on that during the deserialize immediately after, so
the whole settings file failed to load, from a section the upgrade itself had written.
A minimal `{"SpeechToTextSettings": {"TempDirectory": "..."}}` could not be loaded at
all, and the Settings dialog's own "Open Mutation.json" button makes that easy to
produce by hand.

- The collapse now runs only when at least one of the loose legacy fields is actually
  present. A section carrying none of them is a short file, not a legacy one, and is
  left for `EnsureSettings` to seed with the ordinary OpenAI Whisper default.
- When legacy fields are present but no `Service` names the provider, it writes
  `OpenAi` rather than `""`.
- Any `Provider` the enum does not recognise — blank, null, misspelt, or `None` —
  is repaired to `OpenAi` before deserialization, matching the `None` repair
  `EnsureSettings` already does. One bad service no longer costs the whole file.

## #290 — Splitting an oversized recording decoded it twice

`WriteChunks` called `MeasureDuration` — a full managed-code Opus decode — purely to
get the total length for `AudioChunkPlanner`, then decoded the same file again to write
the chunks. That only runs on files already over the upload limit, so roughly two hours
of audio waited through a whole redundant decode before the first chunk was uploaded.

RFC 7845 puts the answer in the container: the granule position in the final page
header, in 48 kHz samples, minus the `OpusHead` pre-skip.

- New `CognitiveSupport/OggStreamDuration.cs` walks forward to the `OpusHead` page for
  the serial number and pre-skip, then scans the file's tail backwards for that
  stream's last page. Two small reads regardless of file size.
- `MeasureDuration` prefers it and falls back to the decode when the tail cannot
  answer. The cancellation token is still honoured before either path (#289).
- Tests hold the container reading to the decoded duration for several lengths and for
  every chunk the splitter writes, and cover the fallback by erasing the granule
  positions from a fixture (leaving the audio intact).

## Documentation

- `dictation.md` — a short section on cancelling a transcription under way: what you
  hear, that the box empties, and that the recording is still there to retry.
- `troubleshooting.md` — "A speech service came back set to OpenAI", for the #283 repair.
- HTML regenerated with `Documentation\Build-UserGuide.cmd`.

## Quality gate

`dotnet test --configuration Release` — **1434 passed, 0 failed** (1424 before this
change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
