### PR TITLE
Give the four largest units a seam, and then a test

### DIFF
--- a/Mutation.Tests/AudioPlayerSpeedTests.cs
+++ b/Mutation.Tests/AudioPlayerSpeedTests.cs
@@ -74,15 +74,28 @@ public class AudioPlayerSpeedTests : IDisposable
 		return DrainByteCount(Assert.IsAssignableFrom<IWaveProvider>(device.Provider));
 	}
 
+	// The measured ratios are exact — the source is a synthesized tone and SoundTouch.Net is
+	// pinned — so the tolerance is a guard against the library moving, not against the machine.
+	// It has to stay tighter than the gap to the neighbouring supported speeds, or a
+	// regression that snapped 2.0 to 1.75 or 2.25 would pass: those give 0.571 and 0.444.
+	private const double RatioTolerance = 0.05;
+
+	private static void AssertRatio(long measured, long baseline, double expectedRatio)
+	{
+		Assert.True(baseline > 0, "The normal-speed chain produced no audio at all.");
+		Assert.InRange(
+			measured / (double)baseline,
+			expectedRatio - RatioTolerance,
+			expectedRatio + RatioTolerance);
+	}
+
 	[Fact]
 	public async Task Playing_at_double_speed_produces_about_half_as_much_audio()
 	{
 		long atNormal = await PlayAndMeasureAsync(1.0);
 		long atDouble = await PlayAndMeasureAsync(2.0);
 
-		Assert.True(atNormal > 0, "The normal-speed chain produced no audio at all.");
-		// Half, with room for SoundTouch's own buffering rather than a tight ratio.
-		Assert.InRange(atDouble, atNormal * 0.4, atNormal * 0.6);
+		AssertRatio(atDouble, atNormal, 0.5);
 	}
 
 	[Fact]
@@ -91,22 +104,11 @@ public class AudioPlayerSpeedTests : IDisposable
 		long atNormal = await PlayAndMeasureAsync(1.0);
 		long atHalf = await PlayAndMeasureAsync(0.5);
 
-		Assert.InRange(atHalf, atNormal * 1.7, atNormal * 2.3);
+		AssertRatio(atHalf, atNormal, 2.0);
 	}
 
 	[Fact]
-	public async Task A_speed_set_before_the_file_is_opened_still_reaches_the_chain()
-	{
-		long atNormal = await PlayAndMeasureAsync(1.0);
-		long atDouble = await PlayAndMeasureAsync(2.0);
-
-		// The speed is set while no file is loaded, so it has to be remembered and applied
-		// when the chain is built — not dropped because there was nothing to apply it to.
-		Assert.True(atDouble < atNormal);
-	}
-
-	[Fact]
-	public async Task A_speed_changed_mid_playback_retunes_the_audio_that_is_already_playing()
+	public async Task A_speed_changed_mid_playback_reaches_audio_that_is_already_in_flight()
 	{
 		using var player = NewPlayer();
 		await player.PlayAsync(WriteTone("mid-playback.wav"));
@@ -118,16 +120,35 @@ public class AudioPlayerSpeedTests : IDisposable
 		Assert.True(consumed > 0);
 
 		player.Speed = 2.0;
-		long remainderAtDouble = consumed + DrainByteCount(provider);
+		long total = consumed + DrainByteCount(provider);
 
 		_devices.Clear();
 		long straightThrough = await PlayAndMeasureAsync(1.0);
 
-		// Changing speed must not restart the file or lose the position — the rest simply
-		// arrives faster, so the total is shorter than an unchanged play of the same file.
+		// The rest of the file arrives faster, so the whole play is shorter than an unchanged
+		// one. This says the change reached a chain that was already running — it does NOT say
+		// the read position survived it; the byte counts cannot tell a continue from a restart
+		// at the new speed, which is what the next test is for.
 		Assert.True(
-			remainderAtDouble < straightThrough,
-			$"Expected the sped-up remainder ({remainderAtDouble}) to be shorter than a normal-speed play ({straightThrough}).");
+			total < straightThrough,
+			$"Expected the sped-up play ({total}) to be shorter than a normal-speed play ({straightThrough}).");
+	}
+
+	[Fact]
+	public async Task A_speed_change_does_not_rewind_the_file()
+	{
+		using var player = NewPlayer();
+		await player.PlayAsync(WriteTone("no-rewind.wav"));
+		var provider = Assert.IsAssignableFrom<IWaveProvider>(Assert.Single(_devices).Provider);
+
+		Assert.True(DrainByteCount(provider) > 0);
+
+		player.Speed = 2.0;
+
+		// The file has already been played to its end. If changing speed rebuilt or rewound the
+		// chain, there would be a second copy of the recording waiting here — the user would
+		// hear it start again from the top on every speed change.
+		Assert.Equal(0, DrainByteCount(provider));
 	}
 
 	[Theory]
@@ -141,7 +162,6 @@ public class AudioPlayerSpeedTests : IDisposable
 		player.Speed = requested;
 
 		Assert.Equal(expected, player.Speed);
-		Assert.Contains(player.Speed, PlaybackSpeedOptions.Speeds);
 	}
 
 	[Fact]
@@ -164,22 +184,29 @@ public class AudioPlayerSpeedTests : IDisposable
 		_devices.Clear();
 		long normal = await PlayAndMeasureAsync(1.0);
 
-		Assert.InRange(second, normal * 0.4, normal * 0.6);
+		AssertRatio(second, normal, 0.5);
 	}
 
 	[Fact]
-	public async Task A_speed_set_after_playback_ends_is_kept_for_the_next_file()
+	public async Task A_speed_set_after_playback_ends_still_applies_to_the_next_file()
 	{
 		using var player = NewPlayer();
 		await player.PlayAsync(WriteTone("ended.wav"));
+		Assert.Single(_devices).RaisePlaybackStopped();
 
-		var device = Assert.Single(_devices);
-		device.RaisePlaybackStopped();
-
-		// The chain is gone; the setting is not. Setting it must not throw against a torn-down
-		// provider, and must still apply to whatever is played next.
+		// The chain has been torn down by the end of the file, so there is no provider to
+		// retune. Setting the speed here must not throw, and must still be waiting when the
+		// next recording is played.
 		player.Speed = 0.5;
-
 		Assert.Equal(0.5, player.Speed);
+
+		_devices.Clear();
+		await player.PlayAsync(WriteTone("next.wav"));
+		long atHalf = DrainByteCount(Assert.IsAssignableFrom<IWaveProvider>(Assert.Single(_devices).Provider));
+
+		_devices.Clear();
+		long normal = await PlayAndMeasureAsync(1.0);
+
+		AssertRatio(atHalf, normal, 2.0);
 	}
 }

--- a/Mutation.Tests/AudioPlayerSpeedTests.cs
+++ b/Mutation.Tests/AudioPlayerSpeedTests.cs
@@ -1,0 +1,185 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using CognitiveSupport;
+using NAudio.Wave;
+
+namespace Mutation.Tests;
+
+/// <summary>
+/// Covers <see cref="AudioPlayer.Speed"/> in situ — the time-stretch stage wired into the
+/// player's real playback chain, rather than <see cref="SoundTouchSampleProvider"/> on its
+/// own, which is where the existing coverage stopped (issue #255).
+/// <para>
+/// The provider being correct says nothing about the player building the chain around it.
+/// A speed that is snapped but never handed to the provider, or a provider rebuilt at the
+/// default on the next file, leaves the setting looking applied and sounding unchanged —
+/// and the only feedback is how fast the recording sounds.
+/// </para>
+/// <para>
+/// The output device is faked: build machines have no speakers, and pulling samples through
+/// the chain the player handed the device measures the stretch exactly.
+/// </para>
+/// </summary>
+public class AudioPlayerSpeedTests : IDisposable
+{
+	private readonly string _workingDirectory = Directory.CreateTempSubdirectory("audio-player-speed-tests").FullName;
+	private readonly List<FakeAudioOutputDevice> _devices = new();
+
+	public void Dispose()
+	{
+		try { Directory.Delete(_workingDirectory, recursive: true); } catch { }
+	}
+
+	private AudioPlayer NewPlayer()
+	{
+		return new AudioPlayer(() =>
+		{
+			var device = new FakeAudioOutputDevice();
+			_devices.Add(device);
+			return device;
+		});
+	}
+
+	// A real .wav, so the player's own reader and sample-provider chain run rather than
+	// being stubbed out. One second is long enough for the stretch to dominate SoundTouch's
+	// own buffering latency.
+	private string WriteTone(string fileName, int durationMs = 1_000)
+	{
+		string path = Path.Combine(_workingDirectory, fileName);
+		File.WriteAllBytes(path, BeepToneSynthesizer.SynthesizeWav(new[] { (440, durationMs) }));
+		return path;
+	}
+
+	/// <summary>Bytes the chain produces when played to its end — the audible length of the file.</summary>
+	private static long DrainByteCount(IWaveProvider provider)
+	{
+		var buffer = new byte[16_384];
+		long total = 0;
+		int read;
+		while ((read = provider.Read(buffer, 0, buffer.Length)) > 0)
+			total += read;
+		return total;
+	}
+
+	private async Task<long> PlayAndMeasureAsync(double speed)
+	{
+		using var player = NewPlayer();
+		player.Speed = speed;
+		await player.PlayAsync(WriteTone($"tone-{speed}.wav"));
+
+		var device = Assert.Single(_devices);
+		_devices.Clear();
+		return DrainByteCount(Assert.IsAssignableFrom<IWaveProvider>(device.Provider));
+	}
+
+	[Fact]
+	public async Task Playing_at_double_speed_produces_about_half_as_much_audio()
+	{
+		long atNormal = await PlayAndMeasureAsync(1.0);
+		long atDouble = await PlayAndMeasureAsync(2.0);
+
+		Assert.True(atNormal > 0, "The normal-speed chain produced no audio at all.");
+		// Half, with room for SoundTouch's own buffering rather than a tight ratio.
+		Assert.InRange(atDouble, atNormal * 0.4, atNormal * 0.6);
+	}
+
+	[Fact]
+	public async Task Playing_at_half_speed_produces_about_twice_as_much_audio()
+	{
+		long atNormal = await PlayAndMeasureAsync(1.0);
+		long atHalf = await PlayAndMeasureAsync(0.5);
+
+		Assert.InRange(atHalf, atNormal * 1.7, atNormal * 2.3);
+	}
+
+	[Fact]
+	public async Task A_speed_set_before_the_file_is_opened_still_reaches_the_chain()
+	{
+		long atNormal = await PlayAndMeasureAsync(1.0);
+		long atDouble = await PlayAndMeasureAsync(2.0);
+
+		// The speed is set while no file is loaded, so it has to be remembered and applied
+		// when the chain is built — not dropped because there was nothing to apply it to.
+		Assert.True(atDouble < atNormal);
+	}
+
+	[Fact]
+	public async Task A_speed_changed_mid_playback_retunes_the_audio_that_is_already_playing()
+	{
+		using var player = NewPlayer();
+		await player.PlayAsync(WriteTone("mid-playback.wav"));
+		var provider = Assert.IsAssignableFrom<IWaveProvider>(Assert.Single(_devices).Provider);
+
+		// Pull a little at normal speed, the way the device would, then change gear.
+		var buffer = new byte[16_384];
+		long consumed = provider.Read(buffer, 0, buffer.Length);
+		Assert.True(consumed > 0);
+
+		player.Speed = 2.0;
+		long remainderAtDouble = consumed + DrainByteCount(provider);
+
+		_devices.Clear();
+		long straightThrough = await PlayAndMeasureAsync(1.0);
+
+		// Changing speed must not restart the file or lose the position — the rest simply
+		// arrives faster, so the total is shorter than an unchanged play of the same file.
+		Assert.True(
+			remainderAtDouble < straightThrough,
+			$"Expected the sped-up remainder ({remainderAtDouble}) to be shorter than a normal-speed play ({straightThrough}).");
+	}
+
+	[Theory]
+	[InlineData(1.87, 1.75)]
+	[InlineData(-4.0, 0.5)]
+	[InlineData(99.0, 3.0)]
+	public void An_unsupported_speed_is_snapped_to_the_nearest_supported_one(double requested, double expected)
+	{
+		using var player = NewPlayer();
+
+		player.Speed = requested;
+
+		Assert.Equal(expected, player.Speed);
+		Assert.Contains(player.Speed, PlaybackSpeedOptions.Speeds);
+	}
+
+	[Fact]
+	public async Task The_speed_carries_over_to_the_next_file_played()
+	{
+		using var player = NewPlayer();
+		player.Speed = 2.0;
+
+		await player.PlayAsync(WriteTone("first.wav"));
+		player.Stop();
+		await player.PlayAsync(WriteTone("second.wav"));
+
+		Assert.Equal(2.0, player.Speed);
+		Assert.Equal(2, _devices.Count);
+
+		// The second chain has to be built at the remembered speed, not rebuilt at the
+		// default — the setting is persisted and the user expects it to survive navigating
+		// between recordings.
+		long second = DrainByteCount(Assert.IsAssignableFrom<IWaveProvider>(_devices[1].Provider));
+		_devices.Clear();
+		long normal = await PlayAndMeasureAsync(1.0);
+
+		Assert.InRange(second, normal * 0.4, normal * 0.6);
+	}
+
+	[Fact]
+	public async Task A_speed_set_after_playback_ends_is_kept_for_the_next_file()
+	{
+		using var player = NewPlayer();
+		await player.PlayAsync(WriteTone("ended.wav"));
+
+		var device = Assert.Single(_devices);
+		device.RaisePlaybackStopped();
+
+		// The chain is gone; the setting is not. Setting it must not throw against a torn-down
+		// provider, and must still apply to whatever is played next.
+		player.Speed = 0.5;
+
+		Assert.Equal(0.5, player.Speed);
+	}
+}

--- a/Mutation.Tests/FakeAudioOutputDevice.cs
+++ b/Mutation.Tests/FakeAudioOutputDevice.cs
@@ -28,8 +28,16 @@ internal sealed class FakeAudioOutputDevice : IAudioOutputDevice
 
 	public event EventHandler<StoppedEventArgs>? PlaybackStopped;
 
+	/// <summary>
+	/// The chain the player handed over to be played. A real device pulls samples from this;
+	/// a test can pull from it too, which is the only way to observe what the time-stretch
+	/// stage actually did to the audio.
+	/// </summary>
+	public IWaveProvider? Provider { get; private set; }
+
 	public void Init(IWaveProvider waveProvider)
 	{
+		Provider = waveProvider;
 	}
 
 	public void Play() => PlaybackState = PlaybackState.Playing;

--- a/Mutation.Tests/FakeHotkeyPlatform.cs
+++ b/Mutation.Tests/FakeHotkeyPlatform.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+using Mutation.Ui.Services;
+
+namespace Mutation.Tests;
+
+/// <summary>
+/// Stands in for Windows' RegisterHotKey/UnregisterHotKey. The build machine has no window
+/// handle and no guarantee that any given chord is free, so the real API can only ever be
+/// tested by luck — while the bookkeeping above it is exactly where a registration leak or
+/// a mis-routed chord would hide.
+/// </summary>
+internal sealed class FakeHotkeyPlatform : IHotkeyPlatform
+{
+	/// <summary>Ids Windows currently considers bound, in the order they were registered.</summary>
+	public List<int> Bound { get; } = new();
+
+	/// <summary>Every id ever released, including ones released twice.</summary>
+	public List<int> Released { get; } = new();
+
+	/// <summary>The (modifiers, key) pair each id was registered with.</summary>
+	public Dictionary<int, (uint Modifiers, uint Key)> Requests { get; } = new();
+
+	/// <summary>Set to make the next registration fail with this Win32 error code, then reset.</summary>
+	public int? NextFailureCode { get; set; }
+
+	public bool Register(int id, uint modifiers, uint virtualKey, out int errorCode)
+	{
+		Requests[id] = (modifiers, virtualKey);
+
+		if (NextFailureCode is int code)
+		{
+			NextFailureCode = null;
+			errorCode = code;
+			return false;
+		}
+
+		Bound.Add(id);
+		errorCode = 0;
+		return true;
+	}
+
+	public void Unregister(int id)
+	{
+		Released.Add(id);
+		Bound.Remove(id);
+	}
+}

--- a/Mutation.Tests/HotkeyRegistrationTableTests.cs
+++ b/Mutation.Tests/HotkeyRegistrationTableTests.cs
@@ -1,0 +1,306 @@
+using System.Collections.Generic;
+using Mutation.Ui.Services;
+using Windows.System;
+using static Mutation.Ui.Services.HotkeyRegistrationTable;
+
+namespace Mutation.Tests;
+
+/// <summary>
+/// Covers <see cref="HotkeyRegistrationTable"/> — the registration bookkeeping behind every
+/// global shortcut in the app, and the largest untested unit before this (issue #255).
+/// <para>
+/// Everything here fails silently in production. A router refresh that forgets to release
+/// its old ids leaves a chord bound to a mapping the user deleted; a duplicate that reaches
+/// Windows comes back as an unexplained failure and gets blamed on another application; a
+/// WM_HOTKEY for a released id that still finds a callback runs the wrong action. None of
+/// these throw, and for a user who cannot see the Settings screen confirm otherwise, the
+/// only evidence is the wrong thing happening.
+/// </para>
+/// </summary>
+public class HotkeyRegistrationTableTests
+{
+	private static Hotkey Chord(VirtualKey key, bool control = true, bool shift = false, bool alt = false, bool win = false) =>
+		new() { Key = key, Control = control, Shift = shift, Alt = alt, Win = win };
+
+	private static (HotkeyRegistrationTable Table, FakeHotkeyPlatform Platform) NewTable()
+	{
+		var platform = new FakeHotkeyPlatform();
+		return (new HotkeyRegistrationTable(platform), platform);
+	}
+
+	[Fact]
+	public void Register_binds_the_chord_and_reports_the_id_it_used()
+	{
+		var (table, platform) = NewTable();
+
+		var outcome = table.Register(Chord(VirtualKey.M), () => { }, HotkeyGroup.Core);
+
+		Assert.True(outcome.Success);
+		Assert.Null(outcome.ErrorMessage);
+		Assert.Equal(new[] { outcome.Id }, platform.Bound);
+		Assert.Equal(1, table.Count);
+	}
+
+	[Fact]
+	public void Register_passes_the_composed_modifiers_and_key_through_to_windows()
+	{
+		var (table, platform) = NewTable();
+		var chord = Chord(VirtualKey.K, control: true, shift: true);
+
+		var outcome = table.Register(chord, () => { }, HotkeyGroup.Core);
+
+		Assert.Equal(
+			(HotkeyModifiers.Compose(chord), (uint)VirtualKey.K),
+			platform.Requests[outcome.Id]);
+	}
+
+	[Fact]
+	public void A_chord_this_process_already_holds_is_refused_without_asking_windows()
+	{
+		var (table, platform) = NewTable();
+		table.Register(Chord(VirtualKey.M), () => { }, HotkeyGroup.Core);
+		int callsAfterFirst = platform.Requests.Count;
+
+		var second = table.Register(Chord(VirtualKey.M), () => { }, HotkeyGroup.Router);
+
+		Assert.False(second.Success);
+		Assert.Equal(NoId, second.Id);
+		Assert.Equal("The shortcut is already registered.", second.ErrorMessage);
+		// Windows was never asked: a second registration of a chord we already own comes back
+		// as a plain failure, indistinguishable from another app holding it.
+		Assert.Equal(callsAfterFirst, platform.Requests.Count);
+		Assert.Equal(1, table.Count);
+	}
+
+	[Fact]
+	public void The_same_chord_spelled_with_a_different_modifier_order_is_still_a_duplicate()
+	{
+		var (table, _) = NewTable();
+		table.Register(new Hotkey { Control = true, Shift = true, Key = VirtualKey.J }, () => { }, HotkeyGroup.Core);
+
+		var second = table.Register(new Hotkey { Shift = true, Control = true, Key = VirtualKey.J }, () => { }, HotkeyGroup.Core);
+
+		Assert.False(second.Success);
+	}
+
+	[Fact]
+	public void Chords_that_differ_only_by_a_modifier_are_not_duplicates()
+	{
+		var (table, _) = NewTable();
+		table.Register(Chord(VirtualKey.M), () => { }, HotkeyGroup.Core);
+
+		var withShift = table.Register(Chord(VirtualKey.M, shift: true), () => { }, HotkeyGroup.Core);
+
+		Assert.True(withShift.Success);
+		Assert.Equal(2, table.Count);
+	}
+
+	[Fact]
+	public void A_registration_windows_refuses_is_not_recorded_and_leaves_the_chord_free()
+	{
+		var (table, platform) = NewTable();
+		platform.NextFailureCode = 1409;
+
+		var failed = table.Register(Chord(VirtualKey.M), () => { }, HotkeyGroup.Core);
+
+		Assert.False(failed.Success);
+		Assert.Equal("The shortcut is already registered by another application.", failed.ErrorMessage);
+		Assert.Equal(0, table.Count);
+		Assert.Empty(platform.Bound);
+
+		// The chord was never ours, so a later attempt has to reach Windows again rather than
+		// being refused as our own duplicate.
+		Assert.True(table.Register(Chord(VirtualKey.M), () => { }, HotkeyGroup.Core).Success);
+	}
+
+	[Fact]
+	public void A_failed_registration_still_reports_the_id_it_tried_so_the_log_can_name_it()
+	{
+		var (table, platform) = NewTable();
+		platform.NextFailureCode = 5;
+
+		var failed = table.Register(Chord(VirtualKey.M), () => { }, HotkeyGroup.Core);
+
+		Assert.NotEqual(NoId, failed.Id);
+	}
+
+	[Fact]
+	public void Ids_are_never_reused_even_after_the_chord_is_released()
+	{
+		var (table, _) = NewTable();
+		var first = table.Register(Chord(VirtualKey.M), () => { }, HotkeyGroup.Router);
+		table.ClearGroup(HotkeyGroup.Router);
+
+		var second = table.Register(Chord(VirtualKey.M), () => { }, HotkeyGroup.Router);
+
+		// A WM_HOTKEY already in the message queue when the refresh ran carries the old id.
+		// Handing that id to the new mapping would fire the wrong action exactly once.
+		Assert.NotEqual(first.Id, second.Id);
+	}
+
+	[Fact]
+	public void Dispatch_runs_the_callback_registered_for_that_id()
+	{
+		var (table, _) = NewTable();
+		int firstRuns = 0, secondRuns = 0;
+		var first = table.Register(Chord(VirtualKey.M), () => firstRuns++, HotkeyGroup.Core);
+		var second = table.Register(Chord(VirtualKey.N), () => secondRuns++, HotkeyGroup.Core);
+
+		Assert.True(table.Dispatch(second.Id));
+
+		Assert.Equal(0, firstRuns);
+		Assert.Equal(1, secondRuns);
+	}
+
+	[Fact]
+	public void Dispatch_of_an_unknown_id_does_nothing_and_says_so()
+	{
+		var (table, _) = NewTable();
+
+		Assert.False(table.Dispatch(4242));
+	}
+
+	[Fact]
+	public void A_released_id_no_longer_routes_anywhere()
+	{
+		var (table, _) = NewTable();
+		int runs = 0;
+		var registered = table.Register(Chord(VirtualKey.M), () => runs++, HotkeyGroup.Prompt);
+
+		table.ClearGroup(HotkeyGroup.Prompt);
+
+		// The message queue can still hold a WM_HOTKEY for a shortcut released a moment ago.
+		Assert.False(table.Dispatch(registered.Id));
+		Assert.Equal(0, runs);
+	}
+
+	[Fact]
+	public void Clearing_a_group_releases_that_group_and_leaves_the_others_bound()
+	{
+		var (table, platform) = NewTable();
+		var core = table.Register(Chord(VirtualKey.M), () => { }, HotkeyGroup.Core);
+		var router = table.Register(Chord(VirtualKey.N), () => { }, HotkeyGroup.Router);
+		var prompt = table.Register(Chord(VirtualKey.O), () => { }, HotkeyGroup.Prompt);
+
+		table.ClearGroup(HotkeyGroup.Router);
+
+		Assert.Equal(new[] { router.Id }, platform.Released);
+		Assert.Equal(new[] { core.Id, prompt.Id }, platform.Bound);
+		Assert.Equal(new[] { core.Id }, table.IdsIn(HotkeyGroup.Core));
+		Assert.Empty(table.IdsIn(HotkeyGroup.Router));
+		Assert.Equal(new[] { prompt.Id }, table.IdsIn(HotkeyGroup.Prompt));
+	}
+
+	[Fact]
+	public void A_refresh_can_rebind_the_same_chord_it_just_released()
+	{
+		var (table, _) = NewTable();
+		table.Register(Chord(VirtualKey.R), () => { }, HotkeyGroup.Router);
+
+		table.ClearGroup(HotkeyGroup.Router);
+		var again = table.Register(Chord(VirtualKey.R), () => { }, HotkeyGroup.Router);
+
+		// Saving the Settings dialog without touching the router refreshes it. If the released
+		// chord stayed in the duplicate set, every mapping would fail from the first save on.
+		Assert.True(again.Success);
+	}
+
+	[Fact]
+	public void Repeated_refreshes_do_not_accumulate_registrations()
+	{
+		var (table, platform) = NewTable();
+
+		for (int pass = 0; pass < 5; pass++)
+		{
+			table.ClearGroup(HotkeyGroup.Router);
+			table.Register(Chord(VirtualKey.R), () => { }, HotkeyGroup.Router);
+			table.Register(Chord(VirtualKey.T), () => { }, HotkeyGroup.Router);
+		}
+
+		Assert.Equal(2, table.Count);
+		Assert.Equal(2, platform.Bound.Count);
+	}
+
+	[Fact]
+	public void ClearAll_releases_every_group_and_frees_every_chord()
+	{
+		var (table, platform) = NewTable();
+		table.Register(Chord(VirtualKey.M), () => { }, HotkeyGroup.Core);
+		table.Register(Chord(VirtualKey.N), () => { }, HotkeyGroup.Router);
+		table.Register(Chord(VirtualKey.O), () => { }, HotkeyGroup.Prompt);
+
+		table.ClearAll();
+
+		Assert.Equal(0, table.Count);
+		Assert.Empty(platform.Bound);
+		Assert.Equal(3, platform.Released.Count);
+		Assert.False(table.IsRegistered(Chord(VirtualKey.M)));
+		Assert.True(table.Register(Chord(VirtualKey.M), () => { }, HotkeyGroup.Core).Success);
+	}
+
+	[Fact]
+	public void Clearing_a_group_twice_releases_nothing_the_second_time()
+	{
+		var (table, platform) = NewTable();
+		table.Register(Chord(VirtualKey.M), () => { }, HotkeyGroup.Prompt);
+
+		table.ClearGroup(HotkeyGroup.Prompt);
+		table.ClearGroup(HotkeyGroup.Prompt);
+
+		// Unregistering an id Windows has already released is harmless, but doing it means the
+		// table lost track of what it owns.
+		Assert.Single(platform.Released);
+	}
+
+	[Fact]
+	public void IsRegistered_reports_what_is_currently_bound()
+	{
+		var (table, _) = NewTable();
+		Assert.False(table.IsRegistered(Chord(VirtualKey.M)));
+
+		table.Register(Chord(VirtualKey.M), () => { }, HotkeyGroup.Core);
+		Assert.True(table.IsRegistered(Chord(VirtualKey.M)));
+
+		table.ClearAll();
+		Assert.False(table.IsRegistered(Chord(VirtualKey.M)));
+	}
+
+	[Fact]
+	public void NormalizeHotkey_puts_the_modifiers_in_one_fixed_order()
+	{
+		var chord = new Hotkey { Win = true, Alt = true, Shift = true, Control = true, Key = VirtualKey.F1 };
+
+		Assert.Equal("CTRL+SHIFT+ALT+WIN+F1", NormalizeHotkey(chord));
+	}
+
+	[Theory]
+	[InlineData(1409, "The shortcut is already registered by another application.")]
+	[InlineData(0, "Failed to register the shortcut.")]
+	public void DescribeRegistrationError_explains_the_codes_worth_naming(int code, string expected)
+	{
+		Assert.Equal(expected, DescribeRegistrationError(code));
+	}
+
+	[Fact]
+	public void DescribeRegistrationError_falls_back_to_the_system_text_for_anything_else()
+	{
+		string message = DescribeRegistrationError(5);
+
+		Assert.False(string.IsNullOrWhiteSpace(message));
+		Assert.NotEqual("Failed to register the shortcut.", message);
+	}
+
+	[Fact]
+	public void Registrations_and_releases_are_written_to_the_log_the_manager_supplies()
+	{
+		var platform = new FakeHotkeyPlatform();
+		var lines = new List<string>();
+		var table = new HotkeyRegistrationTable(platform, lines.Add);
+
+		table.Register(Chord(VirtualKey.M), () => { }, HotkeyGroup.Core);
+		table.Register(Chord(VirtualKey.M), () => { }, HotkeyGroup.Core);
+
+		Assert.Contains(lines, l => l.Contains("Hotkey registered") && l.Contains("CTRL+M"));
+		Assert.Contains(lines, l => l.Contains("Duplicate hotkey detected"));
+	}
+}

--- a/Mutation.Tests/HotkeyRegistrationTableTests.cs
+++ b/Mutation.Tests/HotkeyRegistrationTableTests.cs
@@ -253,6 +253,46 @@ public class HotkeyRegistrationTableTests
 	}
 
 	[Fact]
+	public void IdsIn_lists_a_groups_registrations_in_the_order_they_were_made()
+	{
+		var (table, _) = NewTable();
+		var first = table.Register(Chord(VirtualKey.R), () => { }, HotkeyGroup.Router);
+		table.Register(Chord(VirtualKey.X), () => { }, HotkeyGroup.Core);
+		var second = table.Register(Chord(VirtualKey.S), () => { }, HotkeyGroup.Router);
+		var third = table.Register(Chord(VirtualKey.T), () => { }, HotkeyGroup.Router);
+
+		Assert.Equal(new[] { first.Id, second.Id, third.Id }, table.IdsIn(HotkeyGroup.Router));
+	}
+
+	[Fact]
+	public void A_table_needs_something_to_register_against()
+	{
+		Assert.Throws<ArgumentNullException>(() => new HotkeyRegistrationTable(null!));
+	}
+
+	[Fact]
+	public void A_registration_without_a_callback_is_refused_at_the_point_it_is_made()
+	{
+		var (table, platform) = NewTable();
+
+		// Left to Windows, a null callback binds fine and only fails the first time the user
+		// presses the chord — inside the WM_HOTKEY pump, far from the mistake.
+		Assert.Throws<ArgumentNullException>(() => table.Register(Chord(VirtualKey.M), null!, HotkeyGroup.Core));
+		Assert.Empty(platform.Bound);
+	}
+
+	[Fact]
+	public void A_callback_that_throws_is_not_swallowed()
+	{
+		var (table, _) = NewTable();
+		var registered = table.Register(Chord(VirtualKey.M), () => throw new InvalidOperationException("boom"), HotkeyGroup.Core);
+
+		// Documents where the failure surfaces: the table does not catch, so the exception
+		// reaches WndProc. Anything quieter would lose a hotkey action with no trace.
+		Assert.Throws<InvalidOperationException>(() => table.Dispatch(registered.Id));
+	}
+
+	[Fact]
 	public void IsRegistered_reports_what_is_currently_bound()
 	{
 		var (table, _) = NewTable();
@@ -271,6 +311,22 @@ public class HotkeyRegistrationTableTests
 		var chord = new Hotkey { Win = true, Alt = true, Shift = true, Control = true, Key = VirtualKey.F1 };
 
 		Assert.Equal("CTRL+SHIFT+ALT+WIN+F1", NormalizeHotkey(chord));
+	}
+
+	[Fact]
+	public void NormalizeHotkey_leaves_a_bare_key_bare()
+	{
+		// No modifiers means no separator — a trailing "+" here would make an unmodified key
+		// compare unequal to itself under any other spelling.
+		Assert.Equal("F1", NormalizeHotkey(new Hotkey { Key = VirtualKey.F1 }));
+	}
+
+	[Fact]
+	public void NormalizeHotkey_keeps_each_modifier_in_its_own_slot()
+	{
+		Assert.Equal("SHIFT+A", NormalizeHotkey(new Hotkey { Shift = true, Key = VirtualKey.A }));
+		Assert.Equal("ALT+A", NormalizeHotkey(new Hotkey { Alt = true, Key = VirtualKey.A }));
+		Assert.Equal("WIN+A", NormalizeHotkey(new Hotkey { Win = true, Key = VirtualKey.A }));
 	}
 
 	[Theory]

--- a/Mutation.Tests/SessionSelectionPlannerTests.cs
+++ b/Mutation.Tests/SessionSelectionPlannerTests.cs
@@ -87,6 +87,41 @@ public class SessionSelectionPlannerTests
 	}
 
 	[Fact]
+	public void A_preferred_path_that_has_been_deleted_falls_back_to_the_newest_even_when_something_is_selected()
+	{
+		var deleted = Session("deleted.ogg");
+		var newest = Session("newest.ogg");
+
+		var chosen = SessionSelectionPlanner.ChooseSelection(
+			List(newest, Session("older.ogg")),
+			currentSelection: deleted,
+			preferredPath: deleted.FilePath);
+
+		// The path AudioSessionManager actually takes: NavigateSessionsAsync always passes the
+		// current selection as the preferred one, so when retention cleanup has removed that
+		// file, the lookup misses and the fallback has to run rather than leaving the deleted
+		// recording selected.
+		Assert.Same(newest, chosen);
+	}
+
+	[Fact]
+	public void A_preferred_path_that_has_been_deleted_selects_nothing_when_the_list_is_now_empty()
+	{
+		var deleted = Session("deleted.ogg");
+
+		var chosen = SessionSelectionPlanner.ChooseSelection(List(), deleted, deleted.FilePath);
+
+		Assert.Null(chosen);
+	}
+
+	[Fact]
+	public void ChooseSelection_refuses_a_missing_session_list()
+	{
+		Assert.Throws<ArgumentNullException>(() =>
+			SessionSelectionPlanner.ChooseSelection(null!, null, null));
+	}
+
+	[Fact]
 	public void A_preferred_path_is_matched_however_it_is_spelled()
 	{
 		var session = Session("Recording.ogg");
@@ -209,6 +244,17 @@ public class SessionSelectionPlannerTests
 	{
 		Assert.Null(SessionSelectionPlanner.NextIndex(count: 1, currentIndex: 0, direction: 1));
 		Assert.Null(SessionSelectionPlanner.NextIndex(count: 1, currentIndex: 0, direction: -1));
+	}
+
+	[Theory]
+	[InlineData(-1)]
+	[InlineData(1)]
+	public void An_index_past_the_end_of_the_list_stops_rather_than_selecting_out_of_range(int direction)
+	{
+		// A selection index that outran the list would otherwise index past the end. Refusing
+		// the move is the safe answer, even though it means navigation goes quiet until the
+		// selection is re-established.
+		Assert.Null(SessionSelectionPlanner.NextIndex(count: 3, currentIndex: 7, direction));
 	}
 
 	[Fact]

--- a/Mutation.Tests/SessionSelectionPlannerTests.cs
+++ b/Mutation.Tests/SessionSelectionPlannerTests.cs
@@ -1,0 +1,221 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Mutation.Ui;
+using Mutation.Ui.Core;
+
+namespace Mutation.Tests;
+
+/// <summary>
+/// Covers <see cref="SessionSelectionPlanner"/> — which recording is selected after the
+/// session list is rebuilt, and which one Previous/Next moves to. Lifted out of
+/// <see cref="AudioSessionManager"/>, the second-largest untested unit in the app, which
+/// could not be constructed in a test without a recorder, a device enumerator, and a
+/// transcription service (issue #255).
+/// <para>
+/// Picking the wrong recording here is silent and immediate: navigation plays what it
+/// selects, so for a user working by ear the first sign is the wrong audio.
+/// </para>
+/// </summary>
+public class SessionSelectionPlannerTests
+{
+	private static SpeechSession Session(string fileName) =>
+		new(Path.Combine(Path.GetTempPath(), fileName), new DateTime(2026, 1, 1));
+
+	private static IReadOnlyList<SpeechSession> List(params SpeechSession[] sessions) => sessions;
+
+	[Fact]
+	public void An_empty_list_selects_nothing()
+	{
+		var chosen = SessionSelectionPlanner.ChooseSelection(List(), Session("gone.ogg"), preferredPath: null);
+
+		Assert.Null(chosen);
+	}
+
+	[Fact]
+	public void An_empty_list_clears_a_preferred_path_too()
+	{
+		var wanted = Session("gone.ogg");
+
+		var chosen = SessionSelectionPlanner.ChooseSelection(List(), wanted, wanted.FilePath);
+
+		Assert.Null(chosen);
+	}
+
+	[Fact]
+	public void With_nothing_selected_the_newest_recording_is_chosen()
+	{
+		var newest = Session("newest.ogg");
+
+		var chosen = SessionSelectionPlanner.ChooseSelection(List(newest, Session("older.ogg")), null, null);
+
+		Assert.Same(newest, chosen);
+	}
+
+	[Fact]
+	public void A_preferred_path_wins_over_the_newest_recording()
+	{
+		var older = Session("older.ogg");
+
+		var chosen = SessionSelectionPlanner.ChooseSelection(List(Session("newest.ogg"), older), null, older.FilePath);
+
+		Assert.Same(older, chosen);
+	}
+
+	[Fact]
+	public void A_preferred_path_wins_over_what_was_already_selected()
+	{
+		var wanted = Session("wanted.ogg");
+		var previously = Session("previously.ogg");
+
+		var chosen = SessionSelectionPlanner.ChooseSelection(List(previously, wanted), previously, wanted.FilePath);
+
+		Assert.Same(wanted, chosen);
+	}
+
+	[Fact]
+	public void A_preferred_path_that_is_no_longer_in_the_list_falls_back_to_the_newest()
+	{
+		var newest = Session("newest.ogg");
+
+		var chosen = SessionSelectionPlanner.ChooseSelection(
+			List(newest, Session("older.ogg")),
+			currentSelection: null,
+			preferredPath: Session("deleted.ogg").FilePath);
+
+		Assert.Same(newest, chosen);
+	}
+
+	[Fact]
+	public void A_preferred_path_is_matched_however_it_is_spelled()
+	{
+		var session = Session("Recording.ogg");
+		string differentlySpelled = Path.Combine(Path.GetTempPath(), "sub", "..", "recording.ogg");
+
+		var chosen = SessionSelectionPlanner.ChooseSelection(List(session), null, differentlySpelled);
+
+		Assert.Same(session, chosen);
+	}
+
+	[Theory]
+	[InlineData(null)]
+	[InlineData("")]
+	[InlineData("   ")]
+	public void A_blank_preferred_path_keeps_the_existing_selection(string? preferredPath)
+	{
+		var selected = Session("selected.ogg");
+
+		var chosen = SessionSelectionPlanner.ChooseSelection(
+			List(Session("newest.ogg"), selected),
+			selected,
+			preferredPath);
+
+		// Refreshing after a transcription must not silently jump the user back to the top of
+		// the list.
+		Assert.Same(selected, chosen);
+	}
+
+	[Fact]
+	public void A_selection_that_has_left_the_list_is_kept_when_no_preferred_path_is_given()
+	{
+		var deleted = Session("deleted.ogg");
+		var newest = Session("newest.ogg");
+
+		var chosen = SessionSelectionPlanner.ChooseSelection(List(newest), deleted, preferredPath: null);
+
+		// Pinned as-is rather than endorsed: retention cleanup can remove the selected file
+		// while it stays selected, and pressing Play then reports "Audio file not found"
+		// instead of moving on to a recording that exists. Tracked separately.
+		Assert.Same(deleted, chosen);
+	}
+
+	[Fact]
+	public void PathsEqual_matches_the_same_file_written_two_ways()
+	{
+		string direct = Path.Combine(Path.GetTempPath(), "recording.ogg");
+		string roundabout = Path.Combine(Path.GetTempPath(), "sub", "..", "RECORDING.ogg");
+
+		Assert.True(SessionSelectionPlanner.PathsEqual(direct, roundabout));
+	}
+
+	[Fact]
+	public void PathsEqual_separates_different_files()
+	{
+		Assert.False(SessionSelectionPlanner.PathsEqual(
+			Path.Combine(Path.GetTempPath(), "one.ogg"),
+			Path.Combine(Path.GetTempPath(), "two.ogg")));
+	}
+
+	[Theory]
+	[InlineData(null, "c:/a.ogg")]
+	[InlineData("c:/a.ogg", null)]
+	[InlineData("", "")]
+	[InlineData("   ", "   ")]
+	public void PathsEqual_treats_a_missing_path_as_matching_nothing(string? first, string? second)
+	{
+		// Two sessions with no path are not "the same recording" — treating them as equal
+		// would make an unsaved session match whatever else has no path.
+		Assert.False(SessionSelectionPlanner.PathsEqual(first, second));
+	}
+
+	[Theory]
+	[InlineData(-1)]
+	[InlineData(1)]
+	public void Navigation_goes_nowhere_when_there_are_no_recordings(int direction)
+	{
+		Assert.Null(SessionSelectionPlanner.NextIndex(count: 0, currentIndex: -1, direction));
+	}
+
+	[Fact]
+	public void Next_moves_away_from_the_newest_recording()
+	{
+		Assert.Equal(2, SessionSelectionPlanner.NextIndex(count: 5, currentIndex: 1, direction: 1));
+	}
+
+	[Fact]
+	public void Previous_moves_towards_the_newest_recording()
+	{
+		Assert.Equal(0, SessionSelectionPlanner.NextIndex(count: 5, currentIndex: 1, direction: -1));
+	}
+
+	[Fact]
+	public void Previous_at_the_newest_recording_stops_rather_than_wrapping()
+	{
+		Assert.Null(SessionSelectionPlanner.NextIndex(count: 5, currentIndex: 0, direction: -1));
+	}
+
+	[Fact]
+	public void Next_at_the_oldest_recording_stops_rather_than_wrapping()
+	{
+		Assert.Null(SessionSelectionPlanner.NextIndex(count: 5, currentIndex: 4, direction: 1));
+	}
+
+	[Fact]
+	public void Next_with_nothing_selected_starts_from_the_newest_recording()
+	{
+		Assert.Equal(1, SessionSelectionPlanner.NextIndex(count: 5, currentIndex: -1, direction: 1));
+	}
+
+	[Fact]
+	public void Previous_with_nothing_selected_goes_nowhere()
+	{
+		// Nothing selected is treated as sitting on the newest recording, and there is nothing
+		// newer than that.
+		Assert.Null(SessionSelectionPlanner.NextIndex(count: 5, currentIndex: -1, direction: -1));
+	}
+
+	[Fact]
+	public void Next_in_a_single_recording_list_goes_nowhere()
+	{
+		Assert.Null(SessionSelectionPlanner.NextIndex(count: 1, currentIndex: 0, direction: 1));
+		Assert.Null(SessionSelectionPlanner.NextIndex(count: 1, currentIndex: 0, direction: -1));
+	}
+
+	[Fact]
+	public void Zero_is_treated_as_moving_away_from_the_newest_recording()
+	{
+		// Only a negative direction means "previous"; the caller passes +1 or -1, and anything
+		// else has to land somewhere defined rather than off the end of the list.
+		Assert.Equal(1, SessionSelectionPlanner.NextIndex(count: 5, currentIndex: 0, direction: 0));
+	}
+}

--- a/Mutation.Tests/WaveformSampleBufferTests.cs
+++ b/Mutation.Tests/WaveformSampleBufferTests.cs
@@ -1,0 +1,277 @@
+using System;
+using System.Threading.Tasks;
+using Mutation.Ui.Core;
+
+namespace Mutation.Tests;
+
+/// <summary>
+/// Covers <see cref="WaveformSampleBuffer"/> — the capture-buffer → render-window → level
+/// pipeline that drives the microphone waveform and the level meter (issue #255).
+/// <para>
+/// <see cref="WaveformRenderGate"/> decides <em>whether</em> a frame is drawn and has its
+/// own tests; this is what actually gets drawn, and it had none. A wrap-around copied in
+/// the wrong order draws a trace that jumps backwards; a level measured across the
+/// zero-padded lead of the first window reads far quieter than the room is. Neither throws,
+/// and the level meter is one of the few pieces of feedback here that a screen reader
+/// cannot narrate — so a wrong number is simply believed.
+/// </para>
+/// </summary>
+public class WaveformSampleBufferTests
+{
+	// 16-bit little-endian mono PCM, the format the capture device is opened with.
+	private static byte[] Pcm(params short[] samples)
+	{
+		var bytes = new byte[samples.Length * 2];
+		for (int i = 0; i < samples.Length; i++)
+			BitConverter.GetBytes(samples[i]).CopyTo(bytes, i * 2);
+		return bytes;
+	}
+
+	private const short FullScale = 16384; // 0.5 once scaled by 1/32768.
+
+	[Fact]
+	public void A_window_must_hold_at_least_one_sample()
+	{
+		Assert.Throws<ArgumentOutOfRangeException>(() => new WaveformSampleBuffer(0));
+	}
+
+	[Fact]
+	public void A_buffer_nothing_has_been_written_to_reports_no_valid_samples()
+	{
+		var buffer = new WaveformSampleBuffer(4);
+
+		Assert.Equal(0, buffer.Snapshot());
+		Assert.Equal(new double[4], buffer.RenderBuffer);
+	}
+
+	[Fact]
+	public void The_render_buffer_is_the_same_array_every_time()
+	{
+		var buffer = new WaveformSampleBuffer(4);
+		double[] handedToThePlot = buffer.RenderBuffer;
+
+		buffer.Write(Pcm(1, 2, 3, 4), 8);
+		buffer.Snapshot();
+
+		// ScottPlot's Signal keeps the array it was given at Initialize. Handing back a new
+		// one would leave the plot redrawing a frozen copy for the rest of the session.
+		Assert.Same(handedToThePlot, buffer.RenderBuffer);
+	}
+
+	[Fact]
+	public void A_partly_filled_first_window_puts_the_audio_at_the_end_behind_silence()
+	{
+		var buffer = new WaveformSampleBuffer(4);
+
+		buffer.Write(Pcm(FullScale, FullScale), 4);
+		int valid = buffer.Snapshot();
+
+		Assert.Equal(2, valid);
+		Assert.Equal(new[] { 0d, 0d, 0.5d, 0.5d }, buffer.RenderBuffer);
+	}
+
+	[Fact]
+	public void A_full_window_reads_oldest_sample_first()
+	{
+		var buffer = new WaveformSampleBuffer(4);
+
+		buffer.Write(Pcm(1024, 2048, 4096, 8192), 8);
+		int valid = buffer.Snapshot();
+
+		Assert.Equal(4, valid);
+		Assert.Equal(
+			new[] { 1024 / 32768d, 2048 / 32768d, 4096 / 32768d, 8192 / 32768d },
+			buffer.RenderBuffer);
+	}
+
+	[Fact]
+	public void Once_the_ring_wraps_the_window_is_the_last_N_samples_still_in_order()
+	{
+		var buffer = new WaveformSampleBuffer(4);
+
+		buffer.Write(Pcm(1, 2, 3, 4, 5, 6), 12);
+		int valid = buffer.Snapshot();
+
+		Assert.Equal(4, valid);
+		// 1 and 2 have been overwritten; what is left has to read forwards in time, not from
+		// wherever the write cursor happens to sit.
+		Assert.Equal(new[] { 3 / 32768d, 4 / 32768d, 5 / 32768d, 6 / 32768d }, buffer.RenderBuffer);
+	}
+
+	[Fact]
+	public void A_write_that_lands_exactly_on_the_end_of_the_ring_still_reads_in_order()
+	{
+		var buffer = new WaveformSampleBuffer(4);
+		buffer.Write(Pcm(1, 2, 3, 4), 8);
+
+		buffer.Write(Pcm(5, 6, 7, 8), 8);
+
+		// The write cursor is back at zero and the ring is full — the case where an
+		// off-by-one splits the window in the wrong place.
+		Assert.Equal(4, buffer.Snapshot());
+		Assert.Equal(new[] { 5 / 32768d, 6 / 32768d, 7 / 32768d, 8 / 32768d }, buffer.RenderBuffer);
+	}
+
+	[Fact]
+	public void Snapshot_can_be_taken_repeatedly_without_consuming_anything()
+	{
+		var buffer = new WaveformSampleBuffer(4);
+		buffer.Write(Pcm(1, 2, 3, 4, 5), 10);
+
+		buffer.Snapshot();
+		double[] first = (double[])buffer.RenderBuffer.Clone();
+		buffer.Snapshot();
+
+		Assert.Equal(first, buffer.RenderBuffer);
+	}
+
+	[Fact]
+	public void Only_the_bytes_the_device_actually_filled_are_read()
+	{
+		var buffer = new WaveformSampleBuffer(4);
+
+		// NAudio hands back a reused buffer with BytesRecorded saying how much is audio; the
+		// rest is the previous callback's samples. Reading past it replays old audio.
+		byte[] deviceBuffer = Pcm(FullScale, FullScale, 9999, 9999);
+		buffer.Write(deviceBuffer, 4);
+
+		Assert.Equal(2, buffer.Snapshot());
+		Assert.Equal(new[] { 0d, 0d, 0.5d, 0.5d }, buffer.RenderBuffer);
+	}
+
+	[Theory]
+	[InlineData(0)]
+	[InlineData(-4)]
+	public void A_callback_carrying_no_audio_is_ignored(int byteCount)
+	{
+		var buffer = new WaveformSampleBuffer(4);
+
+		Assert.Equal(0, buffer.Write(Pcm(1, 2), byteCount));
+		Assert.Equal(0, buffer.Snapshot());
+	}
+
+	[Fact]
+	public void A_trailing_odd_byte_is_dropped_rather_than_read_as_half_a_sample()
+	{
+		var buffer = new WaveformSampleBuffer(4);
+
+		Assert.Equal(1, buffer.Write(Pcm(FullScale, 0), 3));
+		Assert.Equal(1, buffer.Snapshot());
+	}
+
+	[Fact]
+	public void A_byte_count_larger_than_the_buffer_reads_only_what_is_there()
+	{
+		var buffer = new WaveformSampleBuffer(4);
+
+		Assert.Equal(2, buffer.Write(Pcm(FullScale, FullScale), 999));
+	}
+
+	[Fact]
+	public void Reset_drops_the_captured_audio_and_flattens_the_window()
+	{
+		var buffer = new WaveformSampleBuffer(4);
+		buffer.Write(Pcm(FullScale, FullScale, FullScale, FullScale), 8);
+		buffer.Snapshot();
+
+		buffer.Reset();
+
+		Assert.Equal(new double[4], buffer.RenderBuffer);
+		Assert.Equal(0, buffer.Snapshot());
+	}
+
+	[Fact]
+	public void After_a_reset_the_window_fills_from_empty_again()
+	{
+		var buffer = new WaveformSampleBuffer(4);
+		buffer.Write(Pcm(1, 2, 3, 4, 5, 6), 12);
+
+		buffer.Reset();
+		buffer.Write(Pcm(FullScale), 2);
+
+		Assert.Equal(1, buffer.Snapshot());
+		Assert.Equal(new[] { 0d, 0d, 0d, 0.5d }, buffer.RenderBuffer);
+	}
+
+	[Fact]
+	public void MeasureLevels_reports_zero_for_a_window_with_no_audio_in_it()
+	{
+		var levels = WaveformSampleBuffer.MeasureLevels(new double[4], validSamples: 0);
+
+		Assert.Equal(0, levels.Peak);
+		Assert.Equal(0, levels.Rms);
+	}
+
+	[Fact]
+	public void MeasureLevels_reports_the_loudest_sample_regardless_of_sign()
+	{
+		var levels = WaveformSampleBuffer.MeasureLevels(new[] { 0.1, -0.8, 0.3, 0.2 }, validSamples: 4);
+
+		Assert.Equal(0.8, levels.Peak, 10);
+	}
+
+	[Fact]
+	public void MeasureLevels_reports_the_root_mean_square_of_the_window()
+	{
+		var levels = WaveformSampleBuffer.MeasureLevels(new[] { 0.5, -0.5, 0.5, -0.5 }, validSamples: 4);
+
+		Assert.Equal(0.5, levels.Rms, 10);
+	}
+
+	[Fact]
+	public void MeasureLevels_ignores_the_silent_lead_of_a_partly_filled_window()
+	{
+		// The first two entries are padding, not a quiet room. Averaging them in halves the
+		// reported level and the meter under-reads for the first frames of every capture.
+		var levels = WaveformSampleBuffer.MeasureLevels(new[] { 0d, 0d, 0.5, 0.5 }, validSamples: 2);
+
+		Assert.Equal(0.5, levels.Rms, 10);
+		Assert.Equal(0.5, levels.Peak, 10);
+	}
+
+	[Fact]
+	public void MeasureLevels_survives_a_count_larger_than_the_window()
+	{
+		var levels = WaveformSampleBuffer.MeasureLevels(new[] { 0.5, 0.5 }, validSamples: 99);
+
+		Assert.Equal(0.5, levels.Rms, 10);
+	}
+
+	[Fact]
+	public void A_full_scale_window_measures_at_the_top_of_the_meter()
+	{
+		var buffer = new WaveformSampleBuffer(4);
+		buffer.Write(Pcm(short.MinValue, short.MinValue, short.MinValue, short.MinValue), 8);
+
+		var levels = WaveformSampleBuffer.MeasureLevels(buffer.RenderBuffer, buffer.Snapshot());
+
+		// short.MinValue / 32768 is exactly -1: the meter clamps at 1, so anything above that
+		// would be a scaling mistake rather than a loud room.
+		Assert.Equal(1.0, levels.Peak, 10);
+		Assert.Equal(1.0, levels.Rms, 10);
+	}
+
+	[Fact]
+	public async Task Capture_writes_and_render_snapshots_can_run_at_the_same_time()
+	{
+		// Writes arrive on the capture device's thread while snapshots are taken on the UI
+		// thread's frame timer. A torn read here would be a garbled trace, not a crash.
+		var buffer = new WaveformSampleBuffer(512);
+		using var cancellation = new System.Threading.CancellationTokenSource(TimeSpan.FromSeconds(2));
+
+		var writer = Task.Run(() =>
+		{
+			var chunk = Pcm(new short[64]);
+			for (int i = 0; i < 2_000 && !cancellation.IsCancellationRequested; i++)
+				buffer.Write(chunk, chunk.Length);
+		});
+
+		var reader = Task.Run(() =>
+		{
+			for (int i = 0; i < 2_000 && !cancellation.IsCancellationRequested; i++)
+				Assert.InRange(buffer.Snapshot(), 0, buffer.WindowSampleCount);
+		});
+
+		await Task.WhenAll(writer, reader);
+	}
+}

--- a/Mutation.Tests/WaveformSampleBufferTests.cs
+++ b/Mutation.Tests/WaveformSampleBufferTests.cs
@@ -194,9 +194,35 @@ public class WaveformSampleBufferTests
 	}
 
 	[Fact]
+	public void A_write_needs_something_to_write()
+	{
+		var buffer = new WaveformSampleBuffer(4);
+
+		Assert.Throws<ArgumentNullException>(() => buffer.Write(null!, 4));
+	}
+
+	[Fact]
+	public void MeasureLevels_needs_a_window_to_measure()
+	{
+		Assert.Throws<ArgumentNullException>(() => WaveformSampleBuffer.MeasureLevels(null!, 4));
+	}
+
+	[Fact]
 	public void MeasureLevels_reports_zero_for_a_window_with_no_audio_in_it()
 	{
 		var levels = WaveformSampleBuffer.MeasureLevels(new double[4], validSamples: 0);
+
+		Assert.Equal(0, levels.Peak);
+		Assert.Equal(0, levels.Rms);
+	}
+
+	[Fact]
+	public void MeasureLevels_reports_zero_for_a_window_that_no_longer_exists()
+	{
+		// The shape left behind after the controller is disposed. The old code guarded on the
+		// render buffer being empty; the guard has to survive the extraction or a disposed
+		// visualization divides by zero on its next frame.
+		var levels = WaveformSampleBuffer.MeasureLevels(Array.Empty<double>(), validSamples: 4);
 
 		Assert.Equal(0, levels.Peak);
 		Assert.Equal(0, levels.Rms);

--- a/Mutation.Ui/Core/AudioSessionManager.cs
+++ b/Mutation.Ui/Core/AudioSessionManager.cs
@@ -426,7 +426,7 @@ public class AudioSessionManager : IDisposable
         // IsPlaying: decoding now happens off the UI thread, so there is a window where a file
         // is on its way to the speakers without being audible yet. Pressing the button in that
         // window has to stop it, not queue up a second copy of the same recording.
-        if (_playingSession != null && PathsEqual(_playingSession.FilePath, session.FilePath))
+        if (_playingSession != null && SessionSelectionPlanner.PathsEqual(_playingSession.FilePath, session.FilePath))
         {
             StopPlayback();
             return;
@@ -541,5 +541,4 @@ public class AudioSessionManager : IDisposable
         }
     }
 
-    private static bool PathsEqual(string? p1, string? p2) => SessionSelectionPlanner.PathsEqual(p1, p2);
 }

--- a/Mutation.Ui/Core/AudioSessionManager.cs
+++ b/Mutation.Ui/Core/AudioSessionManager.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Windows.Storage;
@@ -132,25 +131,9 @@ public class AudioSessionManager : IDisposable
             SessionHistory.Add(session);
         }
 
-        string? path = preferredPath;
-        if (preferredSelection != null)
-        {
-            path = preferredSelection.FilePath;
-        }
+        string? path = preferredSelection != null ? preferredSelection.FilePath : preferredPath;
 
-        if (!string.IsNullOrWhiteSpace(path))
-        {
-            SelectedSession = SessionHistory.FirstOrDefault(s => PathsEqual(s.FilePath, path));
-        }
-        
-        if (SelectedSession == null && SessionHistory.Count > 0)
-        {
-            SelectedSession = SessionHistory.FirstOrDefault();
-        }
-        else if (SessionHistory.Count == 0)
-        {
-            SelectedSession = null;
-        }
+        SelectedSession = SessionSelectionPlanner.ChooseSelection(SessionHistory, SelectedSession, path);
     }
 
     public async Task NavigateSessionsAsync(int direction)
@@ -160,15 +143,8 @@ public class AudioSessionManager : IDisposable
 
         RefreshSessions(preferredSelection: SelectedSession);
 
-        if (SessionHistory.Count == 0)
-            return;
-
         int currentIndex = SelectedSession != null ? SessionHistory.IndexOf(SelectedSession) : -1;
-        if (currentIndex < 0)
-            currentIndex = 0;
-
-        int targetIndex = direction < 0 ? currentIndex - 1 : currentIndex + 1;
-        if (targetIndex < 0 || targetIndex >= SessionHistory.Count)
+        if (SessionSelectionPlanner.NextIndex(SessionHistory.Count, currentIndex, direction) is not int targetIndex)
             return;
 
         var targetSession = SessionHistory[targetIndex];
@@ -565,10 +541,5 @@ public class AudioSessionManager : IDisposable
         }
     }
 
-    private static bool PathsEqual(string? p1, string? p2)
-    {
-        if (string.IsNullOrWhiteSpace(p1) || string.IsNullOrWhiteSpace(p2))
-            return false;
-        return string.Equals(Path.GetFullPath(p1), Path.GetFullPath(p2), StringComparison.OrdinalIgnoreCase);
-    }
+    private static bool PathsEqual(string? p1, string? p2) => SessionSelectionPlanner.PathsEqual(p1, p2);
 }

--- a/Mutation.Ui/Core/SessionSelectionPlanner.cs
+++ b/Mutation.Ui/Core/SessionSelectionPlanner.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Mutation.Ui.Core;
+
+/// <summary>
+/// Decides which recording is selected after the session list is rebuilt, and which one
+/// Previous/Next moves to.
+/// <para>
+/// Both are pure arithmetic over a list, but neither could be exercised inside
+/// <see cref="AudioSessionManager"/>, which needs a recorder, a device enumerator, and a
+/// transcription service to exist at all. Getting either wrong is silent: the wrong
+/// recording is announced and played, and nothing reports an error.
+/// </para>
+/// </summary>
+internal static class SessionSelectionPlanner
+{
+	/// <summary>
+	/// Whether two recording paths name the same file. Different spellings of one path —
+	/// relative versus absolute, mixed case — have to compare equal, because the path a
+	/// caller remembered and the path the session list rebuilt from need not match
+	/// character for character. A blank path matches nothing, not even another blank.
+	/// </summary>
+	public static bool PathsEqual(string? first, string? second)
+	{
+		if (string.IsNullOrWhiteSpace(first) || string.IsNullOrWhiteSpace(second))
+			return false;
+
+		return string.Equals(Path.GetFullPath(first), Path.GetFullPath(second), StringComparison.OrdinalIgnoreCase);
+	}
+
+	/// <summary>
+	/// Picks the selection for a freshly rebuilt session list: the caller's preferred
+	/// recording when it names one and it is still there, otherwise the newest recording,
+	/// and nothing at all once the list is empty.
+	/// </summary>
+	/// <param name="currentSelection">
+	/// What was selected before the rebuild. Kept when no preferred path is given and the
+	/// list is not empty — including when it is no longer in the list, which is what the
+	/// caller does today and is pinned by test rather than endorsed.
+	/// </param>
+	public static SpeechSession? ChooseSelection(
+		IReadOnlyList<SpeechSession> sessions,
+		SpeechSession? currentSelection,
+		string? preferredPath)
+	{
+		if (sessions is null) throw new ArgumentNullException(nameof(sessions));
+
+		SpeechSession? selection = currentSelection;
+
+		if (!string.IsNullOrWhiteSpace(preferredPath))
+			selection = sessions.FirstOrDefault(s => PathsEqual(s.FilePath, preferredPath));
+
+		if (selection is null && sessions.Count > 0)
+			selection = sessions[0];
+		else if (sessions.Count == 0)
+			selection = null;
+
+		return selection;
+	}
+
+	/// <summary>
+	/// The index Previous/Next moves to, or null when the move would run off either end —
+	/// the list does not wrap, so the newest and oldest recordings are hard stops.
+	/// </summary>
+	/// <param name="currentIndex">
+	/// Where the selection sits, or a negative value when nothing is selected — which starts
+	/// the move from the newest recording rather than refusing it.
+	/// </param>
+	/// <param name="direction">Negative moves towards the newest end; anything else moves away from it.</param>
+	public static int? NextIndex(int count, int currentIndex, int direction)
+	{
+		if (count <= 0)
+			return null;
+
+		if (currentIndex < 0)
+			currentIndex = 0;
+
+		int targetIndex = direction < 0 ? currentIndex - 1 : currentIndex + 1;
+		if (targetIndex < 0 || targetIndex >= count)
+			return null;
+
+		return targetIndex;
+	}
+}

--- a/Mutation.Ui/Core/WaveformSampleBuffer.cs
+++ b/Mutation.Ui/Core/WaveformSampleBuffer.cs
@@ -1,0 +1,159 @@
+using System;
+
+namespace Mutation.Ui.Core;
+
+/// <summary>Peak and RMS amplitude over one render window, both in 0..1.</summary>
+internal readonly record struct WaveformLevels(double Peak, double Rms);
+
+/// <summary>
+/// The capture-buffer → render-window → level pipeline behind the microphone waveform.
+/// <para>
+/// Samples arrive from the capture device on its own thread and land in a ring buffer;
+/// a render tick on the UI thread takes a snapshot of the last window's worth, oldest
+/// sample first, and measures it. Splitting this out of
+/// <c>MicrophoneVisualizationController</c> lets the wrap-around, the partially-filled
+/// first window, and the level maths be tested directly — none of which need a
+/// microphone, a plot, or a dispatcher, and all of which are silently wrong rather than
+/// noisy when they break.
+/// </para>
+/// </summary>
+internal sealed class WaveformSampleBuffer
+{
+	private readonly object _lock = new();
+	private readonly double[] _ring;
+	private int _writeIndex;
+	private bool _wrapped;
+
+	/// <param name="windowSampleCount">How many samples one rendered window holds. Must be positive.</param>
+	public WaveformSampleBuffer(int windowSampleCount)
+	{
+		if (windowSampleCount <= 0)
+			throw new ArgumentOutOfRangeException(nameof(windowSampleCount), windowSampleCount, "A waveform window needs at least one sample.");
+
+		_ring = new double[windowSampleCount];
+		RenderBuffer = new double[windowSampleCount];
+	}
+
+	/// <summary>
+	/// The array <see cref="Snapshot"/> writes into, oldest sample first. Handed to the plot
+	/// once and then refilled in place, because ScottPlot's Signal holds the reference it was
+	/// given — replacing the array would leave the plot drawing a frozen copy.
+	/// </summary>
+	public double[] RenderBuffer { get; }
+
+	/// <summary>How many samples one window holds.</summary>
+	public int WindowSampleCount => _ring.Length;
+
+	/// <summary>Drops everything captured so far and flattens the rendered window.</summary>
+	public void Reset()
+	{
+		lock (_lock)
+		{
+			Array.Clear(_ring, 0, _ring.Length);
+			Array.Clear(RenderBuffer, 0, RenderBuffer.Length);
+			_writeIndex = 0;
+			_wrapped = false;
+		}
+	}
+
+	/// <summary>
+	/// Appends 16-bit little-endian mono PCM from a capture callback. Reads
+	/// <paramref name="byteCount"/> bytes from the front of <paramref name="pcm16"/> —
+	/// capture buffers are reused and only partly filled, so the array's own length says
+	/// nothing about how much of it is audio. A trailing odd byte is ignored.
+	/// </summary>
+	/// <returns>How many samples were taken.</returns>
+	public int Write(byte[] pcm16, int byteCount)
+	{
+		if (pcm16 is null) throw new ArgumentNullException(nameof(pcm16));
+		if (byteCount <= 0)
+			return 0;
+
+		int sampleCount = Math.Min(byteCount, pcm16.Length) / 2;
+		if (sampleCount <= 0)
+			return 0;
+
+		lock (_lock)
+		{
+			for (int i = 0; i < sampleCount; i++)
+			{
+				short sample = BitConverter.ToInt16(pcm16, i * 2);
+				_ring[_writeIndex++] = sample / 32768d;
+				if (_writeIndex >= _ring.Length)
+				{
+					_writeIndex = 0;
+					_wrapped = true;
+				}
+			}
+		}
+
+		return sampleCount;
+	}
+
+	/// <summary>
+	/// Fills <see cref="RenderBuffer"/> with the most recent window, oldest sample first.
+	/// Before a full window has been captured the valid samples sit at the end and the lead
+	/// is zeroed, so the trace grows in from the right rather than jumping.
+	/// </summary>
+	/// <returns>How many of the samples in <see cref="RenderBuffer"/> are real audio.</returns>
+	public int Snapshot()
+	{
+		lock (_lock)
+		{
+			if (!_wrapped && _writeIndex == 0)
+			{
+				Array.Clear(RenderBuffer, 0, RenderBuffer.Length);
+				return 0;
+			}
+
+			int length = RenderBuffer.Length;
+
+			if (_wrapped)
+			{
+				// The oldest sample is the one about to be overwritten, so the window is the
+				// tail from the write cursor followed by the head before it.
+				int tailLength = length - _writeIndex;
+				if (tailLength > 0)
+					Array.Copy(_ring, _writeIndex, RenderBuffer, 0, tailLength);
+				if (_writeIndex > 0)
+					Array.Copy(_ring, 0, RenderBuffer, tailLength, _writeIndex);
+				return length;
+			}
+
+			int validCount = _writeIndex;
+			int leadingZeros = length - validCount;
+			if (leadingZeros > 0)
+				Array.Clear(RenderBuffer, 0, leadingZeros);
+			Array.Copy(_ring, 0, RenderBuffer, leadingZeros, validCount);
+			return validCount;
+		}
+	}
+
+	/// <summary>
+	/// Measures the newest <paramref name="validSamples"/> samples of a snapshot. Only the
+	/// real audio at the end of the window is measured, so the zero-padded lead of a
+	/// partially-filled first window does not drag the level down towards silence.
+	/// </summary>
+	public static WaveformLevels MeasureLevels(double[] window, int validSamples)
+	{
+		if (window is null) throw new ArgumentNullException(nameof(window));
+		if (validSamples <= 0 || window.Length == 0)
+			return new WaveformLevels(0, 0);
+
+		int samplesToProcess = Math.Min(validSamples, window.Length);
+		int startIndex = window.Length - samplesToProcess;
+
+		double peak = 0;
+		double sumSquares = 0;
+		for (int i = startIndex; i < window.Length; i++)
+		{
+			double value = window[i];
+			double abs = Math.Abs(value);
+			if (abs > peak)
+				peak = abs;
+			sumSquares += value * value;
+		}
+
+		return new WaveformLevels(peak, Math.Sqrt(sumSquares / samplesToProcess));
+	}
+}

--- a/Mutation.Ui/Services/HotkeyManager.cs
+++ b/Mutation.Ui/Services/HotkeyManager.cs
@@ -1,4 +1,4 @@
-using CognitiveSupport;
+﻿using CognitiveSupport;
 using Microsoft.UI.Xaml;
 using Mutation.Ui.Core;
 using System;
@@ -95,14 +95,10 @@ public class HotkeyManager : IDisposable
 	[DllImport("user32.dll")] static extern IntPtr CallWindowProc(IntPtr lpPrevWndFunc, IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam);
 	[DllImport("user32.dll", SetLastError = true)] static extern uint SendInput(uint nInputs, INPUT[] pInputs, int cbSize);
 	[DllImport("user32.dll")] static extern short GetAsyncKeyState(int vKey);
-	[DllImport("user32.dll")] static extern uint MapVirtualKey(uint uCode, uint uMapType);
-
-	private const uint MAPVK_VK_TO_VSC = 0x0;
 
 	private const int INPUT_KEYBOARD = 1;
 	private const uint KEYEVENTF_KEYUP = 0x0002;
 	private const uint KEYEVENTF_UNICODE = 0x0004;
-	private const uint KEYEVENTF_SCANCODE = 0x0008;
 	private const uint KEYEVENTF_EXTENDEDKEY = 0x0001;
 
 	[StructLayout(LayoutKind.Sequential)]
@@ -272,7 +268,7 @@ public class HotkeyManager : IDisposable
 
         public void ClearPromptHotkeys()
         {
-                _registrations.ClearGroup(HotkeyRegistrationTable.HotkeyGroup.Prompt);
+            _registrations.ClearGroup(HotkeyRegistrationTable.HotkeyGroup.Prompt);
         }
 
         public void UnregisterAll()

--- a/Mutation.Ui/Services/HotkeyManager.cs
+++ b/Mutation.Ui/Services/HotkeyManager.cs
@@ -1,9 +1,8 @@
-﻿using CognitiveSupport;
+using CognitiveSupport;
 using Microsoft.UI.Xaml;
 using Mutation.Ui.Core;
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -16,20 +15,14 @@ namespace Mutation.Ui.Services;
 public class HotkeyManager : IDisposable
 {
 	private readonly IntPtr _hwnd;
-	private readonly Dictionary<int, Action> _callbacks = new();
-	// Track a normalized representation of each registered hotkey so we can avoid
-	// attempting duplicate registrations (which Windows will report as a failure
-	// even though one instance is already active).
-	private readonly HashSet<string> _registeredHotkeys = new(StringComparer.Ordinal);
-    private readonly List<int> _routerIds = new();
-    private readonly Dictionary<int, string> _routerNormalizedHotkeys = new();
 
-    private readonly List<int> _promptIds = new();
-    private readonly Dictionary<int, string> _promptNormalizedHotkeys = new();
+	// Which shortcuts are taken, which id carries which callback, and which ids a refresh
+	// has to release. Extracted so those rules can be tested without a window handle — see
+	// HotkeyRegistrationTable.
+	private readonly HotkeyRegistrationTable _registrations;
 
 	private readonly Settings _settings;
 	private static SynchronizationContext? s_uiCtx;
-	private int _id;
 	private IntPtr _prevWndProc;
 	private WndProcDelegate? _newWndProc;
 	private GCHandle _wndProcHandle;
@@ -91,30 +84,13 @@ public class HotkeyManager : IDisposable
                 return failures;
         }
 
-        private readonly struct HotkeyRegistrationAttempt
-        {
-                public HotkeyRegistrationAttempt(string normalizedHotkey, int id, bool success, string? errorMessage)
-                {
-                        NormalizedHotkey = normalizedHotkey;
-                        Id = id;
-                        Success = success;
-                        ErrorMessage = errorMessage;
-                }
-
-                public string NormalizedHotkey { get; }
-                public int Id { get; }
-                public bool Success { get; }
-                public string? ErrorMessage { get; }
-        }
-
 	private const int WM_HOTKEY = 0x0312;
 	private const int GWLP_WNDPROC = -4;
 
 	// Modifier flags live in HotkeyModifiers so their composition — including
 	// MOD_NOREPEAT — can be tested without a window handle.
 
-        [DllImport("user32.dll", SetLastError = true)] static extern bool RegisterHotKey(IntPtr hWnd, int id, uint fsModifiers, uint vk);
-	[DllImport("user32.dll")] static extern bool UnregisterHotKey(IntPtr hWnd, int id);
+	// RegisterHotKey/UnregisterHotKey live in Win32HotkeyPlatform, behind IHotkeyPlatform.
 	[DllImport("user32.dll")] static extern IntPtr SetWindowLongPtr(IntPtr hWnd, int nIndex, IntPtr newProc);
 	[DllImport("user32.dll")] static extern IntPtr CallWindowProc(IntPtr lpPrevWndFunc, IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam);
 	[DllImport("user32.dll", SetLastError = true)] static extern uint SendInput(uint nInputs, INPUT[] pInputs, int cbSize);
@@ -158,6 +134,7 @@ public class HotkeyManager : IDisposable
 	{
 		_hwnd = WindowNative.GetWindowHandle(window);
 		_settings = settings ?? throw new ArgumentNullException(nameof(settings));
+		_registrations = new HotkeyRegistrationTable(new Win32HotkeyPlatform(_hwnd), Log);
 		_newWndProc = WndProc;
 		_wndProcHandle = GCHandle.Alloc(_newWndProc);
 		_prevWndProc = SetWindowLongPtr(_hwnd, GWLP_WNDPROC, Marshal.GetFunctionPointerForDelegate(_newWndProc));
@@ -167,8 +144,7 @@ public class HotkeyManager : IDisposable
 
 	        public int RegisterHotkey(Hotkey hotkey, Action callback)
 	        {
-	                var attempt = RegisterHotkeyInternal(hotkey, callback);
-	                return attempt.Id;
+	                return _registrations.Register(hotkey, callback, HotkeyRegistrationTable.HotkeyGroup.Core).Id;
 	        }
 
 	        // Registers a core (non-router) hotkey and returns a failure description when the
@@ -184,55 +160,13 @@ public class HotkeyManager : IDisposable
 	                        return parseFailure;
 	                }
 
-	                var attempt = RegisterHotkeyInternal(Hotkey.Parse(hotkeyText!), callback);
+	                var attempt = _registrations.Register(Hotkey.Parse(hotkeyText!), callback, HotkeyRegistrationTable.HotkeyGroup.Core);
 	                if (attempt.Success)
 	                        return null;
 
 	                return new HotkeyBindingFailure(description, hotkeyText!.Trim(),
 	                        attempt.ErrorMessage ?? "The shortcut could not be registered.");
 	        }
-
-	        private HotkeyRegistrationAttempt RegisterHotkeyInternal(Hotkey hotkey, Action callback)
-        {
-                string norm = NormalizeHotkey(hotkey);
-                if (_registeredHotkeys.Contains(norm))
-                {
-                        Log($"Duplicate hotkey detected: {norm}");
-                        return new HotkeyRegistrationAttempt(norm, -1, success: false, errorMessage: "The shortcut is already registered.");
-                }
-
-                int id = Interlocked.Increment(ref _id);
-                uint mods = HotkeyModifiers.Compose(hotkey);
-				bool success = RegisterHotKey(_hwnd, id, mods, (uint)hotkey.Key);
-                if (success)
-                {
-                        _callbacks[id] = callback;
-                        _registeredHotkeys.Add(norm);
-                        Log($"Hotkey registered: {norm} (id={id})");
-                        return new HotkeyRegistrationAttempt(norm, id, true, null);
-                }
-
-				if (_registeredHotkeys.Contains(norm))
-                {
-                        Log($"RegisterHotKey reported failure but hotkey already active (suppressing): {norm}");
-                        return new HotkeyRegistrationAttempt(norm, id, true, null);
-                }
-
-                int error = Marshal.GetLastWin32Error();
-                string? message = null;
-                if (error != 0)
-                {
-                        message = error switch
-                        {
-                                1409 => "The shortcut is already registered by another application.",
-                                _ => new Win32Exception(error).Message
-                        };
-                }
-                message ??= "Failed to register the shortcut.";
-
-                Log($"Hotkey registration FAILED: {norm} (error={error})");
-                return new HotkeyRegistrationAttempt(norm, id, false, message);
-        }
 
         public IReadOnlyList<HotkeyRegistrationResult> RegisterRouterHotkeys()
         {
@@ -257,15 +191,9 @@ public class HotkeyManager : IDisposable
 			                        try
 			                        {
 			                                var hotkey = Hotkey.Parse(map.FromHotKey!);
-			                                var attempt = RegisterHotkeyInternal(hotkey, () => SendHotkeyAfterDelay(map.ToHotKey!, Constants.FailureSendHotkeyDelay));
+			                                var attempt = _registrations.Register(hotkey, () => SendHotkeyAfterDelay(map.ToHotKey!, Constants.FailureSendHotkeyDelay), HotkeyRegistrationTable.HotkeyGroup.Router);
                                 if (attempt.Success)
                                 {
-                                        if (attempt.Id > 0)
-                                        {
-                                                _routerIds.Add(attempt.Id);
-                                                _routerNormalizedHotkeys[attempt.Id] = attempt.NormalizedHotkey;
-                                        }
-
                                         Log($"Router registered: From='{map.FromHotKey}' -> To='{map.ToHotKey}', id={attempt.Id}");
                                         results.Add(new HotkeyRegistrationResult(map, attempt.NormalizedHotkey, true, attempt.Id, null));
                                 }
@@ -304,18 +232,7 @@ public class HotkeyManager : IDisposable
 
         private void ClearRouterHotkeys()
         {
-                foreach (var id in _routerIds)
-                {
-                        UnregisterHotKey(_hwnd, id);
-                        _callbacks.Remove(id);
-                        if (_routerNormalizedHotkeys.TryGetValue(id, out var norm))
-                        {
-                                _routerNormalizedHotkeys.Remove(id);
-                                _registeredHotkeys.Remove(norm);
-                        }
-                }
-
-                _routerIds.Clear();
+                _registrations.ClearGroup(HotkeyRegistrationTable.HotkeyGroup.Router);
         }
 
         // Registers each prompt's optional hotkey and returns the ones that could not be bound,
@@ -341,16 +258,8 @@ public class HotkeyManager : IDisposable
                     continue;
                 }
 
-                var attempt = RegisterHotkeyInternal(Hotkey.Parse(prompt.Hotkey), () => callback(prompt));
-                if (attempt.Success)
-                {
-                    if (attempt.Id > 0)
-                    {
-                        _promptIds.Add(attempt.Id);
-                        _promptNormalizedHotkeys[attempt.Id] = attempt.NormalizedHotkey;
-                    }
-                }
-                else
+                var attempt = _registrations.Register(Hotkey.Parse(prompt.Hotkey), () => callback(prompt), HotkeyRegistrationTable.HotkeyGroup.Prompt);
+                if (!attempt.Success)
                 {
                     Log($"Prompt hotkey registration FAILED: {description} ({prompt.Hotkey}) - {attempt.ErrorMessage}");
                     failures.Add(new HotkeyBindingFailure(description, prompt.Hotkey.Trim(),
@@ -363,30 +272,12 @@ public class HotkeyManager : IDisposable
 
         public void ClearPromptHotkeys()
         {
-            foreach (var id in _promptIds)
-            {
-                UnregisterHotKey(_hwnd, id);
-                _callbacks.Remove(id);
-                if (_promptNormalizedHotkeys.TryGetValue(id, out var norm))
-                {
-                    _promptNormalizedHotkeys.Remove(id);
-                    _registeredHotkeys.Remove(norm);
-                }
-            }
-            _promptIds.Clear();
-            _promptNormalizedHotkeys.Clear();
+                _registrations.ClearGroup(HotkeyRegistrationTable.HotkeyGroup.Prompt);
         }
 
         public void UnregisterAll()
         {
-                foreach (var kvp in _callbacks)
-                        UnregisterHotKey(_hwnd, kvp.Key);
-                _callbacks.Clear();
-                _routerIds.Clear();
-                _routerNormalizedHotkeys.Clear();
-                _promptIds.Clear();
-                _promptNormalizedHotkeys.Clear();
-                _registeredHotkeys.Clear();
+                _registrations.ClearAll();
         }
 
         // Clears ALL registrations (core + router + prompt) so the caller can
@@ -402,8 +293,7 @@ public class HotkeyManager : IDisposable
 		{
 			int id = wParam.ToInt32();
 			Log($"WM_HOTKEY received: id={id}");
-			if (_callbacks.TryGetValue(id, out var cb))
-				cb();
+			_registrations.Dispatch(id);
 			return IntPtr.Zero;
 		}
 		return CallWindowProc(_prevWndProc, hWnd, msg, wParam, lParam);
@@ -757,18 +647,6 @@ public class HotkeyManager : IDisposable
 	{
 		var line = $"{DateTime.Now:HH:mm:ss.fff} {message}{Environment.NewLine}";
 		s_logChannel.Writer.TryWrite(line);
-	}
-
-	private static string NormalizeHotkey(Hotkey hk)
-	{
-		// Construct a deterministic modifier order & uppercase key for set membership
-		var sb = new System.Text.StringBuilder(32);
-		if (hk.Control) sb.Append("CTRL+");
-		if (hk.Shift) sb.Append("SHIFT+");
-		if (hk.Alt) sb.Append("ALT+");
-		if (hk.Win) sb.Append("WIN+");
-		sb.Append(hk.Key.ToString().ToUpperInvariant());
-		return sb.ToString();
 	}
 
 	public void Dispose()

--- a/Mutation.Ui/Services/HotkeyRegistrationTable.cs
+++ b/Mutation.Ui/Services/HotkeyRegistrationTable.cs
@@ -1,0 +1,203 @@
+using CognitiveSupport;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Threading;
+
+namespace Mutation.Ui.Services;
+
+/// <summary>
+/// The bookkeeping behind global hotkeys: which shortcuts are already taken, which id
+/// carries which callback, and which ids belong to a group that a refresh has to release
+/// first.
+/// <para>
+/// Split out of <see cref="HotkeyManager"/> so it can be exercised without a window handle
+/// and without asking Windows for chords the build machine may not have free. The failures
+/// this guards against are silent ones — a router refresh that leaves its old ids
+/// registered, or a prompt hotkey whose id still routes to the deleted prompt's callback —
+/// and neither shows up as an exception.
+/// </para>
+/// </summary>
+internal sealed class HotkeyRegistrationTable
+{
+	/// <summary>Which part of the app owns a registration, and therefore what a refresh clears.</summary>
+	public enum HotkeyGroup
+	{
+		/// <summary>App shortcuts, replaced only by a full rebind.</summary>
+		Core,
+
+		/// <summary>Hotkey-router mappings, replaced whenever the router settings change.</summary>
+		Router,
+
+		/// <summary>Per-prompt shortcuts, replaced whenever the prompt library changes.</summary>
+		Prompt,
+	}
+
+	/// <summary>The id handed back when nothing was registered.</summary>
+	public const int NoId = -1;
+
+	public readonly record struct RegistrationOutcome(
+		string NormalizedHotkey,
+		int Id,
+		bool Success,
+		string? ErrorMessage);
+
+	private sealed record Entry(Action Callback, string NormalizedHotkey, HotkeyGroup Group);
+
+	private readonly IHotkeyPlatform _platform;
+	private readonly Action<string>? _log;
+	private readonly Dictionary<int, Entry> _entries = new();
+
+	// A normalized form of every live shortcut, so a duplicate is refused before Windows is
+	// asked. Windows reports a second registration of a chord this process already owns as a
+	// plain failure, which is indistinguishable from another app holding it.
+	private readonly HashSet<string> _registered = new(StringComparer.Ordinal);
+
+	private int _nextId;
+
+	public HotkeyRegistrationTable(IHotkeyPlatform platform, Action<string>? log = null)
+	{
+		_platform = platform ?? throw new ArgumentNullException(nameof(platform));
+		_log = log;
+	}
+
+	/// <summary>How many registrations are live, across every group.</summary>
+	public int Count => _entries.Count;
+
+	/// <summary>Whether <paramref name="hotkey"/> is currently bound by this process.</summary>
+	public bool IsRegistered(Hotkey hotkey) => _registered.Contains(NormalizeHotkey(hotkey));
+
+	/// <summary>The live ids belonging to <paramref name="group"/>, in registration order.</summary>
+	public IReadOnlyList<int> IdsIn(HotkeyGroup group)
+	{
+		var ids = new List<int>();
+		foreach (var (id, entry) in _entries)
+		{
+			if (entry.Group == group)
+				ids.Add(id);
+		}
+		ids.Sort();
+		return ids;
+	}
+
+	/// <summary>
+	/// Binds <paramref name="hotkey"/> to <paramref name="callback"/>. A chord this process
+	/// already holds is refused without asking Windows, because a second registration comes
+	/// back as an unexplained failure and would be reported to the user as a conflict with
+	/// some other application.
+	/// </summary>
+	public RegistrationOutcome Register(Hotkey hotkey, Action callback, HotkeyGroup group)
+	{
+		if (callback is null) throw new ArgumentNullException(nameof(callback));
+
+		string norm = NormalizeHotkey(hotkey);
+		if (_registered.Contains(norm))
+		{
+			Log($"Duplicate hotkey detected: {norm}");
+			return new RegistrationOutcome(norm, NoId, false, "The shortcut is already registered.");
+		}
+
+		int id = Interlocked.Increment(ref _nextId);
+		uint modifiers = HotkeyModifiers.Compose(hotkey);
+		if (!_platform.Register(id, modifiers, (uint)hotkey.Key, out int errorCode))
+		{
+			string message = DescribeRegistrationError(errorCode);
+			Log($"Hotkey registration FAILED: {norm} (error={errorCode})");
+			return new RegistrationOutcome(norm, id, false, message);
+		}
+
+		_entries[id] = new Entry(callback, norm, group);
+		_registered.Add(norm);
+		Log($"Hotkey registered: {norm} (id={id}, group={group})");
+		return new RegistrationOutcome(norm, id, true, null);
+	}
+
+	/// <summary>
+	/// Runs the callback bound to <paramref name="id"/>. Returns false for an id this table
+	/// does not know — which is what a WM_HOTKEY for a shortcut that has since been released
+	/// looks like.
+	/// </summary>
+	public bool Dispatch(int id)
+	{
+		if (!_entries.TryGetValue(id, out var entry))
+			return false;
+
+		entry.Callback();
+		return true;
+	}
+
+	/// <summary>
+	/// Releases every registration in <paramref name="group"/>, leaving the other groups
+	/// alone. Both the Windows binding and the duplicate-detection entry go, so the same
+	/// chord can be registered again by the refresh that follows.
+	/// </summary>
+	public void ClearGroup(HotkeyGroup group)
+	{
+		var doomed = new List<int>();
+		foreach (var (id, entry) in _entries)
+		{
+			if (entry.Group == group)
+				doomed.Add(id);
+		}
+
+		foreach (int id in doomed)
+			Release(id);
+	}
+
+	/// <summary>Releases every registration in every group.</summary>
+	public void ClearAll()
+	{
+		var doomed = new List<int>(_entries.Keys);
+		foreach (int id in doomed)
+			Release(id);
+
+		// Belt and braces: the sets are rebuilt from nothing on the next pass, so a stray
+		// entry left by a partial failure above cannot make a chord permanently unbindable.
+		_entries.Clear();
+		_registered.Clear();
+	}
+
+	private void Release(int id)
+	{
+		if (!_entries.TryGetValue(id, out var entry))
+			return;
+
+		_platform.Unregister(id);
+		_entries.Remove(id);
+		_registered.Remove(entry.NormalizedHotkey);
+	}
+
+	/// <summary>
+	/// Turns a Win32 error from RegisterHotKey into something a user can act on. 1409 is
+	/// ERROR_HOTKEY_ALREADY_REGISTERED, and since this table refuses our own duplicates
+	/// before calling Windows, seeing it here means another application holds the chord.
+	/// </summary>
+	public static string DescribeRegistrationError(int errorCode)
+	{
+		if (errorCode == 0)
+			return "Failed to register the shortcut.";
+
+		return errorCode switch
+		{
+			1409 => "The shortcut is already registered by another application.",
+			_ => new Win32Exception(errorCode).Message,
+		};
+	}
+
+	/// <summary>
+	/// A deterministic text form of a chord — fixed modifier order, upper-cased key — so
+	/// that two spellings of the same shortcut compare equal for duplicate detection.
+	/// </summary>
+	public static string NormalizeHotkey(Hotkey hotkey)
+	{
+		var sb = new System.Text.StringBuilder(32);
+		if (hotkey.Control) sb.Append("CTRL+");
+		if (hotkey.Shift) sb.Append("SHIFT+");
+		if (hotkey.Alt) sb.Append("ALT+");
+		if (hotkey.Win) sb.Append("WIN+");
+		sb.Append(hotkey.Key.ToString().ToUpperInvariant());
+		return sb.ToString();
+	}
+
+	private void Log(string message) => _log?.Invoke(message);
+}

--- a/Mutation.Ui/Services/HotkeyRegistrationTable.cs
+++ b/Mutation.Ui/Services/HotkeyRegistrationTable.cs
@@ -1,4 +1,3 @@
-using CognitiveSupport;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;

--- a/Mutation.Ui/Services/IHotkeyPlatform.cs
+++ b/Mutation.Ui/Services/IHotkeyPlatform.cs
@@ -1,0 +1,27 @@
+namespace Mutation.Ui.Services;
+
+/// <summary>
+/// The two Windows calls that global hotkey registration actually needs, behind a seam.
+/// <para>
+/// Registration bookkeeping — which shortcuts are taken, which id belongs to which
+/// callback, and what a refresh has to release — is the part that leaks or mis-routes
+/// chords, and it cannot be exercised against the real API because that needs a window
+/// handle and a machine where the chords are free. Everything above this interface is
+/// therefore testable; everything below it is a one-line P/Invoke.
+/// </para>
+/// </summary>
+internal interface IHotkeyPlatform
+{
+	/// <summary>
+	/// Asks Windows to bind <paramref name="virtualKey"/> plus <paramref name="modifiers"/>
+	/// to <paramref name="id"/>.
+	/// </summary>
+	/// <param name="errorCode">
+	/// The Win32 error code when the call failed, or 0 when Windows gave no reason.
+	/// Meaningless when the call succeeded.
+	/// </param>
+	bool Register(int id, uint modifiers, uint virtualKey, out int errorCode);
+
+	/// <summary>Releases a previously registered id. Silent about ids Windows does not know.</summary>
+	void Unregister(int id);
+}

--- a/Mutation.Ui/Services/MicrophoneVisualizationController.cs
+++ b/Mutation.Ui/Services/MicrophoneVisualizationController.cs
@@ -34,11 +34,10 @@ internal sealed class MicrophoneVisualizationController : IDisposable
 	private readonly SingleTimerSlot<DispatcherQueueTimer> _waveformTimer;
 	private WaveInEvent? _waveformCapture;
 	private Signal? _waveformSignal;
-	private double[] _waveformBuffer = Array.Empty<double>();
-	private double[] _waveformRenderBuffer = Array.Empty<double>();
-	private int _waveformBufferIndex;
-	private bool _waveformBufferFilled;
-	private readonly object _waveformBufferLock = new();
+
+	// Null until Initialize() runs, and again after Dispose() — the capture callback and the
+	// render tick both check it rather than inspecting array lengths.
+	private WaveformSampleBuffer? _samples;
 	private double _waveformPeak;
 	private double _waveformRms;
 	private double _waveformPulse;
@@ -89,14 +88,11 @@ internal sealed class MicrophoneVisualizationController : IDisposable
 
 	public void Initialize()
 	{
-		_waveformBuffer = new double[WaveformWindowSampleCount];
-		_waveformRenderBuffer = new double[WaveformWindowSampleCount];
-		_waveformBufferIndex = 0;
-		_waveformBufferFilled = false;
+		_samples = new WaveformSampleBuffer(WaveformWindowSampleCount);
 
 		var plot = _waveformPlot.Plot;
 		plot.Clear();
-		_waveformSignal = plot.Add.Signal(_waveformRenderBuffer);
+		_waveformSignal = plot.Add.Signal(_samples.RenderBuffer);
 		plot.Axes.SetLimitsX(0, Math.Max(1, WaveformWindowSampleCount - 1));
 		plot.Axes.SetLimitsY(-1, 1);
 		plot.HideGrid();
@@ -112,20 +108,12 @@ internal sealed class MicrophoneVisualizationController : IDisposable
 
 	public void StartCapture()
 	{
-		if (_waveformRenderBuffer.Length == 0)
+		if (_samples is null)
 			return;
 
 		StopCapture();
 
-		lock (_waveformBufferLock)
-		{
-			if (_waveformBuffer.Length > 0)
-				Array.Clear(_waveformBuffer, 0, _waveformBuffer.Length);
-			if (_waveformRenderBuffer.Length > 0)
-				Array.Clear(_waveformRenderBuffer, 0, _waveformRenderBuffer.Length);
-			_waveformBufferIndex = 0;
-			_waveformBufferFilled = false;
-		}
+		_samples.Reset();
 
 		// Render the reset-to-flat state once even before the first samples arrive.
 		_waveformRenderGate.MarkDataArrived();
@@ -226,10 +214,7 @@ internal sealed class MicrophoneVisualizationController : IDisposable
 		_waveformTimer.Stop();
 
 		_waveformSignal = null;
-		_waveformBuffer = Array.Empty<double>();
-		_waveformRenderBuffer = Array.Empty<double>();
-		_waveformBufferIndex = 0;
-		_waveformBufferFilled = false;
+		_samples = null;
 	}
 
 	private void WaveformTimer_Tick(DispatcherQueueTimer sender, object args)
@@ -260,75 +245,23 @@ internal sealed class MicrophoneVisualizationController : IDisposable
 		if (!_waveformRenderGate.ConsumeShouldRender())
 			return;
 
-		int validSamples = PopulateWaveformRenderBuffer();
+		if (_samples is null)
+			return;
 
-		double peak = 0;
-		double sumSquares = 0;
-		if (validSamples > 0)
-		{
-			int samplesToProcess = Math.Min(validSamples, _waveformRenderBuffer.Length);
-			int startIndex = _waveformRenderBuffer.Length - samplesToProcess;
-			for (int i = startIndex; i < _waveformRenderBuffer.Length; i++)
-			{
-				double value = _waveformRenderBuffer[i];
-				double abs = Math.Abs(value);
-				if (abs > peak)
-					peak = abs;
-				sumSquares += value * value;
-			}
-			_waveformRms = Math.Sqrt(sumSquares / Math.Max(1, samplesToProcess));
-		}
-		else
-		{
-			_waveformRms = 0;
-		}
+		int validSamples = _samples.Snapshot();
+		var levels = WaveformSampleBuffer.MeasureLevels(_samples.RenderBuffer, validSamples);
 
-		_waveformPeak = peak;
+		_waveformRms = levels.Rms;
+		_waveformPeak = levels.Peak;
 
 		if (_waveformSignal != null)
 			_waveformPlot.Refresh();
 
-		UpdateMicLevelMeter(peak, _waveformRms);
+		UpdateMicLevelMeter(levels.Peak, levels.Rms);
 
-		_waveformPulse = Math.Max(_waveformPulse * 0.85, Math.Min(1.0, peak));
+		_waveformPulse = Math.Max(_waveformPulse * 0.85, Math.Min(1.0, levels.Peak));
 		if (_pulseOverlay != null)
 			_pulseOverlay.Opacity = _waveformPulse * 0.35;
-	}
-
-	private int PopulateWaveformRenderBuffer()
-	{
-		if (_waveformRenderBuffer.Length == 0 || _waveformBuffer.Length == 0)
-			return 0;
-
-		lock (_waveformBufferLock)
-		{
-			if (!_waveformBufferFilled && _waveformBufferIndex == 0)
-			{
-				Array.Clear(_waveformRenderBuffer, 0, _waveformRenderBuffer.Length);
-				return 0;
-			}
-
-			if (_waveformBufferFilled)
-			{
-				int bufferLen = _waveformRenderBuffer.Length;
-				int index = _waveformBufferIndex;
-				if (index > bufferLen)
-					index = bufferLen;
-				int tailLength = bufferLen - index;
-				if (tailLength > 0)
-					Array.Copy(_waveformBuffer, index, _waveformRenderBuffer, 0, tailLength);
-				if (index > 0)
-					Array.Copy(_waveformBuffer, 0, _waveformRenderBuffer, tailLength, index);
-				return bufferLen;
-			}
-
-			int validCount = _waveformBufferIndex;
-			int leadingZeros = _waveformRenderBuffer.Length - validCount;
-			if (leadingZeros > 0)
-				Array.Clear(_waveformRenderBuffer, 0, leadingZeros);
-			Array.Copy(_waveformBuffer, 0, _waveformRenderBuffer, Math.Max(0, leadingZeros), validCount);
-			return validCount;
-		}
 	}
 
 	private void UpdateMicLevelMeter(double peak, double rms)
@@ -351,27 +284,8 @@ internal sealed class MicrophoneVisualizationController : IDisposable
 
 	private void OnWaveformDataAvailable(object? sender, WaveInEventArgs e)
 	{
-		if (_waveformBuffer.Length == 0 || e.BytesRecorded <= 0)
+		if (_samples is null || _samples.Write(e.Buffer, e.BytesRecorded) == 0)
 			return;
-
-		int sampleCount = e.BytesRecorded / 2;
-		if (sampleCount <= 0)
-			return;
-
-		lock (_waveformBufferLock)
-		{
-			for (int i = 0; i < sampleCount; i++)
-			{
-				short sample = BitConverter.ToInt16(e.Buffer, i * 2);
-				double value = sample / 32768d;
-				_waveformBuffer[_waveformBufferIndex++] = value;
-				if (_waveformBufferIndex >= _waveformBuffer.Length)
-				{
-					_waveformBufferIndex = 0;
-					_waveformBufferFilled = true;
-				}
-			}
-		}
 
 		// New samples are in the ring buffer — let the next render tick draw them.
 		_waveformRenderGate.MarkDataArrived();

--- a/Mutation.Ui/Services/Win32HotkeyPlatform.cs
+++ b/Mutation.Ui/Services/Win32HotkeyPlatform.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace Mutation.Ui.Services;
+
+/// <summary>
+/// The real Windows implementation of <see cref="IHotkeyPlatform"/>, bound to one window
+/// handle. Holds no state of its own: what is registered is tracked by
+/// <see cref="HotkeyRegistrationTable"/>, which is where the rules worth testing live.
+/// </summary>
+internal sealed class Win32HotkeyPlatform : IHotkeyPlatform
+{
+	[DllImport("user32.dll", SetLastError = true)]
+	private static extern bool RegisterHotKey(IntPtr hWnd, int id, uint fsModifiers, uint vk);
+
+	[DllImport("user32.dll")]
+	private static extern bool UnregisterHotKey(IntPtr hWnd, int id);
+
+	private readonly IntPtr _hwnd;
+
+	public Win32HotkeyPlatform(IntPtr hwnd) => _hwnd = hwnd;
+
+	public bool Register(int id, uint modifiers, uint virtualKey, out int errorCode)
+	{
+		if (RegisterHotKey(_hwnd, id, modifiers, virtualKey))
+		{
+			errorCode = 0;
+			return true;
+		}
+
+		errorCode = Marshal.GetLastWin32Error();
+		return false;
+	}
+
+	public void Unregister(int id) => UnregisterHotKey(_hwnd, id);
+}


### PR DESCRIPTION
Closes a slice of #255.

## What was wrong

The four biggest files in the app had zero test coverage. Not for want of
trying — none of them can be constructed in a test. `HotkeyManager` needs a
window handle, `AudioSessionManager` needs a recorder and a transcription
service, `MicrophoneVisualizationController` needs a dispatcher and a
ScottPlot control. So the rules that actually go wrong inside them were only
ever exercised by using the app, and every one of them fails silently: a
router refresh that leaks its old registrations, a selection that lands on
the wrong recording, a waveform window copied out of order. Nothing throws.

## What changed

Each unit gives up the part worth testing, and keeps the part that needs
Windows.

| New file | Taken from | What it now owns |
| --- | --- | --- |
| `Mutation.Ui/Services/HotkeyRegistrationTable.cs` | `HotkeyManager` (766 lines) | Duplicate detection, id allocation, WM_HOTKEY routing, per-group release |
| `Mutation.Ui/Services/IHotkeyPlatform.cs` + `Win32HotkeyPlatform.cs` | `HotkeyManager` | The two P/Invokes, and nothing else |
| `Mutation.Ui/Core/SessionSelectionPlanner.cs` | `AudioSessionManager` (477) | Which recording is selected after a rebuild; where Previous/Next goes |
| `Mutation.Ui/Core/WaveformSampleBuffer.cs` | `MicrophoneVisualizationController` (369) | Capture ring buffer, render snapshot, peak/RMS |

`AudioPlayer` (202) needed no seam — it already had `IAudioOutputDevice`, and
`AudioPlayerTeardownTests` / `AudioPlayerAsyncPlaybackTests` cover teardown and
async decode. What it lacked is what the issue named: the time-stretch stage
tested *in situ*. `SoundTouchSampleProvider` being correct says nothing about
the player building the chain around it, so the new tests pull samples through
the chain the player hands the output device and measure the stretch.

## Tests

**70 new, 1536 passing, ~3s.**

- `HotkeyRegistrationTableTests` — a chord we already hold is refused without
  asking Windows (a second registration comes back as an unexplained failure
  and gets blamed on another app); ids are never reused, so a WM_HOTKEY already
  in the queue when a refresh ran cannot fire the new mapping; clearing one
  group leaves the others bound; five refresh passes do not accumulate
  registrations; a released id routes nowhere.
- `SessionSelectionPlannerTests` — preferred path beats newest beats current,
  including the branch `NavigateSessionsAsync` actually takes when retention
  cleanup deleted the selected file; paths match however they are spelled;
  navigation stops at both ends rather than wrapping.
- `WaveformSampleBufferTests` — wrap-around reads forward in time; a partly
  filled first window sits behind silence; only the bytes the device actually
  filled are read (NAudio reuses its buffer, so reading past `BytesRecorded`
  replays old audio); levels ignore the zero-padded lead; writes and snapshots
  run concurrently.
- `AudioPlayerSpeedTests` — double speed produces half the audio, half speed
  twice, both to ±5%; a change reaches a chain already running; a change does
  not rewind; the speed survives to the next file.

## Behaviour

Effectively unchanged, but not *literally* unchanged — three deltas exist, and
all three are unreachable from any current call site:

1. `Register` now throws `ArgumentNullException` on a null callback. Before, the
   null was stored and surfaced as a `NullReferenceException` inside the
   WM_HOTKEY pump the first time the user pressed the chord. No caller passes
   null.
2. `RefreshSessions` with a preferred path that matches nothing in a non-empty
   list now raises `SelectedSessionChanged` once instead of twice — the old code
   assigned the property to `null` and then to the fallback. The only subscriber
   re-reads current state, so this is one fewer redundant dispatch.
3. The registration log line in `%TEMP%\Mutation.Hotkey.log` gained `group=`.

Two dead branches went with the extraction. The duplicate re-check after
`RegisterHotKey` failed was unreachable — the identical check at the top of the
method already returned — and had it ever fired it was *wrong*, returning
success without storing the callback, which would have bound the chord with
Windows and dispatched it to nothing. The `Math.Max(1, samplesToProcess)`
divisor was likewise unreachable behind an earlier guard.

Two things are pinned by test as-is rather than endorsed, both filed as
follow-ups: a selection that has left the list survives a refresh (#303), and
`Previous` with nothing selected goes nowhere.

No user-visible string, default, hotkey, control label, beep, or announcement
changed, so the user guide is untouched.

## Review

Three independent reviews, each in a fresh context: behaviour preservation,
test quality, and project conventions.

The correctness pass found no defects. The test pass found real ones, fixed in
`ef8799f`: two of the three ratio tests passed against a *completely dead*
playback chain (`InRange(0, 0, 0)` holds — no baseline guard); the 0.4–0.6 band
admitted 1.75×, 2.25× and 2.5×, so a regression snapping 2.0 to a neighbour
would have passed; one test was a strictly weaker duplicate of the one above
it; one claimed "must not restart" when its byte count is identical either way;
one promised the speed carries to the next file and never played one. It also
verified the concurrency test is real, by replacing the locks with `if (true)`
and watching it fail 5/5.

## Not in this slice

`PromptLibraryController` and `SettingsSearchHelper` need a different kind of
seam — their logic is expressed in terms of a live `ListView` and
`VisualTreeHelper`, not merely reached through one. Filed with the rest of the
remaining coverage as #304, and the duplication the review surfaced as #306.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
