### PR TITLE
Let a slow microphone take its time without taking the window with it

### DIFF
--- a/Documentation/UserGuide/html/microphone.html
+++ b/Documentation/UserGuide/html/microphone.html
@@ -195,6 +195,19 @@ dictation, and the one the level meter and the level controls apply to.</p>
 <p>This choice does not affect muting. Muting always covers every microphone,
 whichever one is selected. Your choice is remembered the next time you start
 Mutation.</p>
+<p>Some microphones take a moment to hand over — a USB mic that has just been plugged
+in, or a Bluetooth headset waking up. Mutation waits for it in the background, so
+the window stays usable and you keep your place in the dropdown while it works. If
+you change your mind and pick another microphone before the first one is ready, the
+last one you pick is the one you end up on.</p>
+<p>If the switch does not work, Mutation tells you rather than leave you with a
+microphone that quietly hears nothing:</p>
+<ul>
+<li>&quot;... is no longer available. Choose another microphone.&quot; means the mic was
+unplugged between you picking it and Mutation getting to it. Pick another one.</li>
+<li>&quot;Could not switch to ...&quot;, followed by the reason, means the microphone was
+there but would not start. Try it again, or pick another one.</li>
+</ul>
 <h2 id="the-live-level-display">The live level display</h2>
 <p>Underneath the dropdown is a live picture of what your microphone is hearing: a
 waveform that moves as you speak, and a vertical bar next to it that rises and falls

--- a/Documentation/UserGuide/markdown/microphone.md
+++ b/Documentation/UserGuide/markdown/microphone.md
@@ -66,6 +66,20 @@ This choice does not affect muting. Muting always covers every microphone,
 whichever one is selected. Your choice is remembered the next time you start
 Mutation.
 
+Some microphones take a moment to hand over — a USB mic that has just been plugged
+in, or a Bluetooth headset waking up. Mutation waits for it in the background, so
+the window stays usable and you keep your place in the dropdown while it works. If
+you change your mind and pick another microphone before the first one is ready, the
+last one you pick is the one you end up on.
+
+If the switch does not work, Mutation tells you rather than leave you with a
+microphone that quietly hears nothing:
+
+- "... is no longer available. Choose another microphone." means the mic was
+  unplugged between you picking it and Mutation getting to it. Pick another one.
+- "Could not switch to ...", followed by the reason, means the microphone was
+  there but would not start. Try it again, or pick another one.
+
 ## The live level display
 
 Underneath the dropdown is a live picture of what your microphone is hearing: a

--- a/Mutation.Tests/MicrophoneSwitchCoordinatorTests.cs
+++ b/Mutation.Tests/MicrophoneSwitchCoordinatorTests.cs
@@ -1,0 +1,272 @@
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+using Mutation.Ui.Core;
+using Xunit;
+
+namespace Mutation.Tests;
+
+public class MicrophoneSwitchCoordinatorTests
+{
+	private static MicrophoneSwitchCoordinator Create(
+		Func<string, bool>? selectDevice = null,
+		Action? restartCapture = null,
+		Action? stopCapture = null,
+		Action<Exception>? onError = null) =>
+		new(
+			selectDevice ?? (_ => true),
+			restartCapture ?? (() => { }),
+			stopCapture ?? (() => { }),
+			onError);
+
+	[Fact]
+	public void Constructor_NullDelegates_Throw()
+	{
+		Assert.Throws<ArgumentNullException>(() => new MicrophoneSwitchCoordinator(null!, () => { }, () => { }));
+		Assert.Throws<ArgumentNullException>(() => new MicrophoneSwitchCoordinator(_ => true, null!, () => { }));
+		Assert.Throws<ArgumentNullException>(() => new MicrophoneSwitchCoordinator(_ => true, () => { }, null!));
+	}
+
+	[Theory]
+	[InlineData("")]
+	[InlineData(null)]
+	public void SwitchAsync_WithoutADeviceId_Throws(string? deviceId)
+	{
+		var coordinator = Create();
+
+		// Thrown synchronously, not handed back on a faulted task: a caller with no
+		// device ID has a bug, not a device problem.
+		Assert.Throws<ArgumentException>(() => { _ = coordinator.SwitchAsync(deviceId!); });
+	}
+
+	[Fact]
+	public async Task SwitchAsync_SelectsTheDeviceThenRestartsCapture()
+	{
+		var steps = new ConcurrentQueue<string>();
+		var coordinator = Create(
+			selectDevice: id => { steps.Enqueue($"select:{id}"); return true; },
+			restartCapture: () => steps.Enqueue("restart"));
+
+		var result = await coordinator.SwitchAsync("mic-a");
+
+		Assert.Equal(MicrophoneSwitchOutcome.Switched, result!.Value.Outcome);
+		Assert.True(result.Value.Switched);
+		Assert.Null(result.Value.FailureMessage);
+		Assert.Equal(new[] { "select:mic-a", "restart" }, steps);
+		Assert.False(coordinator.IsSwitching);
+	}
+
+	[Fact]
+	public async Task SwitchAsync_RunsTheDeviceWorkOffTheCallingThread()
+	{
+		// The delegate signals when it starts and then blocks. If the switch ran
+		// synchronously on this thread, SwitchAsync would block inside the delegate and
+		// never hand back a task — so simply reaching the asserts below, with "started"
+		// already signalled, proves the work runs on another thread. That is the whole
+		// point of the type: a wedged device must not be able to freeze the window.
+		var started = new ManualResetEventSlim(false);
+		var release = new ManualResetEventSlim(false);
+		var coordinator = Create(selectDevice: _ =>
+		{
+			started.Set();
+			release.Wait();
+			return true;
+		});
+
+		var pending = coordinator.SwitchAsync("mic-a");
+
+		Assert.True(started.Wait(TimeSpan.FromSeconds(5)), "the switch did not start on a background thread");
+		Assert.False(pending.IsCompleted);
+		Assert.True(coordinator.IsSwitching);
+
+		release.Set();
+
+		Assert.Equal(MicrophoneSwitchOutcome.Switched, (await pending)!.Value.Outcome);
+	}
+
+	[Fact]
+	public async Task SwitchAsync_DeviceGone_ReportsUnavailableAndLeavesCaptureAlone()
+	{
+		int restarts = 0;
+		var coordinator = Create(
+			selectDevice: _ => false,
+			restartCapture: () => Interlocked.Increment(ref restarts));
+
+		var result = await coordinator.SwitchAsync("mic-gone");
+
+		Assert.Equal(MicrophoneSwitchOutcome.Unavailable, result!.Value.Outcome);
+		Assert.False(result.Value.Switched);
+		Assert.Equal(0, restarts);
+	}
+
+	[Fact]
+	public async Task SwitchAsync_DeviceFaults_ReportsTheFailureAndHandsTheExceptionToTheLogger()
+	{
+		Exception? logged = null;
+		var coordinator = Create(
+			selectDevice: _ => throw new InvalidOperationException("driver is wedged"),
+			onError: ex => logged = ex);
+
+		var result = await coordinator.SwitchAsync("mic-a");
+
+		Assert.Equal(MicrophoneSwitchOutcome.Failed, result!.Value.Outcome);
+		Assert.Equal("driver is wedged", result.Value.FailureMessage);
+		Assert.IsType<InvalidOperationException>(logged);
+	}
+
+	[Fact]
+	public async Task SwitchAsync_CaptureRestartFaults_ReportsTheFailure()
+	{
+		var coordinator = Create(restartCapture: () => throw new InvalidOperationException("waveInOpen failed"));
+
+		var result = await coordinator.SwitchAsync("mic-a");
+
+		Assert.Equal(MicrophoneSwitchOutcome.Failed, result!.Value.Outcome);
+		Assert.Equal("waveInOpen failed", result.Value.FailureMessage);
+	}
+
+	[Fact]
+	public async Task SwitchAsync_AThrowingErrorReporterStillLetsTheOutcomeThrough()
+	{
+		var coordinator = Create(
+			selectDevice: _ => throw new InvalidOperationException("driver is wedged"),
+			onError: _ => throw new InvalidOperationException("the log is also broken"));
+
+		var result = await coordinator.SwitchAsync("mic-a");
+
+		Assert.Equal(MicrophoneSwitchOutcome.Failed, result!.Value.Outcome);
+	}
+
+	[Fact]
+	public async Task SwitchAsync_QueuedRequestIsSupersededByANewerOne()
+	{
+		var started = new ManualResetEventSlim(false);
+		var release = new ManualResetEventSlim(false);
+		var selected = new ConcurrentQueue<string>();
+		var coordinator = Create(selectDevice: id =>
+		{
+			selected.Enqueue(id);
+			// Only the first switch blocks; the rest run straight through.
+			if (id == "mic-a")
+			{
+				started.Set();
+				release.Wait();
+			}
+			return true;
+		});
+
+		var first = coordinator.SwitchAsync("mic-a");
+		Assert.True(started.Wait(TimeSpan.FromSeconds(5)), "the first switch did not start");
+
+		// Both queue behind the running first one, so the middle request never reaches
+		// the device at all — the user's final choice is the only one applied.
+		var second = coordinator.SwitchAsync("mic-b");
+		var third = coordinator.SwitchAsync("mic-c");
+
+		Assert.Null(await second);
+
+		release.Set();
+
+		// The first switch had already started, so it did touch the device — but a
+		// newer choice landed while it ran, so it reports nothing rather than letting
+		// the UI settle its controls on a device the user has moved on from.
+		Assert.Null(await first);
+		Assert.Equal(MicrophoneSwitchOutcome.Switched, (await third)!.Value.Outcome);
+		Assert.Equal(new[] { "mic-a", "mic-c" }, selected);
+		Assert.False(coordinator.IsSwitching);
+	}
+
+	[Fact]
+	public async Task SwitchAsync_LastRequestOfABurstIsTheOneApplied()
+	{
+		var started = new ManualResetEventSlim(false);
+		var release = new ManualResetEventSlim(false);
+		string? lastSelected = null;
+		var coordinator = Create(selectDevice: id =>
+		{
+			if (id == "mic-a")
+			{
+				started.Set();
+				release.Wait();
+			}
+			lastSelected = id;
+			return true;
+		});
+
+		var first = coordinator.SwitchAsync("mic-a");
+		Assert.True(started.Wait(TimeSpan.FromSeconds(5)), "the first switch did not start");
+
+		for (int i = 0; i < 5; i++)
+			_ = coordinator.SwitchAsync($"mic-{i}");
+		var last = coordinator.SwitchAsync("mic-final");
+
+		release.Set();
+		await first;
+
+		Assert.Equal(MicrophoneSwitchOutcome.Switched, (await last)!.Value.Outcome);
+		Assert.Equal("mic-final", lastSelected);
+	}
+
+	[Fact]
+	public async Task ReleaseAsync_StopsCaptureWithoutSelectingADevice()
+	{
+		int selects = 0;
+		int stops = 0;
+		var coordinator = Create(
+			selectDevice: _ => { Interlocked.Increment(ref selects); return true; },
+			stopCapture: () => Interlocked.Increment(ref stops));
+
+		var result = await coordinator.ReleaseAsync();
+
+		Assert.Equal(MicrophoneSwitchOutcome.Switched, result!.Value.Outcome);
+		Assert.Equal(0, selects);
+		Assert.Equal(1, stops);
+	}
+
+	[Fact]
+	public async Task ReleaseAsync_AndSwitchAsync_ShareOneWorkerSoTheyCannotOvertakeEachOther()
+	{
+		var started = new ManualResetEventSlim(false);
+		var release = new ManualResetEventSlim(false);
+		var steps = new ConcurrentQueue<string>();
+		var coordinator = Create(
+			selectDevice: id =>
+			{
+				steps.Enqueue($"select:{id}");
+				if (id == "mic-a")
+				{
+					started.Set();
+					release.Wait();
+				}
+				return true;
+			},
+			restartCapture: () => steps.Enqueue("restart"),
+			stopCapture: () => steps.Enqueue("stop"));
+
+		var first = coordinator.SwitchAsync("mic-a");
+		Assert.True(started.Wait(TimeSpan.FromSeconds(5)), "the first switch did not start");
+
+		var stop = coordinator.ReleaseAsync();
+
+		release.Set();
+		await first;
+		await stop;
+
+		Assert.Equal(new[] { "select:mic-a", "restart", "stop" }, steps);
+	}
+
+	[Fact]
+	public async Task SwitchAsync_AfterThePreviousOneSettles_RunsAgain()
+	{
+		var selected = new ConcurrentQueue<string>();
+		var coordinator = Create(selectDevice: id => { selected.Enqueue(id); return true; });
+
+		var first = await coordinator.SwitchAsync("mic-a");
+		var second = await coordinator.SwitchAsync("mic-b");
+
+		Assert.Equal(MicrophoneSwitchOutcome.Switched, first!.Value.Outcome);
+		Assert.Equal(MicrophoneSwitchOutcome.Switched, second!.Value.Outcome);
+		Assert.Equal(new[] { "mic-a", "mic-b" }, selected);
+	}
+}

--- a/Mutation.Tests/MicrophoneSwitchCoordinatorTests.cs
+++ b/Mutation.Tests/MicrophoneSwitchCoordinatorTests.cs
@@ -54,7 +54,9 @@ public class MicrophoneSwitchCoordinatorTests
 		Assert.True(result.Value.Switched);
 		Assert.Null(result.Value.FailureMessage);
 		Assert.Equal(new[] { "select:mic-a", "restart" }, steps);
-		Assert.False(coordinator.IsSwitching);
+		// The awaiter is completed just before the worker records that it has gone
+		// idle, so this settles a moment later rather than in lockstep.
+		AssertEventually(() => !coordinator.IsSwitching, "the worker did not settle");
 	}
 
 	[Fact]
@@ -174,7 +176,7 @@ public class MicrophoneSwitchCoordinatorTests
 		Assert.Null(await first);
 		Assert.Equal(MicrophoneSwitchOutcome.Switched, (await third)!.Value.Outcome);
 		Assert.Equal(new[] { "mic-a", "mic-c" }, selected);
-		Assert.False(coordinator.IsSwitching);
+		AssertEventually(() => !coordinator.IsSwitching, "the worker did not settle");
 	}
 
 	[Fact]
@@ -268,5 +270,21 @@ public class MicrophoneSwitchCoordinatorTests
 		Assert.Equal(MicrophoneSwitchOutcome.Switched, first!.Value.Outcome);
 		Assert.Equal(MicrophoneSwitchOutcome.Switched, second!.Value.Outcome);
 		Assert.Equal(new[] { "mic-a", "mic-b" }, selected);
+	}
+
+	// The worker completes an awaiter before it records that it has gone idle, so a
+	// resumed test can observe IsSwitching either way for an instant. Polled rather
+	// than asserted outright, so a loaded machine cannot turn that into a failure.
+	private static void AssertEventually(Func<bool> condition, string message)
+	{
+		var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+		while (DateTime.UtcNow < deadline)
+		{
+			if (condition())
+				return;
+			Thread.Sleep(10);
+		}
+
+		Assert.True(condition(), message);
 	}
 }

--- a/Mutation.Tests/MicrophoneSwitchCoordinatorTests.cs
+++ b/Mutation.Tests/MicrophoneSwitchCoordinatorTests.cs
@@ -227,6 +227,78 @@ public class MicrophoneSwitchCoordinatorTests
 	}
 
 	[Fact]
+	public async Task RestartCaptureAsync_ReopensCaptureWithoutTouchingTheSelection()
+	{
+		int selects = 0;
+		int stops = 0;
+		int restarts = 0;
+		var coordinator = Create(
+			selectDevice: _ => { Interlocked.Increment(ref selects); return true; },
+			restartCapture: () => Interlocked.Increment(ref restarts),
+			stopCapture: () => Interlocked.Increment(ref stops));
+
+		var result = await coordinator.RestartCaptureAsync();
+
+		Assert.Equal(MicrophoneSwitchOutcome.Switched, result!.Value.Outcome);
+		Assert.Equal(1, restarts);
+		Assert.Equal(0, selects);
+		Assert.Equal(0, stops);
+	}
+
+	[Fact]
+	public async Task RestartCaptureAsync_AfterAFailedSwitch_PutsCaptureBackOnTheLiveDevice()
+	{
+		// The recovery the UI runs when a switch does not take: Apply never reaches
+		// the capture restart on an Unavailable or Failed switch, which at startup
+		// leaves nothing capturing at all.
+		var steps = new ConcurrentQueue<string>();
+		var coordinator = Create(
+			selectDevice: id => { steps.Enqueue($"select:{id}"); return false; },
+			restartCapture: () => steps.Enqueue("restart"));
+
+		var failed = await coordinator.SwitchAsync("mic-gone");
+		var recovery = await coordinator.RestartCaptureAsync();
+
+		Assert.Equal(MicrophoneSwitchOutcome.Unavailable, failed!.Value.Outcome);
+		Assert.Equal(MicrophoneSwitchOutcome.Switched, recovery!.Value.Outcome);
+		Assert.Equal(new[] { "select:mic-gone", "restart" }, steps);
+	}
+
+	[Fact]
+	public async Task RestartCaptureAsync_IsSupersededByANewerSwitchLikeAnyOtherRequest()
+	{
+		var started = new ManualResetEventSlim(false);
+		var release = new ManualResetEventSlim(false);
+		var steps = new ConcurrentQueue<string>();
+		var coordinator = Create(
+			selectDevice: id =>
+			{
+				steps.Enqueue($"select:{id}");
+				if (id == "mic-a")
+				{
+					started.Set();
+					release.Wait();
+				}
+				return true;
+			},
+			restartCapture: () => steps.Enqueue("restart"));
+
+		var first = coordinator.SwitchAsync("mic-a");
+		Assert.True(started.Wait(TimeSpan.FromSeconds(5)), "the first switch did not start");
+
+		var recovery = coordinator.RestartCaptureAsync();
+		var newer = coordinator.SwitchAsync("mic-b");
+
+		Assert.Null(await recovery);
+
+		release.Set();
+		await first;
+
+		Assert.Equal(MicrophoneSwitchOutcome.Switched, (await newer)!.Value.Outcome);
+		Assert.Equal(new[] { "select:mic-a", "restart", "select:mic-b", "restart" }, steps);
+	}
+
+	[Fact]
 	public async Task ReleaseAsync_AndSwitchAsync_ShareOneWorkerSoTheyCannotOvertakeEachOther()
 	{
 		var started = new ManualResetEventSlim(false);

--- a/Mutation.Ui/Core/AudioDeviceManager.cs
+++ b/Mutation.Ui/Core/AudioDeviceManager.cs
@@ -17,9 +17,11 @@ namespace Mutation.Ui;
 ///
 /// <c>_sync</c> guards the device fields and is only ever held for a field read or
 /// swap — never across a COM call. The UI thread takes it (the CaptureDeviceInfos,
-/// SelectedMicrophone and MicrophoneDeviceIndex properties, SelectMicrophoneById,
-/// GetEndpoint), so anything that can block on hardware must stay outside it or the
-/// window and the screen reader freeze with it.
+/// SelectedMicrophone and MicrophoneDeviceIndex properties, GetEndpoint), so anything
+/// that can block on hardware must stay outside it or the window and the screen reader
+/// freeze with it. SelectMicrophoneById runs on MicrophoneSwitchCoordinator's worker
+/// (issue #267) and obeys the same rule, because the properties it races are still
+/// read from the UI thread.
 ///
 /// <c>_comGate</c> serializes the operations that actually talk to the devices — the
 /// mute toggle, the level-endpoint refresh, and the hot-plug re-sync — so two of them

--- a/Mutation.Ui/Core/MicrophoneSwitchCoordinator.cs
+++ b/Mutation.Ui/Core/MicrophoneSwitchCoordinator.cs
@@ -140,10 +140,36 @@ public sealed class MicrophoneSwitchCoordinator
 		return mine.Task;
 	}
 
+	// Nothing should escape DrainLoop — Apply catches every device fault. This is the
+	// backstop for the one failure mode that would be permanent: a worker that dies
+	// with _workerRunning still set is a coordinator that never starts another one, so
+	// every microphone switch for the rest of the session would hang unreported.
+	private void Drain()
+	{
+		try
+		{
+			DrainLoop();
+		}
+		catch (Exception ex)
+		{
+			TaskCompletionSource<MicrophoneSwitchResult?>? orphan;
+			lock (_gate)
+			{
+				_workerRunning = false;
+				orphan = _pendingCompletion;
+				_pendingDeviceId = null;
+				_pendingCompletion = null;
+			}
+
+			orphan?.TrySetResult(null);
+			ReportError(ex);
+		}
+	}
+
 	// Applies queued requests one at a time until none remain. Only the request
 	// currently held in _pendingCompletion is applied each pass, so a burst collapses
 	// to its most recent entry.
-	private void Drain()
+	private void DrainLoop()
 	{
 		while (true)
 		{

--- a/Mutation.Ui/Core/MicrophoneSwitchCoordinator.cs
+++ b/Mutation.Ui/Core/MicrophoneSwitchCoordinator.cs
@@ -251,14 +251,21 @@ public sealed class MicrophoneSwitchCoordinator
 					_restartCapture();
 					break;
 
-				default:
+				case RequestKind.Switch:
 					// The device may have been unplugged between the click and this
 					// call; the selection is left where it was and the caller says so.
+					// Never null here — SwitchAsync is the only way to reach this kind
+					// and it rejects an empty ID.
 					if (!_selectDevice(deviceId!))
 						return new MicrophoneSwitchResult(MicrophoneSwitchOutcome.Unavailable);
 
 					_restartCapture();
 					break;
+
+				default:
+					// A kind added later must land here rather than quietly taking the
+					// switch branch and dereferencing a device ID it does not carry.
+					throw new NotSupportedException($"Unhandled microphone request kind: {kind}.");
 			}
 
 			return new MicrophoneSwitchResult(MicrophoneSwitchOutcome.Switched);

--- a/Mutation.Ui/Core/MicrophoneSwitchCoordinator.cs
+++ b/Mutation.Ui/Core/MicrophoneSwitchCoordinator.cs
@@ -1,0 +1,224 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Mutation.Ui.Core;
+
+/// <summary>
+/// Runs a microphone switch — resolving the chosen device and pointing waveform
+/// capture at it — on a single background worker, so neither half ever runs on the
+/// UI thread.
+///
+/// <para>
+/// Both halves block on the audio driver stack. Resolving the device walks the
+/// winmm device table (<c>waveInGetNumDevs</c> / <c>waveInGetDevCaps</c> for every
+/// device), and restarting capture is <c>waveInStop</c>/<c>waveInReset</c>/
+/// <c>waveInClose</c> followed by <c>waveInOpen</c>/<c>waveInStart</c>. On a USB
+/// device mid-reconnect, a Bluetooth headset, or a device whose driver is wedged,
+/// either can take seconds — and on the UI thread that is the window and the screen
+/// reader frozen with it (issue #267).
+/// </para>
+///
+/// <para>
+/// Requests coalesce to the latest, and the latest also wins the reporting. A
+/// request still queued when a newer one arrives is dropped, and a request that was
+/// already running when a newer one arrived reports <c>null</c> rather than its own
+/// outcome — the newer switch owns the settings, the capture, and the level controls
+/// by then, so acting on the older result would leave the UI describing a device the
+/// user has moved on from.
+/// </para>
+///
+/// <para>
+/// A wedged device still blocks this worker; nothing can cancel a winmm call already
+/// inside the driver. What it cannot do any more is block the window. The user keeps
+/// their focus and their selection in the microphone combo throughout, and hears the
+/// outcome when it arrives.
+/// </para>
+///
+/// The device work is injected as delegates, keeping this coordinator unit-testable
+/// without audio hardware or a UI.
+/// </summary>
+public sealed class MicrophoneSwitchCoordinator
+{
+	private readonly Func<string, bool> _selectDevice;
+	private readonly Action _restartCapture;
+	private readonly Action _stopCapture;
+	private readonly Action<Exception>? _onError;
+	private readonly object _gate = new();
+
+	// The request most recently made but not yet picked up, and the awaiter tied to
+	// it. A null ID means "no device — release capture". Both are cleared the moment
+	// the worker picks the request up. Guarded by _gate.
+	private string? _pendingDeviceId;
+	private TaskCompletionSource<MicrophoneSwitchResult?>? _pendingCompletion;
+
+	// True while the drain worker is alive (a switch is in flight or a request is
+	// queued). Guarded by _gate.
+	private bool _workerRunning;
+
+	/// <param name="selectDevice">Selects the device with the given endpoint ID,
+	/// returning false when no such device exists any more.</param>
+	/// <param name="restartCapture">Points waveform capture at the newly-selected
+	/// device.</param>
+	/// <param name="stopCapture">Releases waveform capture, for when there is no
+	/// device to switch to.</param>
+	/// <param name="onError">Called with the fault behind a
+	/// <see cref="MicrophoneSwitchOutcome.Failed"/> result, so it can be logged.
+	/// Without it the exception is only ever seen as the message in the result.</param>
+	public MicrophoneSwitchCoordinator(
+		Func<string, bool> selectDevice,
+		Action restartCapture,
+		Action stopCapture,
+		Action<Exception>? onError = null)
+	{
+		_selectDevice = selectDevice ?? throw new ArgumentNullException(nameof(selectDevice));
+		_restartCapture = restartCapture ?? throw new ArgumentNullException(nameof(restartCapture));
+		_stopCapture = stopCapture ?? throw new ArgumentNullException(nameof(stopCapture));
+		_onError = onError;
+	}
+
+	/// <summary>
+	/// True while a switch started by this coordinator is in flight or a newer
+	/// request is queued behind it.
+	/// </summary>
+	public bool IsSwitching
+	{
+		get { lock (_gate) return _workerRunning; }
+	}
+
+	/// <summary>
+	/// Requests a switch to the device with the given endpoint ID. The returned task
+	/// completes with the outcome when this request is the one the user ends up on,
+	/// or with <c>null</c> when a newer request superseded it. The continuation
+	/// resumes on the caller's synchronization context (the UI thread when awaited
+	/// from a UI event), so the caller can report the outcome directly.
+	/// </summary>
+	public Task<MicrophoneSwitchResult?> SwitchAsync(string deviceId)
+	{
+		if (string.IsNullOrEmpty(deviceId))
+			throw new ArgumentException("A device ID is required.", nameof(deviceId));
+
+		return EnqueueAsync(deviceId);
+	}
+
+	/// <summary>
+	/// Requests that capture be released, for when the selection has become no device
+	/// at all. Queued on the same worker as the switches, so it cannot overtake or be
+	/// overtaken by one, and closing the capture handle — a winmm call like any other
+	/// — stays off the UI thread.
+	/// </summary>
+	public Task<MicrophoneSwitchResult?> ReleaseAsync() => EnqueueAsync(null);
+
+	private Task<MicrophoneSwitchResult?> EnqueueAsync(string? deviceId)
+	{
+		TaskCompletionSource<MicrophoneSwitchResult?>? superseded;
+		var mine = new TaskCompletionSource<MicrophoneSwitchResult?>(
+			TaskCreationOptions.RunContinuationsAsynchronously);
+		bool startWorker = false;
+
+		lock (_gate)
+		{
+			// Any request still queued (not yet started) is now stale — this newer one
+			// replaces it.
+			superseded = _pendingCompletion;
+			_pendingDeviceId = deviceId;
+			_pendingCompletion = mine;
+
+			if (!_workerRunning)
+			{
+				_workerRunning = true;
+				startWorker = true;
+			}
+		}
+
+		// A dropped request completes with null. Done outside the lock so a
+		// continuation cannot run while it is held.
+		superseded?.TrySetResult(null);
+
+		if (startWorker)
+			_ = Task.Run(Drain);
+
+		return mine.Task;
+	}
+
+	// Applies queued requests one at a time until none remain. Only the request
+	// currently held in _pendingCompletion is applied each pass, so a burst collapses
+	// to its most recent entry.
+	private void Drain()
+	{
+		while (true)
+		{
+			string? deviceId;
+			TaskCompletionSource<MicrophoneSwitchResult?> completion;
+
+			lock (_gate)
+			{
+				if (_pendingCompletion is null)
+				{
+					_workerRunning = false;
+					return;
+				}
+
+				deviceId = _pendingDeviceId;
+				completion = _pendingCompletion;
+				_pendingDeviceId = null;
+				_pendingCompletion = null;
+			}
+
+			MicrophoneSwitchResult result = Apply(deviceId);
+
+			// A newer request arrived while this one was running. It is about to
+			// re-point the device and will report its own outcome, so this one reports
+			// nothing: acting on it would save the wrong device name, re-probe the
+			// level controls against a device that is already being replaced, or show a
+			// failure for a choice the user has moved on from.
+			bool superseded;
+			lock (_gate)
+			{
+				superseded = _pendingCompletion is not null;
+			}
+
+			completion.TrySetResult(superseded ? null : result);
+		}
+	}
+
+	private MicrophoneSwitchResult Apply(string? deviceId)
+	{
+		try
+		{
+			if (deviceId is null)
+			{
+				_stopCapture();
+				return new MicrophoneSwitchResult(MicrophoneSwitchOutcome.Switched);
+			}
+
+			// The device may have been unplugged between the click and this call; the
+			// selection is left where it was and the caller says so.
+			if (!_selectDevice(deviceId))
+				return new MicrophoneSwitchResult(MicrophoneSwitchOutcome.Unavailable);
+
+			_restartCapture();
+			return new MicrophoneSwitchResult(MicrophoneSwitchOutcome.Switched);
+		}
+		catch (Exception ex)
+		{
+			ReportError(ex);
+			return new MicrophoneSwitchResult(MicrophoneSwitchOutcome.Failed, ex.Message);
+		}
+	}
+
+	private void ReportError(Exception exception)
+	{
+		if (_onError is null)
+			return;
+
+		try
+		{
+			_onError(exception);
+		}
+		catch
+		{
+			// A failing reporter must not take the worker with it — the switch's own
+			// outcome still has to reach the caller.
+		}
+	}
+}

--- a/Mutation.Ui/Core/MicrophoneSwitchCoordinator.cs
+++ b/Mutation.Ui/Core/MicrophoneSwitchCoordinator.cs
@@ -45,9 +45,25 @@ public sealed class MicrophoneSwitchCoordinator
 	private readonly Action<Exception>? _onError;
 	private readonly object _gate = new();
 
+	// What a queued request asks the worker to do.
+	private enum RequestKind
+	{
+		// Select the requested device, then point capture at it.
+		Switch,
+
+		// Re-open capture on whatever device is already selected, without touching
+		// the selection. For recovering capture that a failed switch left with
+		// nothing running.
+		Restart,
+
+		// Release capture; there is no device to record from.
+		Release,
+	}
+
 	// The request most recently made but not yet picked up, and the awaiter tied to
-	// it. A null ID means "no device — release capture". Both are cleared the moment
-	// the worker picks the request up. Guarded by _gate.
+	// it. All three are cleared the moment the worker picks the request up. Guarded
+	// by _gate.
+	private RequestKind _pendingKind;
 	private string? _pendingDeviceId;
 	private TaskCompletionSource<MicrophoneSwitchResult?>? _pendingCompletion;
 
@@ -97,8 +113,19 @@ public sealed class MicrophoneSwitchCoordinator
 		if (string.IsNullOrEmpty(deviceId))
 			throw new ArgumentException("A device ID is required.", nameof(deviceId));
 
-		return EnqueueAsync(deviceId);
+		return EnqueueAsync(RequestKind.Switch, deviceId);
 	}
+
+	/// <summary>
+	/// Requests that capture be re-opened on the device that is already selected,
+	/// without changing the selection. A switch that reports
+	/// <see cref="MicrophoneSwitchOutcome.Unavailable"/> or
+	/// <see cref="MicrophoneSwitchOutcome.Failed"/> never reaches its capture restart,
+	/// which at app startup means nothing is capturing at all; this puts the waveform
+	/// and the level meter back on the device that is actually live rather than
+	/// leaving them dead for the session.
+	/// </summary>
+	public Task<MicrophoneSwitchResult?> RestartCaptureAsync() => EnqueueAsync(RequestKind.Restart, null);
 
 	/// <summary>
 	/// Requests that capture be released, for when the selection has become no device
@@ -106,9 +133,9 @@ public sealed class MicrophoneSwitchCoordinator
 	/// overtaken by one, and closing the capture handle — a winmm call like any other
 	/// — stays off the UI thread.
 	/// </summary>
-	public Task<MicrophoneSwitchResult?> ReleaseAsync() => EnqueueAsync(null);
+	public Task<MicrophoneSwitchResult?> ReleaseAsync() => EnqueueAsync(RequestKind.Release, null);
 
-	private Task<MicrophoneSwitchResult?> EnqueueAsync(string? deviceId)
+	private Task<MicrophoneSwitchResult?> EnqueueAsync(RequestKind kind, string? deviceId)
 	{
 		TaskCompletionSource<MicrophoneSwitchResult?>? superseded;
 		var mine = new TaskCompletionSource<MicrophoneSwitchResult?>(
@@ -120,6 +147,7 @@ public sealed class MicrophoneSwitchCoordinator
 			// Any request still queued (not yet started) is now stale — this newer one
 			// replaces it.
 			superseded = _pendingCompletion;
+			_pendingKind = kind;
 			_pendingDeviceId = deviceId;
 			_pendingCompletion = mine;
 
@@ -173,6 +201,7 @@ public sealed class MicrophoneSwitchCoordinator
 	{
 		while (true)
 		{
+			RequestKind kind;
 			string? deviceId;
 			TaskCompletionSource<MicrophoneSwitchResult?> completion;
 
@@ -184,13 +213,14 @@ public sealed class MicrophoneSwitchCoordinator
 					return;
 				}
 
+				kind = _pendingKind;
 				deviceId = _pendingDeviceId;
 				completion = _pendingCompletion;
 				_pendingDeviceId = null;
 				_pendingCompletion = null;
 			}
 
-			MicrophoneSwitchResult result = Apply(deviceId);
+			MicrophoneSwitchResult result = Apply(kind, deviceId);
 
 			// A newer request arrived while this one was running. It is about to
 			// re-point the device and will report its own outcome, so this one reports
@@ -207,22 +237,30 @@ public sealed class MicrophoneSwitchCoordinator
 		}
 	}
 
-	private MicrophoneSwitchResult Apply(string? deviceId)
+	private MicrophoneSwitchResult Apply(RequestKind kind, string? deviceId)
 	{
 		try
 		{
-			if (deviceId is null)
+			switch (kind)
 			{
-				_stopCapture();
-				return new MicrophoneSwitchResult(MicrophoneSwitchOutcome.Switched);
+				case RequestKind.Release:
+					_stopCapture();
+					break;
+
+				case RequestKind.Restart:
+					_restartCapture();
+					break;
+
+				default:
+					// The device may have been unplugged between the click and this
+					// call; the selection is left where it was and the caller says so.
+					if (!_selectDevice(deviceId!))
+						return new MicrophoneSwitchResult(MicrophoneSwitchOutcome.Unavailable);
+
+					_restartCapture();
+					break;
 			}
 
-			// The device may have been unplugged between the click and this call; the
-			// selection is left where it was and the caller says so.
-			if (!_selectDevice(deviceId))
-				return new MicrophoneSwitchResult(MicrophoneSwitchOutcome.Unavailable);
-
-			_restartCapture();
 			return new MicrophoneSwitchResult(MicrophoneSwitchOutcome.Switched);
 		}
 		catch (Exception ex)

--- a/Mutation.Ui/Core/MicrophoneSwitchResult.cs
+++ b/Mutation.Ui/Core/MicrophoneSwitchResult.cs
@@ -1,0 +1,33 @@
+namespace Mutation.Ui.Core;
+
+/// <summary>
+/// What happened when a microphone switch was applied.
+/// </summary>
+public enum MicrophoneSwitchOutcome
+{
+	/// <summary>The device was selected and capture was pointed at it.</summary>
+	Switched,
+
+	/// <summary>The device is no longer in the current enumeration — unplugged between the click and the switch.</summary>
+	Unavailable,
+
+	/// <summary>The device faulted while it was being selected or opened.</summary>
+	Failed,
+}
+
+/// <summary>
+/// Outcome of one microphone switch, together with the message to show when it
+/// did not succeed. The message is carried here rather than composed by the
+/// coordinator's caller from an exception it never saw, so the UI can report a
+/// device fault without the switch having to run on the UI thread to throw there.
+/// </summary>
+/// <param name="Outcome">Which of the three ways the switch ended.</param>
+/// <param name="FailureMessage">The device fault's message, set only for
+/// <see cref="MicrophoneSwitchOutcome.Failed"/>.</param>
+public readonly record struct MicrophoneSwitchResult(
+	MicrophoneSwitchOutcome Outcome,
+	string? FailureMessage = null)
+{
+	/// <summary>True when capture is now running on the requested device.</summary>
+	public bool Switched => Outcome == MicrophoneSwitchOutcome.Switched;
+}

--- a/Mutation.Ui/MainWindow.xaml.cs
+++ b/Mutation.Ui/MainWindow.xaml.cs
@@ -102,6 +102,13 @@ public sealed partial class MainWindow : Window, IDisposable
 	// Set while the microphone combo is being rebuilt programmatically, so the
 	// selection handler does not treat the resulting event as a user choice.
 	private bool _suppressMicrophoneSelection;
+	// Runs microphone switches — resolving the device over winmm and restarting
+	// waveform capture — on a background worker, so a device that is slow to respond
+	// cannot freeze the window and the screen reader with it (issue #267). Also the
+	// ordering authority: the latest selection supersedes any older one, in flight or
+	// queued, so the level controls can never end up describing a different device
+	// than the one the user chose.
+	private readonly Mutation.Ui.Core.MicrophoneSwitchCoordinator _microphoneSwitch;
 	// Set as soon as the window starts closing, so async continuations that resume
 	// afterwards do not touch torn-down controls.
 	private bool _isClosing;
@@ -206,6 +213,14 @@ public sealed partial class MainWindow : Window, IDisposable
             ShowStatus);
         _microphoneVisualization.Initialize();
         SyncMicWaveToggleState();
+
+        // Built before anything can select a microphone — restoring the persisted
+        // choice below raises SelectionChanged, and that handler goes through here.
+        _microphoneSwitch = new Mutation.Ui.Core.MicrophoneSwitchCoordinator(
+            _audioDeviceManager.SelectMicrophoneById,
+            _microphoneVisualization.RestartCapture,
+            _microphoneVisualization.StopCapture,
+            ex => ErrorLogger.LogError("Selecting the microphone failed", ex));
 
         _audioSessionManager.RefreshSessions();
                 UpdatePlaybackButtonVisuals("Play selected session", PlayGlyph);
@@ -663,7 +678,10 @@ public sealed partial class MainWindow : Window, IDisposable
 				break;
 
 			default:
-				_microphoneVisualization?.StopCapture();
+				// Queued on the switch worker rather than closed here: it is the same
+				// winmm teardown, and going through the worker also orders it against a
+				// switch that may still be in flight.
+				_ = _microphoneSwitch.ReleaseAsync();
 				ShowStatus("Microphone", "No microphones are available.", InfoBarSeverity.Warning);
 				break;
 		}
@@ -2620,7 +2638,17 @@ public sealed partial class MainWindow : Window, IDisposable
             StatusAnnouncement.ActivityId);
     }
 
-	private void CmbMicrophone_SelectionChanged(object sender, SelectionChangedEventArgs e)
+	// The user picked a different microphone. Everything on this path that can block
+	// on the device — resolving it over winmm, and closing and reopening the capture
+	// handle — runs on the switch coordinator's background worker, so a USB device
+	// mid-reconnect, a Bluetooth headset, or a wedged driver can no longer freeze the
+	// window and the screen reader with it (issue #267).
+	//
+	// Nothing here disables or reassigns the combo, so a screen-reader user keeps
+	// their focus and their selection for the whole switch, however long it takes;
+	// what they get is the outcome, announced through the status bar, rather than a
+	// dead window and then silently dead capture.
+	private async void CmbMicrophone_SelectionChanged(object sender, SelectionChangedEventArgs e)
 	{
 		// A programmatic rebuild of the list re-raises this; it is not a user choice.
 		if (_suppressMicrophoneSelection)
@@ -2628,7 +2656,10 @@ public sealed partial class MainWindow : Window, IDisposable
 
 		if (CmbMicrophone.SelectedItem is not Mutation.Ui.Core.CaptureDeviceInfo device)
 		{
-			_microphoneVisualization?.StopCapture();
+			// Releasing the handle is a winmm call like any other, so it goes through
+			// the same worker — and queueing it there is also what keeps it ordered
+			// against a switch that may still be in flight.
+			_ = _microphoneSwitch.ReleaseAsync();
 			return;
 		}
 
@@ -2640,39 +2671,55 @@ public sealed partial class MainWindow : Window, IDisposable
 		if (string.Equals(device.Id, _audioDeviceManager.SelectedMicrophone?.Id, StringComparison.OrdinalIgnoreCase))
 			return;
 
-		try
+		// Selected by ID: the manager re-resolves the live device out of its current
+		// enumeration, so a list entry that predates a hot-plug cannot become the
+		// selection (issue #264).
+		//
+		// A null result means a newer selection superseded this one. That switch owns
+		// the settings, the capture, and the level controls now, so this one reports
+		// nothing — otherwise the controls would end up describing a device the user
+		// has already moved on from.
+		if (await _microphoneSwitch.SwitchAsync(device.Id) is not Mutation.Ui.Core.MicrophoneSwitchResult result)
+			return;
+
+		// The window closed while the device was being opened; its controls are torn
+		// down and there is nobody left to tell.
+		if (_isClosing)
+			return;
+
+		switch (result.Outcome)
 		{
-			// Selected by ID: the manager re-resolves the live device out of its current
-			// enumeration, so a list entry that predates a hot-plug cannot become the
-			// selection (issue #264).
-			if (!_audioDeviceManager.SelectMicrophoneById(device.Id))
-			{
+			case Mutation.Ui.Core.MicrophoneSwitchOutcome.Switched:
+				if (_settings.AudioSettings != null)
+				{
+					_settings.AudioSettings.ActiveCaptureDeviceFullName = device.FriendlyName;
+					// Debounced rather than written inline: the save serializes the whole
+					// settings object and atomically replaces the file plus its .bak, and
+					// that disk I/O has no business on the UI thread. Nothing is at risk
+					// of being lost — the close handler saves _settings unconditionally.
+					_settingsSaveDebouncer.Trigger();
+				}
+
+				// Re-sync the level controls to the newly-selected device (support and
+				// current level may differ) and re-assert the pinned level on it.
+				if (_micLevelInitialized)
+					InitializeMicrophoneLevelControls();
+				break;
+
+			case Mutation.Ui.Core.MicrophoneSwitchOutcome.Unavailable:
 				ShowStatus("Microphone",
 					$"{device.FriendlyName} is no longer available. Choose another microphone.",
 					InfoBarSeverity.Warning);
-				return;
-			}
+				break;
 
-			if (_settings.AudioSettings != null)
-			{
-				_settings.AudioSettings.ActiveCaptureDeviceFullName = device.FriendlyName;
-				_settingsManager.SaveSettingsToFile(_settings);
-			}
-			_microphoneVisualization?.RestartCapture();
-
-			// Re-sync the level controls to the newly-selected device (support and
-			// current level may differ) and re-assert the pinned level on it.
-			if (_micLevelInitialized)
-				InitializeMicrophoneLevelControls();
-		}
-		catch (Exception ex)
-		{
-			// A device fault must reach the user as a status message; escaping here
-			// would take down an unguarded UI event handler.
-			ErrorLogger.LogError("Selecting the microphone failed", ex);
-			ShowStatus("Microphone",
-				$"Could not switch to {device.FriendlyName}: {ex.Message}",
-				InfoBarSeverity.Error);
+			default:
+				// A device fault must reach the user as a status message: capture is
+				// dead, and without this they would be left dictating into nothing. The
+				// coordinator has already logged the exception behind the message.
+				ShowStatus("Microphone",
+					$"Could not switch to {device.FriendlyName}: {result.FailureMessage}",
+					InfoBarSeverity.Error);
+				break;
 		}
 	}
 

--- a/Mutation.Ui/MainWindow.xaml.cs
+++ b/Mutation.Ui/MainWindow.xaml.cs
@@ -116,6 +116,13 @@ public sealed partial class MainWindow : Window, IDisposable
 	// silently skipped — leaving the combo and the live device permanently disagreeing.
 	// UI thread only.
 	private string? _requestedMicrophoneId;
+	// Set when the constructor skips its inline capture start because restoring the
+	// persisted microphone queued a switch. If that switch then fails, nothing is
+	// capturing at all and the waveform would stay dead for the session — unlike a
+	// mid-session failure, which leaves the previous device's capture running
+	// untouched and must not be disturbed. Cleared by the first switch that lands.
+	// UI thread only.
+	private bool _startupCapturePending;
 	// Set as soon as the window starts closing, so async continuations that resume
 	// afterwards do not touch torn-down controls.
 	private bool _isClosing;
@@ -265,6 +272,8 @@ public sealed partial class MainWindow : Window, IDisposable
 		// wait for, and this is what gets the waveform going.
 		if (_requestedMicrophoneId is null)
 			_microphoneVisualization.StartCapture();
+		else
+			_startupCapturePending = true;
 
 		CmbSpeechService.ItemsSource = _speechServices;
 		CmbSpeechService.DisplayMemberPath = nameof(ISpeechToTextService.ServiceName);
@@ -2733,6 +2742,10 @@ public sealed partial class MainWindow : Window, IDisposable
 		switch (result.Outcome)
 		{
 			case Mutation.Ui.Core.MicrophoneSwitchOutcome.Switched:
+				// This switch opened capture, so there is no longer a startup start
+				// waiting to be made good.
+				_startupCapturePending = false;
+
 				// Re-sync the level controls to the newly-selected device (support and
 				// current level may differ) and re-assert the pinned level on it.
 				if (_micLevelInitialized)
@@ -2763,21 +2776,22 @@ public sealed partial class MainWindow : Window, IDisposable
 		_requestedMicrophoneId ?? _audioDeviceManager.SelectedMicrophone?.Id;
 
 	// Undoes what a switch that did not take left behind. The manager is still on the
-	// previous device, so everything the UI thread wrote ahead of the attempt has to
-	// follow it back:
-	//
-	// - The requested ID, or the next pick would be compared against a microphone
-	//   that is not the one being recorded from.
-	// - The persisted name, or one transient device fault destroys the last choice
-	//   that worked and every later launch starts on the microphone that failed.
-	//
-	// Capture is re-opened on the device that is live, because a failed switch never
-	// reaches its own capture restart — and at startup the inline start is skipped in
-	// favour of the switch, so without this the waveform and the level meter would
-	// stay dead for the whole session.
+	// previous device, so what the UI thread wrote ahead of the attempt has to follow
+	// it back: the requested ID, or the next pick would be compared against a
+	// microphone that is not the one being recorded from, and the persisted name, or
+	// one transient device fault destroys the last choice that worked and every later
+	// launch starts on the microphone that failed.
 	//
 	// Skipped entirely if the user has already asked for something else in the
-	// meantime: that request is the one that owns this state now.
+	// meantime: that request is the one that owns this state now, and because all of
+	// this is UI-thread-serial it has already written both fields itself.
+	//
+	// Does not cover a window closed mid-switch. PersistClosingState runs as the close
+	// sequence's first step, so by the time a failure lands there is nothing left to
+	// roll back into — the optimistic name is already on disk. That costs one startup
+	// on the device that failed, which then rolls back for real. The alternative,
+	// writing the name only on success, loses the choice every time a *successful*
+	// switch is still running at close, and that is the common case.
 	private void RollBackFailedMicrophoneSwitch(Mutation.Ui.Core.CaptureDeviceInfo attempted)
 	{
 		if (!string.Equals(_requestedMicrophoneId, attempted.Id, StringComparison.OrdinalIgnoreCase))
@@ -2786,13 +2800,27 @@ public sealed partial class MainWindow : Window, IDisposable
 		var live = _audioDeviceManager.SelectedMicrophone;
 		_requestedMicrophoneId = live?.Id;
 
-		if (_settings.AudioSettings != null)
+		// Only over a name worth having. With no live device there is nothing better
+		// to record, and blanking the setting would erase the user's choice for good —
+		// the next launch would silently adopt whatever device sorts first, every
+		// time. Keeping the name they last picked at least gets them back onto it when
+		// the device returns.
+		if (_settings.AudioSettings != null && !string.IsNullOrWhiteSpace(live?.FriendlyName))
 		{
-			_settings.AudioSettings.ActiveCaptureDeviceFullName = live?.FriendlyName;
+			_settings.AudioSettings.ActiveCaptureDeviceFullName = live.FriendlyName;
 			_settingsSaveDebouncer.Trigger();
 		}
 
-		_ = _microphoneSwitch.RestartCaptureAsync();
+		// Capture is only re-opened when the startup start was skipped in favour of
+		// this switch, so nothing is running at all. A mid-session failure is left
+		// alone on purpose: the switch never reached its own capture restart, which
+		// means the previous device is still open and streaming, and cycling
+		// waveInClose/waveInOpen on a healthy handle to recover from someone else's
+		// failure is how a user with working capture ends up with none. A live device
+		// is required too — without one the restart could only report "device not
+		// resolved", talking over the message that actually tells them what to do.
+		if (_startupCapturePending && live is not null)
+			_ = _microphoneSwitch.RestartCaptureAsync();
 	}
 
 	private void MicWaveToggle_Click(object sender, RoutedEventArgs e)

--- a/Mutation.Ui/MainWindow.xaml.cs
+++ b/Mutation.Ui/MainWindow.xaml.cs
@@ -2820,7 +2820,17 @@ public sealed partial class MainWindow : Window, IDisposable
 		// is required too — without one the restart could only report "device not
 		// resolved", talking over the message that actually tells them what to do.
 		if (_startupCapturePending && live is not null)
+		{
+			// Cleared as the recovery is queued, not when it lands: the flag's job is
+			// to make this happen once, and a request that is queued to open capture
+			// has done that job. Leaving it set would re-arm the restart on the next
+			// failed switch, and that one would be cycling a handle this one opened —
+			// the healthy-capture teardown this guard exists to prevent, reached the
+			// long way round. A recovery that fails reports itself through
+			// StartCapture; it does not get retried by a later, unrelated failure.
+			_startupCapturePending = false;
 			_ = _microphoneSwitch.RestartCaptureAsync();
+		}
 	}
 
 	private void MicWaveToggle_Click(object sender, RoutedEventArgs e)

--- a/Mutation.Ui/MainWindow.xaml.cs
+++ b/Mutation.Ui/MainWindow.xaml.cs
@@ -109,6 +109,18 @@ public sealed partial class MainWindow : Window, IDisposable
 	// queued, so the level controls can never end up describing a different device
 	// than the one the user chose.
 	private readonly Mutation.Ui.Core.MicrophoneSwitchCoordinator _microphoneSwitch;
+	// The microphone the user has most recently asked for, which is not the same as
+	// the one the device manager has settled on: the switch is applied on a background
+	// worker and lags. Comparing a new selection against the manager's would let the
+	// user pick B, change their mind back to the still-current-looking A, and be
+	// silently skipped — leaving the combo and the live device permanently disagreeing.
+	// UI thread only.
+	private string? _requestedMicrophoneId;
+	// The most recent switch request, or a completed task when none has been made.
+	// Awaited before a recording starts so the recorder is handed the device the user
+	// chose rather than the one they moved away from — a hotkey press no longer waits
+	// behind a frozen UI thread, so it can now arrive mid-switch. UI thread only.
+	private Task _microphoneSwitchSettled = Task.CompletedTask;
 	// Set as soon as the window starts closing, so async continuations that resume
 	// afterwards do not touch torn-down controls.
 	private bool _isClosing;
@@ -249,7 +261,15 @@ public sealed partial class MainWindow : Window, IDisposable
 
 		RestorePersistedMicrophoneSelection(micList);
 		_audioDeviceManager.CaptureDeviceListChanged += AudioDeviceManager_CaptureDeviceListChanged;
-		_microphoneVisualization.StartCapture();
+
+		// Skipped when restoring the persisted choice queued a switch: that switch
+		// starts capture on the device the user actually chose, and opening one here
+		// first would briefly run the OS default instead — an activity light on a
+		// microphone they are not using, and an error message naming it if it will not
+		// open. When the persisted choice is already the default there is no switch to
+		// wait for, and this is what gets the waveform going.
+		if (_requestedMicrophoneId is null)
+			_microphoneVisualization.StartCapture();
 
 		CmbSpeechService.ItemsSource = _speechServices;
 		CmbSpeechService.DisplayMemberPath = nameof(ISpeechToTextService.ServiceName);
@@ -681,7 +701,8 @@ public sealed partial class MainWindow : Window, IDisposable
 				// Queued on the switch worker rather than closed here: it is the same
 				// winmm teardown, and going through the worker also orders it against a
 				// switch that may still be in flight.
-				_ = _microphoneSwitch.ReleaseAsync();
+				_requestedMicrophoneId = null;
+				_microphoneSwitchSettled = _microphoneSwitch.ReleaseAsync();
 				ShowStatus("Microphone", "No microphones are available.", InfoBarSeverity.Warning);
 				break;
 		}
@@ -1276,6 +1297,17 @@ public sealed partial class MainWindow : Window, IDisposable
 				return;
             }
             
+            // A microphone switch may still be opening the device the user just picked;
+            // the recorder is about to be handed the device index, and that index does
+            // not move until the switch lands. Before this ran off the UI thread a
+            // hotkey press could not arrive mid-switch at all — the frozen message pump
+            // held it back — so waiting here restores what the freeze used to
+            // guarantee: you record from the microphone you chose, not the one you
+            // moved away from. Only on the way in; a stop must never be held up by a
+            // device that is slow to open.
+            if (!_audioSessionManager.IsRecording)
+                await _microphoneSwitchSettled;
+
             LlmSettings.LlmPrompt? autoRunPrompt = _promptLibrary?.GetAutoRunPrompt();
             await _audioSessionManager.StartStopRecordingAsync(_activeSpeechService, useLlmProcessing, GetActivePrompt(), autoRunPrompt, _shutdownCts.Token);
 		}
@@ -2659,7 +2691,8 @@ public sealed partial class MainWindow : Window, IDisposable
 			// Releasing the handle is a winmm call like any other, so it goes through
 			// the same worker — and queueing it there is also what keeps it ordered
 			// against a switch that may still be in flight.
-			_ = _microphoneSwitch.ReleaseAsync();
+			_requestedMicrophoneId = null;
+			_microphoneSwitchSettled = _microphoneSwitch.ReleaseAsync();
 			return;
 		}
 
@@ -2668,8 +2701,32 @@ public sealed partial class MainWindow : Window, IDisposable
 		// the pipeline for the device already selected would save settings, drop and
 		// reopen capture, and re-probe the level controls — an audible glitch and a
 		// screen-reader interruption for a selection that did not change.
-		if (string.Equals(device.Id, _audioDeviceManager.SelectedMicrophone?.Id, StringComparison.OrdinalIgnoreCase))
+		//
+		// Compared against what was last *asked for*, not what the device manager has
+		// settled on: the switch runs on a worker and the manager lags behind it, so
+		// asking the manager would skip a genuine change of mind — pick B, go back to
+		// A while B is still opening, and A looks like the current device — and leave
+		// the combo naming one microphone while another is live.
+		if (string.Equals(device.Id, RequestedOrSelectedMicrophoneId(), StringComparison.OrdinalIgnoreCase))
 			return;
+
+		_requestedMicrophoneId = device.Id;
+
+		if (_settings.AudioSettings != null)
+		{
+			// Written into the settings object before the switch is attempted, not
+			// after it succeeds: closing the window mid-switch runs PersistClosingState
+			// first, and an assignment left to the continuation would never make it
+			// into that save. A name that turns out to belong to an unavailable device
+			// costs nothing — the next startup does not find it in the list and falls
+			// back to whatever the device manager settled on.
+			//
+			// The file write itself is debounced. The save serializes the whole
+			// settings object and atomically replaces the file plus its .bak, and that
+			// disk I/O has no business on the UI thread.
+			_settings.AudioSettings.ActiveCaptureDeviceFullName = device.FriendlyName;
+			_settingsSaveDebouncer.Trigger();
+		}
 
 		// Selected by ID: the manager re-resolves the live device out of its current
 		// enumeration, so a list entry that predates a hot-plug cannot become the
@@ -2679,7 +2736,9 @@ public sealed partial class MainWindow : Window, IDisposable
 		// the settings, the capture, and the level controls now, so this one reports
 		// nothing — otherwise the controls would end up describing a device the user
 		// has already moved on from.
-		if (await _microphoneSwitch.SwitchAsync(device.Id) is not Mutation.Ui.Core.MicrophoneSwitchResult result)
+		var pending = _microphoneSwitch.SwitchAsync(device.Id);
+		_microphoneSwitchSettled = pending;
+		if (await pending is not Mutation.Ui.Core.MicrophoneSwitchResult result)
 			return;
 
 		// The window closed while the device was being opened; its controls are torn
@@ -2687,19 +2746,16 @@ public sealed partial class MainWindow : Window, IDisposable
 		if (_isClosing)
 			return;
 
+		// A switch that did not take leaves the manager on the previous device, so the
+		// request that failed must not go on standing in for the live selection — the
+		// next pick has to be compared against what is actually being recorded from.
+		// Skipped if the user has already asked for something else in the meantime.
+		if (!result.Switched && string.Equals(_requestedMicrophoneId, device.Id, StringComparison.OrdinalIgnoreCase))
+			_requestedMicrophoneId = _audioDeviceManager.SelectedMicrophone?.Id;
+
 		switch (result.Outcome)
 		{
 			case Mutation.Ui.Core.MicrophoneSwitchOutcome.Switched:
-				if (_settings.AudioSettings != null)
-				{
-					_settings.AudioSettings.ActiveCaptureDeviceFullName = device.FriendlyName;
-					// Debounced rather than written inline: the save serializes the whole
-					// settings object and atomically replaces the file plus its .bak, and
-					// that disk I/O has no business on the UI thread. Nothing is at risk
-					// of being lost — the close handler saves _settings unconditionally.
-					_settingsSaveDebouncer.Trigger();
-				}
-
 				// Re-sync the level controls to the newly-selected device (support and
 				// current level may differ) and re-assert the pinned level on it.
 				if (_micLevelInitialized)
@@ -2722,6 +2778,12 @@ public sealed partial class MainWindow : Window, IDisposable
 				break;
 		}
 	}
+
+	// The microphone the selection path is currently working towards. Falls back to
+	// the device manager's own selection when nothing has been asked for yet — at
+	// startup, before the persisted choice is restored.
+	private string? RequestedOrSelectedMicrophoneId() =>
+		_requestedMicrophoneId ?? _audioDeviceManager.SelectedMicrophone?.Id;
 
 	private void MicWaveToggle_Click(object sender, RoutedEventArgs e)
 	{

--- a/Mutation.Ui/MainWindow.xaml.cs
+++ b/Mutation.Ui/MainWindow.xaml.cs
@@ -116,11 +116,6 @@ public sealed partial class MainWindow : Window, IDisposable
 	// silently skipped — leaving the combo and the live device permanently disagreeing.
 	// UI thread only.
 	private string? _requestedMicrophoneId;
-	// The most recent switch request, or a completed task when none has been made.
-	// Awaited before a recording starts so the recorder is handed the device the user
-	// chose rather than the one they moved away from — a hotkey press no longer waits
-	// behind a frozen UI thread, so it can now arrive mid-switch. UI thread only.
-	private Task _microphoneSwitchSettled = Task.CompletedTask;
 	// Set as soon as the window starts closing, so async continuations that resume
 	// afterwards do not touch torn-down controls.
 	private bool _isClosing;
@@ -702,7 +697,7 @@ public sealed partial class MainWindow : Window, IDisposable
 				// winmm teardown, and going through the worker also orders it against a
 				// switch that may still be in flight.
 				_requestedMicrophoneId = null;
-				_microphoneSwitchSettled = _microphoneSwitch.ReleaseAsync();
+				_ = _microphoneSwitch.ReleaseAsync();
 				ShowStatus("Microphone", "No microphones are available.", InfoBarSeverity.Warning);
 				break;
 		}
@@ -1297,17 +1292,6 @@ public sealed partial class MainWindow : Window, IDisposable
 				return;
             }
             
-            // A microphone switch may still be opening the device the user just picked;
-            // the recorder is about to be handed the device index, and that index does
-            // not move until the switch lands. Before this ran off the UI thread a
-            // hotkey press could not arrive mid-switch at all — the frozen message pump
-            // held it back — so waiting here restores what the freeze used to
-            // guarantee: you record from the microphone you chose, not the one you
-            // moved away from. Only on the way in; a stop must never be held up by a
-            // device that is slow to open.
-            if (!_audioSessionManager.IsRecording)
-                await _microphoneSwitchSettled;
-
             LlmSettings.LlmPrompt? autoRunPrompt = _promptLibrary?.GetAutoRunPrompt();
             await _audioSessionManager.StartStopRecordingAsync(_activeSpeechService, useLlmProcessing, GetActivePrompt(), autoRunPrompt, _shutdownCts.Token);
 		}
@@ -2692,7 +2676,7 @@ public sealed partial class MainWindow : Window, IDisposable
 			// the same worker — and queueing it there is also what keeps it ordered
 			// against a switch that may still be in flight.
 			_requestedMicrophoneId = null;
-			_microphoneSwitchSettled = _microphoneSwitch.ReleaseAsync();
+			_ = _microphoneSwitch.ReleaseAsync();
 			return;
 		}
 
@@ -2717,9 +2701,8 @@ public sealed partial class MainWindow : Window, IDisposable
 			// Written into the settings object before the switch is attempted, not
 			// after it succeeds: closing the window mid-switch runs PersistClosingState
 			// first, and an assignment left to the continuation would never make it
-			// into that save. A name that turns out to belong to an unavailable device
-			// costs nothing — the next startup does not find it in the list and falls
-			// back to whatever the device manager settled on.
+			// into that save. A switch that then fails puts the previous name back
+			// below, so an optimistic write cannot outlive the attempt.
 			//
 			// The file write itself is debounced. The save serializes the whole
 			// settings object and atomically replaces the file plus its .bak, and that
@@ -2736,9 +2719,7 @@ public sealed partial class MainWindow : Window, IDisposable
 		// the settings, the capture, and the level controls now, so this one reports
 		// nothing — otherwise the controls would end up describing a device the user
 		// has already moved on from.
-		var pending = _microphoneSwitch.SwitchAsync(device.Id);
-		_microphoneSwitchSettled = pending;
-		if (await pending is not Mutation.Ui.Core.MicrophoneSwitchResult result)
+		if (await _microphoneSwitch.SwitchAsync(device.Id) is not Mutation.Ui.Core.MicrophoneSwitchResult result)
 			return;
 
 		// The window closed while the device was being opened; its controls are torn
@@ -2746,12 +2727,8 @@ public sealed partial class MainWindow : Window, IDisposable
 		if (_isClosing)
 			return;
 
-		// A switch that did not take leaves the manager on the previous device, so the
-		// request that failed must not go on standing in for the live selection — the
-		// next pick has to be compared against what is actually being recorded from.
-		// Skipped if the user has already asked for something else in the meantime.
-		if (!result.Switched && string.Equals(_requestedMicrophoneId, device.Id, StringComparison.OrdinalIgnoreCase))
-			_requestedMicrophoneId = _audioDeviceManager.SelectedMicrophone?.Id;
+		if (!result.Switched)
+			RollBackFailedMicrophoneSwitch(device);
 
 		switch (result.Outcome)
 		{
@@ -2784,6 +2761,39 @@ public sealed partial class MainWindow : Window, IDisposable
 	// startup, before the persisted choice is restored.
 	private string? RequestedOrSelectedMicrophoneId() =>
 		_requestedMicrophoneId ?? _audioDeviceManager.SelectedMicrophone?.Id;
+
+	// Undoes what a switch that did not take left behind. The manager is still on the
+	// previous device, so everything the UI thread wrote ahead of the attempt has to
+	// follow it back:
+	//
+	// - The requested ID, or the next pick would be compared against a microphone
+	//   that is not the one being recorded from.
+	// - The persisted name, or one transient device fault destroys the last choice
+	//   that worked and every later launch starts on the microphone that failed.
+	//
+	// Capture is re-opened on the device that is live, because a failed switch never
+	// reaches its own capture restart — and at startup the inline start is skipped in
+	// favour of the switch, so without this the waveform and the level meter would
+	// stay dead for the whole session.
+	//
+	// Skipped entirely if the user has already asked for something else in the
+	// meantime: that request is the one that owns this state now.
+	private void RollBackFailedMicrophoneSwitch(Mutation.Ui.Core.CaptureDeviceInfo attempted)
+	{
+		if (!string.Equals(_requestedMicrophoneId, attempted.Id, StringComparison.OrdinalIgnoreCase))
+			return;
+
+		var live = _audioDeviceManager.SelectedMicrophone;
+		_requestedMicrophoneId = live?.Id;
+
+		if (_settings.AudioSettings != null)
+		{
+			_settings.AudioSettings.ActiveCaptureDeviceFullName = live?.FriendlyName;
+			_settingsSaveDebouncer.Trigger();
+		}
+
+		_ = _microphoneSwitch.RestartCaptureAsync();
+	}
 
 	private void MicWaveToggle_Click(object sender, RoutedEventArgs e)
 	{

--- a/Mutation.Ui/Services/MicrophoneVisualizationController.cs
+++ b/Mutation.Ui/Services/MicrophoneVisualizationController.cs
@@ -32,7 +32,27 @@ internal sealed class MicrophoneVisualizationController : IDisposable
 
 	private readonly WaveformRenderGate _waveformRenderGate = new();
 	private readonly SingleTimerSlot<DispatcherQueueTimer> _waveformTimer;
+
+	// Guards the capture handle and the epoch that decides which start owns it.
+	// Capture transitions now arrive from two directions — the UI thread (startup,
+	// the visualization toggle, window close) and the background switch worker
+	// (issue #267) — so the handle can no longer be a plain field. Held for field
+	// access only, never across a device call: a background start blocked on a
+	// wedged waveInOpen must not be able to stall a UI-thread caller that takes it.
+	private readonly object _captureSync = new();
 	private WaveInEvent? _waveformCapture;
+	// Bumped by every start and stop. A start that finds its epoch superseded while
+	// it was opening the device closes the handle it just opened rather than
+	// publishing it — otherwise a switch that lands after a stop leaves a capture
+	// running that nothing owns, and the microphone stays live with no way to
+	// release it.
+	private int _captureEpoch;
+	// Set by Dispose, cleared by Initialize. Separate from the epoch because Dispose
+	// also tears down _samples: a start that read _samples just before Dispose ran
+	// would otherwise claim a *newer* epoch and publish a handle into a controller
+	// that has already been shut down.
+	private bool _captureDisposed;
+
 	private Signal? _waveformSignal;
 
 	// Null until Initialize() runs, and again after Dispose() — the capture callback and the
@@ -88,6 +108,11 @@ internal sealed class MicrophoneVisualizationController : IDisposable
 
 	public void Initialize()
 	{
+		// Re-opens the controller after a Dispose that was really an "off" switch
+		// (ApplyEnabledStateFromSettings), so capture can be published again.
+		lock (_captureSync)
+			_captureDisposed = false;
+
 		_samples = new WaveformSampleBuffer(WaveformWindowSampleCount);
 
 		var plot = _waveformPlot.Plot;
@@ -106,12 +131,34 @@ internal sealed class MicrophoneVisualizationController : IDisposable
 		_waveformTimer.Restart();
 	}
 
+	/// <summary>
+	/// Opens capture on the currently-selected device. Safe to call from the
+	/// background switch worker as well as the UI thread: everything it touches is
+	/// either thread-safe on its own (the sample ring, the render gate) or published
+	/// under <c>_captureSync</c>, and the status messages it raises are marshalled
+	/// back to the UI thread.
+	/// </summary>
 	public void StartCapture()
 	{
 		if (_samples is null)
 			return;
 
-		StopCapture();
+		int epoch;
+		WaveInEvent? superseded;
+		lock (_captureSync)
+		{
+			if (_captureDisposed)
+				return;
+
+			epoch = ++_captureEpoch;
+			superseded = _waveformCapture;
+			_waveformCapture = null;
+		}
+
+		// Outside the lock: closing a handle is a winmm call into the driver and is
+		// exactly the kind of work that must never be held over a lock the UI thread
+		// can take.
+		CloseCapture(superseded);
 
 		_samples.Reset();
 
@@ -126,24 +173,39 @@ internal sealed class MicrophoneVisualizationController : IDisposable
 			return;
 		}
 
+		WaveInEvent? capture = null;
 		try
 		{
-			_waveformCapture = new WaveInEvent
+			capture = new WaveInEvent
 			{
 				DeviceNumber = deviceIndex,
 				WaveFormat = new WaveFormat(WaveformSampleRate, 16, 1),
 				BufferMilliseconds = WaveformBufferMilliseconds
 			};
-			_waveformCapture.DataAvailable += OnWaveformDataAvailable;
-			_waveformCapture.StartRecording();
+			capture.DataAvailable += OnWaveformDataAvailable;
+			capture.StartRecording();
 		}
 		catch (Exception ex)
 		{
-			_waveformCapture?.Dispose();
-			_waveformCapture = null;
+			CloseCapture(capture);
 			_dispatcherQueue.TryEnqueue(() =>
 				_showStatus("Microphone", $"Unable to monitor audio: {ex.Message}", InfoBarSeverity.Error));
+			return;
 		}
+
+		bool stillCurrent;
+		lock (_captureSync)
+		{
+			stillCurrent = !_captureDisposed && _captureEpoch == epoch;
+			if (stillCurrent)
+				_waveformCapture = capture;
+		}
+
+		// Someone stopped, disposed, or started a newer capture while this one was
+		// opening. Release the handle here rather than leave the microphone live with
+		// nothing holding a reference to close it.
+		if (!stillCurrent)
+			CloseCapture(capture);
 	}
 
 	public void RestartCapture()
@@ -152,23 +214,53 @@ internal sealed class MicrophoneVisualizationController : IDisposable
 		StartCapture();
 	}
 
+	/// <summary>
+	/// Releases capture. Callable from either thread; see <see cref="StartCapture"/>.
+	/// </summary>
 	public void StopCapture()
 	{
-		if (_waveformCapture is null)
+		WaveInEvent? capture;
+		lock (_captureSync)
+		{
+			// Bumped even when there is no handle to close: a start that is mid-
+			// waveInOpen right now has to learn that its result is no longer wanted.
+			_captureEpoch++;
+			capture = _waveformCapture;
+			_waveformCapture = null;
+		}
+
+		CloseCapture(capture);
+	}
+
+	// Shuts a capture handle down and releases it, treating any failure as nothing to
+	// act on — the handle is being abandoned either way, and a throw from the teardown
+	// of the device being replaced must not be reported as a failure to switch to the
+	// new one.
+	private void CloseCapture(WaveInEvent? capture)
+	{
+		if (capture is null)
 			return;
 
 		try
 		{
-			_waveformCapture.DataAvailable -= OnWaveformDataAvailable;
-			_waveformCapture.StopRecording();
+			capture.DataAvailable -= OnWaveformDataAvailable;
+			capture.StopRecording();
 		}
 		catch
 		{
 			// Ignore failures that occur while shutting down capture.
 		}
 
-		_waveformCapture.Dispose();
-		_waveformCapture = null;
+		// Disposed even when stopping threw, so a device that faults on the way down
+		// does not leak its handle.
+		try
+		{
+			capture.Dispose();
+		}
+		catch
+		{
+			// Ignore failures that occur while shutting down capture.
+		}
 	}
 
 	// Sets the visualization to a specific on/off state, persists it, and applies it.
@@ -209,6 +301,12 @@ internal sealed class MicrophoneVisualizationController : IDisposable
 
 	public void Dispose()
 	{
+		// Set before the stop, so a start already running on the switch worker cannot
+		// slip a freshly-opened handle past the epoch check and leave the microphone
+		// live after the window has closed.
+		lock (_captureSync)
+			_captureDisposed = true;
+
 		StopCapture();
 
 		_waveformTimer.Stop();

--- a/Mutation.Ui/Services/MicrophoneVisualizationController.cs
+++ b/Mutation.Ui/Services/MicrophoneVisualizationController.cs
@@ -140,7 +140,14 @@ internal sealed class MicrophoneVisualizationController : IDisposable
 	/// </summary>
 	public void StartCapture()
 	{
-		if (_samples is null)
+		// Taken once into a local rather than re-read further down: this method blocks
+		// on the device in between, and a Dispose on the UI thread nulls the field
+		// while it does. Re-reading it would throw, and the switch coordinator would
+		// dress that up as "could not switch to this microphone" — a failure message
+		// about a device that was fine, for a visualization the user had just switched
+		// off.
+		var samples = _samples;
+		if (samples is null)
 			return;
 
 		int epoch;
@@ -160,7 +167,7 @@ internal sealed class MicrophoneVisualizationController : IDisposable
 		// can take.
 		CloseCapture(superseded);
 
-		_samples.Reset();
+		samples.Reset();
 
 		// Render the reset-to-flat state once even before the first samples arrive.
 		_waveformRenderGate.MarkDataArrived();
@@ -382,7 +389,11 @@ internal sealed class MicrophoneVisualizationController : IDisposable
 
 	private void OnWaveformDataAvailable(object? sender, WaveInEventArgs e)
 	{
-		if (_samples is null || _samples.Write(e.Buffer, e.BytesRecorded) == 0)
+		// One read into a local, for the same reason as StartCapture: this runs on the
+		// capture device's own thread, and Dispose can null the field between a
+		// null-check and a use of it.
+		var samples = _samples;
+		if (samples is null || samples.Write(e.Buffer, e.BytesRecorded) == 0)
 			return;
 
 		// New samples are in the ring buffer — let the next render tick draw them.


### PR DESCRIPTION
Closes #267.

## The problem

Picking a different microphone ran three blocking things inline on the UI thread in
`CmbMicrophone_SelectionChanged`:

1. `SelectMicrophoneById` → `ResolveNAudioDeviceIndex` → `WaveIn.DeviceCount` and
   `WaveInEvent.GetCapabilities(i)` for every device — `winmm.dll` P/Invokes into the
   audio driver stack.
2. `SaveSettingsToFile` — a full serialize plus atomic replace and `.bak` write.
3. `RestartCapture` — `waveInStop`/`waveInReset`/`waveInClose` then
   `waveInOpen`/`waveInStart`, the most device-dependent call on the path.

On a USB device mid-reconnect, a Bluetooth headset, or a device whose driver is
wedged, the window and the screen reader froze with it. #266 moved the *level probe*
off this path; these three were left.

## What changed

**`MicrophoneSwitchCoordinator`** (new, `Mutation.Ui/Core/`) runs the device work on a
single background worker, in the same shape as `MicrophoneMuteToggleCoordinator` and
`MicrophoneLevelWriteCoordinator` beside it. Three request kinds — switch to a device,
re-open capture on the one already selected, release capture — all queued on the same
worker so none can overtake another. The device work is injected as delegates, so it is
unit-testable without audio hardware or a UI.

Ordering, which #266 established and this had to preserve:

- A request still **queued** when a newer one arrives is dropped and completes `null`.
- A request already **running** when a newer one arrives also completes `null` — it did
  touch the device, but the newer switch owns the settings, the capture, and the level
  controls by then.
- The "already selected" guard compares against the device the UI thread last **asked
  for**, not the one the manager has settled on. The manager now lags the user, and
  comparing against it would silently drop a change of mind — pick B, go back to A
  while B is still opening, and A looks current — leaving the combo naming one
  microphone while another was live, persisted that way, across restarts.

The settings write goes through the existing `_settingsSaveDebouncer`, and the device
name is written *before* the switch is attempted: closing the window mid-switch runs
`PersistClosingState` first, so an assignment left to the continuation would never
reach that save. A switch that then fails rolls the name, the requested ID, and capture
back to the device that is actually live, so one transient fault cannot destroy the
last choice that worked.

**`MicrophoneVisualizationController`** — capture start and stop now arrive from two
threads for the first time, so the handle moved behind a lock held only for the field
swap, never across a device call. A `_captureEpoch` decides which start owns the
handle: a start that finds itself superseded while it was opening closes the handle it
just opened, so a switch landing after `Dispose` cannot leave the microphone live with
nothing holding a reference to release it. `_captureDisposed` covers the one case the
epoch cannot. `_samples` is taken into a local rather than re-read across the blocking
device call, and `CloseCapture` disposes even when `StopRecording` throws.

## Accessibility

Nothing on this path disables or reassigns the combo, so a screen-reader user keeps
their focus and their selection for the whole switch, however long it takes. A failure
arrives as a status message — "… is no longer available. Choose another microphone."
or "Could not switch to …: …" — rather than silently dead capture. Both messages are
unchanged from before.

## Review

Three independent reviews ran on this branch. Two found the stale-guard defect above
independently; a third verification pass found that one of the first round of fixes had
opened worse problems than it closed, and it was withdrawn (see #312). Commits 2 and 3
are those fix rounds and are worth reading separately.

## Not in scope — filed instead

- #308 — `EnsureDefaultMicrophoneSelected` still does `GetDefaultAudioEndpoint` plus the
  same winmm resolution on the UI thread from the `MainWindow` constructor. Making
  startup async ripples into the combo binding, the mute beep and the level controls.
- #312 — a recording started mid-switch is handed the previous device's index. Waiting
  for the switch was tried here and reverted: nothing disables the dictation hotkey
  while that wait is parked, so a second press started a second recording, and a wedged
  device left the hotkey permanently dead and silent. Needs a re-entrancy guard, a
  bounded wait, and audible feedback — its own story.
- #313 — replugging the only microphone leaves the waveform dead and says nothing.
  Pre-existing on `main`, not caused here.

## Tests

`MicrophoneSwitchCoordinatorTests` — 16 tests covering the off-thread guarantee, the
select-then-restart order, the unavailable and faulted outcomes, the error reporter,
queued and in-flight supersession, last-of-a-burst wins, capture recovery after a failed
switch, and release/restart/switch ordering on the shared worker.

`dotnet test --configuration Release`: **1553 passed, 0 failed, 0 warnings.**

## Documentation

`microphone.md` — "Choosing the active microphone" now says the switch happens in the
background, that the window stays usable and the dropdown keeps your place, that the
last microphone you pick is the one you land on, and what the two failure messages
mean. HTML rebuilt and committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
