### PR TITLE
Open the window before the microphones answer, and stop a dictation press landing mid-switch

### DIFF
--- a/CognitiveSupport/BeepPlayer.cs
+++ b/CognitiveSupport/BeepPlayer.cs
@@ -2,7 +2,7 @@
 
 namespace CognitiveSupport;
 
-public enum BeepType { Start, Success, Failure, End, Mute, Unmute }
+public enum BeepType { Start, Success, Failure, End, Mute, Unmute, Waiting }
 
 public static class BeepPlayer
 {
@@ -18,6 +18,12 @@ public static class BeepPlayer
 	public const int DefaultMuteDuration = 200;
 	public const int DefaultUnmuteFrequency = 1300;
 	public const int DefaultUnmuteDuration = 50;
+	// Two low, slow tones — deliberately nothing like the single bright Start beep, so a
+	// hotkey press that is waiting on the microphone cannot be mistaken for one that has
+	// opened it. Silence was the alternative, and to someone driving the app from another
+	// window by ear, silence reads as a shortcut that did not register (issue #312).
+	// Falling, where Success rises, so the two cannot be confused either.
+	public static readonly (int Frequency, int Duration)[] DefaultWaitingSequence = new[] { (440, 90), (350, 90) };
 
 	// Upper bound on how many times a beep is repeated in one PlayRepeated call. Keeps a
 	// runaway retry count from synthesizing a multi-second WAV the user has to sit through.
@@ -223,6 +229,9 @@ public static class BeepPlayer
 		BeepType.End => _playerEnd,
 		BeepType.Mute => _playerMute,
 		BeepType.Unmute => _playerUnmute,
+		// Waiting has no custom-file slot: the Settings dialog offers a file per beep the
+		// user already knew about, and a null here simply falls through to the synthesized
+		// default rather than going silent.
 		_ => null
 	};
 
@@ -258,6 +267,7 @@ public static class BeepPlayer
 		BeepType.End => new[] { (DefaultEndFrequency, DefaultEndDuration) },
 		BeepType.Mute => new[] { (DefaultMuteFrequency, DefaultMuteDuration) },
 		BeepType.Unmute => new[] { (DefaultUnmuteFrequency, DefaultUnmuteDuration) },
+		BeepType.Waiting => DefaultWaitingSequence,
 		_ => throw new ArgumentOutOfRangeException(nameof(type))
 	};
 

--- a/Documentation/UserGuide/html/dictation.html
+++ b/Documentation/UserGuide/html/dictation.html
@@ -164,6 +164,24 @@ never have to switch to Mutation first.</p>
 <p><strong>Shift+Alt+U</strong> is just the default. Every shortcut in Mutation can be changed.
 Open <strong>Settings</strong> with <strong>Ctrl+Comma</strong> and look on the <strong>Hotkeys</strong> tab.</p>
 </blockquote>
+<h2 id="when-the-microphone-is-not-ready-yet">When the microphone is not ready yet</h2>
+<p>Some microphones take a second or two to open — a Bluetooth headset, or a USB mic
+you have only just switched to. If you press the dictation shortcut in that gap,
+Mutation holds your press rather than recording from the microphone you have just
+left.</p>
+<p>You hear a low two-tone sound that falls, and you see &quot;Waiting for the microphone
+to be ready — recording will start in a moment.&quot; As soon as the microphone opens,
+the usual start beep plays and recording begins.</p>
+<p>The low falling sound is worth learning, because it is the opposite of the two-tone
+sound that rises when something has succeeded. Falling means &quot;not yet&quot;.</p>
+<p>Pressing the shortcut again while you are waiting does not start a second recording.
+Mutation just says &quot;Still waiting for the microphone.&quot;</p>
+<p>If the microphone still has not opened after eight seconds, Mutation gives up rather
+than leave you waiting: you get the failure beep and &quot;The microphone is still not
+ready, so nothing was recorded.&quot; Press the shortcut again to try once more, or pick
+a different microphone on the <strong>Microphone</strong> card.</p>
+<p>Stopping a recording never waits. Once you are recording, the microphone is already
+open, and your press to stop takes effect straight away.</p>
 <h2 id="changed-your-mind-while-it-is-transcribing">Changed your mind while it is transcribing</h2>
 <p>While Mutation is turning your recording into text, the <strong>Raw Transcript</strong> box
 reads &quot;Transcribing...&quot; and the buttons are greyed out. Press <strong>Shift+Alt+U</strong> once

--- a/Documentation/UserGuide/html/dictation.html
+++ b/Documentation/UserGuide/html/dictation.html
@@ -166,9 +166,10 @@ Open <strong>Settings</strong> with <strong>Ctrl+Comma</strong> and look on the 
 </blockquote>
 <h2 id="when-the-microphone-is-not-ready-yet">When the microphone is not ready yet</h2>
 <p>Some microphones take a second or two to open — a Bluetooth headset, or a USB mic
-you have only just switched to. If you press the dictation shortcut in that gap,
-Mutation holds your press rather than recording from the microphone you have just
-left.</p>
+you have only just switched to. The same is true in the first moment after Mutation
+starts, while it is still finding out what microphones the PC has. If you press the
+dictation shortcut in that gap, Mutation holds your press rather than recording from
+the microphone you have just left.</p>
 <p>You hear a low two-tone sound that falls, and you see &quot;Waiting for the microphone
 to be ready — recording will start in a moment.&quot; As soon as the microphone opens,
 the usual start beep plays and recording begins.</p>
@@ -176,10 +177,18 @@ the usual start beep plays and recording begins.</p>
 sound that rises when something has succeeded. Falling means &quot;not yet&quot;.</p>
 <p>Pressing the shortcut again while you are waiting does not start a second recording.
 Mutation just says &quot;Still waiting for the microphone.&quot;</p>
-<p>If the microphone still has not opened after eight seconds, Mutation gives up rather
-than leave you waiting: you get the failure beep and &quot;The microphone is still not
-ready, so nothing was recorded.&quot; Press the shortcut again to try once more, or pick
-a different microphone on the <strong>Microphone</strong> card.</p>
+<p>If the microphone still has not opened after eight seconds, Mutation stops waiting.
+What happens then depends on whether it has a working microphone to fall back on:</p>
+<ul>
+<li><strong>There is one.</strong> You get the failure beep and &quot;The microphone you chose is still
+not ready. Recording from ... instead.&quot; The recording goes ahead on the named
+microphone, so you are never left unable to dictate.</li>
+<li><strong>There is not.</strong> You get the failure beep and &quot;The microphone is still not ready,
+so nothing was recorded.&quot; Press the shortcut again to try once more.</li>
+</ul>
+<p>If that keeps happening, restart Mutation. A microphone whose driver has stopped
+answering does not let go until the app is restarted, so picking a different one in
+the dropdown will not help.</p>
 <p>Stopping a recording never waits. Once you are recording, the microphone is already
 open, and your press to stop takes effect straight away.</p>
 <h2 id="changed-your-mind-while-it-is-transcribing">Changed your mind while it is transcribing</h2>

--- a/Documentation/UserGuide/html/microphone.html
+++ b/Documentation/UserGuide/html/microphone.html
@@ -195,14 +195,7 @@ dictation, and the one the level meter and the level controls apply to.</p>
 <p>This choice does not affect muting. Muting always covers every microphone,
 whichever one is selected. Your choice is remembered the next time you start
 Mutation.</p>
-<h3 id="when-mutation-starts">When Mutation starts</h3>
-<p>Finding out which microphones a PC has can take a moment — longer if one of them is
-a USB mic that is still waking up, or a Bluetooth headset that is still connecting.
-Mutation does not hold the window shut while it asks. The window opens straight
-away, and the dropdown says &quot;Finding microphones...&quot; until the answer comes back.</p>
-<p>When it does, the dropdown fills in, your saved microphone is selected, and a
-message tells you which one you are on: &quot;Using ...&quot;. If the PC has no microphones
-at all, you get &quot;No microphones are available.&quot; instead.</p>
+<h3 id="switching-while-mutation-is-running">Switching while Mutation is running</h3>
 <p>Some microphones take a moment to hand over — a USB mic that has just been plugged
 in, or a Bluetooth headset waking up. Mutation waits for it in the background, so
 the window stays usable and you keep your place in the dropdown while it works. If
@@ -216,6 +209,18 @@ unplugged between you picking it and Mutation getting to it. Pick another one.</
 <li>&quot;Could not switch to ...&quot;, followed by the reason, means the microphone was
 there but would not start. Try it again, or pick another one.</li>
 </ul>
+<h3 id="when-mutation-starts">When Mutation starts</h3>
+<p>Finding out which microphones a PC has can take a moment — longer if one of them is
+a USB mic that is still waking up, or a Bluetooth headset that is still connecting.
+Mutation does not hold the window shut while it asks. The window opens straight
+away, and the dropdown says &quot;Finding microphones...&quot; until the answer comes back.</p>
+<p>When it does, the dropdown fills in, your saved microphone is selected, and a
+message tells you which one you are on: &quot;Using ...&quot;. If the PC has no microphones
+at all, you get &quot;No microphones are available.&quot; instead.</p>
+<p>You can use the rest of the window in the meantime. If you press the dictation
+shortcut before the microphone is ready, Mutation holds your press rather than
+losing it — see
+<a href="dictation.html">When the microphone is not ready yet</a>.</p>
 <h2 id="the-live-level-display">The live level display</h2>
 <p>Underneath the dropdown is a live picture of what your microphone is hearing: a
 waveform that moves as you speak, and a vertical bar next to it that rises and falls

--- a/Documentation/UserGuide/html/microphone.html
+++ b/Documentation/UserGuide/html/microphone.html
@@ -195,6 +195,14 @@ dictation, and the one the level meter and the level controls apply to.</p>
 <p>This choice does not affect muting. Muting always covers every microphone,
 whichever one is selected. Your choice is remembered the next time you start
 Mutation.</p>
+<h3 id="when-mutation-starts">When Mutation starts</h3>
+<p>Finding out which microphones a PC has can take a moment — longer if one of them is
+a USB mic that is still waking up, or a Bluetooth headset that is still connecting.
+Mutation does not hold the window shut while it asks. The window opens straight
+away, and the dropdown says &quot;Finding microphones...&quot; until the answer comes back.</p>
+<p>When it does, the dropdown fills in, your saved microphone is selected, and a
+message tells you which one you are on: &quot;Using ...&quot;. If the PC has no microphones
+at all, you get &quot;No microphones are available.&quot; instead.</p>
 <p>Some microphones take a moment to hand over — a USB mic that has just been plugged
 in, or a Bluetooth headset waking up. Mutation waits for it in the background, so
 the window stays usable and you keep your place in the dropdown while it works. If
@@ -247,6 +255,10 @@ audio changed, so there is nothing to interrupt you with.</li>
 microphone in the list and tells you: &quot;The selected microphone was disconnected.
 Now using ...&quot;.</li>
 <li><strong>No microphones at all</strong> — you get a message saying none are available.</li>
+<li><strong>A microphone comes back</strong> — plug it in again and Mutation picks it up, starts
+listening to it, and says &quot;Microphone connected. Now using ...&quot;. This matters most
+on a PC with only one microphone: you were told when it went away, so you are told
+when it returns.</li>
 </ul>
 <p>There is one more nicety. If you are muted and then plug in a new microphone, the
 new one comes up muted too. Connecting a headset mid-call will not quietly put you

--- a/Documentation/UserGuide/html/settings.html
+++ b/Documentation/UserGuide/html/settings.html
@@ -198,7 +198,7 @@ Leaving Advanced off simply hides that button.</p>
 </tr>
 <tr>
 <td>Beep files</td>
-<td>One file each for Success, Failure, Start, End, Mute and Unmute. <strong>Browse...</strong> picks a file, and the small play button lets you hear it.</td>
+<td>One file each for Success, Failure, Start, End, Mute and Unmute. <strong>Browse...</strong> picks a file, and the small play button lets you hear it. The low falling &quot;waiting for the microphone&quot; sound is built in and always plays as-is.</td>
 </tr>
 </tbody>
 </table>

--- a/Documentation/UserGuide/html/troubleshooting.html
+++ b/Documentation/UserGuide/html/troubleshooting.html
@@ -384,12 +384,15 @@ headset that never finishes connecting, can leave the question unanswered.</p>
 <ol>
 <li>Give it a few seconds. A USB microphone that has just been plugged in, or a headset
 still pairing, is often simply slow.</li>
-<li>Unplug the microphone, wait a moment, and plug it back in. Mutation notices and says
-&quot;Microphone connected. Now using ...&quot; when it comes back.</li>
-<li>If Mutation says &quot;Could not read the microphones on this computer&quot;, close it,
-reconnect your microphone, and start it again.</li>
-<li>Check the microphone works elsewhere — Windows Settings has a sound page that shows
-a test bar moving when you speak.</li>
+<li>If it is still saying it after that, close Mutation and start it again. While the
+question is unanswered Mutation is not yet watching for microphones being plugged
+in or out, so unplugging and re-plugging will not shake it loose.</li>
+<li>Before restarting, check the microphone works elsewhere — Windows Settings has a
+sound page that shows a test bar moving when you speak. If it does not move there
+either, the problem is the microphone or its driver, not Mutation.</li>
+<li>&quot;Could not read the microphones on this computer&quot; means the question came back with
+an error rather than an answer. Close Mutation, reconnect your microphone, and start
+it again.</li>
 </ol>
 <h3 id="dictation-says-it-is-waiting-for-the-microphone">Dictation says it is waiting for the microphone</h3>
 <p><strong>What's happening.</strong> You pressed the dictation shortcut while Mutation was still
@@ -400,11 +403,17 @@ that falls, and see &quot;Waiting for the microphone to be ready&quot;.</p>
 <ol>
 <li>Wait a beat. Normally the start beep follows within a second or two and recording
 begins as usual.</li>
-<li>If you get the failure beep and &quot;The microphone is still not ready, so nothing was
-recorded&quot;, the device did not open in time. Press the shortcut again to try once
-more.</li>
-<li>If it keeps failing, pick a different microphone on the <strong>Microphone</strong> card. A
-Bluetooth headset that is half-connected is the usual culprit.</li>
+<li>After eight seconds Mutation stops waiting. If it has a working microphone to fall
+back on, it records from that one and tells you which: &quot;The microphone you chose is
+still not ready. Recording from ... instead.&quot; Your words are not lost — just check
+the recording came from a mic you are actually speaking into.</li>
+<li>If instead you get &quot;The microphone is still not ready, so nothing was recorded&quot;,
+there was nothing to fall back on. Press the shortcut again to try once more.</li>
+<li>If it keeps happening, restart Mutation. A microphone whose driver has stopped
+answering holds Mutation's microphone switching until the app is restarted, so
+picking a different one in the dropdown will not clear it. A Bluetooth headset that
+is half-connected is the usual culprit — turn it off, or unpair it, before you start
+Mutation again.</li>
 </ol>
 <h3 id="no-voices-in-the-voice-list-or-the-voice-sounds-wrong">No voices in the voice list, or the voice sounds wrong</h3>
 <p><strong>What's happening.</strong> The voices Mutation offers for reading aloud come from Windows

--- a/Documentation/UserGuide/html/troubleshooting.html
+++ b/Documentation/UserGuide/html/troubleshooting.html
@@ -375,6 +375,37 @@ confirmed otherwise.</li>
 <strong>Microphone</strong> card. Setting the input level can also fail if a device is busy or
 was just unplugged — you will be told, and can try again.</li>
 </ol>
+<h3 id="the-microphone-list-says-finding-microphones-and-stays-that-way">The microphone list says &quot;Finding microphones...&quot; and stays that way</h3>
+<p><strong>What's happening.</strong> Mutation asks Windows which microphones the PC has as soon as it
+starts, but it does not hold the window shut while it waits. On most PCs the answer
+comes back before you notice. A microphone whose driver has got stuck, or a Bluetooth
+headset that never finishes connecting, can leave the question unanswered.</p>
+<p><strong>What to do.</strong></p>
+<ol>
+<li>Give it a few seconds. A USB microphone that has just been plugged in, or a headset
+still pairing, is often simply slow.</li>
+<li>Unplug the microphone, wait a moment, and plug it back in. Mutation notices and says
+&quot;Microphone connected. Now using ...&quot; when it comes back.</li>
+<li>If Mutation says &quot;Could not read the microphones on this computer&quot;, close it,
+reconnect your microphone, and start it again.</li>
+<li>Check the microphone works elsewhere — Windows Settings has a sound page that shows
+a test bar moving when you speak.</li>
+</ol>
+<h3 id="dictation-says-it-is-waiting-for-the-microphone">Dictation says it is waiting for the microphone</h3>
+<p><strong>What's happening.</strong> You pressed the dictation shortcut while Mutation was still
+opening a microphone. Rather than record from the one you have just switched away
+from, it holds your press until the right one is ready. You hear a low two-tone sound
+that falls, and see &quot;Waiting for the microphone to be ready&quot;.</p>
+<p><strong>What to do.</strong></p>
+<ol>
+<li>Wait a beat. Normally the start beep follows within a second or two and recording
+begins as usual.</li>
+<li>If you get the failure beep and &quot;The microphone is still not ready, so nothing was
+recorded&quot;, the device did not open in time. Press the shortcut again to try once
+more.</li>
+<li>If it keeps failing, pick a different microphone on the <strong>Microphone</strong> card. A
+Bluetooth headset that is half-connected is the usual culprit.</li>
+</ol>
 <h3 id="no-voices-in-the-voice-list-or-the-voice-sounds-wrong">No voices in the voice list, or the voice sounds wrong</h3>
 <p><strong>What's happening.</strong> The voices Mutation offers for reading aloud come from Windows
 itself, not from Mutation. An empty or very short list means Windows has few voices

--- a/Documentation/UserGuide/markdown/dictation.md
+++ b/Documentation/UserGuide/markdown/dictation.md
@@ -24,9 +24,10 @@ If you prefer clicking, the **Speech to Text** card on the main window has a
 ## When the microphone is not ready yet
 
 Some microphones take a second or two to open — a Bluetooth headset, or a USB mic
-you have only just switched to. If you press the dictation shortcut in that gap,
-Mutation holds your press rather than recording from the microphone you have just
-left.
+you have only just switched to. The same is true in the first moment after Mutation
+starts, while it is still finding out what microphones the PC has. If you press the
+dictation shortcut in that gap, Mutation holds your press rather than recording from
+the microphone you have just left.
 
 You hear a low two-tone sound that falls, and you see "Waiting for the microphone
 to be ready — recording will start in a moment." As soon as the microphone opens,
@@ -38,10 +39,18 @@ sound that rises when something has succeeded. Falling means "not yet".
 Pressing the shortcut again while you are waiting does not start a second recording.
 Mutation just says "Still waiting for the microphone."
 
-If the microphone still has not opened after eight seconds, Mutation gives up rather
-than leave you waiting: you get the failure beep and "The microphone is still not
-ready, so nothing was recorded." Press the shortcut again to try once more, or pick
-a different microphone on the **Microphone** card.
+If the microphone still has not opened after eight seconds, Mutation stops waiting.
+What happens then depends on whether it has a working microphone to fall back on:
+
+- **There is one.** You get the failure beep and "The microphone you chose is still
+  not ready. Recording from ... instead." The recording goes ahead on the named
+  microphone, so you are never left unable to dictate.
+- **There is not.** You get the failure beep and "The microphone is still not ready,
+  so nothing was recorded." Press the shortcut again to try once more.
+
+If that keeps happening, restart Mutation. A microphone whose driver has stopped
+answering does not let go until the app is restarted, so picking a different one in
+the dropdown will not help.
 
 Stopping a recording never waits. Once you are recording, the microphone is already
 open, and your press to stop takes effect straight away.

--- a/Documentation/UserGuide/markdown/dictation.md
+++ b/Documentation/UserGuide/markdown/dictation.md
@@ -21,6 +21,31 @@ If you prefer clicking, the **Speech to Text** card on the main window has a
 > **Shift+Alt+U** is just the default. Every shortcut in Mutation can be changed.
 > Open **Settings** with **Ctrl+Comma** and look on the **Hotkeys** tab.
 
+## When the microphone is not ready yet
+
+Some microphones take a second or two to open — a Bluetooth headset, or a USB mic
+you have only just switched to. If you press the dictation shortcut in that gap,
+Mutation holds your press rather than recording from the microphone you have just
+left.
+
+You hear a low two-tone sound that falls, and you see "Waiting for the microphone
+to be ready — recording will start in a moment." As soon as the microphone opens,
+the usual start beep plays and recording begins.
+
+The low falling sound is worth learning, because it is the opposite of the two-tone
+sound that rises when something has succeeded. Falling means "not yet".
+
+Pressing the shortcut again while you are waiting does not start a second recording.
+Mutation just says "Still waiting for the microphone."
+
+If the microphone still has not opened after eight seconds, Mutation gives up rather
+than leave you waiting: you get the failure beep and "The microphone is still not
+ready, so nothing was recorded." Press the shortcut again to try once more, or pick
+a different microphone on the **Microphone** card.
+
+Stopping a recording never waits. Once you are recording, the microphone is already
+open, and your press to stop takes effect straight away.
+
 ## Changed your mind while it is transcribing
 
 While Mutation is turning your recording into text, the **Raw Transcript** box

--- a/Documentation/UserGuide/markdown/microphone.md
+++ b/Documentation/UserGuide/markdown/microphone.md
@@ -66,16 +66,7 @@ This choice does not affect muting. Muting always covers every microphone,
 whichever one is selected. Your choice is remembered the next time you start
 Mutation.
 
-### When Mutation starts
-
-Finding out which microphones a PC has can take a moment — longer if one of them is
-a USB mic that is still waking up, or a Bluetooth headset that is still connecting.
-Mutation does not hold the window shut while it asks. The window opens straight
-away, and the dropdown says "Finding microphones..." until the answer comes back.
-
-When it does, the dropdown fills in, your saved microphone is selected, and a
-message tells you which one you are on: "Using ...". If the PC has no microphones
-at all, you get "No microphones are available." instead.
+### Switching while Mutation is running
 
 Some microphones take a moment to hand over — a USB mic that has just been plugged
 in, or a Bluetooth headset waking up. Mutation waits for it in the background, so
@@ -90,6 +81,22 @@ microphone that quietly hears nothing:
   unplugged between you picking it and Mutation getting to it. Pick another one.
 - "Could not switch to ...", followed by the reason, means the microphone was
   there but would not start. Try it again, or pick another one.
+
+### When Mutation starts
+
+Finding out which microphones a PC has can take a moment — longer if one of them is
+a USB mic that is still waking up, or a Bluetooth headset that is still connecting.
+Mutation does not hold the window shut while it asks. The window opens straight
+away, and the dropdown says "Finding microphones..." until the answer comes back.
+
+When it does, the dropdown fills in, your saved microphone is selected, and a
+message tells you which one you are on: "Using ...". If the PC has no microphones
+at all, you get "No microphones are available." instead.
+
+You can use the rest of the window in the meantime. If you press the dictation
+shortcut before the microphone is ready, Mutation holds your press rather than
+losing it — see
+[When the microphone is not ready yet](dictation.md).
 
 ## The live level display
 

--- a/Documentation/UserGuide/markdown/microphone.md
+++ b/Documentation/UserGuide/markdown/microphone.md
@@ -66,6 +66,17 @@ This choice does not affect muting. Muting always covers every microphone,
 whichever one is selected. Your choice is remembered the next time you start
 Mutation.
 
+### When Mutation starts
+
+Finding out which microphones a PC has can take a moment — longer if one of them is
+a USB mic that is still waking up, or a Bluetooth headset that is still connecting.
+Mutation does not hold the window shut while it asks. The window opens straight
+away, and the dropdown says "Finding microphones..." until the answer comes back.
+
+When it does, the dropdown fills in, your saved microphone is selected, and a
+message tells you which one you are on: "Using ...". If the PC has no microphones
+at all, you get "No microphones are available." instead.
+
 Some microphones take a moment to hand over — a USB mic that has just been plugged
 in, or a Bluetooth headset waking up. Mutation waits for it in the background, so
 the window stays usable and you keep your place in the dropdown while it works. If
@@ -129,6 +140,10 @@ updates the list on its own.
   microphone in the list and tells you: "The selected microphone was disconnected.
   Now using ...".
 - **No microphones at all** — you get a message saying none are available.
+- **A microphone comes back** — plug it in again and Mutation picks it up, starts
+  listening to it, and says "Microphone connected. Now using ...". This matters most
+  on a PC with only one microphone: you were told when it went away, so you are told
+  when it returns.
 
 There is one more nicety. If you are muted and then plug in a new microphone, the
 new one comes up muted too. Connecting a headset mid-call will not quietly put you

--- a/Documentation/UserGuide/markdown/settings.md
+++ b/Documentation/UserGuide/markdown/settings.md
@@ -50,7 +50,7 @@ Your microphone and the little sounds Mutation makes.
 | Microphone visualization | Shows a live waveform of the microphone input while recording. Turn it off to save a bit of CPU. |
 | Toggle microphone mute | The shortcut that mutes and unmutes everything. |
 | Use custom beeps | Play your own sound files instead of the built-in beeps for status cues. |
-| Beep files | One file each for Success, Failure, Start, End, Mute and Unmute. **Browse...** picks a file, and the small play button lets you hear it. |
+| Beep files | One file each for Success, Failure, Start, End, Mute and Unmute. **Browse...** picks a file, and the small play button lets you hear it. The low falling "waiting for the microphone" sound is built in and always plays as-is. |
 
 ### Screen capture & OCR
 

--- a/Documentation/UserGuide/markdown/troubleshooting.md
+++ b/Documentation/UserGuide/markdown/troubleshooting.md
@@ -288,12 +288,15 @@ headset that never finishes connecting, can leave the question unanswered.
 
 1. Give it a few seconds. A USB microphone that has just been plugged in, or a headset
    still pairing, is often simply slow.
-2. Unplug the microphone, wait a moment, and plug it back in. Mutation notices and says
-   "Microphone connected. Now using ..." when it comes back.
-3. If Mutation says "Could not read the microphones on this computer", close it,
-   reconnect your microphone, and start it again.
-4. Check the microphone works elsewhere — Windows Settings has a sound page that shows
-   a test bar moving when you speak.
+2. If it is still saying it after that, close Mutation and start it again. While the
+   question is unanswered Mutation is not yet watching for microphones being plugged
+   in or out, so unplugging and re-plugging will not shake it loose.
+3. Before restarting, check the microphone works elsewhere — Windows Settings has a
+   sound page that shows a test bar moving when you speak. If it does not move there
+   either, the problem is the microphone or its driver, not Mutation.
+4. "Could not read the microphones on this computer" means the question came back with
+   an error rather than an answer. Close Mutation, reconnect your microphone, and start
+   it again.
 
 ### Dictation says it is waiting for the microphone
 
@@ -306,11 +309,17 @@ that falls, and see "Waiting for the microphone to be ready".
 
 1. Wait a beat. Normally the start beep follows within a second or two and recording
    begins as usual.
-2. If you get the failure beep and "The microphone is still not ready, so nothing was
-   recorded", the device did not open in time. Press the shortcut again to try once
-   more.
-3. If it keeps failing, pick a different microphone on the **Microphone** card. A
-   Bluetooth headset that is half-connected is the usual culprit.
+2. After eight seconds Mutation stops waiting. If it has a working microphone to fall
+   back on, it records from that one and tells you which: "The microphone you chose is
+   still not ready. Recording from ... instead." Your words are not lost — just check
+   the recording came from a mic you are actually speaking into.
+3. If instead you get "The microphone is still not ready, so nothing was recorded",
+   there was nothing to fall back on. Press the shortcut again to try once more.
+4. If it keeps happening, restart Mutation. A microphone whose driver has stopped
+   answering holds Mutation's microphone switching until the app is restarted, so
+   picking a different one in the dropdown will not clear it. A Bluetooth headset that
+   is half-connected is the usual culprit — turn it off, or unpair it, before you start
+   Mutation again.
 
 ### No voices in the voice list, or the voice sounds wrong
 

--- a/Documentation/UserGuide/markdown/troubleshooting.md
+++ b/Documentation/UserGuide/markdown/troubleshooting.md
@@ -277,6 +277,41 @@ mute state. The microphone may still be live — please try again."
    **Microphone** card. Setting the input level can also fail if a device is busy or
    was just unplugged — you will be told, and can try again.
 
+### The microphone list says "Finding microphones..." and stays that way
+
+**What's happening.** Mutation asks Windows which microphones the PC has as soon as it
+starts, but it does not hold the window shut while it waits. On most PCs the answer
+comes back before you notice. A microphone whose driver has got stuck, or a Bluetooth
+headset that never finishes connecting, can leave the question unanswered.
+
+**What to do.**
+
+1. Give it a few seconds. A USB microphone that has just been plugged in, or a headset
+   still pairing, is often simply slow.
+2. Unplug the microphone, wait a moment, and plug it back in. Mutation notices and says
+   "Microphone connected. Now using ..." when it comes back.
+3. If Mutation says "Could not read the microphones on this computer", close it,
+   reconnect your microphone, and start it again.
+4. Check the microphone works elsewhere — Windows Settings has a sound page that shows
+   a test bar moving when you speak.
+
+### Dictation says it is waiting for the microphone
+
+**What's happening.** You pressed the dictation shortcut while Mutation was still
+opening a microphone. Rather than record from the one you have just switched away
+from, it holds your press until the right one is ready. You hear a low two-tone sound
+that falls, and see "Waiting for the microphone to be ready".
+
+**What to do.**
+
+1. Wait a beat. Normally the start beep follows within a second or two and recording
+   begins as usual.
+2. If you get the failure beep and "The microphone is still not ready, so nothing was
+   recorded", the device did not open in time. Press the shortcut again to try once
+   more.
+3. If it keeps failing, pick a different microphone on the **Microphone** card. A
+   Bluetooth headset that is half-connected is the usual culprit.
+
 ### No voices in the voice list, or the voice sounds wrong
 
 **What's happening.** The voices Mutation offers for reading aloud come from Windows

--- a/Mutation.Tests/CaptureSelectionSurvivalTests.cs
+++ b/Mutation.Tests/CaptureSelectionSurvivalTests.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections.Generic;
+using Mutation.Ui;
+using Mutation.Ui.Core;
+using Xunit;
+
+namespace Mutation.Tests;
+
+/// <summary>
+/// Covers what a re-enumeration does to a selection whose device has gone (issue #313).
+///
+/// <para>
+/// The manager used to keep the selected device's ID for ever, on the grounds that the
+/// level-write retry path re-resolves it. On a machine with one microphone that turned a
+/// re-plug into a dead end: unplug it and the list empties, plug it back in and the ID
+/// matches again, so <see cref="CaptureDeviceSelectionPlanner"/> reported the selection
+/// preserved — silent by design — and nothing re-opened capture. The waveform and the
+/// level meter stayed dead, and a blind user was told nothing at all.
+/// </para>
+///
+/// <para>
+/// Real <c>MMDevice</c> instances need hardware, so the two halves of the fix are covered
+/// where they are decidable: the rule that drops the selection, and what the planner then
+/// makes of the device coming back.
+/// </para>
+/// </summary>
+public class CaptureSelectionSurvivalTests
+{
+	private static CaptureDeviceInfo Device(string id) => new(id, $"Microphone {id}");
+
+	private static readonly CaptureDeviceInfo Usb = Device("usb");
+	private static readonly CaptureDeviceInfo Onboard = Device("onboard");
+
+	[Fact]
+	public void A_selection_survives_a_re_enumeration_that_still_contains_it()
+	{
+		Assert.True(AudioDeviceManager.ContainsDeviceId(new[] { Onboard, Usb }, Usb.Id));
+	}
+
+	[Fact]
+	public void A_selection_does_not_survive_a_re_enumeration_without_it()
+	{
+		Assert.False(AudioDeviceManager.ContainsDeviceId(new[] { Onboard }, Usb.Id));
+	}
+
+	[Fact]
+	public void A_selection_does_not_survive_an_empty_enumeration()
+	{
+		Assert.False(AudioDeviceManager.ContainsDeviceId(Array.Empty<CaptureDeviceInfo>(), Usb.Id));
+	}
+
+	// Endpoint IDs are compared the same way everywhere else in the manager. A casing
+	// difference between two enumerations must not read as the device having vanished —
+	// that would drop the user's microphone and announce a replacement for nothing.
+	[Fact]
+	public void A_selection_survives_a_difference_in_the_casing_of_its_id()
+	{
+		Assert.True(AudioDeviceManager.ContainsDeviceId(new[] { Device("USB") }, "usb"));
+	}
+
+	// The whole point, in sequence: with the stale ID dropped, the device coming back is
+	// something the planner can see, and SelectionAdopted is the outcome that both
+	// announces and runs the full selection path — which is what re-opens capture.
+	[Fact]
+	public void Re_plugging_the_only_microphone_is_adopted_and_announced()
+	{
+		var afterUnplug = Array.Empty<CaptureDeviceInfo>();
+		Assert.False(AudioDeviceManager.ContainsDeviceId(afterUnplug, Usb.Id));
+
+		// The selection has been dropped, so the re-plug is planned with nothing selected.
+		var update = CaptureDeviceSelectionPlanner.Plan(new[] { Usb }, selectedId: null);
+
+		Assert.Equal(CaptureDeviceListOutcome.SelectionAdopted, update.Outcome);
+		Assert.Equal(Usb, update.Device);
+	}
+
+	// The other half of the contract. The mute and level retry paths re-enumerate
+	// routinely and get the same set back; if that started dropping the selection, the
+	// app would announce a microphone change and restart capture over and over.
+	[Fact]
+	public void A_routine_re_enumeration_leaves_a_present_selection_silent()
+	{
+		IReadOnlyList<CaptureDeviceInfo> devices = new[] { Onboard, Usb };
+
+		Assert.True(AudioDeviceManager.ContainsDeviceId(devices, Usb.Id));
+		Assert.Equal(
+			CaptureDeviceListOutcome.SelectionPreserved,
+			CaptureDeviceSelectionPlanner.Plan(devices, Usb.Id).Outcome);
+	}
+}

--- a/Mutation.Tests/DictationPressPlannerTests.cs
+++ b/Mutation.Tests/DictationPressPlannerTests.cs
@@ -95,6 +95,30 @@ public class DictationPressPlannerTests
 			For(isTranscribing: true, transcriptionCancelRequested: true));
 	}
 
+	// ----- Which presses may be held for a microphone that is still opening (issue #312).
+
+	// AudioSessionManager.NextPressStartsRecording is this same call, and the dictation
+	// path waits only when it says StartRecording. The rule that matters is the negative
+	// one: a press that ends or cancels something must never be delayed by a device that
+	// is slow to open, or a user with a wedged microphone cannot stop the recording they
+	// are already making.
+	[Theory]
+	[InlineData(true, false, false)]
+	[InlineData(false, true, false)]
+	[InlineData(false, false, true)]
+	public void APressThatEndsSomething_IsNeverAStart_SoItIsNeverHeldForTheMicrophone(
+		bool isRecording,
+		bool isTranscribing,
+		bool isProcessingWithLlm)
+	{
+		Assert.NotEqual(
+			DictationPressAction.StartRecording,
+			For(
+				isTranscribing: isTranscribing,
+				isProcessingWithLlm: isProcessingWithLlm,
+				isRecording: isRecording));
+	}
+
 	[Fact]
 	public void ACancelRequestFlagWithNothingRunning_IsIgnored()
 	{

--- a/Mutation.Tests/MicrophoneSwitchCoordinatorTests.cs
+++ b/Mutation.Tests/MicrophoneSwitchCoordinatorTests.cs
@@ -344,6 +344,144 @@ public class MicrophoneSwitchCoordinatorTests
 		Assert.Equal(new[] { "mic-a", "mic-b" }, selected);
 	}
 
+	// The wait a dictation start parks on (issue #312). Nothing is running, so there is
+	// nothing to wait for and the recorder must not be held up for even one dispatch.
+	[Fact]
+	public void WaitForIdleAsync_WhenNothingIsRunning_IsAlreadyComplete()
+	{
+		var coordinator = Create();
+
+		Assert.True(coordinator.WaitForIdleAsync().IsCompleted);
+	}
+
+	// The point of the whole thing: the wait must not release until the device work has
+	// actually finished, because that is when MicrophoneDeviceIndex finally moves.
+	[Fact]
+	public async Task WaitForIdleAsync_DoesNotCompleteUntilTheSwitchHasLanded()
+	{
+		var started = new ManualResetEventSlim(false);
+		var release = new ManualResetEventSlim(false);
+		var restarted = false;
+		var coordinator = Create(
+			selectDevice: _ => { started.Set(); release.Wait(); return true; },
+			restartCapture: () => restarted = true);
+
+		var switching = coordinator.SwitchAsync("mic-a");
+		Assert.True(started.Wait(TimeSpan.FromSeconds(5)), "the switch did not start");
+
+		var idle = coordinator.WaitForIdleAsync();
+		Assert.False(idle.IsCompleted);
+
+		release.Set();
+		await switching;
+		await idle.WaitAsync(TimeSpan.FromSeconds(5));
+
+		Assert.True(restarted);
+		Assert.False(coordinator.IsSwitching);
+	}
+
+	// A request superseded mid-flight completes with null the moment the newer one
+	// arrives, long before any device is open. Waiting on that task would let a recording
+	// start into a switch that is still running — hence a separate idle signal, which
+	// must cover the newest request and not the one that was dropped.
+	[Fact]
+	public async Task WaitForIdleAsync_CoversARequestQueuedBehindTheRunningOne()
+	{
+		var started = new ManualResetEventSlim(false);
+		var release = new ManualResetEventSlim(false);
+		var selected = new ConcurrentQueue<string>();
+		var coordinator = Create(
+			selectDevice: id =>
+			{
+				selected.Enqueue(id);
+				if (id == "mic-a")
+				{
+					started.Set();
+					release.Wait();
+				}
+				return true;
+			});
+
+		var first = coordinator.SwitchAsync("mic-a");
+		Assert.True(started.Wait(TimeSpan.FromSeconds(5)), "the first switch did not start");
+
+		var second = coordinator.SwitchAsync("mic-b");
+		var idle = coordinator.WaitForIdleAsync();
+
+		release.Set();
+		Assert.Null(await first);
+		await second;
+		await idle.WaitAsync(TimeSpan.FromSeconds(5));
+
+		Assert.Equal(new[] { "mic-a", "mic-b" }, selected);
+	}
+
+	// Every waiter is waiting for the same thing, and a second one must not be handed a
+	// source nothing will ever complete.
+	[Fact]
+	public async Task WaitForIdleAsync_ReleasesEveryWaiter()
+	{
+		var started = new ManualResetEventSlim(false);
+		var release = new ManualResetEventSlim(false);
+		var coordinator = Create(selectDevice: _ => { started.Set(); release.Wait(); return true; });
+
+		var switching = coordinator.SwitchAsync("mic-a");
+		Assert.True(started.Wait(TimeSpan.FromSeconds(5)), "the switch did not start");
+
+		var first = coordinator.WaitForIdleAsync();
+		var second = coordinator.WaitForIdleAsync();
+
+		release.Set();
+		await switching;
+		await Task.WhenAll(first, second).WaitAsync(TimeSpan.FromSeconds(5));
+	}
+
+	// A wait that survived a failed switch would be a dictation hotkey parked forever on
+	// a device that already gave up.
+	[Fact]
+	public async Task WaitForIdleAsync_CompletesWhenTheSwitchFails()
+	{
+		var coordinator = Create(restartCapture: () => throw new InvalidOperationException("wedged"));
+
+		var result = await coordinator.SwitchAsync("mic-a");
+
+		Assert.Equal(MicrophoneSwitchOutcome.Failed, result!.Value.Outcome);
+		await coordinator.WaitForIdleAsync().WaitAsync(TimeSpan.FromSeconds(5));
+	}
+
+	// A second switch after the first has settled has to re-arm the signal: the source is
+	// consumed when the worker goes idle, and a stale completed one would let a start
+	// straight through the middle of the new switch.
+	[Fact]
+	public async Task WaitForIdleAsync_ReArmsForTheNextSwitch()
+	{
+		var started = new ManualResetEventSlim(false);
+		var release = new ManualResetEventSlim(false);
+		var coordinator = Create(
+			selectDevice: id =>
+			{
+				if (id == "mic-b")
+				{
+					started.Set();
+					release.Wait();
+				}
+				return true;
+			});
+
+		await coordinator.SwitchAsync("mic-a");
+		AssertEventually(() => coordinator.WaitForIdleAsync().IsCompleted, "the first switch did not settle");
+
+		var second = coordinator.SwitchAsync("mic-b");
+		Assert.True(started.Wait(TimeSpan.FromSeconds(5)), "the second switch did not start");
+
+		var idle = coordinator.WaitForIdleAsync();
+		Assert.False(idle.IsCompleted);
+
+		release.Set();
+		await second;
+		await idle.WaitAsync(TimeSpan.FromSeconds(5));
+	}
+
 	// The worker completes an awaiter before it records that it has gone idle, so a
 	// resumed test can observe IsSwitching either way for an instant. Polled rather
 	// than asserted outright, so a loaded machine cannot turn that into a failure.

--- a/Mutation.Tests/WaitingBeepTests.cs
+++ b/Mutation.Tests/WaitingBeepTests.cs
@@ -1,0 +1,64 @@
+using System.Linq;
+using CognitiveSupport;
+
+namespace Mutation.Tests;
+
+/// <summary>
+/// The sound a dictation press makes when the microphone is not open yet (issue #312).
+///
+/// <para>
+/// It exists because the alternatives were both wrong for someone driving Mutation by
+/// ear from another window. Silence reads as a shortcut that did not register. The Start
+/// beep says the microphone is live, and a user who believes that talks into nothing for
+/// as long as the device takes.
+/// </para>
+/// </summary>
+public class WaitingBeepTests
+{
+	[Fact]
+	public void The_waiting_beep_has_a_default_sequence()
+	{
+		// Every beep the app can play must synthesize; GetDefaultSequence throws on a type
+		// that was added to the enum and nowhere else.
+		Assert.NotEmpty(BeepPlayer.GetDefaultSequence(BeepType.Waiting));
+	}
+
+	[Fact]
+	public void The_waiting_beep_is_not_the_start_beep()
+	{
+		Assert.NotEqual(
+			BeepPlayer.GetDefaultSequence(BeepType.Start),
+			BeepPlayer.GetDefaultSequence(BeepType.Waiting));
+	}
+
+	// Success rises and Waiting falls. Both are two tones, so the direction is the only
+	// thing telling them apart, and "ready" and "not ready" are the two answers the user
+	// most needs to keep separate.
+	[Fact]
+	public void The_waiting_beep_falls_where_the_success_beep_rises()
+	{
+		var waiting = BeepPlayer.GetDefaultSequence(BeepType.Waiting);
+		var success = BeepPlayer.GetDefaultSequence(BeepType.Success);
+
+		Assert.True(waiting.Count > 1, "Waiting is a two-tone beep; the fixture assumes so.");
+		Assert.True(waiting.Last().Frequency < waiting.First().Frequency, "Waiting must fall.");
+		Assert.True(success.Last().Frequency > success.First().Frequency, "Success must rise.");
+	}
+
+	// It is lower than every beep that reports a finished action, so it does not read as
+	// one of them.
+	[Fact]
+	public void The_waiting_beep_sits_below_the_beeps_that_report_completion()
+	{
+		int highestWaitingTone = BeepPlayer.GetDefaultSequence(BeepType.Waiting).Max(tone => tone.Frequency);
+
+		Assert.True(highestWaitingTone < BeepPlayer.DefaultStartFrequency);
+		Assert.True(highestWaitingTone < BeepPlayer.GetDefaultSequence(BeepType.Success).Min(tone => tone.Frequency));
+	}
+
+	[Fact]
+	public void The_waiting_beep_synthesizes()
+	{
+		Assert.NotEmpty(BeepToneSynthesizer.SynthesizeWav(BeepPlayer.GetDefaultSequence(BeepType.Waiting)));
+	}
+}

--- a/Mutation.Ui/Core/AudioDeviceManager.cs
+++ b/Mutation.Ui/Core/AudioDeviceManager.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace Mutation.Ui;
 
@@ -32,7 +33,14 @@ namespace Mutation.Ui;
 public class AudioDeviceManager : IMuteEndpointProvider, ICaptureLevelEndpointProvider
 {
 	private readonly MMDeviceEnumerator _deviceEnumerator;
-	private readonly MuteStateController _muteState;
+	private readonly ICaptureDeviceChangeNotifier _deviceChangeNotifier;
+	// Null until InitializeAsync has read the hardware mute state. Volatile because the
+	// UI thread reads it (IsMuted) while the initialization worker publishes it.
+	private volatile MuteStateController? _muteState;
+	// The one initialization run, so every caller waits on the same work rather than
+	// starting a second enumeration. Guarded by _initializationGate.
+	private Task? _initialization;
+	private readonly object _initializationGate = new();
 	// Guards the capture-device list and the selected-microphone fields against the
 	// background thread that OS device-change notifications arrive on: a hot-plug
 	// re-enumeration must not race a selection or a property read. Held for field
@@ -45,6 +53,12 @@ public class AudioDeviceManager : IMuteEndpointProvider, ICaptureLevelEndpointPr
 	// The describable subset of _captureDevices, cached so a UI read is a field read
 	// rather than a projection. Rebuilt with the list it is derived from.
 	private IReadOnlyList<CaptureDeviceInfo> _captureDeviceInfos = Array.Empty<CaptureDeviceInfo>();
+	// False until the first enumeration has published a list. Nothing "changed" when a
+	// device set appears where there was none, and the initial population is the caller's
+	// own job — since startup moved off the UI thread the UI is already subscribed by
+	// then, and raising here would have it adopt the first device out from under the
+	// persisted choice InitializeAsync is about to restore (issue #308).
+	private bool _hasEnumerated;
 	private MMDevice? _microphone;
 	private CaptureDeviceInfo? _microphoneInfo;
 	private int _microphoneDeviceIndex = -1;
@@ -69,17 +83,65 @@ public class AudioDeviceManager : IMuteEndpointProvider, ICaptureLevelEndpointPr
 	// re-resolve it later.
 	private sealed record CaptureDeviceEntry(MMDevice Device, CaptureDeviceInfo? Info);
 
+	/// <summary>
+	/// Deliberately does no device work. This type is resolved on the UI thread while the
+	/// main window is being built, and every call it used to make here — enumerating the
+	/// capture endpoints, describing each one, reading a mute state — is a COM call that
+	/// can take seconds on a machine with a USB microphone that is slow to enumerate, a
+	/// Bluetooth headset still connecting, or a wedged driver. On the UI thread that is
+	/// the window not appearing and the screen reader with nothing to announce
+	/// (issue #308). <see cref="InitializeAsync"/> does that work off-thread.
+	/// </summary>
 	public AudioDeviceManager(MMDeviceEnumerator deviceEnumerator, ICaptureDeviceChangeNotifier deviceChangeNotifier)
 	{
 		_deviceEnumerator = deviceEnumerator ?? throw new ArgumentNullException(nameof(deviceEnumerator));
-		if (deviceChangeNotifier is null)
-			throw new ArgumentNullException(nameof(deviceChangeNotifier));
-		RefreshCaptureDevices();
-		_muteState = new MuteStateController(this, ReadInitialMuteState());
+		_deviceChangeNotifier = deviceChangeNotifier ?? throw new ArgumentNullException(nameof(deviceChangeNotifier));
+	}
 
-		// Subscribe only after _muteState exists, so a notification that
-		// arrives during construction cannot reach a half-built object.
-		deviceChangeNotifier.CaptureDevicesChanged += OnCaptureDevicesChanged;
+	/// <summary>
+	/// Enumerates the capture devices, adopts the OS default microphone, and reads the
+	/// hardware mute state — all on a thread-pool thread, so a slow audio stack delays
+	/// the microphone controls settling rather than the window opening (issue #308).
+	///
+	/// <para>
+	/// Idempotent: every caller gets the same task, so a second call cannot start a
+	/// second enumeration. The returned task faults only if the whole run threw; the
+	/// individual device calls already swallow their own failures and simply leave less
+	/// selected.
+	/// </para>
+	/// </summary>
+	public Task InitializeAsync()
+	{
+		lock (_initializationGate)
+			return _initialization ??= Task.Run(Initialize);
+	}
+
+	/// <summary>
+	/// True once <see cref="InitializeAsync"/> has finished, successfully or not. Until
+	/// then there is no device list, no selection, and no confirmed mute state.
+	/// </summary>
+	public bool IsInitialized => _initialization is { IsCompleted: true };
+
+	private void Initialize()
+	{
+		// Held across the whole run so a mute toggle — which takes this gate on its own
+		// background thread — cannot reach a half-built object, and so the toggle simply
+		// waits for startup instead of needing a "not ready yet" answer of its own.
+		lock (_comGate)
+		{
+			RefreshCaptureDevices();
+
+			// Before the mute read, so the read can prefer the device the user will
+			// actually be on: the startup beep is meant to tell them whether *their*
+			// microphone is live.
+			EnsureDefaultMicrophoneSelected();
+
+			_muteState = new MuteStateController(this, ReadInitialMuteState());
+		}
+
+		// Subscribed only after _muteState exists, so a hot-plug notification that
+		// arrives during startup cannot reach a half-built object.
+		_deviceChangeNotifier.CaptureDevicesChanged += OnCaptureDevicesChanged;
 	}
 
 	// When a microphone is added or removed at the OS level, re-enumerate so
@@ -91,7 +153,9 @@ public class AudioDeviceManager : IMuteEndpointProvider, ICaptureLevelEndpointPr
 		lock (_comGate)
 		{
 			RefreshCaptureDevices();
-			_muteState.SynchronizeDevices();
+			// Null-safe purely as a backstop: the notifier is subscribed after the state
+			// is built, so this cannot be null in practice.
+			_muteState?.SynchronizeDevices();
 		}
 	}
 
@@ -118,7 +182,11 @@ public class AudioDeviceManager : IMuteEndpointProvider, ICaptureLevelEndpointPr
 	// Reflects the aggregate mute state that was actually written to the
 	// capture devices and confirmed by read-back — not an optimistic guess
 	// and not a stale read of a single unrelated device instance.
-	public bool IsMuted => _muteState.IsMuted;
+	//
+	// Read on the UI thread, so it never waits for startup: before initialization
+	// finishes it reports unmuted, which is what it already reported on a machine whose
+	// devices could not be read.
+	public bool IsMuted => _muteState?.IsMuted ?? false;
 
 	// Private because it is only safe under _comGate: it disposes wrappers that an
 	// in-flight endpoint batch may still be driving, and only the COM-serialized
@@ -141,10 +209,27 @@ public class AudioDeviceManager : IMuteEndpointProvider, ICaptureLevelEndpointPr
 
 		IReadOnlyList<CaptureDeviceEntry> superseded;
 		bool listChanged;
+		MMDevice? abandonedSelection = null;
 		lock (_sync)
 		{
 			superseded = _captureDevices;
-			listChanged = !SameDeviceIds(_captureDeviceInfos, infos);
+			listChanged = _hasEnumerated && !SameDeviceIds(_captureDeviceInfos, infos);
+			_hasEnumerated = true;
+
+			// The selected microphone is not in the new enumeration — unplugged, disabled,
+			// or otherwise gone. Let the selection go with it. Keeping the stale ID is what
+			// made re-plugging the only microphone a dead end: the ID comes back, and
+			// CaptureDeviceSelectionPlanner reads "still present" as "nothing about the
+			// user's audio changed", so capture is never re-opened and a blind user is
+			// never told their microphone is back (issue #313).
+			if (_microphoneInfo is { } selected && !ContainsDeviceId(infos, selected.Id))
+			{
+				abandonedSelection = _microphone;
+				_microphone = null;
+				_microphoneInfo = null;
+				_microphoneDeviceIndex = -1;
+			}
+
 			_captureDevices = devices;
 			_captureDeviceInfos = infos;
 		}
@@ -161,8 +246,29 @@ public class AudioDeviceManager : IMuteEndpointProvider, ICaptureLevelEndpointPr
 		// user just chose would leave the selected mic dead until restart.
 		DisposeSuperseded(superseded.Select(entry => entry.Device), IsSelectedMicrophone);
 
+		// A selection just dropped is normally one of the wrappers the pass above released
+		// — it is no longer the selection, so it is no longer skipped. The exception is the
+		// default endpoint EnsureDefaultMicrophoneSelected adopts, which never belonged to
+		// an enumeration and so would otherwise be left to finalization.
+		if (abandonedSelection is not null
+			&& !superseded.Any(entry => ReferenceEquals(entry.Device, abandonedSelection)))
+			DisposeQuietly(abandonedSelection);
+
 		if (listChanged)
 			RaiseCaptureDeviceListChanged();
+	}
+
+	// Whether an enumeration still contains a given endpoint ID. Internal so the rule
+	// behind the dropped selection above is unit-testable without CoreAudio devices.
+	internal static bool ContainsDeviceId(IReadOnlyList<CaptureDeviceInfo> devices, string deviceId)
+	{
+		for (int i = 0; i < devices.Count; i++)
+		{
+			if (string.Equals(devices[i].Id, deviceId, StringComparison.OrdinalIgnoreCase))
+				return true;
+		}
+
+		return false;
 	}
 
 	// Notifies subscribers off the enumerating thread, so no handler code runs under
@@ -299,7 +405,10 @@ public class AudioDeviceManager : IMuteEndpointProvider, ICaptureLevelEndpointPr
 			entry => entry.Info is not null
 				&& string.Equals(entry.Info.Id, deviceId, StringComparison.OrdinalIgnoreCase));
 
-	public void EnsureDefaultMicrophoneSelected()
+	// Adopts the OS default capture endpoint when nothing is selected yet. Private
+	// because it is part of startup: it is COM and winmm work that belongs on
+	// InitializeAsync's worker, and a UI-thread caller is exactly what issue #308 was.
+	private void EnsureDefaultMicrophoneSelected()
 	{
 		lock (_sync)
 		{
@@ -313,10 +422,9 @@ public class AudioDeviceManager : IMuteEndpointProvider, ICaptureLevelEndpointPr
 		try
 		{
 			// COM: resolved outside _sync so a stalled enumerator cannot block the
-			// property readers on the UI thread. Every call stays inside the guard —
-			// this runs from the window constructor, where a throw from a flaky device
-			// would surface as a fatal startup error instead of simply leaving no
-			// microphone selected.
+			// property readers on the UI thread. Every call stays inside the guard — a
+			// throw from a flaky device would otherwise fault the startup task instead of
+			// simply leaving no microphone selected.
 			defaultMic = _deviceEnumerator.GetDefaultAudioEndpoint(DataFlow.Capture, Role.Console);
 			if (defaultMic is null)
 				return;
@@ -394,10 +502,18 @@ public class AudioDeviceManager : IMuteEndpointProvider, ICaptureLevelEndpointPr
 	public MuteToggleResult ToggleMute()
 	{
 		// Serialize with the device-change handler so a hot-plug refresh
-		// cannot swap the device list out from under an in-flight toggle.
+		// cannot swap the device list out from under an in-flight toggle. Initialize
+		// holds the same gate across building the mute state, so a toggle pressed during
+		// startup simply waits for the devices rather than being turned away.
 		lock (_comGate)
 		{
-			return _muteState.Toggle();
+			// Only reachable when startup itself threw, which leaves no device list to
+			// write to. Reported as an unconfirmed, unmuted state — the same answer a
+			// machine whose endpoints all refuse to be written already gets.
+			if (_muteState is not { } state)
+				return new MuteToggleResult(Success: false, IsMuted: false);
+
+			return state.Toggle();
 		}
 	}
 
@@ -472,8 +588,9 @@ public class AudioDeviceManager : IMuteEndpointProvider, ICaptureLevelEndpointPr
 	// instance carrying the same device ID, so its COM proxy is live again. This
 	// is the level-side mirror of RefreshEndpoints() for mute — both recover a
 	// stale proxy by re-acquiring from a fresh enumeration. A no-op when no mic
-	// is selected; if the previously-selected device is gone, the stale
-	// reference is left in place for the caller's retry to fail against.
+	// is selected; if the previously-selected device is gone, the re-enumeration has
+	// already dropped and released it (issue #313) and the caller's retry runs against
+	// no endpoint at all rather than a dead proxy.
 	private void RefreshActiveMicrophone()
 	{
 		MMDevice? previous;
@@ -489,9 +606,10 @@ public class AudioDeviceManager : IMuteEndpointProvider, ICaptureLevelEndpointPr
 		if (previous is null || id is null)
 			return;
 
-		// RefreshCaptureDevices deliberately preserves the selected wrapper, so
-		// `previous` is still live here; it is disposed once a fresh instance
-		// replaces it below.
+		// RefreshCaptureDevices preserves the selected wrapper as long as its device is
+		// still there, so `previous` is live below and is disposed once a fresh instance
+		// replaces it. When the device has gone the re-enumeration drops the selection
+		// and releases the wrapper itself, and the lookup below finds nothing.
 		RefreshCaptureDevices();
 
 		CaptureDeviceEntry? fresh;
@@ -501,6 +619,8 @@ public class AudioDeviceManager : IMuteEndpointProvider, ICaptureLevelEndpointPr
 				e => e.Info is not null && string.Equals(e.Info.Id, id, StringComparison.OrdinalIgnoreCase));
 		}
 
+		// `previous` is not disposed here: either it was never superseded, or the
+		// re-enumeration that dropped it has already released it.
 		if (fresh is null)
 			return;
 
@@ -571,12 +691,19 @@ public class AudioDeviceManager : IMuteEndpointProvider, ICaptureLevelEndpointPr
 	// Best-effort read of the current device mute state at startup so the
 	// tracked state starts in sync with the hardware. Defaults to unmuted if
 	// no device can be read.
+	//
+	// The selected microphone is read first. The startup beep this seeds is meant to tell
+	// the user whether *their* microphone is live, and on a machine whose first enumerated
+	// device is some other, muted endpoint that answer was simply the wrong device's
+	// (issue #308).
 	private bool ReadInitialMuteState()
 	{
 		List<MMDevice> devices;
 		lock (_sync)
 		{
 			devices = _captureDevices.Select(entry => entry.Device).ToList();
+			if (_microphone is { } selected)
+				devices.Insert(0, selected);
 		}
 
 		foreach (var device in devices)

--- a/Mutation.Ui/Core/AudioDeviceManager.cs
+++ b/Mutation.Ui/Core/AudioDeviceManager.cs
@@ -53,11 +53,12 @@ public class AudioDeviceManager : IMuteEndpointProvider, ICaptureLevelEndpointPr
 	// The describable subset of _captureDevices, cached so a UI read is a field read
 	// rather than a projection. Rebuilt with the list it is derived from.
 	private IReadOnlyList<CaptureDeviceInfo> _captureDeviceInfos = Array.Empty<CaptureDeviceInfo>();
-	// False until the first enumeration has published a list. Nothing "changed" when a
-	// device set appears where there was none, and the initial population is the caller's
-	// own job — since startup moved off the UI thread the UI is already subscribed by
-	// then, and raising here would have it adopt the first device out from under the
-	// persisted choice InitializeAsync is about to restore (issue #308).
+	// False until initialization has published its list. Nothing "changed" when a device
+	// set appears where there was none, and that initial population is the caller's own
+	// job — since startup moved off the UI thread the UI is already subscribed by then,
+	// and raising there would have it adopt the first device out from under the persisted
+	// choice startup is about to restore (issue #308). Set by Initialize, not by the
+	// enumeration itself, so a startup that threw still lets a later hot-plug through.
 	private bool _hasEnumerated;
 	private MMDevice? _microphone;
 	private CaptureDeviceInfo? _microphoneInfo;
@@ -116,32 +117,41 @@ public class AudioDeviceManager : IMuteEndpointProvider, ICaptureLevelEndpointPr
 			return _initialization ??= Task.Run(Initialize);
 	}
 
-	/// <summary>
-	/// True once <see cref="InitializeAsync"/> has finished, successfully or not. Until
-	/// then there is no device list, no selection, and no confirmed mute state.
-	/// </summary>
-	public bool IsInitialized => _initialization is { IsCompleted: true };
-
 	private void Initialize()
 	{
-		// Held across the whole run so a mute toggle — which takes this gate on its own
-		// background thread — cannot reach a half-built object, and so the toggle simply
-		// waits for startup instead of needing a "not ready yet" answer of its own.
-		lock (_comGate)
+		try
 		{
-			RefreshCaptureDevices();
+			// Held across the whole run so a mute toggle — which takes this gate on its
+			// own background thread — cannot reach a half-built object.
+			lock (_comGate)
+			{
+				RefreshCaptureDevices();
 
-			// Before the mute read, so the read can prefer the device the user will
-			// actually be on: the startup beep is meant to tell them whether *their*
-			// microphone is live.
-			EnsureDefaultMicrophoneSelected();
+				// Before the mute read, so the read can prefer the device that was just
+				// adopted: the startup beep is meant to say whether the microphone the
+				// user is about to be on is live.
+				EnsureDefaultMicrophoneSelected();
 
-			_muteState = new MuteStateController(this, ReadInitialMuteState());
+				_muteState = new MuteStateController(this, ReadInitialMuteState());
+			}
 		}
+		finally
+		{
+			lock (_sync)
+			{
+				// From here on a re-enumeration that changes the device set is news the UI
+				// has to hear. Set even when the work above threw: a startup that failed
+				// to read the devices is exactly the case where a later hot-plug is the
+				// user's way back, and leaving this false would swallow it.
+				_hasEnumerated = true;
+			}
 
-		// Subscribed only after _muteState exists, so a hot-plug notification that
-		// arrives during startup cannot reach a half-built object.
-		_deviceChangeNotifier.CaptureDevicesChanged += OnCaptureDevicesChanged;
+			// Subscribed last, so a notification cannot reach a half-built object — and in
+			// the finally, so a startup that threw still leaves hot-plug recovery wired.
+			// A notification that arrives while the work above is still running blocks on
+			// _comGate until it finishes, which is the ordering we want anyway.
+			_deviceChangeNotifier.CaptureDevicesChanged += OnCaptureDevicesChanged;
+		}
 	}
 
 	// When a microphone is added or removed at the OS level, re-enumerate so
@@ -214,7 +224,6 @@ public class AudioDeviceManager : IMuteEndpointProvider, ICaptureLevelEndpointPr
 		{
 			superseded = _captureDevices;
 			listChanged = _hasEnumerated && !SameDeviceIds(_captureDeviceInfos, infos);
-			_hasEnumerated = true;
 
 			// The selected microphone is not in the new enumeration — unplugged, disabled,
 			// or otherwise gone. Let the selection go with it. Keeping the stale ID is what
@@ -501,10 +510,26 @@ public class AudioDeviceManager : IMuteEndpointProvider, ICaptureLevelEndpointPr
 	/// which is what makes it safe to hold _comGate across the COM writes here.
 	public MuteToggleResult ToggleMute()
 	{
+		// A toggle pressed while startup is still running waits for it rather than being
+		// turned away with a failure the user did not cause. Waiting on the task rather
+		// than on _comGate alone, because InitializeAsync only queues the work: between
+		// the queue and the worker taking the gate there is a window where the gate is
+		// free and the mute state does not exist yet.
+		//
+		// Blocking is safe and deliberate. This runs on MicrophoneMuteToggleCoordinator's
+		// thread-pool thread, never the UI thread.
+		try
+		{
+			InitializeAsync().GetAwaiter().GetResult();
+		}
+		catch
+		{
+			// Reported below as an unconfirmed toggle: startup already logged the fault,
+			// and what the user needs here is the honest "could not confirm" answer.
+		}
+
 		// Serialize with the device-change handler so a hot-plug refresh
-		// cannot swap the device list out from under an in-flight toggle. Initialize
-		// holds the same gate across building the mute state, so a toggle pressed during
-		// startup simply waits for the devices rather than being turned away.
+		// cannot swap the device list out from under an in-flight toggle.
 		lock (_comGate)
 		{
 			// Only reachable when startup itself threw, which leaves no device list to

--- a/Mutation.Ui/Core/AudioSessionManager.cs
+++ b/Mutation.Ui/Core/AudioSessionManager.cs
@@ -86,6 +86,26 @@ public class AudioSessionManager : IDisposable
     /// </summary>
     public bool IsProcessingWithLlm => _llmOperation.Running;
 
+    /// <summary>
+    /// Whether the next dictation press would open the microphone, rather than stop or
+    /// cancel something already in flight.
+    ///
+    /// <para>
+    /// Answered by <see cref="DictationPressPlanner"/> — the same decision
+    /// <see cref="StartStopRecordingAsync"/> makes from the same five facts — so the
+    /// caller that has to hold a *start* until the microphone is ready cannot drift out
+    /// of step with what the press actually does (issue #312). Getting that wrong the
+    /// other way would be worse than the bug: a stop delayed behind a device that will
+    /// not open is a recording the user cannot end.
+    /// </para>
+    /// </summary>
+    public bool NextPressStartsRecording => DictationPressPlanner.For(
+        isTranscribing: IsTranscribing,
+        transcriptionCancelRequested: _speechManager.TranscriptionCancelRequested,
+        isProcessingWithLlm: IsProcessingWithLlm,
+        llmCancelRequested: _llmOperation.CancelRequested,
+        isRecording: IsRecording) == DictationPressAction.StartRecording;
+
     // The recorder's own view of what it is doing. Used only where a failure has left
     // the session in a state this class cannot name from where it stands — everywhere
     // else the raising code states the activity it is entering, so a change that is

--- a/Mutation.Ui/Core/MicrophoneSwitchCoordinator.cs
+++ b/Mutation.Ui/Core/MicrophoneSwitchCoordinator.cs
@@ -71,6 +71,11 @@ public sealed class MicrophoneSwitchCoordinator
 	// queued). Guarded by _gate.
 	private bool _workerRunning;
 
+	// Handed to callers of WaitForIdleAsync and completed when the worker goes idle.
+	// Created on demand, so a coordinator nobody waits on allocates nothing. Guarded by
+	// _gate.
+	private TaskCompletionSource<bool>? _idleCompletion;
+
 	/// <param name="selectDevice">Selects the device with the given endpoint ID,
 	/// returning false when no such device exists any more.</param>
 	/// <param name="restartCapture">Points waveform capture at the newly-selected
@@ -99,6 +104,45 @@ public sealed class MicrophoneSwitchCoordinator
 	public bool IsSwitching
 	{
 		get { lock (_gate) return _workerRunning; }
+	}
+
+	/// <summary>
+	/// Completes when no request is in flight or queued — i.e. when the selected device
+	/// and the capture handle have caught up with what the user last asked for.
+	///
+	/// <para>
+	/// This is what a dictation start waits on. <see cref="SwitchAsync"/>'s own task is
+	/// no use there: it belongs to whoever made the request, and a superseded one
+	/// completes with <c>null</c> the moment a newer request arrives rather than when
+	/// the device is actually open (issue #312).
+	/// </para>
+	///
+	/// <para>
+	/// It carries no deadline of its own. A wedged winmm call cannot be cancelled, so a
+	/// device that never answers never completes this — the caller must bound its own
+	/// wait.
+	/// </para>
+	/// </summary>
+	public Task WaitForIdleAsync()
+	{
+		lock (_gate)
+		{
+			if (!_workerRunning)
+				return Task.CompletedTask;
+
+			// One source shared by every waiter: they are all waiting for the same thing.
+			return (_idleCompletion ??= new TaskCompletionSource<bool>(
+				TaskCreationOptions.RunContinuationsAsynchronously)).Task;
+		}
+	}
+
+	// Called wherever _workerRunning is cleared, always with _gate held, and its result
+	// completed outside the lock so no continuation runs under it.
+	private TaskCompletionSource<bool>? TakeIdleCompletion()
+	{
+		var idle = _idleCompletion;
+		_idleCompletion = null;
+		return idle;
 	}
 
 	/// <summary>
@@ -181,15 +225,21 @@ public sealed class MicrophoneSwitchCoordinator
 		catch (Exception ex)
 		{
 			TaskCompletionSource<MicrophoneSwitchResult?>? orphan;
+			TaskCompletionSource<bool>? idle;
 			lock (_gate)
 			{
 				_workerRunning = false;
 				orphan = _pendingCompletion;
 				_pendingDeviceId = null;
 				_pendingCompletion = null;
+				idle = TakeIdleCompletion();
 			}
 
 			orphan?.TrySetResult(null);
+			// Released here too, and not only on the clean exit below: a waiter parked on
+			// a worker that died would otherwise never be woken, which is the permanent
+			// dead hotkey this whole backstop exists to prevent.
+			idle?.TrySetResult(true);
 			ReportError(ex);
 		}
 	}
@@ -210,6 +260,10 @@ public sealed class MicrophoneSwitchCoordinator
 				if (_pendingCompletion is null)
 				{
 					_workerRunning = false;
+					var idle = TakeIdleCompletion();
+					// Completed asynchronously (the source is built that way), so this
+					// does not run a continuation under _gate.
+					idle?.TrySetResult(true);
 					return;
 				}
 

--- a/Mutation.Ui/MainWindow.xaml.cs
+++ b/Mutation.Ui/MainWindow.xaml.cs
@@ -641,32 +641,51 @@ public sealed partial class MainWindow : Window, IDisposable
 	/// actually on, and the level controls are probed last so their generation counter is
 	/// claimed after any switch the restore queued.
 	///
-	/// Never throws: it is the task the dictation path waits on, and a waiter must get an
-	/// answer rather than an exception.
+	/// Never throws — not just around the await, but over the whole body. It is the task
+	/// the dictation path waits on, and that path only ever reads
+	/// <see cref="Task.IsCompleted"/>: a fault here would be observed by nobody, leaving
+	/// no log, no message, and a half-built microphone card.
 	/// </remarks>
 	private async Task AdoptMicrophonesWhenReadyAsync()
 	{
 		try
 		{
 			await _audioDeviceManager.InitializeAsync();
+
+			// The window closed while the audio stack was waking up.
+			if (_isClosing)
+				return;
+
+			AdoptMicrophones();
 		}
 		catch (Exception ex)
 		{
 			ErrorLogger.LogError("Setting up the audio devices failed", ex);
-			if (!_isClosing)
-			{
-				CmbMicrophone.PlaceholderText = NoMicrophonesPlaceholder;
-				ShowStatus("Microphone",
-					"Could not read the microphones on this computer. Reconnect your microphone and restart Mutation.",
-					InfoBarSeverity.Error);
-			}
-			return;
+			if (_isClosing)
+				return;
+
+			SetMicrophonePlaceholder(NoMicrophonesPlaceholder);
+			ShowStatus("Microphone",
+				"Could not read the microphones on this computer. Reconnect your microphone and restart Mutation.",
+				InfoBarSeverity.Error);
 		}
+		finally
+		{
+			// Run on every path, including the ones that found no device. It is the only
+			// thing that sets _micLevelInitialized, and the microphone-selection handler
+			// re-probes the level controls only when that flag is set — so skipping it
+			// here left the level slider and the pin switch enabled, announced, and
+			// permanently inert for a user who started Mutation with their microphone
+			// unplugged and then plugged it in.
+			if (!_isClosing)
+				InitializeMicrophoneLevelControls();
+		}
+	}
 
-		// The window closed while the audio stack was waking up.
-		if (_isClosing)
-			return;
-
+	// The UI-thread half of startup, once the devices have answered. Split out so the
+	// method above is a plain try/catch/finally over it.
+	private void AdoptMicrophones()
+	{
 		var micList = _audioDeviceManager.CaptureDeviceInfos;
 
 		// Suppressed: filling an empty combo raises SelectionChanged, and the selection
@@ -682,16 +701,20 @@ public sealed partial class MainWindow : Window, IDisposable
 			_suppressMicrophoneSelection = wasSuppressed;
 		}
 
+		// The mute glyph and its label were built from an unread state while the devices
+		// were still being enumerated; now there is a real one behind them. Ahead of the
+		// empty-list return, because "no microphones" is a real state for them to show
+		// too.
+		UpdateMicrophoneToggleVisuals();
+
 		if (micList.Count == 0)
 		{
-			CmbMicrophone.PlaceholderText = NoMicrophonesPlaceholder;
-			AutomationProperties.SetHelpText(CmbMicrophone, NoMicrophonesPlaceholder);
+			SetMicrophonePlaceholder(NoMicrophonesPlaceholder);
 			ShowStatus("Microphone", "No microphones are available.", InfoBarSeverity.Warning);
 			return;
 		}
 
-		CmbMicrophone.PlaceholderText = SelectMicrophonePlaceholder;
-		AutomationProperties.SetHelpText(CmbMicrophone, SelectMicrophonePlaceholder);
+		SetMicrophonePlaceholder(SelectMicrophonePlaceholder);
 
 		// Assigned outside the suppression on purpose: the selection handler is what
 		// resolves the device over winmm, opens capture on it, and re-probes the level
@@ -710,12 +733,11 @@ public sealed partial class MainWindow : Window, IDisposable
 		else
 			_startupCapturePending = true;
 
-		// The mute glyph and its label were built from an unread state while the devices
-		// were still being enumerated; now there is a real one behind them.
-		UpdateMicrophoneToggleVisuals();
-
 		// Play a sound representing the current mute state, as the constructor used to
-		// once the active microphone had been restored.
+		// once the active microphone had been restored. Mute is an aggregate across every
+		// capture device in this app, so this answers "are you live?" rather than naming
+		// one endpoint — and it is seeded from the adopted device, not from whichever
+		// endpoint happened to enumerate first.
 		if (_audioDeviceManager.SelectedMicrophone is not null)
 			BeepPlayer.Play(_audioDeviceManager.IsMuted ? BeepType.Mute : BeepType.Unmute);
 
@@ -725,12 +747,15 @@ public sealed partial class MainWindow : Window, IDisposable
 		// is simply the app naming the microphone it opened.
 		if (CmbMicrophone.SelectedItem is Mutation.Ui.Core.CaptureDeviceInfo adopted)
 			ShowStatus("Microphone", $"Using {adopted.FriendlyName}.", InfoBarSeverity.Informational);
+	}
 
-		// Fire and forget: the probe it performs is a COM read of a device that may be
-		// slow, so it runs off the UI thread and the controls settle a moment later.
-		// The synchronous part — disabling the controls and claiming the initialization
-		// generation — has already run by the time this returns.
-		InitializeMicrophoneLevelControls();
+	// The placeholder is what a screen reader reads on a combo with nothing selected, and
+	// the help text is what it reads as the control's description. They are set together
+	// so a branch cannot leave one of them describing a state the app has left.
+	private void SetMicrophonePlaceholder(string placeholder)
+	{
+		CmbMicrophone.PlaceholderText = placeholder;
+		AutomationProperties.SetHelpText(CmbMicrophone, placeholder);
 	}
 
 	private void RestorePersistedMicrophoneSelection(IReadOnlyList<Mutation.Ui.Core.CaptureDeviceInfo> micList)
@@ -810,8 +835,7 @@ public sealed partial class MainWindow : Window, IDisposable
 			case Mutation.Ui.Core.CaptureDeviceListOutcome.SelectionReplaced:
 			case Mutation.Ui.Core.CaptureDeviceListOutcome.SelectionAdopted:
 				// A device is about to be selected again, so undo the empty-list wording.
-				CmbMicrophone.PlaceholderText = SelectMicrophonePlaceholder;
-				AutomationProperties.SetHelpText(CmbMicrophone, SelectMicrophonePlaceholder);
+				SetMicrophonePlaceholder(SelectMicrophonePlaceholder);
 
 				// Announced before the assignment: selecting runs the handler, which
 				// reports its own failure if the device turns out to be unusable, and
@@ -836,8 +860,7 @@ public sealed partial class MainWindow : Window, IDisposable
 				// The combo is empty, so its placeholder is what a screen reader landing
 				// on it will read. "Select a microphone" would be an instruction the user
 				// cannot follow.
-				CmbMicrophone.PlaceholderText = NoMicrophonesPlaceholder;
-				AutomationProperties.SetHelpText(CmbMicrophone, NoMicrophonesPlaceholder);
+				SetMicrophonePlaceholder(NoMicrophonesPlaceholder);
 				ShowStatus("Microphone", "No microphones are available.", InfoBarSeverity.Warning);
 				break;
 		}
@@ -1473,13 +1496,15 @@ public sealed partial class MainWindow : Window, IDisposable
 	/// </remarks>
 	private async Task<bool> WaitForMicrophoneAsync()
 	{
-		if (!MicrophoneIsSettling())
-			return true;
-
-		// A second press while the first is still parked. Answered rather than ignored, and
-		// never queued: two waits resume together and either start two recordings or
-		// instantly stop one that has barely begun. No second beep — the first press
-		// already gave the audible acknowledgement, and nothing has changed since.
+		// Checked before the settle test, not after. Between the switch landing and the
+		// parked press's continuation being dispatched, the microphone reads as settled
+		// while a start is still pending — and a second press taken as a fresh start
+		// there is the double entry this guard exists to stop.
+		//
+		// A second press is answered rather than ignored, and never queued: two waits
+		// resume together and either start two recordings or instantly stop one that has
+		// barely begun. No second beep — the first press already gave the audible
+		// acknowledgement, and nothing has changed since.
 		if (_dictationStartWaiting)
 		{
 			ShowStatus("Speech to Text",
@@ -1487,6 +1512,9 @@ public sealed partial class MainWindow : Window, IDisposable
 				InfoBarSeverity.Informational);
 			return false;
 		}
+
+		if (!MicrophoneIsSettling())
+			return true;
 
 		_dictationStartWaiting = true;
 		UpdateRecordingActionAvailability();
@@ -1505,11 +1533,7 @@ public sealed partial class MainWindow : Window, IDisposable
 				if (_isClosing)
 					return false;
 
-				BeepPlayer.Play(BeepType.Failure);
-				ShowStatus("Speech to Text",
-					"The microphone is still not ready, so nothing was recorded. Try again, or choose another microphone.",
-					InfoBarSeverity.Warning);
-				return false;
+				return FallBackToTheLiveMicrophone();
 			}
 		}
 		finally
@@ -1522,6 +1546,41 @@ public sealed partial class MainWindow : Window, IDisposable
 		// The window closed while the device was opening; teardown would dispose the
 		// recording as fast as it started.
 		return !_isClosing;
+	}
+
+	/// <summary>
+	/// What a dictation start does once the wait has run out of budget. Returns whether
+	/// the caller should still go on to start.
+	/// </summary>
+	/// <remarks>
+	/// Refusing outright was the obvious answer and it is the wrong one. A winmm call
+	/// wedged inside a driver never returns, so the switch worker never goes idle and the
+	/// microphone never stops "settling" — every later press would then cost the full
+	/// budget and refuse, which is the permanently dead hotkey issue #312 set out to
+	/// prevent, reached the long way round. Worse, the obvious remedy would not work
+	/// either: choosing another microphone queues behind the same wedged worker.
+	///
+	/// So when there is a device that is actually open, the recording goes ahead on it and
+	/// the user is told which one, by name — a bounded wait and a plain sentence, rather
+	/// than the silent wrong-microphone recording that was the bug. Only when nothing is
+	/// live at all is there no recording to make.
+	/// </remarks>
+	private bool FallBackToTheLiveMicrophone()
+	{
+		BeepPlayer.Play(BeepType.Failure);
+
+		if (_audioDeviceManager.SelectedMicrophone is not { } live)
+		{
+			ShowStatus("Speech to Text",
+				"The microphone is still not ready, so nothing was recorded. Try again, or choose another microphone.",
+				InfoBarSeverity.Warning);
+			return false;
+		}
+
+		ShowStatus("Speech to Text",
+			$"The microphone you chose is still not ready. Recording from {live.FriendlyName} instead.",
+			InfoBarSeverity.Warning);
+		return true;
 	}
 
 	// Whether the microphone the recorder would open may still be about to change:

--- a/Mutation.Ui/MainWindow.xaml.cs
+++ b/Mutation.Ui/MainWindow.xaml.cs
@@ -133,6 +133,24 @@ public sealed partial class MainWindow : Window, IDisposable
 	// Set as soon as the window starts closing, so async continuations that resume
 	// afterwards do not touch torn-down controls.
 	private bool _isClosing;
+	// Completes when the audio stack has been enumerated and the microphone combo has
+	// been filled in from it — or when that failed and the user has been told. Never
+	// faults: AdoptMicrophonesWhenReadyAsync reports its own trouble, and a waiter on the
+	// dictation path must not be handed an exception instead of an answer.
+	private readonly Task _audioDevicesReady;
+	// True while a dictation start is parked waiting for the microphone to settle.
+	// Nothing else disables the shortcut for that stretch — the session is neither
+	// recording nor transcribing yet — so without this a second press would queue a
+	// second start and the two would resume together (issue #312). UI thread only.
+	private bool _dictationStartWaiting;
+	// How long a dictation start waits for the microphone before giving up. A winmm call
+	// already inside a wedged driver cannot be cancelled, so an unbounded wait would
+	// leave every later press queued behind one that never completes — a hotkey that is
+	// silently dead for the rest of the session.
+	private static readonly TimeSpan MicrophoneReadyTimeout = TimeSpan.FromSeconds(8);
+	private const string DetectingMicrophonesPlaceholder = "Finding microphones...";
+	private const string SelectMicrophonePlaceholder = "Select a microphone";
+	private const string NoMicrophonesPlaceholder = "No microphones available";
 	private const string DefaultVoiceLabel = "(System default)";
 
 	private static readonly IReadOnlyDictionary<string, string> AudioMimeTypeMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
@@ -256,31 +274,24 @@ public sealed partial class MainWindow : Window, IDisposable
 		_statusDismissTimer.Tick += StatusDismissTimer_Tick;
 		StatusInfoBar.CloseButtonClick += StatusInfoBar_CloseButtonClick;
 
-		_audioDeviceManager.EnsureDefaultMicrophoneSelected();
-
 		UpdateMicrophoneToggleVisuals();
 		UpdateSpeechButtonVisuals("Record", RecordGlyph);
 		// The combo binds immutable descriptions, not live MMDevice wrappers: the device
 		// list is re-enumerated on every hot-plug and on the mute and level retry paths,
 		// and the superseded wrappers are disposed — so live devices held here go stale
 		// and even the display binding ends up reading a dead COM proxy (issue #264).
-		var micList = _audioDeviceManager.CaptureDeviceInfos;
-		CmbMicrophone.ItemsSource = micList;
+		//
+		// Bound empty here and filled in when the audio stack answers. The control itself
+		// is in the tree, enabled and focusable, from the moment the window opens — what
+		// used to hold the window back was the enumeration behind it, not the combo
+		// (issue #308). Its placeholder says so, so a screen reader landing on it before
+		// the devices arrive gets an explanation rather than an empty list.
+		CmbMicrophone.ItemsSource = Array.Empty<Mutation.Ui.Core.CaptureDeviceInfo>();
 		CmbMicrophone.DisplayMemberPath = nameof(Mutation.Ui.Core.CaptureDeviceInfo.FriendlyName);
+		CmbMicrophone.PlaceholderText = DetectingMicrophonesPlaceholder;
+		AutomationProperties.SetHelpText(CmbMicrophone, DetectingMicrophonesPlaceholder);
 
-		RestorePersistedMicrophoneSelection(micList);
 		_audioDeviceManager.CaptureDeviceListChanged += AudioDeviceManager_CaptureDeviceListChanged;
-
-		// Skipped when restoring the persisted choice queued a switch: that switch
-		// starts capture on the device the user actually chose, and opening one here
-		// first would briefly run the OS default instead — an activity light on a
-		// microphone they are not using, and an error message naming it if it will not
-		// open. When the persisted choice is already the default there is no switch to
-		// wait for, and this is what gets the waveform going.
-		if (_requestedMicrophoneId is null)
-			_microphoneVisualization.StartCapture();
-		else
-			_startupCapturePending = true;
 
 		CmbSpeechService.ItemsSource = _speechServices;
 		CmbSpeechService.DisplayMemberPath = nameof(ISpeechToTextService.ServiceName);
@@ -325,19 +336,17 @@ public sealed partial class MainWindow : Window, IDisposable
 		// screen reader says as the window opens.
 		_announceThirdPartyExplanation = true;
 
-		// After initializing and restoring the active microphone, play a sound
-		// representing the current state (mute/unmute) to reflect actual status.
-		if (_audioDeviceManager.SelectedMicrophone is not null)
-			BeepPlayer.Play(_audioDeviceManager.IsMuted ? BeepType.Mute : BeepType.Unmute);
-
 		InitializeTextToSpeechControls();
 		InitializePlaybackSpeedControl();
-		// Fire and forget: the probe it performs is a COM read of a device that may be
-		// slow, so it runs off the UI thread and the controls settle a moment later.
-		// The synchronous part — disabling the controls and claiming the initialization
-		// generation — has already run by the time this returns.
-		InitializeMicrophoneLevelControls();
 		InitializeHotkeyVisuals();
+
+		// Everything that has to ask the audio hardware a question — the enumeration, the
+		// OS default, the winmm index, the mute state, and the capture handle — happens
+		// from here, off the UI thread, and lands back on it when it answers (issue #308).
+		// Kept as a task rather than fired and forgotten: a dictation press that arrives
+		// while it is still running waits on it, so the recorder cannot open device
+		// index -1 (issue #312).
+		_audioDevicesReady = AdoptMicrophonesWhenReadyAsync();
 
 		_closeSequence = new Mutation.Ui.Core.ApplicationCloseSequence(
 			PersistClosingState,
@@ -619,6 +628,111 @@ public sealed partial class MainWindow : Window, IDisposable
 		}
 	}
 
+	/// <summary>
+	/// Waits for the audio stack to answer, then fills in the microphone combo, restores
+	/// the persisted choice, opens capture, and seeds the mute beep and the level
+	/// controls — everything the constructor used to do inline, on the UI thread, behind
+	/// COM and winmm calls that can take seconds on a machine with a microphone that is
+	/// slow to enumerate (issue #308).
+	/// </summary>
+	/// <remarks>
+	/// The order below is the constructor's old order, kept deliberately. The persisted
+	/// choice is restored before the beep so the beep describes the device the user is
+	/// actually on, and the level controls are probed last so their generation counter is
+	/// claimed after any switch the restore queued.
+	///
+	/// Never throws: it is the task the dictation path waits on, and a waiter must get an
+	/// answer rather than an exception.
+	/// </remarks>
+	private async Task AdoptMicrophonesWhenReadyAsync()
+	{
+		try
+		{
+			await _audioDeviceManager.InitializeAsync();
+		}
+		catch (Exception ex)
+		{
+			ErrorLogger.LogError("Setting up the audio devices failed", ex);
+			if (!_isClosing)
+			{
+				CmbMicrophone.PlaceholderText = NoMicrophonesPlaceholder;
+				ShowStatus("Microphone",
+					"Could not read the microphones on this computer. Reconnect your microphone and restart Mutation.",
+					InfoBarSeverity.Error);
+			}
+			return;
+		}
+
+		// The window closed while the audio stack was waking up.
+		if (_isClosing)
+			return;
+
+		var micList = _audioDeviceManager.CaptureDeviceInfos;
+
+		// Suppressed: filling an empty combo raises SelectionChanged, and the selection
+		// that matters is the one RestorePersistedMicrophoneSelection makes just below.
+		bool wasSuppressed = _suppressMicrophoneSelection;
+		_suppressMicrophoneSelection = true;
+		try
+		{
+			CmbMicrophone.ItemsSource = micList;
+		}
+		finally
+		{
+			_suppressMicrophoneSelection = wasSuppressed;
+		}
+
+		if (micList.Count == 0)
+		{
+			CmbMicrophone.PlaceholderText = NoMicrophonesPlaceholder;
+			AutomationProperties.SetHelpText(CmbMicrophone, NoMicrophonesPlaceholder);
+			ShowStatus("Microphone", "No microphones are available.", InfoBarSeverity.Warning);
+			return;
+		}
+
+		CmbMicrophone.PlaceholderText = SelectMicrophonePlaceholder;
+		AutomationProperties.SetHelpText(CmbMicrophone, SelectMicrophonePlaceholder);
+
+		// Assigned outside the suppression on purpose: the selection handler is what
+		// resolves the device over winmm, opens capture on it, and re-probes the level
+		// controls, all on the switch worker.
+		RestorePersistedMicrophoneSelection(micList);
+
+		// Skipped when restoring the persisted choice queued a switch: that switch starts
+		// capture on the device the user actually chose, and opening one here first would
+		// briefly run the OS default instead — an activity light on a microphone they are
+		// not using, and an error message naming it if it will not open. When the
+		// persisted choice is already the default there is no switch to wait for, and
+		// this is what gets the waveform going. Queued on the switch worker rather than
+		// called inline, because waveInOpen is the same kind of blocking call as the rest.
+		if (_requestedMicrophoneId is null)
+			_ = _microphoneSwitch.RestartCaptureAsync();
+		else
+			_startupCapturePending = true;
+
+		// The mute glyph and its label were built from an unread state while the devices
+		// were still being enumerated; now there is a real one behind them.
+		UpdateMicrophoneToggleVisuals();
+
+		// Play a sound representing the current mute state, as the constructor used to
+		// once the active microphone had been restored.
+		if (_audioDeviceManager.SelectedMicrophone is not null)
+			BeepPlayer.Play(_audioDeviceManager.IsMuted ? BeepType.Mute : BeepType.Unmute);
+
+		// The combo changed under the user after the window was already up, so say what
+		// they ended up on rather than letting it happen in silence. The screen reader
+		// has read an empty combo by this point on a slow machine, and on a fast one this
+		// is simply the app naming the microphone it opened.
+		if (CmbMicrophone.SelectedItem is Mutation.Ui.Core.CaptureDeviceInfo adopted)
+			ShowStatus("Microphone", $"Using {adopted.FriendlyName}.", InfoBarSeverity.Informational);
+
+		// Fire and forget: the probe it performs is a COM read of a device that may be
+		// slow, so it runs off the UI thread and the controls settle a moment later.
+		// The synchronous part — disabling the controls and claiming the initialization
+		// generation — has already run by the time this returns.
+		InitializeMicrophoneLevelControls();
+	}
+
 	private void RestorePersistedMicrophoneSelection(IReadOnlyList<Mutation.Ui.Core.CaptureDeviceInfo> micList)
 	{
 		var match = FindPersistedMicrophone(micList);
@@ -695,6 +809,10 @@ public sealed partial class MainWindow : Window, IDisposable
 
 			case Mutation.Ui.Core.CaptureDeviceListOutcome.SelectionReplaced:
 			case Mutation.Ui.Core.CaptureDeviceListOutcome.SelectionAdopted:
+				// A device is about to be selected again, so undo the empty-list wording.
+				CmbMicrophone.PlaceholderText = SelectMicrophonePlaceholder;
+				AutomationProperties.SetHelpText(CmbMicrophone, SelectMicrophonePlaceholder);
+
 				// Announced before the assignment: selecting runs the handler, which
 				// reports its own failure if the device turns out to be unusable, and
 				// that more specific message should be the one left standing.
@@ -715,6 +833,11 @@ public sealed partial class MainWindow : Window, IDisposable
 				// switch that may still be in flight.
 				_requestedMicrophoneId = null;
 				_ = _microphoneSwitch.ReleaseAsync();
+				// The combo is empty, so its placeholder is what a screen reader landing
+				// on it will read. "Select a microphone" would be an instruction the user
+				// cannot follow.
+				CmbMicrophone.PlaceholderText = NoMicrophonesPlaceholder;
+				AutomationProperties.SetHelpText(CmbMicrophone, NoMicrophonesPlaceholder);
 				ShowStatus("Microphone", "No microphones are available.", InfoBarSeverity.Warning);
 				break;
 		}
@@ -1309,6 +1432,13 @@ public sealed partial class MainWindow : Window, IDisposable
 				return;
             }
             
+			// Only a start waits. Asked of the session, through the same planner the
+			// recorder itself uses, because a stop must never be held up by a device that
+			// is slow to open: the recording is already running on a device that opened
+			// fine, and the user has finished speaking.
+			if (_audioSessionManager.NextPressStartsRecording && !await WaitForMicrophoneAsync())
+				return;
+
             LlmSettings.LlmPrompt? autoRunPrompt = _promptLibrary?.GetAutoRunPrompt();
             await _audioSessionManager.StartStopRecordingAsync(_activeSpeechService, useLlmProcessing, GetActivePrompt(), autoRunPrompt, _shutdownCts.Token);
 		}
@@ -1317,6 +1447,116 @@ public sealed partial class MainWindow : Window, IDisposable
 			ShowStatus("Speech to Text", ex.Message, InfoBarSeverity.Error);
 			await ShowErrorDialog("Speech to Text Error", ex);
 		}
+	}
+
+	/// <summary>
+	/// Holds a dictation start until the microphone the user last chose is the one the
+	/// recorder will open. Returns false when the caller must not go on to start.
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// Since #267 the microphone switch runs on a background worker, so
+	/// <c>MicrophoneDeviceIndex</c> does not move until the switch lands. Arrow onto a
+	/// Bluetooth headset, hear the combo announce it, press the dictation hotkey while it
+	/// is still opening, and the session recorded from the previous microphone — with
+	/// nothing in the UI to contradict what had just been announced (issue #312). Before
+	/// #267 the frozen message pump held the press back; the freeze was the bug, but it
+	/// was also what made this ordering safe.
+	/// </para>
+	/// <para>
+	/// Three things make the wait safe to have on the dictation path. It is re-entrant-
+	/// guarded, so a second press cannot queue a second start behind the first. It is
+	/// bounded, because a wedged device is a hang rather than an exception and would
+	/// otherwise leave the shortcut permanently dead and silent. And it is audible from
+	/// the first beat, so the press never reads as one that did not register.
+	/// </para>
+	/// </remarks>
+	private async Task<bool> WaitForMicrophoneAsync()
+	{
+		if (!MicrophoneIsSettling())
+			return true;
+
+		// A second press while the first is still parked. Answered rather than ignored, and
+		// never queued: two waits resume together and either start two recordings or
+		// instantly stop one that has barely begun. No second beep — the first press
+		// already gave the audible acknowledgement, and nothing has changed since.
+		if (_dictationStartWaiting)
+		{
+			ShowStatus("Speech to Text",
+				"Still waiting for the microphone. Recording will start as soon as it is ready.",
+				InfoBarSeverity.Informational);
+			return false;
+		}
+
+		_dictationStartWaiting = true;
+		UpdateRecordingActionAvailability();
+		try
+		{
+			// Within a beat of the press, whatever the device is doing. The beep is the
+			// half that carries when Mutation is in the background and the shortcut was
+			// pressed from another app, where a status message is never read out.
+			BeepPlayer.Play(BeepType.Waiting);
+			ShowStatus("Speech to Text",
+				"Waiting for the microphone to be ready — recording will start in a moment.",
+				InfoBarSeverity.Informational);
+
+			if (!await MicrophoneSettledAsync(MicrophoneReadyTimeout))
+			{
+				if (_isClosing)
+					return false;
+
+				BeepPlayer.Play(BeepType.Failure);
+				ShowStatus("Speech to Text",
+					"The microphone is still not ready, so nothing was recorded. Try again, or choose another microphone.",
+					InfoBarSeverity.Warning);
+				return false;
+			}
+		}
+		finally
+		{
+			_dictationStartWaiting = false;
+			if (!_isClosing)
+				UpdateRecordingActionAvailability();
+		}
+
+		// The window closed while the device was opening; teardown would dispose the
+		// recording as fast as it started.
+		return !_isClosing;
+	}
+
+	// Whether the microphone the recorder would open may still be about to change:
+	// startup has not finished adopting a device, or a switch is in flight or queued.
+	private bool MicrophoneIsSettling() =>
+		!_audioDevicesReady.IsCompleted || _microphoneSwitch.IsSwitching;
+
+	// Waits out the settling, giving up once the budget is spent. The loop is what covers
+	// a user who changes their mind mid-wait: a switch that lands only for a newer one to
+	// start means the recording still has to follow the last choice, not the first. The
+	// budget spans the whole loop, so re-arming cannot extend the wait indefinitely.
+	private async Task<bool> MicrophoneSettledAsync(TimeSpan budget)
+	{
+		var spent = System.Diagnostics.Stopwatch.StartNew();
+
+		while (!_isClosing && MicrophoneIsSettling())
+		{
+			TimeSpan remaining = budget - spent.Elapsed;
+			if (remaining <= TimeSpan.Zero)
+				return false;
+
+			var settled = Task.WhenAll(_audioDevicesReady, _microphoneSwitch.WaitForIdleAsync());
+
+			// Linked to the shutdown token so the timer does not outlive the window, and
+			// cancelled the moment the race is decided so a settled microphone does not
+			// leave a timer ticking for the rest of the budget.
+			using var expiry = CancellationTokenSource.CreateLinkedTokenSource(_shutdownCts.Token);
+			var finished = await Task.WhenAny(settled, Task.Delay(remaining, expiry.Token));
+			expiry.Cancel();
+
+			if (finished != settled)
+				return false;
+		}
+
+		return !_isClosing;
 	}
 
 	/// <summary>
@@ -2428,7 +2668,13 @@ public sealed partial class MainWindow : Window, IDisposable
         // Same reason as UpdateSessionNavigationAvailability: Retry and Upload both refuse
         // during the model call, so leaving them enabled offered the user an action that
         // could only answer "finish the current operation first".
-        bool busy = _audioSessionManager.IsRecording
+        //
+        // A dictation start parked waiting for the microphone counts too (issue #312). It
+        // is neither recording nor transcribing yet, but it is committed to becoming a
+        // recording, and offering Retry or Upload in that window invites a second audio
+        // operation to start underneath the one that is already on its way.
+        bool busy = _dictationStartWaiting
+            || _audioSessionManager.IsRecording
             || _audioSessionManager.IsTranscribing
             || _audioSessionManager.IsProcessingWithLlm;
         // Asked of the session rather than the speakers: a long recording spends seconds


### PR DESCRIPTION
Closes #308, closes #312, closes #313.

Three microphone-path bugs found while reviewing #307. They are in one PR because they share a seam: what the app does between asking the audio stack a question and getting an answer.

## #308 — the window no longer waits for the audio stack

`AudioDeviceManager`'s constructor did the capture enumeration, the describe pass and the initial mute read. The window constructor then resolved the OS default endpoint (`GetDefaultAudioEndpoint`) and walked the winmm device table (`waveInGetNumDevs` / `waveInGetDevCaps`). All of it on the UI thread, so a USB mic that is slow to enumerate, a Bluetooth headset still connecting, or a wedged driver held the window shut with the screen reader holding nothing to announce.

- Construction does no device work at all. `AudioDeviceManager.InitializeAsync()` does the enumeration, the default adoption and the mute read on a thread-pool thread, once, idempotently.
- `MainWindow` binds the combo empty and kicks the initialization off; `AdoptMicrophonesWhenReadyAsync` fills in the list, restores the persisted choice, opens capture on the switch worker, plays the mute beep and probes the level controls when the answer arrives — the constructor's old order, kept deliberately.
- **Accessibility.** The combo is in the tree, enabled and focusable, from the moment the window opens. Its placeholder reads "Finding microphones..." until the devices land, so a screen reader arriving early gets an explanation rather than an empty list, and the adoption is then announced ("Using ...") rather than happening in silence.
- **Preserved.** An explicit selection still wins over a default that resolves later. The startup beep now reads the *selected* device's hardware mute state rather than whichever endpoint happened to enumerate first.
- Capture start moved onto the switch worker too — `waveInOpen` is the same class of blocking call as the rest.
- The first enumeration no longer raises `CaptureDeviceListChanged`. Nothing changed when a device set appears where there was none, and with startup off the UI thread the window is already subscribed by then — raising would have it adopt the first device out from under the persisted choice.

## #312 — a dictation start waits for the switch to land

Since #267 the switch runs on a background worker, so `MicrophoneDeviceIndex` does not move until it lands. Arrow onto a Jabra headset, hear the combo announce it, press the hotkey straight away, and the session recorded from the previous microphone with nothing contradicting what had just been announced.

The wait is the fix #307 drafted and withdrew, with the three holes closed that made it worse than the bug:

| Hole | Closed by |
| --- | --- |
| Double entry — nothing disabled the hotkey while the wait was parked | `_dictationStartWaiting`, which answers a second press instead of queueing it, and counts as busy in `UpdateRecordingActionAvailability` |
| A wedged device is a hang, not an exception — silence, then a permanently dead hotkey | An eight-second bound on the wait, then the failure beep and a message |
| No `_isClosing` guard | Checked after the wait, before the start |

- **Audible from the first beat.** A new `BeepType.Waiting` — two low tones that *fall*, where `Success` rises and `Start` is a single bright tone. Silence reads as a shortcut that did not register to someone driving the app by ear from another window, and the `Start` beep would say the microphone is live when it is not.
- **Only a start waits.** Asked through `AudioSessionManager.NextPressStartsRecording`, which is `DictationPressPlanner` — the same decision the recorder makes from the same five facts. A stop is never delayed by a device that is slow to open.
- `MicrophoneSwitchCoordinator.WaitForIdleAsync()` is the signal. `SwitchAsync`'s own task is no use here: a superseded request completes with `null` the moment a newer one arrives, long before any device is open.

## #313 — re-plugging the only microphone brings it back

`RefreshCaptureDevices` never cleared `_microphone` / `_microphoneInfo` when the selected device left the enumeration. On a one-microphone PC: unplug, the list empties; plug back in, the ID matches again, so `CaptureDeviceSelectionPlanner` reported `SelectionPreserved` — silent by design — and nothing re-opened capture. The waveform stayed dead and a blind user was told nothing at all.

- The selection is dropped when its ID is absent from the new enumeration, which makes the re-plug a `SelectionAdopted`: announced, and routed through the normal selection path that re-opens capture.
- A device that is still present is still preserved in silence, so the mute and level retry paths — which re-enumerate routinely — stay quiet.
- The abandoned COM wrapper is now released rather than left to finalization, including the default endpoint that never belonged to an enumeration.
- `RefreshActiveMicrophone`'s comments are corrected: it no longer relies on a stale wrapper surviving a re-enumeration that dropped it.

## Tests

`dotnet test --configuration Release` — 1638 passed, 0 failed.

New coverage:

- `MicrophoneSwitchCoordinatorTests` — six cases for `WaitForIdleAsync`: already complete when idle, does not release until the device work lands, covers a request queued behind the running one, releases every waiter, completes when the switch fails, and re-arms for the next switch.
- `CaptureSelectionSurvivalTests` — the dropped-selection rule, including the re-plug sequence end to end and the negative case that keeps routine re-enumerations silent.
- `WaitingBeepTests` — the new beep synthesizes, and is distinguishable from `Start` and `Success` by direction and by pitch.
- `DictationPressPlannerTests` — a press that ends something is never a start, which is what keeps the stop path out of the wait.

Real `MMDevice` instances need hardware, so the `AudioDeviceManager` changes are covered where they are decidable (the pure rules) rather than through the COM paths.

## Documentation

`microphone.md`, `dictation.md`, `troubleshooting.md` and `settings.md` updated, HTML rebuilt and committed alongside: the startup placeholder and adoption message, the re-plug announcement, the waiting sound and its timeout, and two new troubleshooting entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)