### PR TITLE
Move the routine packages on, and put a test on the retry ladders

### DIFF
--- a/CognitiveSupport/DeepgramSpeechToTextService.cs
+++ b/CognitiveSupport/DeepgramSpeechToTextService.cs
@@ -10,23 +10,41 @@ public class DeepgramSpeechToTextService : ISpeechToTextService
 	public string ServiceName { get; init; }
 
 	// Holds no call state, so one pipeline serves every transcription, concurrent or not.
-	private static readonly ResiliencePipeline RetryPipeline =
-		TransientRetry.Pipeline(retryCount: 3, TransientRetry.Transient());
+	// Built per instance rather than shared statically only so the clock behind it can be
+	// replaced; the app makes one of these, so that costs nothing.
+	private readonly ResiliencePipeline _retryPipeline;
 
 	private readonly string _modelId;
 	private readonly Deepgram.Clients.Interfaces.v1.IListenRESTClient _deepgramClient;
 	private readonly int _timeoutSeconds;
+	private readonly TimeProvider _timeProvider;
+	private readonly Action<int> _announceAttempt;
 
+	/// <param name="timeProvider">
+	/// Test seam only; null in production. Drives both the retry backoff and each
+	/// attempt's deadline, so a test can read back the waits that were armed instead of
+	/// sitting through them.
+	/// </param>
+	/// <param name="announceAttempt">
+	/// Test seam only; null in production, where it beeps. Substituting it is what lets a
+	/// test assert the attempt number the listener is told about — and, just as usefully,
+	/// keeps a suite that drives real retries from playing sounds at whoever ran it.
+	/// </param>
 	public DeepgramSpeechToTextService(
 		string serviceName,
 		Deepgram.Clients.Interfaces.v1.IListenRESTClient deepgramClient,
 		string modelId,
-		int timeoutSeconds = 10)
+		int timeoutSeconds = 10,
+		TimeProvider? timeProvider = null,
+		Action<int>? announceAttempt = null)
 	{
 		ServiceName = serviceName;
 		_deepgramClient = deepgramClient ?? throw new ArgumentNullException(nameof(deepgramClient));
 		_modelId = modelId ?? throw new ArgumentNullException(nameof(modelId), "Check your Deepgram API documentation for supported modelIds.");
 		_timeoutSeconds = timeoutSeconds > 0 ? timeoutSeconds : 10;
+		_timeProvider = timeProvider ?? TimeProvider.System;
+		_announceAttempt = announceAttempt ?? (attempt => this.Beep(attempt));
+		_retryPipeline = TransientRetry.Pipeline(retryCount: 3, TransientRetry.Transient(), timeProvider);
 	}
 
 	public async Task<string> ConvertAudioToText(
@@ -42,17 +60,18 @@ public class DeepgramSpeechToTextService : ISpeechToTextService
 
 		var audioBytes = await File.ReadAllBytesAsync(audioffilePath, overallCancellationToken).ConfigureAwait(false);
 
-		var response = await RetryPipeline.ExecuteWithAttemptAsync(async (attempt, overallToken) =>
+		var response = await _retryPipeline.ExecuteWithAttemptAsync(async (attempt, overallToken) =>
 		{
 			int baseTimeout = timeoutSeconds ?? _timeoutSeconds;
 			// Linear backoff for timeout duration, but respect the requested timeout as a minimum for the first attempt.
 			// Removing the 60s cap to allow for longer file transcriptions.
 			int timeout = baseTimeout * attempt;
-			using var thisTryCts = new CancellationTokenSource(TimeSpan.FromSeconds(timeout));
+			using var thisTryCts = new CancellationTokenSource(TimeSpan.FromSeconds(timeout), _timeProvider);
 			using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(overallToken, thisTryCts.Token);
 
-			// Beep swallows the first, non-retry attempt itself; retries beep once per attempt.
-			this.Beep(attempt);
+			// The default announcer swallows the first, non-retry attempt itself and beeps once
+			// per attempt after that; every attempt is reported here regardless.
+			_announceAttempt(attempt);
 
 			return await TranscribeViaDeepgram(keyterms, audioBytes, linkedCts).ConfigureAwait(false);
 		}, overallCancellationToken).ConfigureAwait(false);

--- a/CognitiveSupport/LlmService.cs
+++ b/CognitiveSupport/LlmService.cs
@@ -11,16 +11,29 @@ public class LlmService : ILlmService
 	private readonly Dictionary<string, LlmModelConfig> _modelConfigs;
 	private readonly int _timeoutSeconds;
 	private readonly ResiliencePipeline _retryPipeline;
+	private readonly TimeProvider _timeProvider;
 
 	/// <param name="transport">
 	/// Test seam only; null in production. See <see cref="OpenAiClientOptionsFactory.Create"/>.
+	/// </param>
+	/// <param name="sdkRetryCount">
+	/// Test seam only; null in production. Turns the OpenAI SDK's own retries down (0 off)
+	/// so the retries a test counts are the ones this class runs, not the SDK's underneath
+	/// them. See <see cref="OpenAiClientOptionsFactory.Create"/>.
+	/// </param>
+	/// <param name="timeProvider">
+	/// Test seam only; null in production. Drives both the retry backoff and each
+	/// attempt's deadline, so a test can read back the waits that were armed instead of
+	/// sitting through them.
 	/// </param>
 	public LlmService(
 		string apiKey,
 		IEnumerable<LlmModelConfig> models,
 		int timeoutSeconds = 60,
 		int retryCount = 3,
-		PipelineTransport? transport = null)
+		PipelineTransport? transport = null,
+		int? sdkRetryCount = null,
+		TimeProvider? timeProvider = null)
 	{
 		if (string.IsNullOrEmpty(apiKey)) throw new ArgumentNullException(nameof(apiKey));
 
@@ -29,6 +42,7 @@ public class LlmService : ILlmService
 		_chatClients = new Dictionary<string, ChatClient>(LlmModelIndex.NameComparer);
 		_modelConfigs = new Dictionary<string, LlmModelConfig>(LlmModelIndex.NameComparer);
 		_timeoutSeconds = timeoutSeconds > 0 ? timeoutSeconds : 60;
+		_timeProvider = timeProvider ?? TimeProvider.System;
 
 		// The OpenAI SDK reports API errors as ClientResultException; only transient
 		// statuses (429, 5xx, connection failures) are retried, so a permanent 4xx such as
@@ -36,7 +50,8 @@ public class LlmService : ILlmService
 		_retryPipeline = TransientRetry.Pipeline(
 			retryCount,
 			TransientRetry.Transient()
-				.Handle<ClientResultException>(ex => LlmHttpStatus.IsTransient(ex.Status)));
+				.Handle<ClientResultException>(ex => LlmHttpStatus.IsTransient(ex.Status)),
+			timeProvider);
 
 		foreach (var model in modelList)
 		{
@@ -45,7 +60,7 @@ public class LlmService : ILlmService
 			_chatClients[model.Name] = new ChatClient(
 				model.Name,
 				new ApiKeyCredential(apiKey),
-				OpenAiClientOptionsFactory.Create(transport: transport));
+				OpenAiClientOptionsFactory.Create(transport: transport, maxRetries: sdkRetryCount));
 			_modelConfigs[model.Name] = model;
 		}
 	}
@@ -87,7 +102,7 @@ public class LlmService : ILlmService
 			return await _retryPipeline.ExecuteWithAttemptAsync(async (attempt, overallToken) =>
 			{
 				int timeout = _timeoutSeconds * attempt;
-				using var thisTryCts = new CancellationTokenSource(TimeSpan.FromSeconds(timeout));
+				using var thisTryCts = new CancellationTokenSource(TimeSpan.FromSeconds(timeout), _timeProvider);
 				using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(overallToken, thisTryCts.Token);
 				return await client.CompleteChatAsync(openAiMessages, options, linkedCts.Token).ConfigureAwait(false);
 			}, cancellationToken).ConfigureAwait(false);

--- a/CognitiveSupport/OcrService.cs
+++ b/CognitiveSupport/OcrService.cs
@@ -25,14 +25,49 @@ public class OcrService : IOcrService, IDisposable
         private string Endpoint { get; }
         private ImageAnalysisClient ImageAnalysisClient { get; }
         private readonly int _timeoutSeconds;
+	private readonly TimeProvider _timeProvider;
+	private readonly Action<int> _announceAttempt;
+	// Holds no call state, so one pipeline serves every read, concurrent or not. Built per
+	// instance rather than shared statically only so the clock behind it can be replaced;
+	// the app makes one of these, so that costs nothing.
+	private readonly ResiliencePipeline _retryPipeline;
 	private static RequestRateLimiter SharedRateLimiter = new(20, TimeSpan.FromMinutes(1));
 
-	public OcrService(string? subscriptionKey, string? endpoint, int timeoutSeconds = 30)
+	/// <param name="imageAnalysisClient">
+	/// Test seam only; null in production, where the client is built from the endpoint and
+	/// key above. Substituting one is what lets a test drive a read to completion — and so
+	/// exercise the retry ladder around it — without an Azure account, the way
+	/// <see cref="AnthropicLlmService"/>'s injected HttpClient already allows (issue #311).
+	/// </param>
+	/// <param name="timeProvider">
+	/// Test seam only; null in production. Drives both the retry backoff and each
+	/// attempt's deadline, so a test can read back the waits that were armed instead of
+	/// sitting through them.
+	/// </param>
+	/// <param name="announceAttempt">
+	/// Test seam only; null in production, where it beeps. Substituting it is what lets a
+	/// test assert the attempt number the listener is told about — and, just as usefully,
+	/// keeps a suite that drives real retries from playing sounds at whoever ran it.
+	/// </param>
+	public OcrService(
+		string? subscriptionKey,
+		string? endpoint,
+		int timeoutSeconds = 30,
+		ImageAnalysisClient? imageAnalysisClient = null,
+		TimeProvider? timeProvider = null,
+		Action<int>? announceAttempt = null)
 	{
 		SubscriptionKey = subscriptionKey ?? throw new ArgumentNullException(nameof(subscriptionKey));
 		Endpoint = endpoint ?? throw new ArgumentNullException(nameof(endpoint));
-		ImageAnalysisClient = CreateImageAnalysisClient(Endpoint, SubscriptionKey);
+		ImageAnalysisClient = imageAnalysisClient ?? CreateImageAnalysisClient(Endpoint, SubscriptionKey);
 		_timeoutSeconds = Math.Max(1, Math.Min(timeoutSeconds, MaxTimeoutSeconds));
+		_timeProvider = timeProvider ?? TimeProvider.System;
+		_announceAttempt = announceAttempt ?? (attempt => this.Beep(attempt));
+		_retryPipeline = TransientRetry.Pipeline(
+			retryCount: 3,
+			TransientRetry.Transient()
+				.Handle<RequestFailedException>(ex => ex.Status == 429 || ex.Status >= 500),
+			timeProvider);
 	}
 
 	public Task<string> ExtractText(
@@ -46,20 +81,17 @@ public class OcrService : IOcrService, IDisposable
 	private static ImageAnalysisClient CreateImageAnalysisClient(string endpoint, string key) =>
 		 new(new Uri(endpoint), new AzureKeyCredential(key));
 
-	// Holds no call state, so one pipeline serves every read, concurrent or not.
-	private static readonly ResiliencePipeline RetryPipeline = TransientRetry.Pipeline(
-		retryCount: 3,
-		TransientRetry.Transient()
-			.Handle<RequestFailedException>(ex => ex.Status == 429 || ex.Status >= 500));
-
 	private TimeSpan GetPerRequestTimeout() => TimeSpan.FromSeconds(Math.Max(1, Math.Min(_timeoutSeconds, MaxTimeoutSeconds)));
 
-	private CancellationTokenSource CreatePerRequestCancellationTokenSource(CancellationToken overallToken)
-	{
-		var cts = CancellationTokenSource.CreateLinkedTokenSource(overallToken);
-		cts.CancelAfter(GetPerRequestTimeout());
-		return cts;
-	}
+	/// <summary>
+	/// Arms this attempt's deadline. It is its own source rather than a <c>CancelAfter</c>
+	/// on the linked one because <see cref="CancellationTokenSource"/> accepts a
+	/// <see cref="TimeProvider"/> only in its constructor, and routing the deadline through
+	/// the injected clock is what lets a test read the deadline back. The caller links it
+	/// to the overall token and disposes both.
+	/// </summary>
+	private CancellationTokenSource CreatePerRequestDeadline() =>
+		new(GetPerRequestTimeout(), _timeProvider);
 
 
 	private async Task<string> ExecuteReadInternal(
@@ -68,8 +100,9 @@ public class OcrService : IOcrService, IDisposable
 		int attempt,
 		CancellationToken overallCancellationToken)
 	{
-		// Beep swallows the first, non-retry attempt itself; retries beep once per attempt.
-		this.Beep(attempt);
+		// The default announcer swallows the first, non-retry attempt itself and beeps
+		// once per attempt after that; every attempt is reported here regardless.
+		_announceAttempt(attempt);
 
 		imageStream.Seek(0, SeekOrigin.Begin);
 
@@ -85,7 +118,7 @@ public class OcrService : IOcrService, IDisposable
 		// Buffer the stream into a byte array so we can create a new stream for each retry
 		byte[] imageBytes = BufferImage(imageStream);
 
-		return await RetryPipeline.ExecuteWithAttemptAsync(
+		return await _retryPipeline.ExecuteWithAttemptAsync(
 			async (attempt, overallToken) =>
 			{
 				var ms = new MemoryStream(imageBytes, writable: false);
@@ -168,8 +201,9 @@ public class OcrService : IOcrService, IDisposable
 
 		await SharedRateLimiter.WaitAsync(overallCancellationToken).ConfigureAwait(false);
 
-		using var requestCts = CreatePerRequestCancellationTokenSource(overallCancellationToken);
-		
+		using var deadline = CreatePerRequestDeadline();
+		using var requestCts = CancellationTokenSource.CreateLinkedTokenSource(overallCancellationToken, deadline.Token);
+
 		var binaryData = BinaryData.FromStream(imageStream);
 
 		ImageAnalysisResult result = await ImageAnalysisClient.AnalyzeAsync(

--- a/CognitiveSupport/OpenAiClientOptionsFactory.cs
+++ b/CognitiveSupport/OpenAiClientOptionsFactory.cs
@@ -17,7 +17,18 @@ public static class OpenAiClientOptionsFactory
 	/// the exact request the SDK puts on the wire can be asserted, the way
 	/// <see cref="AnthropicLlmService"/>'s injected HttpClient already allows.
 	/// </param>
-	public static OpenAIClientOptions Create(Uri? endpoint = null, PipelineTransport? transport = null)
+	/// <param name="maxRetries">
+	/// Caps the SDK's <em>own</em> retry policy, which is a separate loop from the one in
+	/// <see cref="TransientRetry"/>. Left null in production, where the SDK's default
+	/// three retries are wanted. A test that counts requests passes 0: otherwise a single
+	/// transient reply is retried by the SDK before the caller-level pipeline ever sees
+	/// it, and the request count measures two nested retry loops at once rather than the
+	/// one under test (issue #311).
+	/// </param>
+	public static OpenAIClientOptions Create(
+		Uri? endpoint = null,
+		PipelineTransport? transport = null,
+		int? maxRetries = null)
 	{
 		var options = new OpenAIClientOptions
 		{
@@ -27,6 +38,8 @@ public static class OpenAiClientOptionsFactory
 			options.Endpoint = endpoint;
 		if (transport is not null)
 			options.Transport = transport;
+		if (maxRetries is not null)
+			options.RetryPolicy = new ClientRetryPolicy(maxRetries.Value);
 		return options;
 	}
 }

--- a/CognitiveSupport/OpenAiSpeechToTextService.cs
+++ b/CognitiveSupport/OpenAiSpeechToTextService.cs
@@ -1,6 +1,7 @@
 ﻿using CognitiveSupport.Extensions;
 using OpenAI.Audio;
 using Polly;
+using System.ClientModel;
 
 namespace CognitiveSupport;
 
@@ -9,20 +10,49 @@ public class OpenAiSpeechToTextService : ISpeechToTextService
 	public string ServiceName { get; init; }
 
 	// Holds no call state, so one pipeline serves every transcription, concurrent or not.
-	private static readonly ResiliencePipeline RetryPipeline =
-		TransientRetry.Pipeline(retryCount: 3, TransientRetry.Transient());
+	// Built per instance rather than shared statically only so the clock behind it can be
+	// replaced; the app makes one of these, so that costs nothing.
+	private readonly ResiliencePipeline _retryPipeline;
 
 	private readonly AudioClient _audioClient;
 	private readonly int _timeoutSeconds;
+	private readonly TimeProvider _timeProvider;
+	private readonly Action<int> _announceAttempt;
 
+	/// <param name="timeProvider">
+	/// Test seam only; null in production. Drives both the retry backoff and each
+	/// attempt's deadline, so a test can read back the waits that were armed instead of
+	/// sitting through them.
+	/// </param>
+	/// <param name="announceAttempt">
+	/// Test seam only; null in production, where it beeps. Substituting it is what lets a
+	/// test assert the attempt number the listener is told about — and, just as usefully,
+	/// keeps a suite that drives real retries from playing sounds at whoever ran it.
+	/// </param>
 	public OpenAiSpeechToTextService(
 		string serviceName,
 		AudioClient audioClient,
-		int timeoutSeconds)
+		int timeoutSeconds,
+		TimeProvider? timeProvider = null,
+		Action<int>? announceAttempt = null)
 	{
 		this.ServiceName = serviceName;
 		_audioClient = audioClient ?? throw new ArgumentNullException(nameof(audioClient));
 		_timeoutSeconds = timeoutSeconds > 0 ? timeoutSeconds : 10;
+		_timeProvider = timeProvider ?? TimeProvider.System;
+		_announceAttempt = announceAttempt ?? (attempt => this.Beep(attempt));
+
+		// ClientResultException is the only failure the OpenAI SDK ever reports: it wraps
+		// a dropped connection (Status 0) as readily as a 429 or a 503, so a pipeline that
+		// handled only HttpRequestException — as this one did until issue #311 put a test
+		// on it — retried nothing but its own per-attempt timeout. LlmService already
+		// classified it this way; this is the same call, on the same statuses, so a bad key
+		// (401) still fails fast.
+		_retryPipeline = TransientRetry.Pipeline(
+			retryCount: 3,
+			TransientRetry.Transient()
+				.Handle<ClientResultException>(ex => LlmHttpStatus.IsTransient(ex.Status)),
+			timeProvider);
 	}
 
 	public async Task<string> ConvertAudioToText(
@@ -34,15 +64,16 @@ public class OpenAiSpeechToTextService : ISpeechToTextService
 		if (string.IsNullOrEmpty(audioffilePath))
 			throw new ArgumentException($"'{nameof(audioffilePath)}' cannot be null or empty.", nameof(audioffilePath));
 
-		var response = await RetryPipeline.ExecuteWithAttemptAsync(async (attempt, overallToken) =>
+		var response = await _retryPipeline.ExecuteWithAttemptAsync(async (attempt, overallToken) =>
 		{
 			int baseTimeout = timeoutSeconds ?? _timeoutSeconds;
 			int timeout = baseTimeout * attempt;
-			using var thisTryCts = new CancellationTokenSource(TimeSpan.FromSeconds(timeout));
+			using var thisTryCts = new CancellationTokenSource(TimeSpan.FromSeconds(timeout), _timeProvider);
 			using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(overallToken, thisTryCts.Token);
 
-			// Beep swallows the first, non-retry attempt itself; retries beep once per attempt.
-			this.Beep(attempt);
+			// The default announcer swallows the first, non-retry attempt itself and beeps once
+			// per attempt after that; every attempt is reported here regardless.
+			_announceAttempt(attempt);
 
 			return await TranscribeViaWhisper(speechToTextPrompt, audioffilePath, linkedCts.Token).ConfigureAwait(false);
 		}, overallCancellationToken).ConfigureAwait(false);

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,16 +18,16 @@
 	<ItemGroup>
 		<PackageVersion Include="Azure.AI.Vision.ImageAnalysis" Version="1.0.0" />
 		<PackageVersion Include="Concentus" Version="2.2.2" />
-		<PackageVersion Include="Concentus.Oggfile" Version="1.0.6" />
+		<PackageVersion Include="Concentus.Oggfile" Version="1.0.7" />
 		<PackageVersion Include="CoreAudio" Version="1.40.0" />
 		<PackageVersion Include="coverlet.collector" Version="6.0.4" />
-		<PackageVersion Include="Deepgram" Version="6.6.1" />
+		<PackageVersion Include="Deepgram" Version="6.9.0" />
 		<PackageVersion Include="Markdig" Version="0.44.0" />
 		<PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
 		<PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
 		<PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.7175" />
 		<PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.8.251106002" />
-		<PackageVersion Include="NAudio" Version="2.2.1" />
+		<PackageVersion Include="NAudio" Version="2.3.0" />
 		<PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
 		<PackageVersion Include="OpenAI" Version="2.12.0" />
 		<PackageVersion Include="PDFsharp" Version="6.2.3" />
@@ -35,9 +35,31 @@
 		<PackageVersion Include="Polly" Version="8.7.0" />
 		<PackageVersion Include="ScottPlot.WinUI" Version="5.1.57" />
 		<PackageVersion Include="SoundTouch.Net" Version="2.3.2" />
-		<PackageVersion Include="System.Speech" Version="10.0.0" />
+		<PackageVersion Include="System.Speech" Version="10.0.10" />
 		<PackageVersion Include="xunit" Version="2.9.3" />
 		<PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+	</ItemGroup>
+
+	<!--
+		Also pinned transitively, and for the same reason: nothing references it directly,
+		so without a version here it lands on whatever the deepest dependency asks for.
+		An in-major bump of the plumbing under the OpenAI client (issue #301).
+
+		Two packages #301 also suggested looking at are deliberately absent.
+
+		Azure.Core 1.44.1 -> 1.61.0 was tried and reverted. From 1.45 onwards its net10.0
+		group depends on Microsoft.Identity.Client, so pinning it added three MSAL
+		assemblies — about 1.3 MB — to everything the app ships. It authenticates to Azure
+		Vision with an AzureKeyCredential and never loads any of it. That is a real cost
+		for no benefit, and #301 asks for exactly this treatment: drop a bump that turns
+		out to carry more than it says, rather than hold up the rest.
+
+		Serilog stays on 3.1.1. Deepgram 6.9.0 still declares 3.1.1 and 4.x is a major
+		bump; nothing in the suite exercises Deepgram's logging, so a green run would not
+		be evidence that forcing it is safe. It waits until Deepgram itself moves.
+	-->
+	<ItemGroup>
+		<PackageVersion Include="System.ClientModel" Version="1.15.0" />
 	</ItemGroup>
 
 	<!--

--- a/Documentation/UserGuide/html/accessibility.html
+++ b/Documentation/UserGuide/html/accessibility.html
@@ -182,6 +182,12 @@ screen. There are distinct sounds for:</p>
 <li><strong>Mute</strong> — a low tone when microphones are muted.</li>
 <li><strong>Unmute</strong> — a short high tone when they are live.</li>
 </ul>
+<p>The end beep does one more job. When transcribing a recording, or reading text from
+the screen, has to be tried again, Mutation plays it once for each try — two beeps on
+the first retry, three on the second, four on the third. Nothing is wrong when you hear
+that. It means the request did not get through and Mutation is having another go, and
+the number of beeps tells you how far in it is. AI prompts do not beep this way; they
+retry silently.</p>
 <p>You can replace all of them with your own sound files. Open <strong>Settings</strong> with
 <strong>Ctrl+Comma</strong>, go to the audio settings, turn on the option to play your own sound
 files instead of the built-in beeps, and pick a <code>.wav</code> file for each of the six cues.

--- a/Documentation/UserGuide/html/troubleshooting.html
+++ b/Documentation/UserGuide/html/troubleshooting.html
@@ -192,6 +192,10 @@ say when it is done — then press your dictation shortcut again.</p>
 a busy service makes it slow. Mutation retries a failed attempt, giving each retry a
 longer window than the last, before it gives up. Long recordings naturally take longer
 than short ones.</p>
+<p>You can hear this happening. Each retry plays the end beep once more than the one
+before — two beeps, then three, then four. A burst of end beeps part way through a
+dictation means Mutation is still working, and how many you hear tells you how far into
+its retries it has got.</p>
 <p><strong>What to do.</strong></p>
 <ol>
 <li>Give it a moment — the retries are automatic and you will hear the result.</li>
@@ -281,6 +285,9 @@ page limit only as far as your tier allows.</p>
 <p><strong>What's happening.</strong> Every page of every file you picked is sent off to be read.
 Mutation works on two documents at a time by default, with up to four pages in the air
 at once, so forty PDFs still adds up to a lot of waiting.</p>
+<p>A page that does not get through first time is sent again, and each retry plays the end
+beep once more than the one before. Extra beeps during a batch are normal on a busy
+connection; they mean a page is being retried, not that anything has failed.</p>
 <p><strong>What to do.</strong> Listen for the announcements — Mutation names each file as it finishes,
 and calls out the page count every ten pages inside a long PDF, so you can tell it is
 still working. If you picked the wrong files, or simply want it to stop, click <strong>Cancel

--- a/Documentation/UserGuide/markdown/accessibility.md
+++ b/Documentation/UserGuide/markdown/accessibility.md
@@ -47,6 +47,13 @@ screen. There are distinct sounds for:
 - **Mute** — a low tone when microphones are muted.
 - **Unmute** — a short high tone when they are live.
 
+The end beep does one more job. When transcribing a recording, or reading text from
+the screen, has to be tried again, Mutation plays it once for each try — two beeps on
+the first retry, three on the second, four on the third. Nothing is wrong when you hear
+that. It means the request did not get through and Mutation is having another go, and
+the number of beeps tells you how far in it is. AI prompts do not beep this way; they
+retry silently.
+
 You can replace all of them with your own sound files. Open **Settings** with
 **Ctrl+Comma**, go to the audio settings, turn on the option to play your own sound
 files instead of the built-in beeps, and pick a `.wav` file for each of the six cues.

--- a/Documentation/UserGuide/markdown/troubleshooting.md
+++ b/Documentation/UserGuide/markdown/troubleshooting.md
@@ -60,6 +60,11 @@ a busy service makes it slow. Mutation retries a failed attempt, giving each ret
 longer window than the last, before it gives up. Long recordings naturally take longer
 than short ones.
 
+You can hear this happening. Each retry plays the end beep once more than the one
+before — two beeps, then three, then four. A burst of end beeps part way through a
+dictation means Mutation is still working, and how many you hear tells you how far into
+its retries it has got.
+
 **What to do.**
 
 1. Give it a moment — the retries are automatic and you will hear the result.
@@ -163,6 +168,10 @@ page limit only as far as your tier allows.
 **What's happening.** Every page of every file you picked is sent off to be read.
 Mutation works on two documents at a time by default, with up to four pages in the air
 at once, so forty PDFs still adds up to a lot of waiting.
+
+A page that does not get through first time is sent again, and each retry plays the end
+beep once more than the one before. Extra beeps during a batch are normal on a busy
+connection; they mean a page is being retried, not that anything has failed.
 
 **What to do.** Listen for the announcements — Mutation names each file as it finishes,
 and calls out the page count every ten pages inside a long PDF, so you can tell it is

--- a/Mutation.Tests/DeepgramSpeechToTextServiceRetryTests.cs
+++ b/Mutation.Tests/DeepgramSpeechToTextServiceRetryTests.cs
@@ -1,0 +1,259 @@
+using CognitiveSupport;
+using Deepgram.Clients.Interfaces.v1;
+using Deepgram.Models.Listen.v1.REST;
+
+namespace Mutation.Tests;
+
+/// <summary>
+/// Issue #311: <c>TranscriptionCancellationTests</c> looked like it covered this, but the
+/// thing it drives is a hand-written stand-in that imitates the retry loop. These drive
+/// the real service, so what is asserted is the loop that actually ships.
+/// </summary>
+public class DeepgramSpeechToTextServiceRetryTests
+{
+	private const int BaseTimeoutSeconds = 10;
+
+	private static string WriteAudioFile()
+	{
+		string path = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".wav");
+		File.WriteAllBytes(path, new byte[] { 1, 2, 3, 4 });
+		return path;
+	}
+
+	private static (DeepgramSpeechToTextService Service, FakeListenClient Client, RecordingClock Clock, List<int> Announced)
+		CreateService(params Func<int, SyncResponse>[] replies)
+	{
+		var client = new FakeListenClient(replies);
+		var clock = new RecordingClock();
+		var announced = new List<int>();
+		var service = new DeepgramSpeechToTextService(
+			"Deepgram",
+			client,
+			"nova-3",
+			BaseTimeoutSeconds,
+			clock,
+			announced.Add);
+		return (service, client, clock, announced);
+	}
+
+	private static SyncResponse Transcript(string text) =>
+		new()
+		{
+			Results = new Results
+			{
+				Channels =
+				[
+					new Channel { Alternatives = [new Alternative { Transcript = text }] }
+				]
+			}
+		};
+
+	[Fact]
+	public async Task ADroppedConnectionIsRetriedUntilItSucceeds()
+	{
+		// A dropped connection on the way to Deepgram is the case the retry ladder exists
+		// for: the recording is already made, and losing it to one bad packet would be
+		// the worst possible outcome. Deepgram's client does not catch HttpRequestException,
+		// so this is the exception the service really faces here.
+		var (service, client, _, _) = CreateService(
+			_ => throw new HttpRequestException("connection reset"),
+			_ => throw new HttpRequestException("connection reset"),
+			_ => Transcript("the recovered transcript"));
+
+		string path = WriteAudioFile();
+		try
+		{
+			string text = await service.ConvertAudioToText("", path, CancellationToken.None);
+
+			Assert.Equal("the recovered transcript", text);
+			Assert.Equal(3, client.Calls);
+		}
+		finally
+		{
+			File.Delete(path);
+		}
+	}
+
+	[Fact]
+	public async Task ADroppedConnectionGivesUpAfterThreeRetries()
+	{
+		var (service, client, _, _) = CreateService(
+			_ => throw new HttpRequestException("connection reset"));
+
+		string path = WriteAudioFile();
+		try
+		{
+			await Assert.ThrowsAsync<HttpRequestException>(() =>
+				service.ConvertAudioToText("", path, CancellationToken.None));
+
+			// The first try plus three retries, and then it reports the failure rather
+			// than retrying for ever.
+			Assert.Equal(4, client.Calls);
+		}
+		finally
+		{
+			File.Delete(path);
+		}
+	}
+
+	[Fact]
+	public async Task AFailureDeepgramItselfReportsIsNotRetried()
+	{
+		// A rejected API key does not become valid on the second ask, so reporting it at
+		// once beats making the user wait out the whole ladder first.
+		//
+		// What actually decides it, though, is not the status — it is whether the error
+		// carried a body. Deepgram's client deserializes a JSON error into this exception,
+		// which nothing here handles; an error with an empty body falls through to
+		// EnsureSuccessStatusCode instead and arrives as the HttpRequestException the test
+		// above retries. So the real rule today is "an error with a body is final, one
+		// without gets four attempts", regardless of whether it was a 429 or a 401. That is
+		// stranger than any rule anyone chose, and DeepgramRESTException carries no status
+		// to fix it with. Recorded rather than papered over — see issue #316.
+		var (service, client, _, _) = CreateService(
+			_ => throw new Deepgram.Models.Exceptions.v1.DeepgramRESTException("401 Unauthorized"));
+
+		string path = WriteAudioFile();
+		try
+		{
+			await Assert.ThrowsAsync<Deepgram.Models.Exceptions.v1.DeepgramRESTException>(() =>
+				service.ConvertAudioToText("", path, CancellationToken.None));
+
+			Assert.Equal(1, client.Calls);
+		}
+		finally
+		{
+			File.Delete(path);
+		}
+	}
+
+	[Fact]
+	public async Task EachAttemptGivesItselfLongerThanTheLast()
+	{
+		// The point of the ladder is that a slow cold start gets more room each time, not
+		// the same too-short window four times over.
+		var (service, _, clock, _) = CreateService(
+			_ => throw new HttpRequestException("connection reset"));
+
+		string path = WriteAudioFile();
+		try
+		{
+			await Assert.ThrowsAsync<HttpRequestException>(() =>
+				service.ConvertAudioToText("", path, CancellationToken.None));
+
+			Assert.Equal([10d, 20d, 30d, 40d], clock.DeadlineSeconds);
+			Assert.Equal([500d, 1000d, 1500d], clock.BackoffMilliseconds);
+		}
+		finally
+		{
+			File.Delete(path);
+		}
+	}
+
+	[Fact]
+	public async Task ACallerSuppliedTimeoutSetsTheLadderInsteadOfTheConfiguredOne()
+	{
+		var (service, _, clock, _) = CreateService(
+			_ => throw new HttpRequestException("connection reset"));
+
+		string path = WriteAudioFile();
+		try
+		{
+			await Assert.ThrowsAsync<HttpRequestException>(() =>
+				service.ConvertAudioToText("", path, CancellationToken.None, timeoutSeconds: 15));
+
+			Assert.Equal([15d, 30d, 45d, 60d], clock.DeadlineSeconds);
+		}
+		finally
+		{
+			File.Delete(path);
+		}
+	}
+
+	[Fact]
+	public async Task TheListenerIsToldWhichRetryThisIs()
+	{
+		// One beep per attempt, and none for the first: a first try has nothing to report
+		// yet, and a third retry has to be distinguishable from a first (issue #216).
+		var (service, _, _, announced) = CreateService(
+			_ => throw new HttpRequestException("connection reset"));
+
+		string path = WriteAudioFile();
+		try
+		{
+			await Assert.ThrowsAsync<HttpRequestException>(() =>
+				service.ConvertAudioToText("", path, CancellationToken.None));
+
+			Assert.Equal([1, 2, 3, 4], announced);
+			Assert.Equal([2, 3, 4], announced.Where(RetryBeepPolicy.ShouldBeep));
+		}
+		finally
+		{
+			File.Delete(path);
+		}
+	}
+
+	/// <summary>
+	/// Answers each call from a script, so a test says what the network does on attempt
+	/// one, two and three. The last entry stands in for every call past the end of the
+	/// script, which is what lets "always fails" be written as a single entry.
+	/// </summary>
+	private sealed class FakeListenClient(Func<int, SyncResponse>[] replies) : IListenRESTClient
+	{
+		internal int Calls { get; private set; }
+
+		public Task<SyncResponse> TranscribeFile(
+			byte[] source,
+			PreRecordedSchema? prerecordedSchema,
+			CancellationTokenSource? cancellationToken = null,
+			Dictionary<string, string>? addons = null,
+			Dictionary<string, string>? headers = null)
+		{
+			int call = ++Calls;
+			return Task.FromResult(replies[Math.Min(call, replies.Length) - 1](call));
+		}
+
+		public Task<SyncResponse> TranscribeFile(
+			Stream source,
+			PreRecordedSchema? prerecordedSchema,
+			CancellationTokenSource? cancellationToken = null,
+			Dictionary<string, string>? addons = null,
+			Dictionary<string, string>? headers = null) =>
+			throw new NotSupportedException("The service uploads bytes, not a stream.");
+
+		public Task<SyncResponse> TranscribeUrl(
+			UrlSource source,
+			PreRecordedSchema? prerecordedSchema,
+			CancellationTokenSource? cancellationToken = null,
+			Dictionary<string, string>? addons = null,
+			Dictionary<string, string>? headers = null) =>
+			throw new NotSupportedException("The service uploads a local recording.");
+
+		public Task<AsyncResponse> TranscribeFileCallBack(
+			byte[] source,
+			string? callBack,
+			PreRecordedSchema? prerecordedSchema,
+			CancellationTokenSource? cancellationToken = null,
+			Dictionary<string, string>? addons = null,
+			Dictionary<string, string>? headers = null) =>
+			throw new NotSupportedException("The service transcribes synchronously.");
+
+		public Task<AsyncResponse> TranscribeFileCallBack(
+			Stream source,
+			string? callBack,
+			PreRecordedSchema? prerecordedSchema,
+			CancellationTokenSource? cancellationToken = null,
+			Dictionary<string, string>? addons = null,
+			Dictionary<string, string>? headers = null) =>
+			throw new NotSupportedException("The service transcribes synchronously.");
+
+		public Task<AsyncResponse> TranscribeUrlCallBack(
+			UrlSource source,
+			string? callBack,
+			PreRecordedSchema? prerecordedSchema,
+			CancellationTokenSource? cancellationToken = null,
+			Dictionary<string, string>? addons = null,
+			Dictionary<string, string>? headers = null) =>
+			throw new NotSupportedException("The service transcribes synchronously.");
+	}
+}

--- a/Mutation.Tests/LlmServiceRetryTests.cs
+++ b/Mutation.Tests/LlmServiceRetryTests.cs
@@ -1,0 +1,220 @@
+using System.ClientModel;
+using System.ClientModel.Primitives;
+using System.Net;
+using System.Net.Http;
+using CognitiveSupport;
+
+namespace Mutation.Tests;
+
+/// <summary>
+/// Issue #311: every fast-mode test builds this service with a retry count of zero, so the
+/// pipeline is empty and no retry has ever run. These use a real one — and turn the OpenAI
+/// SDK's own retry policy off, so a request count is the number of times <em>this</em>
+/// service tried rather than the product of two nested loops.
+/// </summary>
+public class LlmServiceRetryTests : IDisposable
+{
+	private const string Model = "gpt-5.6";
+	private const int TimeoutSeconds = 60;
+
+	private const string SuccessBody =
+		"""{"id":"c1","object":"chat.completion","created":1,"model":"gpt-5.6","choices":[{"index":0,"finish_reason":"stop","message":{"role":"assistant","content":"done"}}]}""";
+
+	private static readonly LlmModelConfig Config = new(Model, LlmProvider.OpenAI, customTemperature: null);
+
+	private readonly List<HttpClient> _clients = [];
+
+	public void Dispose()
+	{
+		foreach (var client in _clients)
+			client.Dispose();
+	}
+
+	private (LlmService Service, RecordingClock Clock) CreateService(FakeHttpMessageHandler handler, int retryCount = 3)
+	{
+		var httpClient = new HttpClient(handler);
+		_clients.Add(httpClient);
+
+		var clock = new RecordingClock();
+		var service = new LlmService(
+			"test-key",
+			[Config],
+			timeoutSeconds: TimeoutSeconds,
+			retryCount: retryCount,
+			transport: new HttpClientPipelineTransport(httpClient),
+			sdkRetryCount: 0,
+			timeProvider: clock);
+		return (service, clock);
+	}
+
+	private static IList<LlmChatMessage> Messages() => [new(LlmChatRole.User, "hello")];
+
+	private static string ErrorBody(string message) =>
+		$$$"""{"error":{"message":"{{{message}}}","type":"server_error"}}""";
+
+	[Theory]
+	[InlineData(HttpStatusCode.TooManyRequests)]
+	[InlineData(HttpStatusCode.ServiceUnavailable)]
+	[InlineData(HttpStatusCode.InternalServerError)]
+	[InlineData(HttpStatusCode.RequestTimeout)]
+	public async Task ATransientFailureIsRetriedUntilItSucceeds(HttpStatusCode status)
+	{
+		// The cold-start case this ladder exists for: the first call after a reboot meets a
+		// slow or briefly unavailable service, and a second attempt gets straight through.
+		var handler = new FakeHttpMessageHandler()
+			.Respond(status, ErrorBody("try again"))
+			.Respond(HttpStatusCode.OK, SuccessBody);
+		var (service, _) = CreateService(handler);
+
+		string result = await service.CreateChatCompletion(Messages(), Model);
+
+		Assert.Equal("done", result);
+		Assert.Equal(2, handler.Requests.Count);
+	}
+
+	[Fact]
+	public async Task ATransientFailureGivesUpAfterThreeRetries()
+	{
+		var handler = new FakeHttpMessageHandler()
+			.Respond(HttpStatusCode.ServiceUnavailable, ErrorBody("still down"));
+		var (service, _) = CreateService(handler);
+
+		await Assert.ThrowsAsync<ClientResultException>(() =>
+			service.CreateChatCompletion(Messages(), Model));
+
+		// The first try plus three retries, and then it reports the failure rather than
+		// retrying for ever.
+		Assert.Equal(4, handler.Requests.Count);
+	}
+
+	[Theory]
+	[InlineData(HttpStatusCode.Unauthorized)]
+	[InlineData(HttpStatusCode.Forbidden)]
+	[InlineData(HttpStatusCode.BadRequest)]
+	[InlineData(HttpStatusCode.NotFound)]
+	public async Task APermanentFailureIsNotRetried(HttpStatusCode status)
+	{
+		// With a 60-second base timeout that grows each attempt, retrying a bad API key
+		// could take a minute or more to report something that was never going to work.
+		var handler = new FakeHttpMessageHandler()
+			.Respond(status, ErrorBody("Incorrect API key provided"));
+		var (service, _) = CreateService(handler);
+
+		await Assert.ThrowsAsync<ClientResultException>(() =>
+			service.CreateChatCompletion(Messages(), Model));
+
+		Assert.Single(handler.Requests);
+	}
+
+	[Fact]
+	public async Task NoRetriesConfiguredMeansOneAttempt()
+	{
+		// The retry count is a user setting and zero is a legal value for it.
+		var handler = new FakeHttpMessageHandler()
+			.Respond(HttpStatusCode.ServiceUnavailable, ErrorBody("still down"));
+		var (service, _) = CreateService(handler, retryCount: 0);
+
+		await Assert.ThrowsAsync<ClientResultException>(() =>
+			service.CreateChatCompletion(Messages(), Model));
+
+		Assert.Single(handler.Requests);
+	}
+
+	[Fact]
+	public async Task EachAttemptGivesItselfLongerThanTheLast()
+	{
+		var handler = new FakeHttpMessageHandler()
+			.Respond(HttpStatusCode.ServiceUnavailable, ErrorBody("still down"));
+		var (service, clock) = CreateService(handler);
+
+		await Assert.ThrowsAsync<ClientResultException>(() =>
+			service.CreateChatCompletion(Messages(), Model));
+
+		Assert.Equal([60d, 120d, 180d, 240d], clock.DeadlineSeconds);
+		Assert.Equal([500d, 1000d, 1500d], clock.BackoffMilliseconds);
+	}
+
+	[Fact]
+	public async Task AFastModeFallbackStillGetsItsOwnFullRetryLadder()
+	{
+		// The tier is rejected, then the standard-speed send meets a transient failure. The
+		// user's text is only saved if that second send retries in its own right.
+		//
+		// The deadlines are also what says each send counts its own attempts. A leaked
+		// attempt number — one living on the shared pipeline rather than in Polly's
+		// per-execution context — would open the fallback send on the abandoned send's
+		// stretched deadline and read [60, 120, 180] instead. A fallback after a send that
+		// did *not* retry cannot tell the difference, so this is the case that has to
+		// carry it.
+		var handler = new FakeHttpMessageHandler()
+			.Respond(HttpStatusCode.BadRequest, """{"error":{"message":"Invalid value: 'fast'. Supported values are: 'auto', 'default', 'flex' and 'priority'.","type":"invalid_request_error","param":"service_tier"}}""")
+			.Respond(HttpStatusCode.ServiceUnavailable, ErrorBody("try again"))
+			.Respond(HttpStatusCode.OK, SuccessBody);
+
+		FastModeFallback? reported = null;
+		var (service, clock) = CreateService(handler);
+
+		string result = await service.CreateChatCompletion(
+			Messages(), Model, new LlmRequestOptions { FastMode = true, OnFastModeFallback = f => reported = f });
+
+		Assert.Equal("done", result);
+		Assert.Equal(3, handler.Requests.Count);
+		Assert.NotNull(reported);
+		// Send one: 60. Send two: 60, then 120 for its retry.
+		Assert.Equal([60d, 60d, 120d], clock.DeadlineSeconds);
+	}
+
+	[Fact]
+	public async Task CancellingPartWayUpTheLadderStopsIt()
+	{
+		// Handing the caller's token to the pipeline is what makes the ladder escapable:
+		// Polly checks it at the head of every attempt and waits on it during the backoff,
+		// so an outside cancel ends the loop rather than reading as one more blip (#256).
+		//
+		// The cancel has to land *inside* the ladder to prove any of that. Cancelling
+		// before the call would leave nothing to escape from — the body would run once and
+		// throw, which it does with no retry strategy at all.
+		using var cts = new CancellationTokenSource();
+		var handler = new CancelThenDropHandler(cts);
+		var httpClient = new HttpClient(handler);
+		_clients.Add(httpClient);
+
+		var service = new LlmService(
+			"test-key",
+			[Config],
+			timeoutSeconds: TimeoutSeconds,
+			retryCount: 3,
+			transport: new HttpClientPipelineTransport(httpClient),
+			sdkRetryCount: 0,
+			timeProvider: new RecordingClock());
+
+		await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+			service.CreateChatCompletion(Messages(), Model, cancellationToken: cts.Token));
+
+		// One request, not four. A dropped connection reaches the pipeline as a status-0
+		// ClientResultException, which is transient, so it had earned three more attempts;
+		// the cancelled token is the only reason none of them ran.
+		Assert.Equal(1, handler.Calls);
+	}
+
+	/// <summary>
+	/// Drops the connection, having first tripped the caller's token — so the cancel is in
+	/// place well before Polly reaches its backoff, and the test decides the same way every
+	/// run. Cancelling from a timer hook instead races Polly's own token check; cancelling
+	/// before the call at all proves nothing, because a body that runs once and throws is
+	/// what happens with no retry strategy whatsoever.
+	/// </summary>
+	private sealed class CancelThenDropHandler(CancellationTokenSource cts) : HttpMessageHandler
+	{
+		private int _calls;
+
+		internal int Calls => Volatile.Read(ref _calls);
+
+		protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+		{
+			Interlocked.Increment(ref _calls);
+			cts.Cancel();
+			throw new HttpRequestException("connection reset");
+		}
+	}
+}

--- a/Mutation.Tests/OcrServiceRetryTests.cs
+++ b/Mutation.Tests/OcrServiceRetryTests.cs
@@ -1,0 +1,229 @@
+using System.Net;
+using System.Net.Http;
+using System.Reflection;
+using System.Text;
+using Azure;
+using Azure.AI.Vision.ImageAnalysis;
+using Azure.Core.Pipeline;
+using CognitiveSupport;
+
+namespace Mutation.Tests;
+
+/// <summary>
+/// Issue #311: nothing called <c>OcrService.Read</c>, so the retry ladder around it had no
+/// coverage at all. The client is injected here — a real one, wired to a fake transport, so
+/// the responses go through the SDK's own deserialization rather than a stubbed result.
+/// Azure's own retry policy is turned off, so a request count is the number of times this
+/// service tried, not the number of times two nested loops did.
+/// </summary>
+[Collection(OcrServiceStaticsCollection.Name)]
+public class OcrServiceRetryTests : IDisposable
+{
+	private const int TimeoutSeconds = 30;
+
+	private const string ReadBody = """
+		{"modelVersion":"2023-10-01","metadata":{"width":100,"height":100},
+		 "readResult":{"blocks":[{"lines":[
+		   {"text":"the recovered text",
+		    "boundingPolygon":[{"x":0,"y":0},{"x":50,"y":0},{"x":50,"y":20},{"x":0,"y":20}],
+		    "words":[]}]}]}}
+		""";
+
+	private readonly List<HttpClient> _clients = [];
+
+	// The 20-per-minute limiter is static and outlives a test. Four attempts apiece would
+	// drain it partway through this class and leave the rest of it waiting out a real
+	// minute, so it is cleared either side of every test. Issue #250 created the collection
+	// that makes reaching in here safe.
+	public OcrServiceRetryTests() => ResetSharedRateLimiter();
+
+	public void Dispose()
+	{
+		foreach (var client in _clients)
+			client.Dispose();
+		ResetSharedRateLimiter();
+	}
+
+	private static void ResetSharedRateLimiter()
+	{
+		Type limiterType = typeof(OcrService).GetNestedType("RequestRateLimiter", BindingFlags.NonPublic)!;
+		object limiter = typeof(OcrService)
+			.GetField("SharedRateLimiter", BindingFlags.NonPublic | BindingFlags.Static)!
+			.GetValue(null)!;
+		limiterType.GetMethod("Reset", BindingFlags.NonPublic | BindingFlags.Instance)!
+			.Invoke(limiter, Array.Empty<object>());
+	}
+
+	private (OcrService Service, ScriptedTransport Transport, RecordingClock Clock, List<int> Announced)
+		CreateService(params Func<int, HttpResponseMessage>[] replies)
+	{
+		var transport = new ScriptedTransport(replies);
+		var httpClient = new HttpClient(transport);
+		_clients.Add(httpClient);
+
+		var options = new ImageAnalysisClientOptions
+		{
+			Transport = new HttpClientTransport(httpClient)
+		};
+		// Azure.Core retries 429 and 5xx on its own account. Left on, a single scripted
+		// failure would be swallowed underneath and never reach the ladder under test.
+		options.Retry.MaxRetries = 0;
+
+		var client = new ImageAnalysisClient(
+			new Uri("https://example.cognitiveservices.azure.com/"),
+			new AzureKeyCredential("test-key"),
+			options);
+
+		var clock = new RecordingClock();
+		var announced = new List<int>();
+		var service = new OcrService("test-key", "https://example.cognitiveservices.azure.com/", TimeoutSeconds, client, clock, announced.Add);
+		return (service, transport, clock, announced);
+	}
+
+	private static Stream Image() => new MemoryStream(new byte[] { 1, 2, 3, 4 });
+
+	private static Func<int, HttpResponseMessage> Ok(string body) =>
+		_ => new HttpResponseMessage(HttpStatusCode.OK)
+		{
+			Content = new StringContent(body, Encoding.UTF8, "application/json")
+		};
+
+	private static Func<int, HttpResponseMessage> Status(HttpStatusCode status) =>
+		_ => new HttpResponseMessage(status)
+		{
+			Content = new StringContent("""{"error":{"code":"Nope","message":"nope"}}""", Encoding.UTF8, "application/json")
+		};
+
+	[Fact]
+	public async Task AServerSideBlipIsRetriedUntilItSucceeds()
+	{
+		var (service, transport, _, _) = CreateService(Status(HttpStatusCode.ServiceUnavailable), Ok(ReadBody));
+
+		string text = await service.ExtractText(OcrReadingOrder.TopToBottomColumnAware, Image(), CancellationToken.None);
+
+		Assert.Contains("the recovered text", text);
+		Assert.Equal(2, transport.Calls);
+	}
+
+	[Fact]
+	public async Task ARateLimitIsRetriedUntilItSucceeds()
+	{
+		// Azure Computer Vision allows 20 requests a minute on the free tier, so a 429 in
+		// the middle of a batch is the everyday case, not the exotic one.
+		var (service, transport, _, _) = CreateService(Status(HttpStatusCode.TooManyRequests), Ok(ReadBody));
+
+		string text = await service.ExtractText(OcrReadingOrder.TopToBottomColumnAware, Image(), CancellationToken.None);
+
+		Assert.Contains("the recovered text", text);
+		Assert.Equal(2, transport.Calls);
+	}
+
+	[Fact]
+	public async Task ATransientFailureGivesUpAfterThreeRetries()
+	{
+		var (service, transport, _, _) = CreateService(Status(HttpStatusCode.ServiceUnavailable));
+
+		await Assert.ThrowsAsync<RequestFailedException>(() =>
+			service.ExtractText(OcrReadingOrder.TopToBottomColumnAware, Image(), CancellationToken.None));
+
+		Assert.Equal(4, transport.Calls);
+	}
+
+	[Theory]
+	[InlineData(HttpStatusCode.Unauthorized)]
+	[InlineData(HttpStatusCode.BadRequest)]
+	[InlineData(HttpStatusCode.NotFound)]
+	public async Task APermanentFailureIsNotRetried(HttpStatusCode status)
+	{
+		// A rejected key or a malformed request does not improve on the second ask, and an
+		// OCR batch reports it far sooner this way.
+		var (service, transport, _, _) = CreateService(Status(status));
+
+		await Assert.ThrowsAsync<RequestFailedException>(() =>
+			service.ExtractText(OcrReadingOrder.TopToBottomColumnAware, Image(), CancellationToken.None));
+
+		Assert.Equal(1, transport.Calls);
+	}
+
+	[Fact]
+	public async Task EveryRetrySendsTheWholeImageAgain()
+	{
+		// Read buffers the image precisely so each attempt can re-send it; a stream read to
+		// the end on attempt one would otherwise upload nothing on attempt two (issue #239).
+		var (service, transport, _, _) = CreateService(Status(HttpStatusCode.ServiceUnavailable), Ok(ReadBody));
+
+		await service.ExtractText(OcrReadingOrder.TopToBottomColumnAware, Image(), CancellationToken.None);
+
+		Assert.Equal(2, transport.Bodies.Count);
+		Assert.Equal(transport.Bodies[0], transport.Bodies[1]);
+		Assert.Equal(new byte[] { 1, 2, 3, 4 }, transport.Bodies[1]);
+	}
+
+	[Fact]
+	public async Task EveryAttemptGetsTheSamePerRequestDeadline()
+	{
+		// Unlike the other four callers, this one does not stretch its deadline by the
+		// attempt number: the read is capped at a flat 60 seconds, so a wedged call cannot
+		// hold up an OCR batch for longer each time round. Pinned here because issue #311
+		// assumed the opposite, and because a change of mind should have to edit a test.
+		// See issue #315.
+		var (service, _, clock, _) = CreateService(Status(HttpStatusCode.ServiceUnavailable));
+
+		await Assert.ThrowsAsync<RequestFailedException>(() =>
+			service.ExtractText(OcrReadingOrder.TopToBottomColumnAware, Image(), CancellationToken.None));
+
+		Assert.Equal([30d, 30d, 30d, 30d], clock.DeadlineSeconds);
+		Assert.Equal([500d, 1000d, 1500d], clock.BackoffMilliseconds);
+	}
+
+	[Fact]
+	public async Task TheListenerIsToldWhichRetryThisIs()
+	{
+		// One beep per attempt, and none for the first: a first try has nothing to report
+		// yet, and a third retry has to be distinguishable from a first (issue #216).
+		var (service, _, _, announced) = CreateService(Status(HttpStatusCode.ServiceUnavailable));
+
+		await Assert.ThrowsAsync<RequestFailedException>(() =>
+			service.ExtractText(OcrReadingOrder.TopToBottomColumnAware, Image(), CancellationToken.None));
+
+		Assert.Equal([1, 2, 3, 4], announced);
+		Assert.Equal([2, 3, 4], announced.Where(RetryBeepPolicy.ShouldBeep));
+	}
+
+	/// <summary>
+	/// Answers each request from a script and keeps the body it was sent, so a test can say
+	/// what Azure does on attempt one, two and three — and check that the retry uploaded the
+	/// same image the first attempt did. The last entry stands in for every call past the
+	/// end of the script.
+	/// </summary>
+	private sealed class ScriptedTransport(Func<int, HttpResponseMessage>[] replies) : HttpMessageHandler
+	{
+		private readonly List<byte[]> _bodies = [];
+
+		internal int Calls
+		{
+			get { lock (_bodies) return _bodies.Count; }
+		}
+
+		internal IReadOnlyList<byte[]> Bodies
+		{
+			get { lock (_bodies) return _bodies.ToArray(); }
+		}
+
+		protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+		{
+			byte[] body = request.Content is null
+				? []
+				: await request.Content.ReadAsByteArrayAsync(cancellationToken).ConfigureAwait(false);
+
+			int call;
+			lock (_bodies)
+			{
+				_bodies.Add(body);
+				call = _bodies.Count;
+			}
+
+			return replies[Math.Min(call, replies.Length) - 1](call);
+		}
+	}
+}

--- a/Mutation.Tests/OcrServiceTests.cs
+++ b/Mutation.Tests/OcrServiceTests.cs
@@ -423,42 +423,44 @@ public class OcrServiceTests
 		Assert.Throws<ArgumentNullException>(() => new OcrService("key", null, 10));
 	}
 
-	private static CancellationTokenSource CreatePerRequestCts(OcrService service, CancellationToken overallToken)
+	private static CancellationTokenSource CreatePerRequestDeadline(OcrService service)
 	{
-		MethodInfo? method = typeof(OcrService).GetMethod("CreatePerRequestCancellationTokenSource", BindingFlags.NonPublic | BindingFlags.Instance);
+		MethodInfo? method = typeof(OcrService).GetMethod("CreatePerRequestDeadline", BindingFlags.NonPublic | BindingFlags.Instance);
 		Assert.NotNull(method);
-		return (CancellationTokenSource)method!.Invoke(service, new object[] { overallToken })!;
+		return (CancellationTokenSource)method!.Invoke(service, null)!;
 	}
 
 	[Fact]
-	public void CreatePerRequestCancellationTokenSource_IsLinkedToTheOverallToken()
+	public void PerRequestDeadline_LinksWithTheOverallTokenWithoutCancellingItself()
 	{
-		var service = new OcrService("dummy-key", "https://example.com/", 1);
+		// ReadInternal links the two, so an outside cancel has to reach the request even
+		// though the deadline is now its own source.
+		var service = new OcrService("dummy-key", "https://example.com/", 30);
 
 		using var overall = new CancellationTokenSource();
-		using var cts = CreatePerRequestCts(service, overall.Token);
+		using var deadline = CreatePerRequestDeadline(service);
+		using var linked = CancellationTokenSource.CreateLinkedTokenSource(overall.Token, deadline.Token);
 
-		Assert.False(cts.IsCancellationRequested);
+		Assert.False(linked.IsCancellationRequested);
 
 		overall.Cancel();
-		Assert.True(cts.Token.IsCancellationRequested);
+		Assert.True(linked.Token.IsCancellationRequested);
+		Assert.False(deadline.IsCancellationRequested);
 	}
 
 	[Fact]
-	public void CreatePerRequestCancellationTokenSource_SelfCancelsAfterThePerRequestTimeout()
+	public void PerRequestDeadline_SelfCancelsAfterThePerRequestTimeout()
 	{
 		// The timeout is what stops a wedged Azure call hanging the batch, and linking
 		// alone does not provide it. A one-second service timeout with a ten-second wait
-		// leaves ample slack on a loaded agent while still failing if CancelAfter is lost.
+		// leaves ample slack on a loaded agent while still failing if the deadline is lost.
 		var service = new OcrService("dummy-key", "https://example.com/", 1);
 
-		using var overall = new CancellationTokenSource();
-		using var cts = CreatePerRequestCts(service, overall.Token);
+		using var deadline = CreatePerRequestDeadline(service);
 
 		Assert.True(
-			cts.Token.WaitHandle.WaitOne(TimeSpan.FromSeconds(10)),
+			deadline.Token.WaitHandle.WaitOne(TimeSpan.FromSeconds(10)),
 			"The per-request source never cancelled itself, so no per-request timeout is scheduled.");
-		Assert.False(overall.IsCancellationRequested);
 	}
 
 	// ---------------------------------------------------------------------

--- a/Mutation.Tests/OpenAiClientOptionsFactoryTests.cs
+++ b/Mutation.Tests/OpenAiClientOptionsFactoryTests.cs
@@ -1,3 +1,4 @@
+using System.ClientModel.Primitives;
 using CognitiveSupport;
 
 namespace Mutation.Tests;
@@ -22,5 +23,21 @@ public class OpenAiClientOptionsFactoryTests
 
 		Assert.Equal(Timeout.InfiniteTimeSpan, options.NetworkTimeout);
 		Assert.Equal(endpoint, options.Endpoint);
+	}
+
+	[Fact]
+	public void Create_LeavesTheSdkSOwnRetryPolicyAlone_ByDefault()
+	{
+		// Production wants the SDK's default retries. Only a test that counts requests
+		// turns them off, and it has to ask (issue #311).
+		Assert.Null(OpenAiClientOptionsFactory.Create().RetryPolicy);
+	}
+
+	[Fact]
+	public void Create_CapsTheSdkSOwnRetries_WhenAsked()
+	{
+		var options = OpenAiClientOptionsFactory.Create(maxRetries: 0);
+
+		Assert.IsType<ClientRetryPolicy>(options.RetryPolicy);
 	}
 }

--- a/Mutation.Tests/OpenAiSpeechToTextServiceRetryTests.cs
+++ b/Mutation.Tests/OpenAiSpeechToTextServiceRetryTests.cs
@@ -1,0 +1,216 @@
+using System.ClientModel;
+using System.ClientModel.Primitives;
+using System.Net;
+using System.Net.Http;
+using CognitiveSupport;
+using OpenAI.Audio;
+
+namespace Mutation.Tests;
+
+/// <summary>
+/// Issue #311: nothing drove a retry through this service. The SDK's own retry policy is
+/// turned off here — see <see cref="OpenAiClientOptionsFactory.Create"/> — so a call count
+/// means "this many times our pipeline tried", not "this many times two nested loops did".
+/// </summary>
+public class OpenAiSpeechToTextServiceRetryTests : IDisposable
+{
+	private const int BaseTimeoutSeconds = 10;
+	private const string TranscriptBody = """{"text":"the recovered transcript"}""";
+
+	private readonly List<HttpClient> _clients = [];
+	private readonly List<string> _files = [];
+
+	public void Dispose()
+	{
+		foreach (var client in _clients)
+			client.Dispose();
+		foreach (var file in _files)
+			File.Delete(file);
+	}
+
+	private string WriteAudioFile()
+	{
+		string path = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".wav");
+		File.WriteAllBytes(path, new byte[] { 1, 2, 3, 4 });
+		_files.Add(path);
+		return path;
+	}
+
+	private (OpenAiSpeechToTextService Service, ScriptedHandler Handler, RecordingClock Clock, List<int> Announced)
+		CreateService(params Func<int, HttpResponseMessage>[] replies)
+	{
+		var clock = new RecordingClock();
+		var handler = new ScriptedHandler(replies);
+		var httpClient = new HttpClient(handler);
+		_clients.Add(httpClient);
+
+		var audioClient = new AudioClient(
+			"whisper-1",
+			new ApiKeyCredential("test-key"),
+			OpenAiClientOptionsFactory.Create(
+				transport: new HttpClientPipelineTransport(httpClient),
+				maxRetries: 0));
+
+		var announced = new List<int>();
+		var service = new OpenAiSpeechToTextService("Whisper", audioClient, BaseTimeoutSeconds, clock, announced.Add);
+		return (service, handler, clock, announced);
+	}
+
+	private static Func<int, HttpResponseMessage> Ok(string body) =>
+		_ => new HttpResponseMessage(HttpStatusCode.OK)
+		{
+			Content = new StringContent(body, System.Text.Encoding.UTF8, "application/json")
+		};
+
+	private static Func<int, HttpResponseMessage> Status(HttpStatusCode status) =>
+		_ => new HttpResponseMessage(status)
+		{
+			Content = new StringContent("""{"error":{"message":"nope"}}""", System.Text.Encoding.UTF8, "application/json")
+		};
+
+	private static Func<int, HttpResponseMessage> Dropped() =>
+		_ => throw new HttpRequestException("connection reset");
+
+	/// <summary>
+	/// Drops the connection, having first tripped the caller's token. The cancel is
+	/// therefore in place well before Polly reaches its backoff, which is what makes the
+	/// test that uses it decide the same way every run.
+	/// </summary>
+	private static Func<int, HttpResponseMessage> DroppedAfterCancelling(CancellationTokenSource cts) =>
+		_ =>
+		{
+			cts.Cancel();
+			throw new HttpRequestException("connection reset");
+		};
+
+	[Fact]
+	public async Task ADroppedConnectionIsRetriedUntilItSucceeds()
+	{
+		// The SDK hands a connection failure over as a ClientResultException carrying
+		// status 0, never as the HttpRequestException the handler threw. Retrying it is
+		// the whole point of the ladder: the recording is already made, and losing a
+		// dictated transcript to one bad packet is the worst outcome available.
+		var (service, handler, _, _) = CreateService(Dropped(), Dropped(), Ok(TranscriptBody));
+
+		string text = await service.ConvertAudioToText("", WriteAudioFile(), CancellationToken.None);
+
+		Assert.Equal("the recovered transcript", text);
+		Assert.Equal(3, handler.Calls);
+	}
+
+	[Theory]
+	[InlineData(HttpStatusCode.TooManyRequests)]
+	[InlineData(HttpStatusCode.ServiceUnavailable)]
+	[InlineData(HttpStatusCode.InternalServerError)]
+	public async Task AServerSideBlipIsRetriedUntilItSucceeds(HttpStatusCode status)
+	{
+		var (service, handler, _, _) = CreateService(Status(status), Ok(TranscriptBody));
+
+		string text = await service.ConvertAudioToText("", WriteAudioFile(), CancellationToken.None);
+
+		Assert.Equal("the recovered transcript", text);
+		Assert.Equal(2, handler.Calls);
+	}
+
+	[Fact]
+	public async Task ATransientFailureGivesUpAfterThreeRetries()
+	{
+		var (service, handler, _, _) = CreateService(Dropped());
+
+		await Assert.ThrowsAsync<ClientResultException>(() =>
+			service.ConvertAudioToText("", WriteAudioFile(), CancellationToken.None));
+
+		// The first try plus three retries, and then it reports the failure rather than
+		// retrying for ever.
+		Assert.Equal(4, handler.Calls);
+	}
+
+	[Theory]
+	[InlineData(HttpStatusCode.Unauthorized)]
+	[InlineData(HttpStatusCode.BadRequest)]
+	[InlineData(HttpStatusCode.NotFound)]
+	public async Task APermanentFailureIsNotRetried(HttpStatusCode status)
+	{
+		// A rejected API key does not become valid on the second ask. Reporting it at once
+		// beats making the user sit out four attempts on a lengthening timeout first.
+		var (service, handler, _, _) = CreateService(Status(status));
+
+		await Assert.ThrowsAsync<ClientResultException>(() =>
+			service.ConvertAudioToText("", WriteAudioFile(), CancellationToken.None));
+
+		Assert.Equal(1, handler.Calls);
+	}
+
+	[Fact]
+	public async Task EachAttemptGivesItselfLongerThanTheLast()
+	{
+		var (service, _, clock, _) = CreateService(Dropped());
+
+		await Assert.ThrowsAsync<ClientResultException>(() =>
+			service.ConvertAudioToText("", WriteAudioFile(), CancellationToken.None));
+
+		Assert.Equal([10d, 20d, 30d, 40d], clock.DeadlineSeconds);
+		Assert.Equal([500d, 1000d, 1500d], clock.BackoffMilliseconds);
+	}
+
+	[Fact]
+	public async Task ACallerSuppliedTimeoutSetsTheLadderInsteadOfTheConfiguredOne()
+	{
+		// The file-transcription path passes a much longer timeout than the dictation one.
+		var (service, _, clock, _) = CreateService(Dropped());
+
+		await Assert.ThrowsAsync<ClientResultException>(() =>
+			service.ConvertAudioToText("", WriteAudioFile(), CancellationToken.None, timeoutSeconds: 300));
+
+		Assert.Equal([300d, 600d, 900d, 1200d], clock.DeadlineSeconds);
+	}
+
+	[Fact]
+	public async Task CancellingPartWayUpTheLadderStopsIt()
+	{
+		// This PR widened what gets retried here, so it also has to say that a user who
+		// gives up is still obeyed. Cancelling a dictation has its own history (#179, #256,
+		// #305), and the one test that looked like it covered this drove a hand-written
+		// stand-in rather than the real service — which is what #311 was filed about.
+		using var cts = new CancellationTokenSource();
+		var (service, handler, _, _) = CreateService(DroppedAfterCancelling(cts));
+
+		await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+			service.ConvertAudioToText("", WriteAudioFile(), cts.Token));
+
+		// One request, not four. A dropped connection is transient here, so it had earned
+		// three more attempts; the cancelled token is the only reason none of them ran.
+		Assert.Equal(1, handler.Calls);
+	}
+
+	[Fact]
+	public async Task TheListenerIsToldWhichRetryThisIs()
+	{
+		var (service, _, _, announced) = CreateService(Dropped());
+
+		await Assert.ThrowsAsync<ClientResultException>(() =>
+			service.ConvertAudioToText("", WriteAudioFile(), CancellationToken.None));
+
+		Assert.Equal([1, 2, 3, 4], announced);
+		Assert.Equal([2, 3, 4], announced.Where(RetryBeepPolicy.ShouldBeep));
+	}
+
+	/// <summary>
+	/// Answers each request from a script, so a test can say what the network does on
+	/// attempt one, two and three — including failing to connect at all, which the
+	/// shared <see cref="FakeHttpMessageHandler"/> has no way to express. The last entry
+	/// stands in for every call past the end of the script.
+	/// </summary>
+	private sealed class ScriptedHandler(Func<int, HttpResponseMessage>[] replies) : HttpMessageHandler
+	{
+		private int _calls;
+
+		internal int Calls => Volatile.Read(ref _calls);
+
+		protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+		{
+			int call = Interlocked.Increment(ref _calls);
+			return Task.FromResult(replies[Math.Min(call, replies.Length) - 1](call));
+		}
+	}
+}

--- a/Mutation.Tests/RecordingClock.cs
+++ b/Mutation.Tests/RecordingClock.cs
@@ -1,0 +1,66 @@
+namespace Mutation.Tests;
+
+/// <summary>
+/// Stands in for the clock the five remote-service callers arm their waits on, and writes
+/// down what each one asked for. Two different waits go through it: Polly's retry backoff,
+/// and the deadline each attempt gives itself. Reading those back is what lets a test say
+/// "the second attempt got longer than the first" without timing a stopwatch — the same
+/// trick <c>TransientRetryTests.DelaysGrowLinearlyFromHalfASecond</c> uses, and the reason
+/// issue #253 could take the clock-dependent tests out of this suite.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The two are told apart by who is asking, not by how long the wait is.
+/// <see cref="CancellationTokenSource"/> passes itself as the timer state when it arms a
+/// deadline; Polly's backoff, which goes through <c>Task.Delay</c>, does not. Length would
+/// have been the obvious discriminator and is the wrong one: <see cref="OcrService"/>
+/// clamps its timeout to as little as one second, which no threshold can tell from a
+/// one-second backoff. <c>RecordingClockTests</c> pins the discriminator in both
+/// directions, so if a future runtime stops passing the source as state, that fails rather
+/// than this quietly filing deadlines as backoffs.
+/// </para>
+/// <para>
+/// A backoff fires at once, so no test sits through one. A deadline is left to a real
+/// timer, so it is never sprung on an attempt that is meant to finish.
+/// </para>
+/// </remarks>
+internal sealed class RecordingClock : TimeProvider
+{
+	private readonly List<TimeSpan> _backoffs = [];
+	private readonly List<TimeSpan> _deadlines = [];
+
+	/// <summary>The retry backoff Polly asked for, in order.</summary>
+	internal IReadOnlyList<TimeSpan> Backoffs
+	{
+		get { lock (_backoffs) return _backoffs.ToArray(); }
+	}
+
+	/// <summary>The per-attempt deadlines the service armed, in attempt order.</summary>
+	internal IReadOnlyList<TimeSpan> Deadlines
+	{
+		get { lock (_deadlines) return _deadlines.ToArray(); }
+	}
+
+	internal IReadOnlyList<double> DeadlineSeconds =>
+		Deadlines.Select(d => d.TotalSeconds).ToArray();
+
+	internal IReadOnlyList<double> BackoffMilliseconds =>
+		Backoffs.Select(b => b.TotalMilliseconds).ToArray();
+
+	public override ITimer CreateTimer(TimerCallback callback, object? state, TimeSpan dueTime, TimeSpan period)
+	{
+		// A negative due time is Timeout.InfiniteTimeSpan — a timer armed never to fire.
+		// Nobody is waiting on it, and collapsing it would fire it immediately.
+		if (dueTime < TimeSpan.Zero)
+			return base.CreateTimer(callback, state, dueTime, period);
+
+		if (state is CancellationTokenSource)
+		{
+			lock (_deadlines) _deadlines.Add(dueTime);
+			return base.CreateTimer(callback, state, dueTime, period);
+		}
+
+		lock (_backoffs) _backoffs.Add(dueTime);
+		return base.CreateTimer(callback, state, TimeSpan.Zero, period);
+	}
+}

--- a/Mutation.Tests/RecordingClockTests.cs
+++ b/Mutation.Tests/RecordingClockTests.cs
@@ -1,0 +1,68 @@
+using CognitiveSupport;
+
+namespace Mutation.Tests;
+
+/// <summary>
+/// <see cref="RecordingClock"/> is what four retry-test classes read their assertions off,
+/// so the way it tells a per-attempt deadline from a retry backoff has to be pinned rather
+/// than assumed. It tells them apart by who is asking — a <see cref="CancellationTokenSource"/>
+/// passes itself as the timer state, Polly's backoff does not. If a future runtime stops
+/// doing that, these fail loudly instead of every deadline quietly being filed as a backoff.
+/// </summary>
+public class RecordingClockTests
+{
+	[Fact]
+	public void ADeadlineIsRecordedAsADeadline_AndIsLeftToRun()
+	{
+		var clock = new RecordingClock();
+
+		using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30), clock);
+
+		Assert.Equal([30d], clock.DeadlineSeconds);
+		Assert.Empty(clock.Backoffs);
+		// Left to a real timer: a deadline that fired at once would cancel the very
+		// attempt the test wants to watch succeed.
+		Assert.False(cts.IsCancellationRequested);
+	}
+
+	[Fact]
+	public async Task ABackoffIsRecordedAsABackoff_AndFiresAtOnce()
+	{
+		var clock = new RecordingClock();
+		var pipeline = TransientRetry.Pipeline(retryCount: 3, TransientRetry.Transient(), clock);
+
+		await Assert.ThrowsAsync<HttpRequestException>(async () =>
+			await pipeline.ExecuteWithAttemptAsync<int>((_, __) =>
+				throw new HttpRequestException("transient")));
+
+		Assert.Equal([500d, 1000d, 1500d], clock.BackoffMilliseconds);
+		Assert.Empty(clock.Deadlines);
+	}
+
+	[Fact]
+	public void AShortDeadlineIsStillADeadline()
+	{
+		// The case that rules out telling the two apart by length. OcrService clamps its
+		// per-request timeout to as little as one second, which is shorter than two of the
+		// three backoffs — so any threshold would file this under the wrong heading, arm it
+		// to fire at once, and cancel the attempt before it started.
+		var clock = new RecordingClock();
+
+		using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1), clock);
+
+		Assert.Equal([1d], clock.DeadlineSeconds);
+		Assert.Empty(clock.Backoffs);
+		Assert.False(cts.IsCancellationRequested);
+	}
+
+	[Fact]
+	public void ATimerArmedNeverToFireIsNotRecordedAtAll()
+	{
+		var clock = new RecordingClock();
+
+		using var timer = clock.CreateTimer(_ => { }, null, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+
+		Assert.Empty(clock.Deadlines);
+		Assert.Empty(clock.Backoffs);
+	}
+}


### PR DESCRIPTION
Closes #301. Closes #311.

Two tracked pieces of housekeeping, in one PR because the second touches the
same SDK surfaces the first moves.

Three independent reviews ran against the first push. What they found is folded
in below, including two corrections to claims this description originally made.

## The package bumps (#301, the tail of #259)

Each was applied on its own with the full suite run before the next, so a
regression had a single package to blame.

| Package | From | To |
| --- | --- | --- |
| `NAudio` (lifts `.Asio`/`.Core`/`.Midi`/`.Wasapi`/`.WinForms`/`.WinMM` with it) | 2.2.1 | 2.3.0 |
| `Deepgram` | 6.6.1 | 6.9.0 |
| `Concentus.Oggfile` | 1.0.6 | 1.0.7 |
| `System.Speech` | 10.0.0 | 10.0.10 |
| `System.ClientModel` (newly pinned) | 1.14.0 | 1.15.0 |

**`Azure.Core` was bumped, then reverted.** Review caught that from 1.45 onwards
its `net10.0` group depends on `Microsoft.Identity.Client`. Pinning 1.61.0 put
three MSAL assemblies — about 1.3 MB — into everything the app ships, to support
an authentication mode it does not use: it talks to Azure Vision with an
`AzureKeyCredential` and would never have loaded a byte of it. Verified in
`project.assets.json` and in the output directory, and confirmed gone after the
revert.

**Serilog is likewise not here.** Deepgram 6.9.0 still declares Serilog 3.1.1,
and 4.x is a major bump. Nothing in the suite drives Deepgram's logging, so a
green run would have said nothing about whether forcing it is safe. #301 asks
for exactly this treatment when a bump carries more than it says.

**Still needs a human:** #301 also asks for a manual smoke test of `NAudio` and
`Deepgram` — record and transcribe once each through the UI. A green suite does
not cover the live audio and transcription paths, and I cannot drive the WinUI
app to do it.

## The retry tests (#311)

### The seams

All optional, all documented "Test seam only; null in production", following
`LlmService`'s existing `PipelineTransport? transport` precedent, and all bound
positionally by the existing production call sites so nothing moves.

- **`OcrService`** built its `ImageAnalysisClient` from an endpoint and a key in
  the constructor, so a read could not be driven at all. It can be handed one.
- **`OpenAiClientOptionsFactory`** can turn the OpenAI SDK's *own* retry policy
  down — the seam #311 called out by name.
- **The three services holding their pipeline in a `static` field** build it per
  instance, so the clock can be replaced. All four are singletons; verified.
- **The retry beep** goes through an injected announcer, which is how the
  beep-per-retry wiring #311 lists as uncovered is now covered.

### Telling a deadline from a backoff

`RecordingClock` records both kinds of wait a service arms, which is what lets a
test assert `[10s, 20s, 30s, 40s]` outright rather than timing a stopwatch. #253
took the clock-dependent tests out of this suite on purpose and none go back in —
the whole 1664-test run is still 5 seconds.

The first version told the two apart **by length**, and review was right that
this is undecidable: `OcrService` clamps its timeout to as little as one second,
which no threshold can distinguish from a one-second backoff, and getting it
wrong would silently cancel an attempt before it started. It now discriminates
**structurally** — a `CancellationTokenSource` passes itself as the timer state
when it arms a deadline, and Polly's backoff does not. `RecordingClockTests`
pins that in both directions, including the short-deadline case, so a runtime
that ever stopped doing it would fail loudly rather than quietly misfile every
deadline.

### The defect the tests found

`OpenAiSpeechToTextService` handled `HttpRequestException`. The OpenAI SDK never
throws it — a dropped connection arrives as a `ClientResultException` carrying
status 0, exactly as a 429 or a 503 does.

**Correction to the original description here.** I first wrote that a failed
transcription "was never retried once". That overstated it: the SDK's own retry
policy was still retrying underneath. What never engaged was *our* ladder — so a
Whisper transcription never got the escalating per-attempt deadline that exists
for precisely the cold start it is most likely to meet, and, because our ladder
is what beeps, the listener heard nothing while it happened. The fix applies the
classification `LlmService` already used, on the same statuses, so a bad key
still fails fast on the first try.

### User guide

**Also a correction.** The original description claimed `troubleshooting.md` and
`dictation.md` already covered this and no guide change was needed. Review
checked: the `dictation.md` sentence is about the AI step, not transcription, so
it was never evidence for anything here.

And there was a real gap. The retry beep — the end beep, repeated once more per
attempt — is not documented anywhere in the guide, and this fix makes it audible
on a path where it was silent. For someone who cannot see the screen that is the
only signal there is, so `CLAUDE.md` is right to list beeps as a same-PR trigger.
Added to `accessibility.md` (where the beeps are defined, noting that AI prompts
retry silently) and to both the dictation and OCR-batch entries in
`troubleshooting.md`. HTML regenerated and committed alongside.

### Found, and deliberately left alone

Each has a test pinning what is true today, so none can drift unnoticed:

- **#315** — `OcrService` gives every attempt the same deadline instead of
  stretching it. #311 assumed otherwise. Changing it is a production decision
  about how long a wedged read may hold up a batch.
- **#316** — Deepgram's retry decision turns on whether an error carried a body,
  not on its status: a bare 401 is retried four times and a 503 with a payload is
  not. Neither exception type carries a status to fix it with.
- **#318** — our ladder nests inside the OpenAI SDK's, so a persistent 429 costs
  up to 16 requests. Pre-existing for `LlmService`; this PR makes
  `OpenAiSpeechToTextService` join it. The obvious fix — cap the SDK at 0 — also
  removes the only part of the stack that honours `Retry-After`, so it is a real
  decision rather than a one-liner.

## Coverage

46 tests, 1618 → 1664, green in Release. Per service: a transient failure
retries, a permanent one does not, the deadline ladder is exact, and the attempt
number the listener is told about is exact. Plus cancellation on both the LLM and
the dictation paths — the cancel is made to land *inside* the ladder, since a
token cancelled beforehand proves nothing (that test passes with the retry
strategy deleted, which is what the first version of it did).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
