### PR TITLE
Stop the Hotkeys page calling a working setting wrong, and give one path rule one home

### DIFF
--- a/CognitiveSupport/PathEquality.cs
+++ b/CognitiveSupport/PathEquality.cs
@@ -2,7 +2,7 @@ using System;
 using System.IO;
 using System.Security;
 
-namespace Mutation.Ui.Core;
+namespace CognitiveSupport;
 
 /// <summary>
 /// The one answer to "do these two strings name the same file or folder?".
@@ -13,8 +13,14 @@ namespace Mutation.Ui.Core;
 /// normalization. Two spellings of one recording therefore compared equal in one place and
 /// unequal in the other, and nothing in either signature said so (issue #306).
 /// </para>
+/// <para>
+/// It lives here rather than in <c>Mutation.Ui</c> because <see cref="SilenceRemovalLog"/>
+/// needs the same rule and cannot reach up into the UI project. It depends on nothing but
+/// <see cref="System.IO"/>, so the lower project is where a rule both layers follow belongs
+/// (issue #324).
+/// </para>
 /// </summary>
-internal static class PathEquality
+public static class PathEquality
 {
 	/// <summary>
 	/// Whether <paramref name="first"/> and <paramref name="second"/> name the same file or

--- a/CognitiveSupport/SilenceRemovalLog.cs
+++ b/CognitiveSupport/SilenceRemovalLog.cs
@@ -37,6 +37,11 @@ public sealed class SilenceRemovalLog
 	/// <summary>
 	/// The points recorded for this file, or an empty list if the file is not the one
 	/// most recently preprocessed.
+	/// <para>
+	/// Matched with <see cref="PathEquality.SamePath"/> rather than a raw string compare, so
+	/// the answer here agrees with the rest of the app when the caller spells the recording
+	/// differently from the way preprocessing recorded it (issue #324).
+	/// </para>
 	/// </summary>
 	public IReadOnlyList<SilenceRemovalPoint> PointsFor(string audioFilePath)
 	{
@@ -45,7 +50,7 @@ public sealed class SilenceRemovalLog
 
 		lock (_gate)
 		{
-			return string.Equals(_path, audioFilePath, StringComparison.OrdinalIgnoreCase)
+			return PathEquality.SamePath(_path, audioFilePath)
 				? _points
 				: Array.Empty<SilenceRemovalPoint>();
 		}

--- a/Documentation/UserGuide/html/keyboard-shortcuts.html
+++ b/Documentation/UserGuide/html/keyboard-shortcuts.html
@@ -372,9 +372,15 @@ key before it decides you are finished.</li>
 </ol>
 <p>Changed your mind mid-recording? Press <strong>Escape</strong> and nothing is captured.</p>
 <p>You can also just type into the box if you prefer. Write the keys separated by
-plus signs. Mutation tidies up the capitals for you when you move away from the
-box. The <strong>Clear</strong> button empties a box, which is what you want for the two
-optional &quot;send a key afterwards&quot; fields.</p>
+plus signs. When you move away from the box, Mutation tidies up what you typed: it
+puts the capitals right, and it puts the keys in its own order, always Ctrl, then
+Shift, then Alt, then the Windows key, then the key itself. So if you type
+<strong>Shift+Ctrl+A</strong>, the box shows <code>CTRL+SHIFT+A</code> afterwards. It is the same shortcut
+either way — Mutation just writes it one way everywhere, so two boxes holding the
+same combination look the same. That tidied version is what gets saved, so a
+shortcut you once typed into the settings file by hand is rewritten this way the
+next time you edit it on this page. The <strong>Clear</strong> button empties a box, which is
+what you want for the two optional &quot;send a key afterwards&quot; fields.</p>
 <p>Your changes are held until you press <strong>Save</strong> at the bottom of Settings. Press
 <strong>Cancel</strong> and nothing you changed is kept.</p>
 <h2 id="when-a-combination-is-taken-or-not-allowed">When a combination is taken or not allowed</h2>
@@ -403,6 +409,13 @@ hotkeys could not be registered&quot;, listing each action, its combination, and
 reason, usually &quot;The shortcut is already registered by another application.&quot;
 Go back to the Hotkeys page and pick something else.</li>
 </ul>
+<p>The two &quot;send a key afterwards&quot; boxes are a little more relaxed than the rest. As
+well as ordinary combinations like <strong>Ctrl+V</strong>, they accept Windows' own shorthand
+for typing keys — the style that writes Ctrl as <code>^</code> and puts named keys in curly
+brackets, so Ctrl+F5 becomes <code>^{F5}</code>. You never need it: <strong>Ctrl+F5</strong> does the same
+job and reads better. If you do use it, Mutation keeps exactly what you typed, and
+it is the one thing on this page not checked against your other shortcuts. So if
+you write a key that way, check yourself that no Mutation shortcut already uses it.</p>
 <h2 id="choosing-combinations-that-wont-clash">Choosing combinations that won't clash</h2>
 <ol>
 <li><strong>Use three modifiers.</strong> Combinations like <strong>Ctrl+Shift+Alt+Q</strong> are almost never

--- a/Documentation/UserGuide/html/keyboard-shortcuts.html
+++ b/Documentation/UserGuide/html/keyboard-shortcuts.html
@@ -378,9 +378,12 @@ Shift, then Alt, then the Windows key, then the key itself. So if you type
 <strong>Shift+Ctrl+A</strong>, the box shows <code>CTRL+SHIFT+A</code> afterwards. It is the same shortcut
 either way — Mutation just writes it one way everywhere, so two boxes holding the
 same combination look the same. That tidied version is what gets saved, so a
-shortcut you once typed into the settings file by hand is rewritten this way the
-next time you edit it on this page. The <strong>Clear</strong> button empties a box, which is
-what you want for the two optional &quot;send a key afterwards&quot; fields.</p>
+shortcut you typed into the settings file by hand comes back tidied once Mutation
+has opened that page.</p>
+<p>The two optional &quot;send a key afterwards&quot; boxes are the exception: they keep
+whatever you type, exactly as you typed it, because what goes in them is not
+always a plain combination. There is more on them below. The <strong>Clear</strong> button
+empties a box, which is what you want for those two.</p>
 <p>Your changes are held until you press <strong>Save</strong> at the bottom of Settings. Press
 <strong>Cancel</strong> and nothing you changed is kept.</p>
 <h2 id="when-a-combination-is-taken-or-not-allowed">When a combination is taken or not allowed</h2>
@@ -409,13 +412,20 @@ hotkeys could not be registered&quot;, listing each action, its combination, and
 reason, usually &quot;The shortcut is already registered by another application.&quot;
 Go back to the Hotkeys page and pick something else.</li>
 </ul>
-<p>The two &quot;send a key afterwards&quot; boxes are a little more relaxed than the rest. As
-well as ordinary combinations like <strong>Ctrl+V</strong>, they accept Windows' own shorthand
-for typing keys — the style that writes Ctrl as <code>^</code> and puts named keys in curly
-brackets, so Ctrl+F5 becomes <code>^{F5}</code>. You never need it: <strong>Ctrl+F5</strong> does the same
-job and reads better. If you do use it, Mutation keeps exactly what you typed, and
-it is the one thing on this page not checked against your other shortcuts. So if
-you write a key that way, check yourself that no Mutation shortcut already uses it.</p>
+<p>The two &quot;send a key afterwards&quot; boxes are a little more relaxed than the rest.
+They hold more than one plain combination can say:</p>
+<ul>
+<li><strong>A run of keys, one after the other.</strong> Separate them with commas, like
+<code>Ctrl+V, Enter</code> to paste and then press Enter.</li>
+<li><strong>Windows' own shorthand for typing keys.</strong> That is the style which writes Ctrl
+as <code>^</code> and puts named keys in curly brackets, so Ctrl+F5 becomes <code>^{F5}</code>. You
+never need it — <strong>Ctrl+F5</strong> does the same job and reads better — but it works if
+you already know it.</li>
+</ul>
+<p>Because of those two, Mutation leaves these boxes exactly as you type them rather
+than tidying them up. They are also the one thing on this page not checked against
+your other shortcuts when you write them in the shorthand style, so if you do,
+check yourself that no Mutation shortcut already uses that key.</p>
 <h2 id="choosing-combinations-that-wont-clash">Choosing combinations that won't clash</h2>
 <ol>
 <li><strong>Use three modifiers.</strong> Combinations like <strong>Ctrl+Shift+Alt+Q</strong> are almost never

--- a/Documentation/UserGuide/markdown/keyboard-shortcuts.md
+++ b/Documentation/UserGuide/markdown/keyboard-shortcuts.md
@@ -106,9 +106,15 @@ To record a new combination:
 Changed your mind mid-recording? Press **Escape** and nothing is captured.
 
 You can also just type into the box if you prefer. Write the keys separated by
-plus signs. Mutation tidies up the capitals for you when you move away from the
-box. The **Clear** button empties a box, which is what you want for the two
-optional "send a key afterwards" fields.
+plus signs. When you move away from the box, Mutation tidies up what you typed: it
+puts the capitals right, and it puts the keys in its own order, always Ctrl, then
+Shift, then Alt, then the Windows key, then the key itself. So if you type
+**Shift+Ctrl+A**, the box shows `CTRL+SHIFT+A` afterwards. It is the same shortcut
+either way — Mutation just writes it one way everywhere, so two boxes holding the
+same combination look the same. That tidied version is what gets saved, so a
+shortcut you once typed into the settings file by hand is rewritten this way the
+next time you edit it on this page. The **Clear** button empties a box, which is
+what you want for the two optional "send a key afterwards" fields.
 
 Your changes are held until you press **Save** at the bottom of Settings. Press
 **Cancel** and nothing you changed is kept.
@@ -139,6 +145,14 @@ readers announce it straight away.
   hotkeys could not be registered", listing each action, its combination, and the
   reason, usually "The shortcut is already registered by another application."
   Go back to the Hotkeys page and pick something else.
+
+The two "send a key afterwards" boxes are a little more relaxed than the rest. As
+well as ordinary combinations like **Ctrl+V**, they accept Windows' own shorthand
+for typing keys — the style that writes Ctrl as `^` and puts named keys in curly
+brackets, so Ctrl+F5 becomes `^{F5}`. You never need it: **Ctrl+F5** does the same
+job and reads better. If you do use it, Mutation keeps exactly what you typed, and
+it is the one thing on this page not checked against your other shortcuts. So if
+you write a key that way, check yourself that no Mutation shortcut already uses it.
 
 ## Choosing combinations that won't clash
 

--- a/Documentation/UserGuide/markdown/keyboard-shortcuts.md
+++ b/Documentation/UserGuide/markdown/keyboard-shortcuts.md
@@ -112,9 +112,13 @@ Shift, then Alt, then the Windows key, then the key itself. So if you type
 **Shift+Ctrl+A**, the box shows `CTRL+SHIFT+A` afterwards. It is the same shortcut
 either way — Mutation just writes it one way everywhere, so two boxes holding the
 same combination look the same. That tidied version is what gets saved, so a
-shortcut you once typed into the settings file by hand is rewritten this way the
-next time you edit it on this page. The **Clear** button empties a box, which is
-what you want for the two optional "send a key afterwards" fields.
+shortcut you typed into the settings file by hand comes back tidied once Mutation
+has opened that page.
+
+The two optional "send a key afterwards" boxes are the exception: they keep
+whatever you type, exactly as you typed it, because what goes in them is not
+always a plain combination. There is more on them below. The **Clear** button
+empties a box, which is what you want for those two.
 
 Your changes are held until you press **Save** at the bottom of Settings. Press
 **Cancel** and nothing you changed is kept.
@@ -146,13 +150,20 @@ readers announce it straight away.
   reason, usually "The shortcut is already registered by another application."
   Go back to the Hotkeys page and pick something else.
 
-The two "send a key afterwards" boxes are a little more relaxed than the rest. As
-well as ordinary combinations like **Ctrl+V**, they accept Windows' own shorthand
-for typing keys — the style that writes Ctrl as `^` and puts named keys in curly
-brackets, so Ctrl+F5 becomes `^{F5}`. You never need it: **Ctrl+F5** does the same
-job and reads better. If you do use it, Mutation keeps exactly what you typed, and
-it is the one thing on this page not checked against your other shortcuts. So if
-you write a key that way, check yourself that no Mutation shortcut already uses it.
+The two "send a key afterwards" boxes are a little more relaxed than the rest.
+They hold more than one plain combination can say:
+
+- **A run of keys, one after the other.** Separate them with commas, like
+  `Ctrl+V, Enter` to paste and then press Enter.
+- **Windows' own shorthand for typing keys.** That is the style which writes Ctrl
+  as `^` and puts named keys in curly brackets, so Ctrl+F5 becomes `^{F5}`. You
+  never need it — **Ctrl+F5** does the same job and reads better — but it works if
+  you already know it.
+
+Because of those two, Mutation leaves these boxes exactly as you type them rather
+than tidying them up. They are also the one thing on this page not checked against
+your other shortcuts when you write them in the shorthand style, so if you do,
+check yourself that no Mutation shortcut already uses that key.
 
 ## Choosing combinations that won't clash
 

--- a/Mutation.Tests/HotkeyCanonicalizeTests.cs
+++ b/Mutation.Tests/HotkeyCanonicalizeTests.cs
@@ -1,0 +1,93 @@
+using Mutation.Ui.Services;
+
+namespace Mutation.Tests;
+
+/// <summary>
+/// Covers <see cref="Hotkey.Canonicalize"/>, the one spelling written back to settings.
+/// <para>
+/// The hotkey editor and the hotkey router row each used to split, upper-case and rejoin,
+/// which keeps the order the user typed. So someone who typed <c>SHIFT+CTRL+A</c> by hand
+/// had <c>SHIFT+CTRL+A</c> on disk while the rest of the app spelled that chord
+/// <c>CTRL+SHIFT+A</c> (issue #323).
+/// </para>
+/// <para>
+/// The half-typed cases matter as much as the canonical ones: text is normalized on every
+/// commit, and a fallback that dropped what the user was still typing would erase the box
+/// while they were looking away from it.
+/// </para>
+/// </summary>
+public class HotkeyCanonicalizeTests
+{
+	[Theory]
+	[InlineData("SHIFT+CTRL+A", "CTRL+SHIFT+A")]
+	[InlineData("alt+ctrl+delete", "CTRL+ALT+DELETE")]
+	[InlineData("win+shift+s", "SHIFT+WIN+S")]
+	[InlineData("A+Windows+Control", "CTRL+WIN+A")]
+	public void A_chord_comes_back_in_the_apps_own_order(string typed, string expected)
+	{
+		Assert.Equal(expected, Hotkey.Canonicalize(typed));
+	}
+
+	[Theory]
+	[InlineData("Ctrl+C")]
+	[InlineData("CTRL+SHIFT+F5")]
+	[InlineData("CTRL+ALT+WIN+A")]
+	public void Text_already_canonical_is_left_as_it_is(string text)
+	{
+		Assert.Equal(text.ToUpperInvariant(), Hotkey.Canonicalize(text));
+	}
+
+	[Theory]
+	[InlineData("ctrl-c", "CTRL+C")]
+	[InlineData("ctrl c", "CTRL+C")]
+	[InlineData("shift/ctrl/a", "CTRL+SHIFT+A")]
+	public void Any_separator_the_parser_accepts_comes_back_as_a_plus(string typed, string expected)
+	{
+		Assert.Equal(expected, Hotkey.Canonicalize(typed));
+	}
+
+	[Fact]
+	public void A_digit_key_keeps_the_digit_rather_than_its_Number_alias()
+	{
+		Assert.Equal("CTRL+5", Hotkey.Canonicalize("ctrl+5"));
+	}
+
+	[Theory]
+	[InlineData("Ctrl+", "CTRL")]
+	[InlineData("ctrl+shift+", "CTRL+SHIFT")]
+	[InlineData("Ctrl+Foo", "CTRL+FOO")]
+	[InlineData("not-a-real-hotkey", "NOT+A+REAL+HOTKEY")]
+	public void Half_typed_text_is_upper_cased_and_otherwise_kept(string typed, string expected)
+	{
+		// It cannot be parsed, so there is no canonical spelling for it. Keeping what the user
+		// has typed leaves the validation message to say what is wrong with it, rather than
+		// emptying the box under them.
+		Assert.Equal(expected, Hotkey.Canonicalize(typed));
+	}
+
+	[Theory]
+	[InlineData(null)]
+	[InlineData("")]
+	[InlineData("   ")]
+	public void Nothing_typed_stays_nothing(string? typed)
+	{
+		Assert.Equal(string.Empty, Hotkey.Canonicalize(typed));
+	}
+
+	[Fact]
+	public void A_modifier_on_its_own_is_never_reported_as_the_none_placeholder()
+	{
+		// Hotkey.ToString() answers "(none)" for a chord with no key, which is a description
+		// and not a spelling. It must not reach a settings file.
+		Assert.Equal("SHIFT", Hotkey.Canonicalize("shift"));
+	}
+
+	[Fact]
+	public void The_canonical_form_is_what_a_parsed_chord_prints_as()
+	{
+		string canonical = Hotkey.Canonicalize("shift+ctrl+alt+win+a");
+
+		Assert.Equal(Hotkey.Parse("shift+ctrl+alt+win+a").ToString(), canonical);
+		Assert.Equal(canonical, Hotkey.Canonicalize(canonical));
+	}
+}

--- a/Mutation.Tests/HotkeyRouterEntryTests.cs
+++ b/Mutation.Tests/HotkeyRouterEntryTests.cs
@@ -160,4 +160,39 @@ public class HotkeyRouterEntryTests
 
 		Assert.Equal("CTRL+B", map.ToHotKey);
 	}
+
+	// A row used to keep the modifier order the user typed, so "Shift+Ctrl+X" went to the
+	// settings file spelled that way while the rest of the app spelled the same chord
+	// "CTRL+SHIFT+X" (issue #323).
+	[Fact]
+	public void Commit_WritesTheChordInTheAppsOwnModifierOrder()
+	{
+		var map = Map("Ctrl+C", "Ctrl+V");
+		var entry = new HotkeyRouterEntry(map);
+
+		entry.FromHotkey = "Shift+Ctrl+X";
+		entry.CommitFromHotkey();
+		entry.ToHotkey = "alt+ctrl+y";
+		entry.CommitToHotkey();
+
+		Assert.Equal("CTRL+SHIFT+X", map.FromHotKey);
+		Assert.Equal("CTRL+SHIFT+X", entry.FromHotkey);
+		Assert.Equal("CTRL+ALT+Y", map.ToHotKey);
+		Assert.Equal("CTRL+ALT+Y", entry.ToHotkey);
+	}
+
+	[Fact]
+	public void Commit_LeavesHalfTypedTextOnScreenRatherThanErasingIt()
+	{
+		// It does not parse, so there is no canonical spelling to write. The row still has to
+		// show what the user typed — the validation message beside it is what tells them it is
+		// not finished.
+		var entry = new HotkeyRouterEntry(Map("Ctrl+C", "Ctrl+V"));
+
+		entry.FromHotkey = "ctrl+shift+";
+		entry.CommitFromHotkey();
+
+		Assert.False(entry.IsFromValid);
+		Assert.Equal("CTRL+SHIFT", entry.FromHotkey);
+	}
 }

--- a/Mutation.Tests/HotkeysSettingsPageSpecsTests.cs
+++ b/Mutation.Tests/HotkeysSettingsPageSpecsTests.cs
@@ -1,0 +1,89 @@
+using System.Linq;
+using Mutation.Ui.Services;
+using Mutation.Ui.Views.SettingsUi.Pages;
+
+namespace Mutation.Tests;
+
+/// <summary>
+/// Covers the row table behind the Hotkeys settings page — which rows Mutation claims from
+/// Windows, and which of them therefore accept SendKeys syntax.
+/// <para>
+/// The two "Send key after…" values are editable from two places, and only one of them used
+/// to allow SendKeys syntax. So a <c>^{F5}</c> accepted on the OCR page showed a red
+/// "Unsupported key" message on the Hotkeys page, read out as an error, on a setting that was
+/// perfectly valid and working — on the page whose whole job is telling the user which
+/// shortcuts are wrong (issue #322).
+/// </para>
+/// <para>
+/// The page itself needs a WinUI host and cannot be built here (issue #304), so what is
+/// pinned is the table the page reads and the validator it hands the flag to. The remaining
+/// gap is one property assignment in <c>BuildRows</c>.
+/// </para>
+/// </summary>
+public class HotkeysSettingsPageSpecsTests
+{
+	private const string SendKeyAfterOcr = "Send key after OCR (optional)";
+	private const string SendKeyAfterTranscription = "Send key after transcription (optional)";
+	private const string SendKeysValue = "^{F5}";
+
+	private static HotkeysSettingsPage.HotkeySpec SpecFor(string label) =>
+		HotkeysSettingsPage.Specs.Single(s => s.Label == label);
+
+	[Theory]
+	[InlineData(SendKeyAfterOcr)]
+	[InlineData(SendKeyAfterTranscription)]
+	public void A_send_key_row_takes_a_SendKeys_value_without_calling_it_an_error(string label)
+	{
+		var spec = SpecFor(label);
+
+		Assert.True(spec.AllowsSendKeysSyntax);
+		Assert.Null(HotkeyValidator.Validate(SendKeysValue, spec.AllowsSendKeysSyntax));
+	}
+
+	[Theory]
+	[InlineData("Toggle microphone mute")]
+	[InlineData("Speech to text")]
+	[InlineData("Speak clipboard")]
+	public void A_row_Mutation_claims_from_Windows_still_rejects_one(string label)
+	{
+		// The other direction matters just as much: a shortcut claimed from Windows has to be a
+		// chord, and letting SendKeys text through there would fail at registration instead of
+		// in the box, where the user can see it.
+		var spec = SpecFor(label);
+
+		Assert.False(spec.AllowsSendKeysSyntax);
+		Assert.NotNull(HotkeyValidator.Validate(SendKeysValue, spec.AllowsSendKeysSyntax));
+	}
+
+	[Fact]
+	public void Those_two_are_the_only_rows_that_accept_SendKeys_syntax()
+	{
+		Assert.Equal(
+			new[] { SendKeyAfterOcr, SendKeyAfterTranscription },
+			HotkeysSettingsPage.Specs.Where(s => s.AllowsSendKeysSyntax).Select(s => s.Label).ToArray());
+	}
+
+	[Fact]
+	public void A_row_accepts_SendKeys_syntax_when_and_only_when_it_is_not_registered()
+	{
+		Assert.All(HotkeysSettingsPage.Specs,
+			spec => Assert.Equal(!spec.Registers, spec.AllowsSendKeysSyntax));
+	}
+
+	[Fact]
+	public void An_ordinary_chord_is_still_accepted_on_every_row()
+	{
+		Assert.All(HotkeysSettingsPage.Specs,
+			spec => Assert.Null(HotkeyValidator.Validate("Ctrl+V", spec.AllowsSendKeysSyntax)));
+	}
+
+	[Fact]
+	public void Only_those_two_rows_may_be_left_blank()
+	{
+		// A blank registered shortcut would leave an action with no way to reach it. These two
+		// are the only ones the Clear button is meant for.
+		Assert.Equal(
+			new[] { SendKeyAfterOcr, SendKeyAfterTranscription },
+			HotkeysSettingsPage.Specs.Where(s => s.AllowEmpty).Select(s => s.Label).ToArray());
+	}
+}

--- a/Mutation.Tests/PathEqualityTests.cs
+++ b/Mutation.Tests/PathEqualityTests.cs
@@ -1,5 +1,5 @@
 using System.IO;
-using Mutation.Ui.Core;
+using CognitiveSupport;
 
 namespace Mutation.Tests;
 

--- a/Mutation.Tests/SilenceRemovalLogTests.cs
+++ b/Mutation.Tests/SilenceRemovalLogTests.cs
@@ -1,0 +1,94 @@
+using System.IO;
+using CognitiveSupport;
+
+namespace Mutation.Tests;
+
+/// <summary>
+/// Covers <see cref="SilenceRemovalLog"/>, which carries the silence-removal points from the
+/// preprocessing pass through to whoever transcribes the file.
+/// <para>
+/// It used to compare the two paths as raw strings, so a caller that spelled the recording
+/// differently from the way preprocessing recorded it got no points back and chunking fell
+/// back to cutting at the furthest safe position — quietly, and differently from every other
+/// path compare in the app (issue #324).
+/// </para>
+/// </summary>
+public class SilenceRemovalLogTests
+{
+	private static string Temp(params string[] parts) =>
+		Path.Combine(Path.GetTempPath(), Path.Combine(parts));
+
+	private static SilenceRemovalPoint[] OnePoint() =>
+		new[] { new SilenceRemovalPoint(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2)) };
+
+	[Fact]
+	public void The_file_just_recorded_gets_its_points_back()
+	{
+		var log = new SilenceRemovalLog();
+		var points = OnePoint();
+
+		log.Record(Temp("session.ogg"), points);
+
+		Assert.Equal(points, log.PointsFor(Temp("session.ogg")));
+	}
+
+	[Theory]
+	[InlineData("SESSION.ogg")]
+	[InlineData("sub/../session.ogg")]
+	public void The_same_file_spelled_another_way_is_still_that_file(string spelling)
+	{
+		var log = new SilenceRemovalLog();
+		var points = OnePoint();
+		log.Record(Temp("session.ogg"), points);
+
+		Assert.Equal(points, log.PointsFor(Temp(spelling)));
+	}
+
+	[Fact]
+	public void Another_file_gets_nothing()
+	{
+		var log = new SilenceRemovalLog();
+		log.Record(Temp("session.ogg"), OnePoint());
+
+		Assert.Empty(log.PointsFor(Temp("other.ogg")));
+	}
+
+	[Fact]
+	public void The_same_name_in_another_folder_gets_nothing()
+	{
+		var log = new SilenceRemovalLog();
+		log.Record(Temp("a", "session.ogg"), OnePoint());
+
+		Assert.Empty(log.PointsFor(Temp("b", "session.ogg")));
+	}
+
+	[Theory]
+	[InlineData("")]
+	[InlineData("   ")]
+	public void A_blank_path_gets_nothing(string path)
+	{
+		var log = new SilenceRemovalLog();
+		log.Record(Temp("session.ogg"), OnePoint());
+
+		Assert.Empty(log.PointsFor(path));
+	}
+
+	[Fact]
+	public void Nothing_recorded_yet_means_no_points_for_anyone()
+	{
+		Assert.Empty(new SilenceRemovalLog().PointsFor(Temp("session.ogg")));
+	}
+
+	[Fact]
+	public void A_later_recording_replaces_the_earlier_one()
+	{
+		var log = new SilenceRemovalLog();
+		var second = OnePoint();
+
+		log.Record(Temp("first.ogg"), OnePoint());
+		log.Record(Temp("second.ogg"), second);
+
+		Assert.Equal(second, log.PointsFor(Temp("second.ogg")));
+		Assert.Empty(log.PointsFor(Temp("first.ogg")));
+	}
+}

--- a/Mutation.Ui/Core/SessionRetentionPlanner.cs
+++ b/Mutation.Ui/Core/SessionRetentionPlanner.cs
@@ -1,3 +1,4 @@
+using CognitiveSupport;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Mutation.Ui/Core/SessionSelectionPlanner.cs
+++ b/Mutation.Ui/Core/SessionSelectionPlanner.cs
@@ -1,3 +1,4 @@
+using CognitiveSupport;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Mutation.Ui/HotkeyRouterEntry.cs
+++ b/Mutation.Ui/HotkeyRouterEntry.cs
@@ -3,7 +3,6 @@ using Mutation.Ui.Services;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Media;
 using Windows.UI;
@@ -269,20 +268,14 @@ public sealed class HotkeyRouterEntry : INotifyPropertyChanged
                 }
         }
 
-        private string? FormatHotkey(string? value)
-        {
-                if (string.IsNullOrWhiteSpace(value))
-                        return string.Empty;
-
-                IEnumerable<string> parts = value
-                        .Split(Hotkey.TokenSeparators, StringSplitOptions.RemoveEmptyEntries)
-                        .Select(part => part.Trim())
-                        .Where(part => !string.IsNullOrWhiteSpace(part))
-                        .Select(part => part.ToUpperInvariant());
-
-                string formatted = string.Join('+', parts);
-                return formatted;
-        }
+        /// <summary>
+        /// The text this row shows and persists. Routed through
+        /// <see cref="Hotkey.Canonicalize"/> so a chord typed as <c>SHIFT+CTRL+A</c> is written
+        /// the way the rest of the app spells it, rather than in the order it was typed
+        /// (issue #323). Text that is still half-typed comes back upper-cased and otherwise
+        /// untouched, which is what <see cref="ValidateFormattedHotkey"/> then complains about.
+        /// </summary>
+        private string? FormatHotkey(string? value) => Hotkey.Canonicalize(value);
 
         private void UpdateCombinedError()
         {

--- a/Mutation.Ui/Services/Hotkey.cs
+++ b/Mutation.Ui/Services/Hotkey.cs
@@ -91,6 +91,38 @@ public class Hotkey : IEquatable<Hotkey>
 	}
 
 	/// <summary>
+	/// The canonical spelling of whatever <paramref name="text"/> says, for the two places that
+	/// write a chord back to settings — the hotkey editor and the hotkey router row.
+	/// <para>
+	/// Both used to split, upper-case and rejoin, which keeps the order the user typed. So
+	/// someone who typed <c>SHIFT+CTRL+A</c> by hand had <c>SHIFT+CTRL+A</c> on disk while the
+	/// rest of the app spelled that chord <c>CTRL+SHIFT+A</c> (issue #323). Text that parses now
+	/// comes back as <see cref="ToString"/> writes it.
+	/// </para>
+	/// <para>
+	/// Half-typed text — <c>CTRL+</c> on the way to something, a key name with a typo — does not
+	/// parse, and falls back to the upper-cased join those two produced before. That keeps what
+	/// the user is still typing on screen instead of erasing it, and leaves the validation
+	/// message to say what is wrong with it.
+	/// </para>
+	/// </summary>
+	public static string Canonicalize(string? text)
+	{
+		if (string.IsNullOrWhiteSpace(text))
+			return string.Empty;
+
+		if (TryParse(text, out Hotkey? parsed))
+			return parsed.ToString();
+
+		var parts = text.Split(TokenSeparators,
+			StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+		var upperCased = new string[parts.Length];
+		for (int i = 0; i < parts.Length; i++)
+			upperCased[i] = parts[i].ToUpperInvariant();
+		return string.Join('+', upperCased);
+	}
+
+	/// <summary>
 	/// Parses <paramref name="text"/> as a chord, answering false rather than throwing when
 	/// it is blank or not a chord at all. Callers that check for duplicates run over whatever
 	/// the user has typed so far, where half-finished text is routine and not an error.

--- a/Mutation.Ui/Views/Settings/Controls/HotkeyEditor.xaml.cs
+++ b/Mutation.Ui/Views/Settings/Controls/HotkeyEditor.xaml.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
@@ -217,9 +216,11 @@ public sealed partial class HotkeyEditor : UserControl
 
 	private void Commit()
 	{
+		// SendKeys syntax is not a chord, so it is kept exactly as typed. Anything else goes
+		// through the one canonical spelling the app uses everywhere (issue #323).
 		string committed = AllowSendKeysSyntax
 			? (HotkeyTextBox.Text ?? string.Empty).Trim()
-			: Normalize(HotkeyTextBox.Text);
+			: Mutation.Ui.Services.Hotkey.Canonicalize(HotkeyTextBox.Text);
 
 		if (!string.Equals(committed, HotkeyTextBox.Text, StringComparison.Ordinal))
 		{
@@ -232,19 +233,6 @@ public sealed partial class HotkeyEditor : UserControl
 			Hotkey = committed;
 
 		HotkeyCommitted?.Invoke(this, committed);
-	}
-
-	private static string Normalize(string? value)
-	{
-		if (string.IsNullOrWhiteSpace(value))
-			return string.Empty;
-
-		var parts = value.Split(Mutation.Ui.Services.Hotkey.TokenSeparators,
-			StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-		var normalized = new List<string>(parts.Length);
-		foreach (var p in parts)
-			normalized.Add(p.ToUpperInvariant());
-		return string.Join('+', normalized);
 	}
 
 	private static VirtualKeyModifiers GetCurrentModifiers()

--- a/Mutation.Ui/Views/Settings/Pages/HotkeysSettingsPage.xaml.cs
+++ b/Mutation.Ui/Views/Settings/Pages/HotkeysSettingsPage.xaml.cs
@@ -48,13 +48,29 @@ public sealed partial class HotkeysSettingsPage : UserControl
 	/// one (issue #306). They are still checked against the shortcuts Mutation does claim,
 	/// because Windows routes a synthesized keystroke back to whoever registered it.
 	/// </param>
-	private sealed record HotkeySpec(
+	internal sealed record HotkeySpec(
 		string Label,
 		Func<Settings, string?> Getter,
 		Action<Settings, string?> Setter,
 		bool AllowEmpty,
 		string? Default = null,
-		bool Registers = true);
+		bool Registers = true)
+	{
+		/// <summary>
+		/// Whether this row's box also accepts SendKeys syntax, the way the same two values
+		/// already do on the OCR and Speech pages. This page used to leave the flag off, so a
+		/// working <c>^{F5}</c> was read out here as "Unsupported key" — on the page whose job
+		/// is telling the user which shortcuts are wrong (issue #322).
+		/// <para>
+		/// It follows from <see cref="Registers"/> because the reason is the same one: a value
+		/// that is typed out rather than claimed is a keystroke to send, and a keystroke to
+		/// send is what SendKeys syntax spells. Derived rather than a flag of its own so the
+		/// two cannot be set to disagree — a row that is not registered but must be a plain
+		/// chord would need its own flag, and there is no such row.
+		/// </para>
+		/// </summary>
+		public bool AllowsSendKeysSyntax => !Registers;
+	}
 
 	private sealed class HotkeyRow
 	{
@@ -64,7 +80,12 @@ public sealed partial class HotkeysSettingsPage : UserControl
 		public required TextBlock DuplicateBadge { get; init; }
 	}
 
-	private static readonly HotkeySpec[] Specs = new[]
+	/// <summary>
+	/// Every row on the page, in the order it appears. Reachable from tests because the flags
+	/// on it decide what each box accepts, and the page itself cannot be built without a WinUI
+	/// host (issue #304 tracks that seam).
+	/// </summary>
+	internal static readonly HotkeySpec[] Specs = new[]
 	{
 		new HotkeySpec("Toggle microphone mute",
 			s => s.AudioSettings?.MicrophoneToggleMuteHotKey,
@@ -150,11 +171,7 @@ public sealed partial class HotkeysSettingsPage : UserControl
 			{
 				Header = spec.Label,
 				AllowEmpty = spec.AllowEmpty,
-				// The "Send key after…" rows are typed out rather than registered, so they
-				// accept SendKeys syntax — as they already do on the OCR and Speech pages. This
-				// page used to leave the flag off, so a working `^{F5}` was read out here as an
-				// error on the very page whose job is saying which shortcuts are wrong (#322).
-				AllowSendKeysSyntax = !spec.Registers,
+				AllowSendKeysSyntax = spec.AllowsSendKeysSyntax,
 				Hotkey = spec.Getter(_settings) ?? string.Empty,
 			};
 			var dupBadge = new TextBlock

--- a/Mutation.Ui/Views/Settings/Pages/HotkeysSettingsPage.xaml.cs
+++ b/Mutation.Ui/Views/Settings/Pages/HotkeysSettingsPage.xaml.cs
@@ -150,6 +150,11 @@ public sealed partial class HotkeysSettingsPage : UserControl
 			{
 				Header = spec.Label,
 				AllowEmpty = spec.AllowEmpty,
+				// The "Send key after…" rows are typed out rather than registered, so they
+				// accept SendKeys syntax — as they already do on the OCR and Speech pages. This
+				// page used to leave the flag off, so a working `^{F5}` was read out here as an
+				// error on the very page whose job is saying which shortcuts are wrong (#322).
+				AllowSendKeysSyntax = !spec.Registers,
 				Hotkey = spec.Getter(_settings) ?? string.Empty,
 			};
 			var dupBadge = new TextBlock


### PR DESCRIPTION
Three small items from the Todo column, taken together because two of them touch the same files.

Closes #322
Closes #323
Closes #324

## What changed

### #322 — a false error on the Hotkeys page

The two **Send key after…** values are editable from two places, and only one of them allowed SendKeys syntax. `OcrSettingsPage` and `SpeechSettingsPage` set `AllowSendKeysSyntax="True"`; `HotkeysSettingsPage.BuildRows` did not, so a `^{F5}` configured and accepted on the OCR page showed a red "Unsupported key" message on the Hotkeys page — read out as an error, on a working setting, on the page whose whole job is saying which shortcuts are wrong.

`BuildRows` now takes the flag from the row's spec. `HotkeySpec` gained `AllowsSendKeysSyntax => !Registers` — derived rather than a flag of its own, so the two cannot be set to disagree. `Registers` was added in #320 and already marks exactly those two rows. It is assigned before `Hotkey`, so the first `Validate` pass already sees it.

**It also fixes a quieter bug on the same rows.** With the flag off, `Commit` ran the chord normalizer over those two values, and `,` and ` ` are both in `Hotkey.TokenSeparators`. So tabbing through the Hotkeys page rewrote `+{ENTER}` to `{ENTER}` — dropping the SendKeys Shift prefix — and `CTRL+V, CTRL+S` to `CTRL+V+CTRL+S`, which `HotkeyManager.SendHotkey` splits on `,` only and would then have sent as the single chord Ctrl+S. Merely opening the page was enough to corrupt a working setting. Both are preserved now.

### #323 — one canonical spelling for chord text

`HotkeyRouterEntry.FormatHotkey` and `HotkeyEditor.Normalize` each split, upper-cased and rejoined, which keeps the modifier order the user typed. So `SHIFT+CTRL+A` went to the settings file spelled that way while every other part of the app spelled that chord `CTRL+SHIFT+A`.

Both now call a new `Hotkey.Canonicalize`, which parses and reprints through `Hotkey.ToString()`. Text that does not parse — `CTRL+` on the way to something, a key name with a typo — falls back to the upper-case join those two produced before, so a box being typed into is not emptied under the user, and the validation message beside it still says what is wrong. The `AllowSendKeysSyntax` path is untouched: SendKeys syntax is not a chord and keeps its raw text.

`Hotkey.ToString()` answers `(none)` for a chord with no key; that can never reach a settings file, because `Parse` rejects a chord with no key and the fallback takes over. Pinned by a test.

### #324 — PathEquality moves down a layer

`PathEquality` moves from `Mutation.Ui/Core/` to `CognitiveSupport` and becomes public. It depends on nothing but `System.IO`, and `Mutation.Ui` already references `CognitiveSupport`, so the direction is right. `SilenceRemovalLog.PointsFor` now uses it instead of a raw `string.Equals`. Swept the rest of `CognitiveSupport`: the only other case-insensitive compares are file *extensions*, which are correct as they are.

## Tests

`dotnet test --configuration Release`: **1775 passed, 0 failed.**

- `HotkeyCanonicalizeTests` — new. Modifier order, every separator the parser accepts, digit keys keeping their digit rather than the `Number` alias, half-typed text kept rather than erased, blanks, and the `(none)` guard.
- `HotkeysSettingsPageSpecsTests` — new. Exactly the two send-key rows accept SendKeys syntax, a row Mutation claims from Windows still rejects it, an ordinary chord is accepted on every row, and only those two rows may be left blank. `HotkeySpec` and `Specs` are internal to make this reachable; the page itself still needs a WinUI host, so the one property assignment in `BuildRows` remains out of reach — that seam is #304.
- `SilenceRemovalLogTests` — new. The same recording spelled another way now gets its points back; a different file, the same name in another folder, and a blank path still get nothing.
- `HotkeyRouterEntryTests` — two added: a committed row is written in the app's own modifier order, and half-typed text survives a commit.
- `PathEqualityTests` — moved `using` only. The behaviour did not move with the file, as #324 asked.

## User guide

`keyboard-shortcuts.md` gains the tidy-up rule — the box, and the settings file behind it, are rewritten in Mutation's own modifier order — plus an explicit exception for the two "send a key afterwards" boxes, which keep exactly what you type, and why: they hold a comma-separated run of keys or Windows' shorthand, neither of which survives being tidied. The shorthand form is also the one thing on that page not checked against the other shortcuts, and the guide says so. HTML rebuilt and committed alongside.

## Independent review

Reviewed independently after the first push. Two findings acted on in `d4cc228`:

1. The tidy-up paragraph had become false for exactly the two boxes it pointed at — rewritten.
2. #322 had no automated coverage at all — `HotkeysSettingsPageSpecsTests` added.

The review also confirmed the object-initializer ordering, that no page rewrites another's value on open, that `Canonicalize` is idempotent and round-trips for every `VirtualKey`, that both `SilenceRemovalLog` callers pass real filesystem paths, and that no other raw path compare survives in `CognitiveSupport`.

Two things it raised were filed rather than fixed here:

- #326 — a SendKeys-syntax value still takes no part in duplicate detection. #322 flagged this as "worth a look, not worth holding this up"; catching it needs a reader for SendKeys syntax that does not exist yet. The guide says outright that these values are not checked, until it does.
- #327 — the hotkey box rewrites itself on commit under `_suppressTextChanged`, so a screen-reader user hears nothing. Pre-existing for the capitals; this PR makes the rewrite larger. Fixing it is a UX call about how chatty the live region should be while tabbing through seventeen rows, so it is its own story.

🤖 Generated with [Claude Code](https://claude.com/claude-code)