### PR TITLE
Give the keyboard back the 8 bytes Windows was counting

### DIFF
--- a/Documentation/UserGuide/html/dictation.html
+++ b/Documentation/UserGuide/html/dictation.html
@@ -301,6 +301,11 @@ active app once the transcript has been delivered.</p>
 <p>It exists for apps that need one extra keypress to finish the job — for example
 sending <strong>Ctrl+V</strong> to paste, or a <strong>Tab</strong> or <strong>Enter</strong> to move on. Leave it blank
 if you don't need it.</p>
+<p>If the transcript could not be delivered — you hear the failure beep — the shortcut is
+not sent. It usually acts on the text, and sending it when nothing arrived would aim it
+at whatever was there before.</p>
+<p>Write the shortcut the ordinary way, like <strong>Ctrl+V</strong> or <strong>Ctrl+Shift+Delete</strong>. You can
+list more than one, separated by commas, and they are sent in turn.</p>
 <h2 id="choosing-a-transcription-service">Choosing a transcription service</h2>
 <p>At the top of the <strong>Speech to Text</strong> card is a dropdown listing your transcription
 services.</p>

--- a/Documentation/UserGuide/html/screen-capture-and-ocr.html
+++ b/Documentation/UserGuide/html/screen-capture-and-ocr.html
@@ -314,7 +314,8 @@ remove the limit.</li>
 </ul>
 <p>There is also an optional <strong>Send hotkey after OCR</strong> setting, which fires a keystroke of
 your choosing once the text is ready — handy for kicking off your screen reader
-automatically.</p>
+automatically. It is sent whether the run found text or failed, so a screen-reader
+shortcut in that box reads out the error just as readily as the result.</p>
 <p>The rest of the options are covered in <a href="settings.html">The Settings window</a>.</p>
 <h2 id="where-to-next">Where to next</h2>
 <ul>

--- a/Documentation/UserGuide/html/troubleshooting.html
+++ b/Documentation/UserGuide/html/troubleshooting.html
@@ -334,16 +334,34 @@ whether Windows accepted them and tells you when it did not, rather than announc
 success for text that never arrived.</p>
 <p><strong>What to do.</strong></p>
 <ol>
-<li>Check the other app first. Once in a while Mutation gets the text through on a
-second route and the warning turns out to be a false alarm, so look before you
-paste again — otherwise you may end up with it twice.</li>
-<li>If it really is missing, your text is not lost. It is in the main window and,
-unless the clipboard also failed, on your clipboard — paste it with <strong>Ctrl+V</strong>.</li>
+<li>Your text is not lost. It is in the main window and, unless the clipboard also
+failed, on your clipboard — paste it with <strong>Ctrl+V</strong>.</li>
+<li>Check the other app before you paste, so you don't end up with the text twice.</li>
 <li>The usual cause is an app started with &quot;Run as administrator&quot;, or a system dialog
 that has taken the foreground. Close it, or click into an ordinary window, and
 dictate again.</li>
 <li>Task Manager, the Windows security prompt, and some installer windows behave this
 way too. Nothing is wrong with Mutation or your microphone.</li>
+</ol>
+<h3 id="the-shortcut-i-set-to-run-afterwards-doesnt-happen">The shortcut I set to run afterwards doesn't happen</h3>
+<p><strong>What's happening.</strong> This is the <strong>Send hotkey after transcription</strong> and <strong>Send hotkey
+after OCR</strong> boxes in <strong>Settings</strong>. There are two reasons one may not arrive.</p>
+<p>The first is that dictation only sends it when the text was delivered. If you heard the
+failure beep, the shortcut is deliberately skipped — it is usually something that acts
+on the text, and running it when the text never landed would aim it at the wrong thing.
+OCR is different: it sends the shortcut either way, so a screen-reader command in that
+box reads out the error as readily as the result.</p>
+<p>The second is how the shortcut is written. Write it the ordinary way — modifier names
+joined with plus signs, like <strong>Ctrl+V</strong>, <strong>Alt+F4</strong> or <strong>Ctrl+Shift+Delete</strong>. Mutation
+still understands the older shorthand some settings files hold, such as <code>^{DEL}</code> for
+<strong>Ctrl+Delete</strong>, but the ordinary spelling is the one to reach for.</p>
+<p><strong>What to do.</strong></p>
+<ol>
+<li>Deal with the failure beep first. Whatever stopped the text arriving is stopping
+the shortcut too, and the two entries above cover the usual causes.</li>
+<li>Retype the shortcut the plain way — <strong>Ctrl+Delete</strong> rather than a shorthand.</li>
+<li>You can put more than one in, separated by commas: <strong>Ctrl+A, Ctrl+C</strong> sends the two
+in turn.</li>
 </ol>
 <h3 id="something-went-wrong-while-delivering-the-transcript">Something went wrong while delivering the transcript</h3>
 <p><strong>What's happening.</strong> Very occasionally the delivery itself fails in a way Mutation did

--- a/Documentation/UserGuide/markdown/dictation.md
+++ b/Documentation/UserGuide/markdown/dictation.md
@@ -176,6 +176,13 @@ It exists for apps that need one extra keypress to finish the job — for exampl
 sending **Ctrl+V** to paste, or a **Tab** or **Enter** to move on. Leave it blank
 if you don't need it.
 
+If the transcript could not be delivered — you hear the failure beep — the shortcut is
+not sent. It usually acts on the text, and sending it when nothing arrived would aim it
+at whatever was there before.
+
+Write the shortcut the ordinary way, like **Ctrl+V** or **Ctrl+Shift+Delete**. You can
+list more than one, separated by commas, and they are sent in turn.
+
 ## Choosing a transcription service
 
 At the top of the **Speech to Text** card is a dropdown listing your transcription

--- a/Documentation/UserGuide/markdown/screen-capture-and-ocr.md
+++ b/Documentation/UserGuide/markdown/screen-capture-and-ocr.md
@@ -144,7 +144,8 @@ These live under **Screen capture & OCR** in **Settings** (**Ctrl+Comma**).
 
 There is also an optional **Send hotkey after OCR** setting, which fires a keystroke of
 your choosing once the text is ready — handy for kicking off your screen reader
-automatically.
+automatically. It is sent whether the run found text or failed, so a screen-reader
+shortcut in that box reads out the error just as readily as the result.
 
 The rest of the options are covered in [The Settings window](settings.md).
 

--- a/Documentation/UserGuide/markdown/troubleshooting.md
+++ b/Documentation/UserGuide/markdown/troubleshooting.md
@@ -230,16 +230,38 @@ success for text that never arrived.
 
 **What to do.**
 
-1. Check the other app first. Once in a while Mutation gets the text through on a
-   second route and the warning turns out to be a false alarm, so look before you
-   paste again — otherwise you may end up with it twice.
-2. If it really is missing, your text is not lost. It is in the main window and,
-   unless the clipboard also failed, on your clipboard — paste it with **Ctrl+V**.
+1. Your text is not lost. It is in the main window and, unless the clipboard also
+   failed, on your clipboard — paste it with **Ctrl+V**.
+2. Check the other app before you paste, so you don't end up with the text twice.
 3. The usual cause is an app started with "Run as administrator", or a system dialog
    that has taken the foreground. Close it, or click into an ordinary window, and
    dictate again.
 4. Task Manager, the Windows security prompt, and some installer windows behave this
    way too. Nothing is wrong with Mutation or your microphone.
+
+### The shortcut I set to run afterwards doesn't happen
+
+**What's happening.** This is the **Send hotkey after transcription** and **Send hotkey
+after OCR** boxes in **Settings**. There are two reasons one may not arrive.
+
+The first is that dictation only sends it when the text was delivered. If you heard the
+failure beep, the shortcut is deliberately skipped — it is usually something that acts
+on the text, and running it when the text never landed would aim it at the wrong thing.
+OCR is different: it sends the shortcut either way, so a screen-reader command in that
+box reads out the error as readily as the result.
+
+The second is how the shortcut is written. Write it the ordinary way — modifier names
+joined with plus signs, like **Ctrl+V**, **Alt+F4** or **Ctrl+Shift+Delete**. Mutation
+still understands the older shorthand some settings files hold, such as `^{DEL}` for
+**Ctrl+Delete**, but the ordinary spelling is the one to reach for.
+
+**What to do.**
+
+1. Deal with the failure beep first. Whatever stopped the text arriving is stopping
+   the shortcut too, and the two entries above cover the usual causes.
+2. Retype the shortcut the plain way — **Ctrl+Delete** rather than a shorthand.
+3. You can put more than one in, separated by commas: **Ctrl+A, Ctrl+C** sends the two
+   in turn.
 
 ### Something went wrong while delivering the transcript
 

--- a/Mutation.Tests/HotkeyChordResolutionTests.cs
+++ b/Mutation.Tests/HotkeyChordResolutionTests.cs
@@ -1,0 +1,71 @@
+using Mutation.Ui.Services;
+using Windows.System;
+
+namespace Mutation.Tests;
+
+/// <summary>
+/// Which shortcuts <see cref="HotkeyManager.SendHotkey"/> can put through SendInput, which
+/// is the only path that reports whether the keystrokes were delivered.
+/// <para>
+/// Issue #325: anything that fell off this path went to the WinForms SendKeys fallback,
+/// which answers nothing — so the shortcut sent after transcription and after OCR could
+/// stop arriving with no beep, no message, and no log line saying so.
+/// </para>
+/// </summary>
+public class HotkeyChordResolutionTests
+{
+	[Theory]
+	[InlineData("^{DEL}", VirtualKey.Delete)]     // the shipped send-after setting
+	[InlineData("%{F4}", VirtualKey.F4)]
+	[InlineData("^+{TAB}", VirtualKey.Tab)]
+	[InlineData("^c", VirtualKey.C)]
+	public void SendKeysNotationResolvesToAChord(string text, VirtualKey expected)
+	{
+		var chord = HotkeyManager.ResolveChord(text);
+
+		Assert.NotNull(chord);
+		Assert.Equal(expected, chord.Key);
+	}
+
+	[Theory]
+	[InlineData("CTRL+DELETE", VirtualKey.Delete)]
+	[InlineData("Ctrl+V", VirtualKey.V)]
+	[InlineData("SHIFT+ALT+U", VirtualKey.U)]
+	[InlineData("WIN+D", VirtualKey.D)]
+	public void TheOrdinarySpellingStillResolves(string text, VirtualKey expected)
+	{
+		var chord = HotkeyManager.ResolveChord(text);
+
+		Assert.NotNull(chord);
+		Assert.Equal(expected, chord.Key);
+	}
+
+	[Fact]
+	public void CtrlDeleteResolvesTheSameWhicheverWayItIsWritten()
+	{
+		// Hotkey has value equality, so this compares the chords rather than their spellings.
+		Assert.Equal(HotkeyManager.ResolveChord("CTRL+DELETE"), HotkeyManager.ResolveChord("^{DEL}"));
+	}
+
+	[Fact]
+	public void CtrlVResolves()
+	{
+		// The chord the Paste insert option sends. When SendInput could not deliver it, the
+		// transcript was announced as undelivered even though the fallback had pasted it.
+		var chord = HotkeyManager.ResolveChord("Ctrl+V");
+
+		Assert.NotNull(chord);
+		Assert.True(chord.Control);
+		Assert.Equal(VirtualKey.V, chord.Key);
+	}
+
+	[Theory]
+	[InlineData("{ENTER}hello")]   // literal text to type
+	[InlineData("^(ab)")]          // a group
+	[InlineData("not a hotkey")]
+	[InlineData("")]
+	public void WhatItCannotExpressIsLeftToTheFallback(string text)
+	{
+		Assert.Null(HotkeyManager.ResolveChord(text));
+	}
+}

--- a/Mutation.Tests/KeyboardInputLayoutTests.cs
+++ b/Mutation.Tests/KeyboardInputLayoutTests.cs
@@ -1,0 +1,99 @@
+using System.Runtime.InteropServices;
+using Mutation.Ui.Services;
+
+namespace Mutation.Tests;
+
+/// <summary>
+/// The size of the INPUT struct, which is the one thing Windows validates before it will
+/// deliver a single keystroke.
+/// <para>
+/// Issue #325: the struct declared only the keyboard arm of the union, so it measured 32
+/// bytes in a 64-bit process where Windows requires 40. Every SendInput call in the app
+/// answered "0 events sent, ERROR_INVALID_PARAMETER" — pastes, typed dictation, and every
+/// configured send-a-shortcut-afterwards. Nothing about the code looked wrong, which is
+/// exactly why the size is asserted here rather than left to be noticed again.
+/// </para>
+/// </summary>
+public class KeyboardInputLayoutTests
+{
+	[Fact]
+	public void InputSize_MatchesWhatWindowsRequires()
+	{
+		Assert.Equal(KeyboardInput.RequiredInputSize, KeyboardInput.InputSize);
+	}
+
+	[Fact]
+	public void InputSize_Is40BytesInA64BitProcess()
+	{
+		// Stated as the literal so a change to RequiredInputSize cannot quietly agree with
+		// a change to the struct and let both drift away from Windows.
+		if (IntPtr.Size != 8)
+			return;
+
+		Assert.Equal(40, Marshal.SizeOf<KeyboardInput.INPUT>());
+	}
+
+	[Fact]
+	public void Union_IsSizedByItsLargestArm()
+	{
+		// The mouse arm is the largest of the three; if it is ever dropped from the union
+		// again the INPUT struct shrinks and SendInput stops working, silently.
+		Assert.True(Marshal.SizeOf<KeyboardInput.MOUSEINPUT>() >= Marshal.SizeOf<KeyboardInput.KEYBDINPUT>());
+		Assert.Equal(Marshal.SizeOf<KeyboardInput.MOUSEINPUT>(), Marshal.SizeOf<KeyboardInput.INPUTUNION>());
+	}
+
+	[Fact]
+	public void KeyDown_CarriesTheVirtualKeyAndNoKeyUpFlag()
+	{
+		var input = KeyboardInput.KeyDown(KeyboardInput.VkControl);
+
+		Assert.Equal(KeyboardInput.InputKeyboard, input.type);
+		Assert.Equal(KeyboardInput.VkControl, input.U.ki.wVk);
+		Assert.Equal(0u, input.U.ki.dwFlags & KeyboardInput.KeyEventKeyUp);
+	}
+
+	[Fact]
+	public void KeyUp_SetsTheKeyUpFlag()
+	{
+		var input = KeyboardInput.KeyUp(KeyboardInput.VkControl);
+
+		Assert.Equal(KeyboardInput.KeyEventKeyUp, input.U.ki.dwFlags & KeyboardInput.KeyEventKeyUp);
+	}
+
+	[Theory]
+	[InlineData((ushort)0x2E)] // Delete
+	[InlineData((ushort)0x24)] // Home
+	[InlineData((ushort)0x21)] // Page Up
+	public void NavigationKeys_AreMarkedExtended(ushort virtualKey)
+	{
+		// Without the flag these arrive as their numeric-keypad twins — Delete becomes the
+		// keypad period, which types a full stop into the user's document.
+		var input = KeyboardInput.KeyDown(virtualKey);
+
+		Assert.Equal(KeyboardInput.KeyEventExtendedKey, input.U.ki.dwFlags & KeyboardInput.KeyEventExtendedKey);
+	}
+
+	[Fact]
+	public void LetterKeys_AreNotMarkedExtended()
+	{
+		var input = KeyboardInput.KeyDown(0x56); // V
+
+		Assert.Equal(0u, input.U.ki.dwFlags & KeyboardInput.KeyEventExtendedKey);
+	}
+
+	[Fact]
+	public void Unicode_CarriesTheCharacterAsAScanCodeWithNoVirtualKey()
+	{
+		var down = KeyboardInput.UnicodeDown('é');
+
+		Assert.Equal(0, down.U.ki.wVk);
+		Assert.Equal('é', (char)down.U.ki.wScan);
+		Assert.Equal(KeyboardInput.KeyEventUnicode, down.U.ki.dwFlags & KeyboardInput.KeyEventUnicode);
+	}
+
+	[Fact]
+	public void Send_WithNothingToSend_DoesNotCallWindows()
+	{
+		Assert.Equal(0u, KeyboardInput.Send(Array.Empty<KeyboardInput.INPUT>()));
+	}
+}

--- a/Mutation.Tests/PostOperationHotkeyTests.cs
+++ b/Mutation.Tests/PostOperationHotkeyTests.cs
@@ -1,0 +1,33 @@
+using Mutation.Ui.Core;
+
+namespace Mutation.Tests;
+
+/// <summary>
+/// When the shortcut configured to run after an operation is sent.
+/// </summary>
+public class PostOperationHotkeyTests
+{
+	[Fact]
+	public void OcrSendsTheShortcutWhenItSucceeded()
+	{
+		Assert.Equal(PostOperationHotkey.SuccessDelayMs, PostOperationHotkey.OcrDelay(true));
+	}
+
+	[Fact]
+	public void OcrAlsoSendsTheShortcutWhenItFailed()
+	{
+		// Not zero and not skipped: the OCR shortcuts are commonly routed to a screen-reader
+		// command that reads the result area, and a user working by ear needs to hear the
+		// error just as much as the text.
+		Assert.Equal(PostOperationHotkey.FailureDelayMs, PostOperationHotkey.OcrDelay(false));
+		Assert.True(PostOperationHotkey.OcrDelay(false) > 0);
+	}
+
+	[Fact]
+	public void TheOtherApplicationIsGivenLongerAfterTextArrives()
+	{
+		// The delay is there for the window receiving the text, so the success case — the
+		// one with text settling in it — has to be the longer of the two.
+		Assert.True(PostOperationHotkey.SuccessDelayMs > PostOperationHotkey.FailureDelayMs);
+	}
+}

--- a/Mutation.Tests/SendKeysChordTests.cs
+++ b/Mutation.Tests/SendKeysChordTests.cs
@@ -79,6 +79,35 @@ public class SendKeysChordTests
 		Assert.Equal(expected, hotkey.Key);
 	}
 
+	[Fact]
+	public void EveryLetterAndDigitLandsOnItsOwnKey()
+	{
+		// The reading is arithmetic off VirtualKey.A and VirtualKey.Number0, which is only
+		// sound while those runs stay contiguous. Wrong here means a shortcut quietly sends
+		// a different key rather than failing.
+		for (char c = 'a'; c <= 'z'; c++)
+		{
+			Assert.True(SendKeysChord.TryParse("^" + c, out var hotkey));
+			Assert.Equal(char.ToUpperInvariant(c).ToString(), hotkey.Key.ToString());
+		}
+
+		for (char c = '0'; c <= '9'; c++)
+		{
+			Assert.True(SendKeysChord.TryParse("^" + c, out var hotkey));
+			Assert.Equal("Number" + c, hotkey.Key.ToString());
+		}
+	}
+
+	[Fact]
+	public void EveryFunctionKeyLandsOnItsOwnKey()
+	{
+		for (int n = 1; n <= 24; n++)
+		{
+			Assert.True(SendKeysChord.TryParse($"^{{F{n}}}", out var hotkey));
+			Assert.Equal($"F{n}", hotkey.Key.ToString());
+		}
+	}
+
 	[Theory]
 	[InlineData("")]
 	[InlineData("   ")]

--- a/Mutation.Tests/SendKeysChordTests.cs
+++ b/Mutation.Tests/SendKeysChordTests.cs
@@ -1,0 +1,152 @@
+using Mutation.Ui.Services;
+using Windows.System;
+
+namespace Mutation.Tests;
+
+/// <summary>
+/// Reading a shortcut written in SendKeys notation back into a chord.
+/// <para>
+/// Issue #325: the two "send this shortcut afterwards" settings accept SendKeys notation,
+/// and a settings file saved years ago holds "^{DEL}". Nothing could parse that, so it
+/// only ever reached the WinForms fallback, which cannot say whether the keystrokes
+/// arrived. These tests pin the readings so those settings keep going down the path that
+/// can report a failure.
+/// </para>
+/// </summary>
+public class SendKeysChordTests
+{
+	[Fact]
+	public void CtrlDelete_TheShippedSetting_IsRead()
+	{
+		Assert.True(SendKeysChord.TryParse("^{DEL}", out var hotkey));
+
+		Assert.True(hotkey.Control);
+		Assert.False(hotkey.Shift);
+		Assert.False(hotkey.Alt);
+		Assert.False(hotkey.Win);
+		Assert.Equal(VirtualKey.Delete, hotkey.Key);
+	}
+
+	[Theory]
+	[InlineData("^{DELETE}")]
+	[InlineData("^{del}")]
+	[InlineData("  ^{DEL}  ")]
+	public void CtrlDelete_IsReadHoweverItIsSpelled(string text)
+	{
+		Assert.True(SendKeysChord.TryParse(text, out var hotkey));
+		Assert.True(hotkey.Control);
+		Assert.Equal(VirtualKey.Delete, hotkey.Key);
+	}
+
+	[Fact]
+	public void EveryModifierIsRecognised()
+	{
+		Assert.True(SendKeysChord.TryParse("^+%{HOME}", out var hotkey));
+
+		Assert.True(hotkey.Control);
+		Assert.True(hotkey.Shift);
+		Assert.True(hotkey.Alt);
+		Assert.Equal(VirtualKey.Home, hotkey.Key);
+	}
+
+	[Theory]
+	[InlineData("%{F4}", VirtualKey.F4)]
+	[InlineData("^{F12}", VirtualKey.F12)]
+	[InlineData("^{PGDN}", VirtualKey.PageDown)]
+	[InlineData("^{PGUP}", VirtualKey.PageUp)]
+	[InlineData("+{TAB}", VirtualKey.Tab)]
+	[InlineData("^{ENTER}", VirtualKey.Enter)]
+	[InlineData("^{INS}", VirtualKey.Insert)]
+	[InlineData("^{BACKSPACE}", VirtualKey.Back)]
+	[InlineData("^{ESC}", VirtualKey.Escape)]
+	[InlineData("^{SPACE}", VirtualKey.Space)]
+	[InlineData("^{END}", VirtualKey.End)]
+	[InlineData("^{UP}", VirtualKey.Up)]
+	public void NamedKeysAreRead(string text, VirtualKey expected)
+	{
+		Assert.True(SendKeysChord.TryParse(text, out var hotkey));
+		Assert.Equal(expected, hotkey.Key);
+	}
+
+	[Theory]
+	[InlineData("^c", VirtualKey.C)]
+	[InlineData("^C", VirtualKey.C)]
+	[InlineData("^v", VirtualKey.V)]
+	[InlineData("%1", VirtualKey.Number1)]
+	public void SingleCharacterKeysAreRead(string text, VirtualKey expected)
+	{
+		Assert.True(SendKeysChord.TryParse(text, out var hotkey));
+		Assert.Equal(expected, hotkey.Key);
+	}
+
+	[Theory]
+	[InlineData("")]
+	[InlineData("   ")]
+	[InlineData(null)]
+	public void NothingToSendIsRefused(string? text)
+	{
+		Assert.False(SendKeysChord.TryParse(text, out _));
+	}
+
+	[Theory]
+	[InlineData("c")]                // no modifier and no braces: Hotkey.Parse's job
+	[InlineData("Ctrl+Delete")]      // the ordinary spelling: Hotkey.Parse's job
+	[InlineData("^{DEL}{DEL}")]      // a sequence, not a chord
+	[InlineData("^{DEL 2}")]         // a repeat count
+	[InlineData("^(ab)")]            // a group
+	[InlineData("^{}")]              // an empty name
+	[InlineData("^{NOSUCHKEY}")]
+	[InlineData("^{F25}")]           // beyond F24
+	[InlineData("^{F0}")]
+	[InlineData("^ab")]              // more than one key
+	[InlineData("^;")]               // layout-dependent punctuation
+	[InlineData("^{+}")]             // a braced literal, also layout-dependent
+	[InlineData("^")]                // a modifier with nothing to press
+	public void AnythingItCannotExpressIsRefusedRatherThanGuessed(string text)
+	{
+		// Refusing leaves the WinForms fallback to try. Guessing would send keystrokes the
+		// user did not ask for, into whichever window they are working in.
+		Assert.False(SendKeysChord.TryParse(text, out _));
+	}
+
+	[Fact]
+	public void WinKeyIsNeverProduced()
+	{
+		// SendKeys has no notation for it, so no reading here should ever set it.
+		Assert.True(SendKeysChord.TryParse("^+%{DEL}", out var hotkey));
+		Assert.False(hotkey.Win);
+	}
+
+	[Theory]
+	[InlineData("Ctrl+Delete")]
+	[InlineData("Alt+F4")]
+	[InlineData("Ctrl+Shift+Tab")]
+	[InlineData("Ctrl+C")]
+	[InlineData("Alt+PageDown")]
+	[InlineData("Shift+Home")]
+	[InlineData("Ctrl+Insert")]
+	[InlineData("Ctrl+Alt+End")]
+	public void WhatSendKeysMapperEmitsCanBeReadBack(string chord)
+	{
+		// The two are inverses for the plain chord case. If the mapper gains a spelling this
+		// cannot read, the shortcut silently drops back to the fallback path.
+		var mapped = SendKeysMapper.Map(chord);
+
+		Assert.True(SendKeysChord.TryParse(mapped, out var readBack), $"'{chord}' mapped to '{mapped}' and could not be read back.");
+		Assert.Equal(Hotkey.Parse(chord), readBack);
+	}
+
+	[Theory]
+	[InlineData("Ctrl+PgDn", VirtualKey.PageDown)]
+	[InlineData("Ctrl+Bksp", VirtualKey.Back)]
+	[InlineData("Ctrl+Esc", VirtualKey.Escape)]
+	public void TheMappersOwnKeyAliasesAlsoReadBack(string chord, VirtualKey expected)
+	{
+		// SendKeysMapper accepts short names Hotkey.Parse does not, so these round-trip
+		// through the mapped form rather than through a second Hotkey.Parse.
+		var mapped = SendKeysMapper.Map(chord);
+
+		Assert.True(SendKeysChord.TryParse(mapped, out var readBack));
+		Assert.Equal(expected, readBack.Key);
+	}
+}

--- a/Mutation.Tests/TranscriptCompletionPlannerTests.cs
+++ b/Mutation.Tests/TranscriptCompletionPlannerTests.cs
@@ -1,0 +1,102 @@
+using CognitiveSupport;
+using Mutation.Ui.Core;
+
+namespace Mutation.Tests;
+
+/// <summary>
+/// What the user hears and what runs when a transcript finishes.
+/// <para>
+/// Issue #325: a delivery that had in fact landed was reported as failed, so dictation
+/// ended on the failure beep and the shortcut configured to run afterwards was skipped.
+/// Both came from one decision, and it was three lines inline in two handlers where
+/// nothing could reach it.
+/// </para>
+/// </summary>
+public class TranscriptCompletionPlannerTests
+{
+	[Fact]
+	public void Delivered_PlaysTheSuccessBeep()
+	{
+		var plan = TranscriptCompletionPlanner.Plan(true, TranscriptDeliveryOutcome.Delivered, "transcript");
+
+		Assert.Equal(BeepType.Success, plan.Beep);
+	}
+
+	[Fact]
+	public void Delivered_SendsTheConfiguredHotkey()
+	{
+		var plan = TranscriptCompletionPlanner.Plan(true, TranscriptDeliveryOutcome.Delivered, "transcript");
+
+		Assert.True(plan.SendConfiguredHotkey);
+	}
+
+	[Fact]
+	public void Delivered_SaysNothingWentWrong()
+	{
+		var plan = TranscriptCompletionPlanner.Plan(true, TranscriptDeliveryOutcome.Delivered, "transcript");
+
+		Assert.Null(plan.FailureMessage);
+		Assert.True(plan.Succeeded);
+	}
+
+	[Theory]
+	[InlineData(true, TranscriptDeliveryOutcome.InjectionFailed)]
+	[InlineData(false, TranscriptDeliveryOutcome.InjectionFailed)]
+	[InlineData(false, TranscriptDeliveryOutcome.Delivered)]
+	[InlineData(true, TranscriptDeliveryOutcome.ClipboardBlocked)]
+	public void EveryFailure_PlaysTheFailureBeep(bool copied, TranscriptDeliveryOutcome outcome)
+	{
+		var plan = TranscriptCompletionPlanner.Plan(copied, outcome, "transcript");
+
+		Assert.Equal(BeepType.Failure, plan.Beep);
+		Assert.False(plan.Succeeded);
+	}
+
+	[Theory]
+	[InlineData(true, TranscriptDeliveryOutcome.InjectionFailed)]
+	[InlineData(false, TranscriptDeliveryOutcome.Delivered)]
+	[InlineData(true, TranscriptDeliveryOutcome.ClipboardBlocked)]
+	public void AFailure_DoesNotSendTheConfiguredHotkey(bool copied, TranscriptDeliveryOutcome outcome)
+	{
+		// That shortcut is whatever the user does next with the text. Firing it after a
+		// delivery that did not land aims it at whatever was there before.
+		var plan = TranscriptCompletionPlanner.Plan(copied, outcome, "transcript");
+
+		Assert.False(plan.SendConfiguredHotkey);
+	}
+
+	[Fact]
+	public void AFailure_SaysWhatWentWrongAndWhereTheTextIs()
+	{
+		var plan = TranscriptCompletionPlanner.Plan(true, TranscriptDeliveryOutcome.InjectionFailed, "transcript");
+
+		Assert.NotNull(plan.FailureMessage);
+		Assert.Contains("transcript", plan.FailureMessage);
+		Assert.Contains(TranscriptDeliveryMessages.StillAvailable, plan.FailureMessage);
+	}
+
+	[Fact]
+	public void TheSubjectNamesTheTextInTheMessage()
+	{
+		var plan = TranscriptCompletionPlanner.Plan(true, TranscriptDeliveryOutcome.InjectionFailed, "processed text");
+
+		Assert.Contains("processed text", plan.FailureMessage);
+	}
+
+	[Fact]
+	public void TheBeepAndTheHotkeyNeverDisagree()
+	{
+		// One decision, so the success beep and the shortcut can only be lost together —
+		// never the beep saying it worked while the shortcut is skipped, or the reverse.
+		foreach (var outcome in Enum.GetValues<TranscriptDeliveryOutcome>())
+		{
+			foreach (var copied in new[] { true, false })
+			{
+				var plan = TranscriptCompletionPlanner.Plan(copied, outcome, "transcript");
+
+				Assert.Equal(plan.Beep == BeepType.Success, plan.SendConfiguredHotkey);
+				Assert.Equal(plan.Succeeded, plan.SendConfiguredHotkey);
+			}
+		}
+	}
+}

--- a/Mutation.Ui/Core/Constants.cs
+++ b/Mutation.Ui/Core/Constants.cs
@@ -3,6 +3,6 @@
 internal static class Constants
 {
 	internal const string SessionsDirectoryName = "Sessions";
-	internal const int SendHotkeyDelay = 100;
-	internal const int FailureSendHotkeyDelay = 50;
+	// The two send-hotkey delays moved to Mutation.Ui.Core.PostOperationHotkey, where the
+	// rule about which one an operation uses lives beside them.
 }

--- a/Mutation.Ui/Core/PostOperationHotkey.cs
+++ b/Mutation.Ui/Core/PostOperationHotkey.cs
@@ -1,0 +1,30 @@
+namespace Mutation.Ui.Core;
+
+/// <summary>
+/// How long to wait before sending the shortcut a user has configured to run when an
+/// operation finishes.
+/// <para>
+/// The delay exists because the shortcut lands in whichever window has the keyboard — the
+/// user's editor, not Mutation — and that window needs the moment after the text arrives
+/// before it can act on it.
+/// </para>
+/// </summary>
+internal static class PostOperationHotkey
+{
+	/// <summary>After a run that delivered text, which the shortcut is about to act on.</summary>
+	public const int SuccessDelayMs = 100;
+
+	/// <summary>
+	/// After a run that did not. Shorter, because there is no text settling in the other
+	/// window to wait for.
+	/// </summary>
+	public const int FailureDelayMs = 50;
+
+	/// <summary>
+	/// The delay for an OCR run. OCR sends the shortcut either way: the OCR shortcuts are
+	/// commonly routed to a screen-reader command that reads the result area, and a user
+	/// working by ear needs that to happen just as much when the answer is an error as when
+	/// it is text.
+	/// </summary>
+	public static int OcrDelay(bool success) => success ? SuccessDelayMs : FailureDelayMs;
+}

--- a/Mutation.Ui/Core/TranscriptCompletionPlanner.cs
+++ b/Mutation.Ui/Core/TranscriptCompletionPlanner.cs
@@ -1,0 +1,51 @@
+using CognitiveSupport;
+
+namespace Mutation.Ui.Core;
+
+/// <summary>
+/// What a finished transcript run does: which beep the user hears, what they are told, and
+/// whether the shortcut configured to run afterwards is sent.
+/// </summary>
+/// <param name="Beep">The beep to play. Never absent — the user is driving by ear.</param>
+/// <param name="FailureMessage">
+/// Null when the text landed. Otherwise what went wrong, and where the text still is.
+/// </param>
+/// <param name="SendConfiguredHotkey">
+/// Whether to send <c>SendHotkeyAfterTranscriptionOperation</c>. Only on success: that
+/// shortcut is whatever the user does next with the text — file it, submit it, delete a
+/// line — and firing it after a delivery that did not land aims it at the wrong thing.
+/// </param>
+internal readonly record struct TranscriptCompletionPlan(
+	BeepType Beep,
+	string? FailureMessage,
+	bool SendConfiguredHotkey)
+{
+	public bool Succeeded => FailureMessage is null;
+}
+
+/// <summary>
+/// The end of a transcript run, decided in one place.
+/// <para>
+/// This was three lines inline in two handlers, which made it invisible that all three
+/// outcomes hang together: the success beep, the status, and the shortcut sent afterwards
+/// are one decision, and when a delivery was wrongly reported as failed the user lost all
+/// three at once (issue #325).
+/// </para>
+/// </summary>
+internal static class TranscriptCompletionPlanner
+{
+	/// <param name="clipboardCopied">Whether the text reached the clipboard.</param>
+	/// <param name="outcome">How far the insert into the other application got.</param>
+	/// <param name="subject">Names the text in the message — "transcript", "processed text".</param>
+	public static TranscriptCompletionPlan Plan(
+		bool clipboardCopied,
+		TranscriptDeliveryOutcome outcome,
+		string subject)
+	{
+		string? failure = TranscriptDeliveryMessages.Failure(clipboardCopied, outcome, subject);
+
+		return failure is null
+			? new TranscriptCompletionPlan(BeepType.Success, null, SendConfiguredHotkey: true)
+			: new TranscriptCompletionPlan(BeepType.Failure, failure, SendConfiguredHotkey: false);
+	}
+}

--- a/Mutation.Ui/MainWindow.xaml.cs
+++ b/Mutation.Ui/MainWindow.xaml.cs
@@ -506,7 +506,7 @@ public sealed partial class MainWindow : Window, IDisposable
 					if (!await EnsureOcrConfiguredAsync()) return;
 					var result = await _ocrManager.TakeScreenshotAndExtractTextAsync(OcrReadingOrder.TopToBottomColumnAware);
 					SetOcrText(result.Message);
-					HotkeyManager.SendHotkeyAfterDelay(_settings.AzureComputerVisionSettings?.SendHotkeyAfterOcrOperation, result.Success ? Constants.SendHotkeyDelay : Constants.FailureSendHotkeyDelay);
+					HotkeyManager.SendHotkeyAfterDelay(_settings.AzureComputerVisionSettings?.SendHotkeyAfterOcrOperation, PostOperationHotkey.OcrDelay(result.Success));
 				}
 				catch (Exception ex) { await ShowErrorDialog("Screenshot + OCR Error", ex); }
 			});
@@ -519,7 +519,7 @@ public sealed partial class MainWindow : Window, IDisposable
 					if (!await EnsureOcrConfiguredAsync()) return;
 					var result = await _ocrManager.TakeScreenshotAndExtractTextAsync(OcrReadingOrder.LeftToRightTopToBottom);
 					SetOcrText(result.Message);
-					HotkeyManager.SendHotkeyAfterDelay(_settings.AzureComputerVisionSettings?.SendHotkeyAfterOcrOperation, result.Success ? Constants.SendHotkeyDelay : Constants.FailureSendHotkeyDelay);
+					HotkeyManager.SendHotkeyAfterDelay(_settings.AzureComputerVisionSettings?.SendHotkeyAfterOcrOperation, PostOperationHotkey.OcrDelay(result.Success));
 				}
 				catch (Exception ex) { await ShowErrorDialog("Screenshot + OCR (LRTB) Error", ex); }
 			});
@@ -532,7 +532,7 @@ public sealed partial class MainWindow : Window, IDisposable
 					if (!await EnsureOcrConfiguredAsync()) return;
 					var result = await _ocrManager.ExtractTextFromClipboardImageAsync(OcrReadingOrder.TopToBottomColumnAware);
 					SetOcrText(result.Message);
-					HotkeyManager.SendHotkeyAfterDelay(_settings.AzureComputerVisionSettings?.SendHotkeyAfterOcrOperation, result.Success ? Constants.SendHotkeyDelay : Constants.FailureSendHotkeyDelay);
+					HotkeyManager.SendHotkeyAfterDelay(_settings.AzureComputerVisionSettings?.SendHotkeyAfterOcrOperation, PostOperationHotkey.OcrDelay(result.Success));
 				}
 				catch (Exception ex) { await ShowErrorDialog("OCR Clipboard Error", ex); }
 			});
@@ -545,7 +545,7 @@ public sealed partial class MainWindow : Window, IDisposable
 					if (!await EnsureOcrConfiguredAsync()) return;
 					var result = await _ocrManager.ExtractTextFromClipboardImageAsync(OcrReadingOrder.LeftToRightTopToBottom);
 					SetOcrText(result.Message);
-					HotkeyManager.SendHotkeyAfterDelay(_settings.AzureComputerVisionSettings?.SendHotkeyAfterOcrOperation, result.Success ? Constants.SendHotkeyDelay : Constants.FailureSendHotkeyDelay);
+					HotkeyManager.SendHotkeyAfterDelay(_settings.AzureComputerVisionSettings?.SendHotkeyAfterOcrOperation, PostOperationHotkey.OcrDelay(result.Success));
 				}
 				catch (Exception ex) { await ShowErrorDialog("OCR Clipboard (LRTB) Error", ex); }
 			});
@@ -1021,7 +1021,7 @@ public sealed partial class MainWindow : Window, IDisposable
 			if (!await EnsureOcrConfiguredAsync()) return;
 			var result = await _ocrManager.TakeScreenshotAndExtractTextAsync(OcrReadingOrder.TopToBottomColumnAware);
 			SetOcrText(result.Message);
-			HotkeyManager.SendHotkeyAfterDelay(_settings.AzureComputerVisionSettings?.SendHotkeyAfterOcrOperation, result.Success ? Constants.SendHotkeyDelay : Constants.FailureSendHotkeyDelay);
+			HotkeyManager.SendHotkeyAfterDelay(_settings.AzureComputerVisionSettings?.SendHotkeyAfterOcrOperation, PostOperationHotkey.OcrDelay(result.Success));
 			if (result.Success)
 				ShowStatus("Screenshot & OCR", "Text captured from screenshot.", InfoBarSeverity.Success);
 			else
@@ -1041,7 +1041,7 @@ public sealed partial class MainWindow : Window, IDisposable
 			if (!await EnsureOcrConfiguredAsync()) return;
 			var result = await _ocrManager.TakeScreenshotAndExtractTextAsync(OcrReadingOrder.LeftToRightTopToBottom);
 			SetOcrText(result.Message);
-			HotkeyManager.SendHotkeyAfterDelay(_settings.AzureComputerVisionSettings?.SendHotkeyAfterOcrOperation, result.Success ? Constants.SendHotkeyDelay : Constants.FailureSendHotkeyDelay);
+			HotkeyManager.SendHotkeyAfterDelay(_settings.AzureComputerVisionSettings?.SendHotkeyAfterOcrOperation, PostOperationHotkey.OcrDelay(result.Success));
 			if (result.Success)
 				ShowStatus("Screenshot & OCR (left-to-right)", "Text captured from screenshot using left-to-right reading order.", InfoBarSeverity.Success);
 			else
@@ -1061,7 +1061,7 @@ public sealed partial class MainWindow : Window, IDisposable
 			if (!await EnsureOcrConfiguredAsync()) return;
 			var result = await _ocrManager.ExtractTextFromClipboardImageAsync(OcrReadingOrder.TopToBottomColumnAware);
 			SetOcrText(result.Message);
-			HotkeyManager.SendHotkeyAfterDelay(_settings.AzureComputerVisionSettings?.SendHotkeyAfterOcrOperation ?? string.Empty, result.Success ? Constants.SendHotkeyDelay : Constants.FailureSendHotkeyDelay);
+			HotkeyManager.SendHotkeyAfterDelay(_settings.AzureComputerVisionSettings?.SendHotkeyAfterOcrOperation ?? string.Empty, PostOperationHotkey.OcrDelay(result.Success));
 			if (result.Success)
 				ShowStatus("OCR", "Clipboard image converted to text.", InfoBarSeverity.Success);
 			else
@@ -1422,7 +1422,7 @@ public sealed partial class MainWindow : Window, IDisposable
 			if (!await EnsureOcrConfiguredAsync()) return;
 			var result = await _ocrManager.ExtractTextFromClipboardImageAsync(OcrReadingOrder.LeftToRightTopToBottom);
 			SetOcrText(result.Message);
-			HotkeyManager.SendHotkeyAfterDelay(_settings.AzureComputerVisionSettings?.SendHotkeyAfterOcrOperation ?? string.Empty, result.Success ? Constants.SendHotkeyDelay : Constants.FailureSendHotkeyDelay);
+			HotkeyManager.SendHotkeyAfterDelay(_settings.AzureComputerVisionSettings?.SendHotkeyAfterOcrOperation ?? string.Empty, PostOperationHotkey.OcrDelay(result.Success));
 			if (result.Success)
 				ShowStatus("OCR (left-to-right)", "Clipboard image converted using left-to-right reading order.", InfoBarSeverity.Success);
 			else
@@ -2493,7 +2493,7 @@ public sealed partial class MainWindow : Window, IDisposable
 			TxtFormatTranscript.Text = processed;
 			bool copied = await _clipboard.TrySetTextAsync(processed);
 			var outcome = await TryInsertIntoActiveApplicationAsync(processed, clipboardAvailable: copied);
-			string? failure = TranscriptDeliveryMessages.Failure(copied, outcome, "processed text");
+			var plan = TranscriptCompletionPlanner.Plan(copied, outcome, "processed text");
 
 			// Claimed after everything that can throw and just before the announcement,
 			// so a failure on the delivery path cannot burn the one notice the user gets
@@ -2501,21 +2501,17 @@ public sealed partial class MainWindow : Window, IDisposable
 			// once however the delivery turns out.
 			FastModeFallbackReason? fastModeNotice = ClaimFastModeNotice(prompt.Id, fastModeFallback);
 
-			if (failure is null)
-			{
-				BeepPlayer.Play(BeepType.Success);
-				ShowStatus("Processing",
-					FastModeMessages.AppendTo($"Applied prompt '{prompt.Name}' with the language model.", fastModeNotice),
-					InfoBarSeverity.Success);
-				HotkeyManager.SendHotkeyAfterDelay(_settings.SpeechToTextSettings?.SendHotkeyAfterTranscriptionOperation, Constants.SendHotkeyDelay);
-			}
-			else
-			{
-				BeepPlayer.Play(BeepType.Failure);
-				ShowStatus("Processing",
-					FastModeMessages.AppendTo(failure, fastModeNotice),
-					InfoBarSeverity.Error);
-			}
+			BeepPlayer.Play(plan.Beep);
+			ShowStatus("Processing",
+				FastModeMessages.AppendTo(
+					plan.FailureMessage ?? $"Applied prompt '{prompt.Name}' with the language model.",
+					fastModeNotice),
+				plan.Succeeded ? InfoBarSeverity.Success : InfoBarSeverity.Error);
+
+			if (plan.SendConfiguredHotkey)
+				HotkeyManager.SendHotkeyAfterDelay(
+					_settings.SpeechToTextSettings?.SendHotkeyAfterTranscriptionOperation,
+					PostOperationHotkey.SuccessDelayMs);
         }
         catch (OperationCanceledException) when (_isClosing || _shutdownCts.IsCancellationRequested)
         {
@@ -2788,21 +2784,17 @@ public sealed partial class MainWindow : Window, IDisposable
 
 				bool copied = await _clipboard.TrySetTextAsync(formatted);
 				var outcome = await TryInsertIntoActiveApplicationAsync(formatted, clipboardAvailable: copied);
-				string? failure = TranscriptDeliveryMessages.Failure(copied, outcome, "transcript");
+				var plan = TranscriptCompletionPlanner.Plan(copied, outcome, "transcript");
 
-				if (failure is null)
-				{
-					BeepPlayer.Play(BeepType.Success);
-					ShowStatus("Speech to Text", FastModeMessages.AppendTo(successMessage, fastModeNotice), InfoBarSeverity.Success);
-					HotkeyManager.SendHotkeyAfterDelay(_settings.SpeechToTextSettings?.SendHotkeyAfterTranscriptionOperation, Constants.SendHotkeyDelay);
-				}
-				else
-				{
-					BeepPlayer.Play(BeepType.Failure);
-					ShowStatus("Speech to Text",
-						FastModeMessages.AppendTo(failure, fastModeNotice),
-						InfoBarSeverity.Error);
-				}
+				BeepPlayer.Play(plan.Beep);
+				ShowStatus("Speech to Text",
+					FastModeMessages.AppendTo(plan.FailureMessage ?? successMessage, fastModeNotice),
+					plan.Succeeded ? InfoBarSeverity.Success : InfoBarSeverity.Error);
+
+				if (plan.SendConfiguredHotkey)
+					HotkeyManager.SendHotkeyAfterDelay(
+						_settings.SpeechToTextSettings?.SendHotkeyAfterTranscriptionOperation,
+						PostOperationHotkey.SuccessDelayMs);
 			},
 			onFailure: ex =>
 			{

--- a/Mutation.Ui/Services/HotkeyManager.cs
+++ b/Mutation.Ui/Services/HotkeyManager.cs
@@ -91,38 +91,11 @@ public class HotkeyManager : IDisposable
 	// MOD_NOREPEAT — can be tested without a window handle.
 
 	// RegisterHotKey/UnregisterHotKey live in Win32HotkeyPlatform, behind IHotkeyPlatform.
+	// The SendInput structs live in KeyboardInput, where their size — which is what Windows
+	// validates — can be asserted in a test.
 	[DllImport("user32.dll")] static extern IntPtr SetWindowLongPtr(IntPtr hWnd, int nIndex, IntPtr newProc);
 	[DllImport("user32.dll")] static extern IntPtr CallWindowProc(IntPtr lpPrevWndFunc, IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam);
-	[DllImport("user32.dll", SetLastError = true)] static extern uint SendInput(uint nInputs, INPUT[] pInputs, int cbSize);
 	[DllImport("user32.dll")] static extern short GetAsyncKeyState(int vKey);
-
-	private const int INPUT_KEYBOARD = 1;
-	private const uint KEYEVENTF_KEYUP = 0x0002;
-	private const uint KEYEVENTF_UNICODE = 0x0004;
-	private const uint KEYEVENTF_EXTENDEDKEY = 0x0001;
-
-	[StructLayout(LayoutKind.Sequential)]
-	private struct INPUT
-	{
-		public uint type;
-		public INPUTUNION U;
-	}
-
-	[StructLayout(LayoutKind.Explicit)]
-	private struct INPUTUNION
-	{
-		[FieldOffset(0)] public KEYBDINPUT ki;
-	}
-
-	[StructLayout(LayoutKind.Sequential)]
-	private struct KEYBDINPUT
-	{
-		public ushort wVk;
-		public ushort wScan;
-		public uint dwFlags;
-		public uint time;
-		public IntPtr dwExtraInfo;
-	}
 
 	private delegate IntPtr WndProcDelegate(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam);
 
@@ -187,7 +160,7 @@ public class HotkeyManager : IDisposable
 			                        try
 			                        {
 			                                var hotkey = Hotkey.Parse(map.FromHotKey!);
-			                                var attempt = _registrations.Register(hotkey, () => SendHotkeyAfterDelay(map.ToHotKey!, Constants.FailureSendHotkeyDelay), HotkeyRegistrationTable.HotkeyGroup.Router);
+			                                var attempt = _registrations.Register(hotkey, () => SendHotkeyAfterDelay(map.ToHotKey!, PostOperationHotkey.FailureDelayMs), HotkeyRegistrationTable.HotkeyGroup.Router);
                                 if (attempt.Success)
                                 {
                                         Log($"Router registered: From='{map.FromHotKey}' -> To='{map.ToHotKey}', id={attempt.Id}");
@@ -348,7 +321,14 @@ public class HotkeyManager : IDisposable
 		{
 			try
 			{
-				var hk = Hotkey.Parse(part);
+				var hk = ResolveChord(part);
+				if (hk is null)
+				{
+					Log($"'{part}' is not a chord SendInput can express, falling back to SendKeys mapping.");
+					allSentViaInput = false;
+					break;
+				}
+
 				Log($"Sending via SendInput: '{part}'");
 				bool ok = SendHotkeyViaSendInput(hk);
 				if (!ok)
@@ -384,6 +364,25 @@ public class HotkeyManager : IDisposable
 		}
 
 		return allSentViaInput;
+	}
+
+	/// <summary>
+	/// The chord <paramref name="text"/> spells, however the user wrote it, or null when it
+	/// is something only the WinForms fallback can express.
+	/// </summary>
+	/// <remarks>
+	/// Both spellings are accepted because both are on screen: the hotkey editors take
+	/// "CTRL+DELETE", while the two "send this afterwards" boxes have always also accepted
+	/// SendKeys notation, and settings saved years ago still hold "^{DEL}". Reading the
+	/// second form here is what puts it on the SendInput path, where a failure to deliver
+	/// can be seen (issue #325).
+	/// </remarks>
+	internal static Hotkey? ResolveChord(string text)
+	{
+		if (Hotkey.TryParse(text, out var parsed))
+			return parsed;
+
+		return SendKeysChord.TryParse(text, out var fromSendKeys) ? fromSendKeys : null;
 	}
 
 	private static void SendKeysOnUiThread(string mapped)
@@ -445,22 +444,14 @@ public class HotkeyManager : IDisposable
 		if (string.IsNullOrEmpty(text))
 			return true;
 
-		List<INPUT> inputs = new();
+		List<KeyboardInput.INPUT> inputs = new();
 		foreach (char c in text)
 		{
-			inputs.Add(new INPUT
-			{
-				type = INPUT_KEYBOARD,
-				U = new INPUTUNION { ki = new KEYBDINPUT { wScan = c, dwFlags = KEYEVENTF_UNICODE } }
-			});
-			inputs.Add(new INPUT
-			{
-				type = INPUT_KEYBOARD,
-				U = new INPUTUNION { ki = new KEYBDINPUT { wScan = c, dwFlags = KEYEVENTF_UNICODE | KEYEVENTF_KEYUP } }
-			});
+			inputs.Add(KeyboardInput.UnicodeDown(c));
+			inputs.Add(KeyboardInput.UnicodeUp(c));
 		}
 		uint submitted = (uint)inputs.Count;
-		uint sent = SendInput(submitted, inputs.ToArray(), Marshal.SizeOf<INPUT>());
+		uint sent = KeyboardInput.Send(inputs.ToArray());
 		if (sent == submitted)
 			return true;
 
@@ -473,7 +464,7 @@ public class HotkeyManager : IDisposable
 		// Wait until user releases modifier keys from the original chord to avoid contamination
 		WaitForModifierRelease(timeoutMs: AppConstants.ModifierReleaseTimeoutMs);
 
-		var inputs = new List<INPUT>();
+		var inputs = new List<KeyboardInput.INPUT>();
 
 		bool needCtrl = hotkey.Control;
 		bool needShift = hotkey.Shift;
@@ -492,7 +483,7 @@ public class HotkeyManager : IDisposable
 
 		if (inputs.Count > 0)
 		{
-			var preSent = SendInput((uint)inputs.Count, inputs.ToArray(), Marshal.SizeOf<INPUT>());
+			var preSent = KeyboardInput.Send(inputs.ToArray());
 			Log($"Pre-release injected {preSent}/{inputs.Count} modifier key-ups.");
 			inputs.Clear();
 			// Brief delay after releasing modifiers. Thread.Sleep is acceptable here
@@ -515,7 +506,7 @@ public class HotkeyManager : IDisposable
 		if (hotkey.Control) inputs.Add(KeyUp(VK_CONTROL));
 
 		var count = (uint)inputs.Count;
-		var sent = SendInput(count, inputs.ToArray(), Marshal.SizeOf<INPUT>());
+		var sent = KeyboardInput.Send(inputs.ToArray());
 		bool ok = sent == count && count > 0;
 		if (!ok)
 		{
@@ -525,57 +516,14 @@ public class HotkeyManager : IDisposable
 		return ok;
 	}
 
-	private const ushort VK_CONTROL = 0x11;
-	private const ushort VK_SHIFT = 0x10;
-	private const ushort VK_MENU = 0x12; // ALT
-	private const ushort VK_LWIN = 0x5B;
+	private const ushort VK_CONTROL = KeyboardInput.VkControl;
+	private const ushort VK_SHIFT = KeyboardInput.VkShift;
+	private const ushort VK_MENU = KeyboardInput.VkAlt;
+	private const ushort VK_LWIN = KeyboardInput.VkLeftWindows;
 
-	private static INPUT KeyDown(ushort vk)
-	{
-		return new INPUT
-		{
-			type = INPUT_KEYBOARD,
-			U = new INPUTUNION
-			{
-				ki = new KEYBDINPUT
-				{
-					wVk = vk,
-					wScan = 0,
-					dwFlags = (IsExtended(vk) ? KEYEVENTF_EXTENDEDKEY : 0),
-					time = 0,
-					dwExtraInfo = IntPtr.Zero
-				}
-			}
-		};
-	}
+	private static KeyboardInput.INPUT KeyDown(ushort vk) => KeyboardInput.KeyDown(vk);
 
-	private static INPUT KeyUp(ushort vk)
-	{
-		return new INPUT
-		{
-			type = INPUT_KEYBOARD,
-			U = new INPUTUNION
-			{
-				ki = new KEYBDINPUT
-				{
-					wVk = vk,
-					wScan = 0,
-					dwFlags = KEYEVENTF_KEYUP | (IsExtended(vk) ? KEYEVENTF_EXTENDEDKEY : 0),
-					time = 0,
-					dwExtraInfo = IntPtr.Zero
-				}
-			}
-		};
-	}
-
-	private static bool IsExtended(ushort vk)
-	{
-		// Extended key flag for navigation cluster and some others
-		return vk is 0x21 /*PGUP*/ or 0x22 /*PGDN*/ or 0x23 /*END*/ or 0x24 /*HOME*/
-				or 0x25 /*LEFT*/ or 0x26 /*UP*/ or 0x27 /*RIGHT*/ or 0x28 /*DOWN*/
-				or 0x2D /*INSERT*/ or 0x2E /*DELETE*/ or 0x5B /*LWIN*/ or 0x5C /*RWIN*/
-				or 0xA1 /*RSHIFT*/ or 0xA3 /*RCONTROL*/ or 0xA5 /*RMENU(ALT)*/;
-	}
+	private static KeyboardInput.INPUT KeyUp(ushort vk) => KeyboardInput.KeyUp(vk);
 
 	private static void WaitForModifierRelease(int timeoutMs)
 	{

--- a/Mutation.Ui/Services/KeyboardInput.cs
+++ b/Mutation.Ui/Services/KeyboardInput.cs
@@ -1,0 +1,162 @@
+#nullable enable
+using System;
+using System.Runtime.InteropServices;
+
+namespace Mutation.Ui.Services;
+
+/// <summary>
+/// The <c>SendInput</c> interop, in one place.
+/// <para>
+/// The layout matters more than it looks. Windows rejects the whole call with
+/// ERROR_INVALID_PARAMETER unless <c>cbSize</c> equals the size of the real Win32
+/// <c>INPUT</c> — and the real one carries a union of MOUSEINPUT, KEYBDINPUT and
+/// HARDWAREINPUT, sized by the largest of the three. Declaring only the keyboard arm
+/// makes the struct 32 bytes on x64 where Windows wants 40, so every call returned
+/// zero events sent and nothing was ever typed (issue #325).
+/// </para>
+/// <para>
+/// Nothing said so. The keystrokes silently went nowhere and the app fell through to
+/// the WinForms SendKeys fallback, which cannot report delivery — so a dictation
+/// pasted into another window was announced as a failure it had not had, and the
+/// shortcut configured to run afterwards was skipped along with it.
+/// </para>
+/// </summary>
+internal static class KeyboardInput
+{
+	public const uint InputKeyboard = 1;
+	public const uint KeyEventExtendedKey = 0x0001;
+	public const uint KeyEventKeyUp = 0x0002;
+	public const uint KeyEventUnicode = 0x0004;
+
+	public const ushort VkControl = 0x11;
+	public const ushort VkShift = 0x10;
+	public const ushort VkAlt = 0x12;
+	public const ushort VkLeftWindows = 0x5B;
+
+	[StructLayout(LayoutKind.Sequential)]
+	public struct MOUSEINPUT
+	{
+		public int dx;
+		public int dy;
+		public uint mouseData;
+		public uint dwFlags;
+		public uint time;
+		public IntPtr dwExtraInfo;
+	}
+
+	[StructLayout(LayoutKind.Sequential)]
+	public struct KEYBDINPUT
+	{
+		public ushort wVk;
+		public ushort wScan;
+		public uint dwFlags;
+		public uint time;
+		public IntPtr dwExtraInfo;
+	}
+
+	[StructLayout(LayoutKind.Sequential)]
+	public struct HARDWAREINPUT
+	{
+		public uint uMsg;
+		public ushort wParamL;
+		public ushort wParamH;
+	}
+
+	/// <summary>
+	/// All three arms, because the union's size is what makes <see cref="INPUT"/> the size
+	/// Windows checks for. Only <see cref="ki"/> is ever written; the other two are here to
+	/// be measured.
+	/// </summary>
+	[StructLayout(LayoutKind.Explicit)]
+	public struct INPUTUNION
+	{
+		[FieldOffset(0)] public MOUSEINPUT mi;
+		[FieldOffset(0)] public KEYBDINPUT ki;
+		[FieldOffset(0)] public HARDWAREINPUT hi;
+	}
+
+	[StructLayout(LayoutKind.Sequential)]
+	public struct INPUT
+	{
+		public uint type;
+		public INPUTUNION U;
+	}
+
+	/// <summary>What this build will pass as <c>cbSize</c>.</summary>
+	public static int InputSize => Marshal.SizeOf<INPUT>();
+
+	/// <summary>
+	/// What Windows requires <c>cbSize</c> to be: 40 bytes in a 64-bit process, 28 in a
+	/// 32-bit one. Exposed so the size can be asserted without a keyboard.
+	/// </summary>
+	public static int RequiredInputSize => IntPtr.Size == 8 ? 40 : 28;
+
+	[DllImport("user32.dll", SetLastError = true)]
+	private static extern uint SendInput(uint nInputs, INPUT[] pInputs, int cbSize);
+
+	/// <summary>
+	/// Submits <paramref name="inputs"/> and reports how many Windows accepted. Fewer than
+	/// were submitted means the foreground application refused them — usually because it
+	/// runs at a higher integrity level than Mutation, which Windows enforces in silence.
+	/// </summary>
+	public static uint Send(INPUT[] inputs)
+	{
+		if (inputs is null || inputs.Length == 0)
+			return 0;
+
+		return SendInput((uint)inputs.Length, inputs, InputSize);
+	}
+
+	public static INPUT KeyDown(ushort virtualKey) =>
+		Key(virtualKey, IsExtended(virtualKey) ? KeyEventExtendedKey : 0);
+
+	public static INPUT KeyUp(ushort virtualKey) =>
+		Key(virtualKey, KeyEventKeyUp | (IsExtended(virtualKey) ? KeyEventExtendedKey : 0));
+
+	public static INPUT UnicodeDown(char character) => Unicode(character, KeyEventUnicode);
+
+	public static INPUT UnicodeUp(char character) => Unicode(character, KeyEventUnicode | KeyEventKeyUp);
+
+	private static INPUT Key(ushort virtualKey, uint flags) => new()
+	{
+		type = InputKeyboard,
+		U = new INPUTUNION
+		{
+			ki = new KEYBDINPUT
+			{
+				wVk = virtualKey,
+				wScan = 0,
+				dwFlags = flags,
+				time = 0,
+				dwExtraInfo = IntPtr.Zero,
+			}
+		}
+	};
+
+	private static INPUT Unicode(char character, uint flags) => new()
+	{
+		type = InputKeyboard,
+		U = new INPUTUNION
+		{
+			ki = new KEYBDINPUT
+			{
+				wVk = 0,
+				wScan = character,
+				dwFlags = flags,
+				time = 0,
+				dwExtraInfo = IntPtr.Zero,
+			}
+		}
+	};
+
+	/// <summary>
+	/// The navigation cluster and the right-hand modifiers, which share their virtual-key
+	/// code with a numeric-keypad key and are told apart by this flag. Delete without it
+	/// arrives as the keypad's period.
+	/// </summary>
+	public static bool IsExtended(ushort virtualKey) =>
+		virtualKey is 0x21 /*PGUP*/ or 0x22 /*PGDN*/ or 0x23 /*END*/ or 0x24 /*HOME*/
+			or 0x25 /*LEFT*/ or 0x26 /*UP*/ or 0x27 /*RIGHT*/ or 0x28 /*DOWN*/
+			or 0x2D /*INSERT*/ or 0x2E /*DELETE*/ or 0x5B /*LWIN*/ or 0x5C /*RWIN*/
+			or 0xA1 /*RSHIFT*/ or 0xA3 /*RCONTROL*/ or 0xA5 /*RMENU(ALT)*/;
+}

--- a/Mutation.Ui/Services/SendKeysChord.cs
+++ b/Mutation.Ui/Services/SendKeysChord.cs
@@ -1,0 +1,188 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Windows.System;
+
+namespace Mutation.Ui.Services;
+
+/// <summary>
+/// Reads a chord written in WinForms SendKeys notation — <c>^{DEL}</c>, <c>%{F4}</c>,
+/// <c>^+{TAB}</c>, <c>^c</c> — back into a <see cref="Hotkey"/>.
+/// <para>
+/// This is the inverse of <see cref="SendKeysMapper"/>, and it exists so that the two
+/// "send this shortcut afterwards" settings can be delivered the way every other chord
+/// is: through SendInput, which reports whether the keystrokes were accepted. Without it
+/// a setting saved in SendKeys notation could only ever reach
+/// <c>System.Windows.Forms.SendKeys.SendWait</c>, which answers nothing about whether the
+/// target window took them — so a shortcut that quietly stopped arriving looked exactly
+/// like one that worked (issue #325).
+/// </para>
+/// <para>
+/// Deliberately narrow. Only modifier prefixes and a single key are recognised; anything
+/// with grouping, repeat counts, <c>~</c>, or literal text to type is left to the WinForms
+/// fallback rather than guessed at, because guessing wrong types characters into whatever
+/// the user is working in.
+/// </para>
+/// </summary>
+internal static class SendKeysChord
+{
+	private const char CtrlModifier = '^';
+	private const char ShiftModifier = '+';
+	private const char AltModifier = '%';
+
+	/// <summary>
+	/// The braced key names <see cref="SendKeysMapper"/> emits, read back. Kept in step with
+	/// that map: a name it can produce and this cannot would silently drop back to the
+	/// fallback path rather than fail, which is the failure mode this type exists to remove.
+	/// </summary>
+	private static readonly Dictionary<string, VirtualKey> BracedKeys = new(StringComparer.OrdinalIgnoreCase)
+	{
+		["ENTER"] = VirtualKey.Enter,
+		["TAB"] = VirtualKey.Tab,
+		["ESC"] = VirtualKey.Escape,
+		["ESCAPE"] = VirtualKey.Escape,
+		["BACKSPACE"] = VirtualKey.Back,
+		["BKSP"] = VirtualKey.Back,
+		["BS"] = VirtualKey.Back,
+		["DEL"] = VirtualKey.Delete,
+		["DELETE"] = VirtualKey.Delete,
+		["INS"] = VirtualKey.Insert,
+		["INSERT"] = VirtualKey.Insert,
+		["SPACE"] = VirtualKey.Space,
+		["UP"] = VirtualKey.Up,
+		["DOWN"] = VirtualKey.Down,
+		["LEFT"] = VirtualKey.Left,
+		["RIGHT"] = VirtualKey.Right,
+		["HOME"] = VirtualKey.Home,
+		["END"] = VirtualKey.End,
+		["PGUP"] = VirtualKey.PageUp,
+		["PGDN"] = VirtualKey.PageDown,
+		["APPS"] = VirtualKey.Application,
+		["BREAK"] = VirtualKey.Pause,
+		["HELP"] = VirtualKey.Help,
+		["CAPSLOCK"] = VirtualKey.CapitalLock,
+		["NUMLOCK"] = VirtualKey.NumberKeyLock,
+		["SCROLLLOCK"] = VirtualKey.Scroll,
+		["ADD"] = VirtualKey.Add,
+		["SUBTRACT"] = VirtualKey.Subtract,
+		["MULTIPLY"] = VirtualKey.Multiply,
+		["DIVIDE"] = VirtualKey.Divide,
+		["DECIMAL"] = VirtualKey.Decimal,
+		["SEPARATOR"] = VirtualKey.Separator,
+	};
+
+	/// <summary>
+	/// Whether <paramref name="text"/> is a SendKeys chord this can send, and the chord it
+	/// spells. False leaves the caller to its own fallback; it never throws.
+	/// </summary>
+	public static bool TryParse(string? text, [NotNullWhen(true)] out Hotkey? hotkey)
+	{
+		hotkey = null;
+
+		var chord = (text ?? string.Empty).Trim();
+		if (chord.Length == 0)
+			return false;
+
+		bool control = false, shift = false, alt = false;
+		int i = 0;
+		for (; i < chord.Length; i++)
+		{
+			switch (chord[i])
+			{
+				case CtrlModifier: control = true; continue;
+				case ShiftModifier: shift = true; continue;
+				case AltModifier: alt = true; continue;
+			}
+			break;
+		}
+
+		// A bare key with no modifier at all is not SendKeys notation unless it is braced.
+		// "c" on its own is a chord Hotkey.Parse already handles, and reading it here would
+		// take the same text down two different paths depending on which ran first.
+		bool hasModifier = control || shift || alt;
+		var remainder = chord[i..];
+		if (remainder.Length == 0)
+			return false;
+
+		if (!TryReadKey(remainder, out var key, out bool wasBraced))
+			return false;
+
+		if (!hasModifier && !wasBraced)
+			return false;
+
+		hotkey = new Hotkey { Control = control, Shift = shift, Alt = alt, Key = key };
+		return true;
+	}
+
+	private static bool TryReadKey(string remainder, out VirtualKey key, out bool wasBraced)
+	{
+		key = VirtualKey.None;
+		wasBraced = false;
+
+		if (remainder[0] == '{')
+		{
+			// Exactly one braced group and nothing after it. "{DEL}{DEL}" is a repeat, and
+			// "{DEL 2}" is a count — both are sequences rather than chords, and neither is
+			// something a single SendInput chord can express.
+			if (remainder[^1] != '}' || remainder.IndexOf('}') != remainder.Length - 1)
+				return false;
+
+			var name = remainder[1..^1].Trim();
+			if (name.Length == 0)
+				return false;
+
+			wasBraced = true;
+
+			if (BracedKeys.TryGetValue(name, out key))
+				return true;
+
+			if (TryReadFunctionKey(name, out key))
+				return true;
+
+			// A braced escape of a reserved character — {+}, {^}, {%}, {(} — is a literal
+			// keystroke whose virtual key depends on the keyboard layout. Left to the
+			// fallback rather than mapped to whatever a US layout would use.
+			return false;
+		}
+
+		if (remainder.Length != 1)
+			return false;
+
+		return TryReadCharacter(remainder[0], out key);
+	}
+
+	private static bool TryReadFunctionKey(string name, out VirtualKey key)
+	{
+		key = VirtualKey.None;
+		if (name.Length is < 2 or > 3 || (name[0] != 'F' && name[0] != 'f'))
+			return false;
+
+		if (!int.TryParse(name.AsSpan(1), out int number) || number is < 1 or > 24)
+			return false;
+
+		key = VirtualKey.F1 + (number - 1);
+		return true;
+	}
+
+	private static bool TryReadCharacter(char character, out VirtualKey key)
+	{
+		key = VirtualKey.None;
+
+		if (char.IsAsciiLetter(character))
+		{
+			key = VirtualKey.A + (char.ToUpperInvariant(character) - 'A');
+			return true;
+		}
+
+		if (char.IsAsciiDigit(character))
+		{
+			key = VirtualKey.Number0 + (character - '0');
+			return true;
+		}
+
+		// Punctuation is layout-dependent — ';' is not the same physical key everywhere —
+		// so it goes to the fallback rather than to a guess.
+		return false;
+	}
+}


### PR DESCRIPTION
Fixes the failure beep after dictation, and the shortcut that stopped being sent after transcription and after OCR.

## What was wrong

One cause under all three symptoms. The `INPUT` struct passed to `SendInput` declared only the keyboard arm of its union. A union is sized by its largest arm, and the mouse one is bigger — so the struct measured **32 bytes** in a 64-bit process where Windows requires **40**. Windows validates `cbSize` before it does anything else and rejected every call.

Straight from the app's own log, taken while the user was working:

```
12:26:47.001 Sending via SendInput: 'Ctrl+V'
12:26:47.001 SendInput returned 0/4, GetLastError=87
12:26:47.001 SendInput failed for 'Ctrl+V', falling back to SendKeys mapping.
```

`87` is `ERROR_INVALID_PARAMETER`. Every keystroke the app has ever injected went nowhere.

Nothing said so, because the WinForms `SendKeys` fallback behind it did the work — and cannot report whether the target window took it. So the dictation *was* pasted, and then announced as undelivered. That is #232 doing exactly what it was built to do, on a lie. And since the send-a-shortcut-afterwards step only runs on success, it was skipped along with the success beep.

Verified against the live API, same struct, two sizes:

```
cbSize=32  sent=0/1  GetLastError=87
cbSize=40  sent=1/1  GetLastError=0
```

**The second failure was quieter.** Both send-after settings accept SendKeys notation, and a settings file written years ago holds `^{DEL}`. Nothing in the app could read that back into a chord, so it could only ever reach the fallback — the one path that answers nothing about delivery. So even after the struct fix it would have stayed unverifiable.

## What changed

| File | |
| --- | --- |
| `Services/KeyboardInput.cs` | The interop, with all three union arms, so it is the size Windows checks for. New. |
| `Services/SendKeysChord.cs` | Reads `^{DEL}`, `%{F4}`, `^+{TAB}` back into a chord. Narrow on purpose — modifiers and one key, and a refusal rather than a guess for anything else, because a guess types characters into whatever window the user is in. New. |
| `Core/TranscriptCompletionPlanner.cs` | The beep, the message and the shortcut as the one decision they are. They could not disagree now if they tried. New. |
| `Core/PostOperationHotkey.cs` | The two delays, and the rule that OCR sends its shortcut either way — that box is usually a screen-reader command, and the error wants reading as much as the result. New. |
| `Services/HotkeyManager.cs` | Onto the shared interop; `ResolveChord` accepts both spellings. |
| `MainWindow.xaml.cs` | Both transcript endings through the planner; ten call sites onto the delays. |

## Tests

64 added, **1825 passing, 0 warnings.**

The size assertion is the one that matters — nothing about the old struct *looked* wrong, which is why it survived this long. `KeyboardInputLayoutTests` pins it to 40 as a literal, and pins the union to its largest arm so dropping one shrinks the struct loudly instead of silently.

The rest cover what the user asked to be protected: that a delivered transcript plays the success beep and sends the shortcut, that a failed one does neither, that the two can never disagree, that OCR sends its shortcut on both outcomes, and that `^{DEL}` resolves to Ctrl+Delete on the path that can report a failure.

## Documentation

The troubleshooting entry told the user this warning was *"once in a while ... a false alarm"* — which was this bug being described rather than diagnosed. Corrected, plus a new entry for a send-after shortcut that doesn't arrive, and the two chapters now state the success-only / either-way rule. HTML rebuilt.

## Note for the reviewer

The WinForms `SendKeys` fallback is still there for strings no chord can express. It still cannot report delivery, so `SendHotkey` still returns false for those — deliberately, per #232. This PR shrinks how often that path is reached rather than removing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)