### PR TITLE
Point the new comments at the right number

### DIFF
--- a/Mutation.Tests/HotkeyChordResolutionTests.cs
+++ b/Mutation.Tests/HotkeyChordResolutionTests.cs
@@ -1,4 +1,4 @@
-using Mutation.Ui.Services;
+﻿using Mutation.Ui.Services;
 using Windows.System;
 
 namespace Mutation.Tests;
@@ -7,7 +7,7 @@ namespace Mutation.Tests;
 /// Which shortcuts <see cref="HotkeyManager.SendHotkey"/> can put through SendInput, which
 /// is the only path that reports whether the keystrokes were delivered.
 /// <para>
-/// Issue #325: anything that fell off this path went to the WinForms SendKeys fallback,
+/// PR #328: anything that fell off this path went to the WinForms SendKeys fallback,
 /// which answers nothing — so the shortcut sent after transcription and after OCR could
 /// stop arriving with no beep, no message, and no log line saying so.
 /// </para>

--- a/Mutation.Tests/KeyboardInputLayoutTests.cs
+++ b/Mutation.Tests/KeyboardInputLayoutTests.cs
@@ -1,4 +1,4 @@
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
 using Mutation.Ui.Services;
 
 namespace Mutation.Tests;
@@ -7,7 +7,7 @@ namespace Mutation.Tests;
 /// The size of the INPUT struct, which is the one thing Windows validates before it will
 /// deliver a single keystroke.
 /// <para>
-/// Issue #325: the struct declared only the keyboard arm of the union, so it measured 32
+/// PR #328: the struct declared only the keyboard arm of the union, so it measured 32
 /// bytes in a 64-bit process where Windows requires 40. Every SendInput call in the app
 /// answered "0 events sent, ERROR_INVALID_PARAMETER" — pastes, typed dictation, and every
 /// configured send-a-shortcut-afterwards. Nothing about the code looked wrong, which is

--- a/Mutation.Tests/SendKeysChordTests.cs
+++ b/Mutation.Tests/SendKeysChordTests.cs
@@ -1,4 +1,4 @@
-using Mutation.Ui.Services;
+﻿using Mutation.Ui.Services;
 using Windows.System;
 
 namespace Mutation.Tests;
@@ -6,7 +6,7 @@ namespace Mutation.Tests;
 /// <summary>
 /// Reading a shortcut written in SendKeys notation back into a chord.
 /// <para>
-/// Issue #325: the two "send this shortcut afterwards" settings accept SendKeys notation,
+/// PR #328: the two "send this shortcut afterwards" settings accept SendKeys notation,
 /// and a settings file saved years ago holds "^{DEL}". Nothing could parse that, so it
 /// only ever reached the WinForms fallback, which cannot say whether the keystrokes
 /// arrived. These tests pin the readings so those settings keep going down the path that

--- a/Mutation.Tests/TranscriptCompletionPlannerTests.cs
+++ b/Mutation.Tests/TranscriptCompletionPlannerTests.cs
@@ -1,4 +1,4 @@
-using CognitiveSupport;
+﻿using CognitiveSupport;
 using Mutation.Ui.Core;
 
 namespace Mutation.Tests;
@@ -6,7 +6,7 @@ namespace Mutation.Tests;
 /// <summary>
 /// What the user hears and what runs when a transcript finishes.
 /// <para>
-/// Issue #325: a delivery that had in fact landed was reported as failed, so dictation
+/// PR #328: a delivery that had in fact landed was reported as failed, so dictation
 /// ended on the failure beep and the shortcut configured to run afterwards was skipped.
 /// Both came from one decision, and it was three lines inline in two handlers where
 /// nothing could reach it.

--- a/Mutation.Ui/Core/TranscriptCompletionPlanner.cs
+++ b/Mutation.Ui/Core/TranscriptCompletionPlanner.cs
@@ -1,4 +1,4 @@
-using CognitiveSupport;
+﻿using CognitiveSupport;
 
 namespace Mutation.Ui.Core;
 
@@ -29,7 +29,7 @@ internal readonly record struct TranscriptCompletionPlan(
 /// This was three lines inline in two handlers, which made it invisible that all three
 /// outcomes hang together: the success beep, the status, and the shortcut sent afterwards
 /// are one decision, and when a delivery was wrongly reported as failed the user lost all
-/// three at once (issue #325).
+/// three at once (PR #328).
 /// </para>
 /// </summary>
 internal static class TranscriptCompletionPlanner

--- a/Mutation.Ui/Services/HotkeyManager.cs
+++ b/Mutation.Ui/Services/HotkeyManager.cs
@@ -375,7 +375,7 @@ public class HotkeyManager : IDisposable
 	/// "CTRL+DELETE", while the two "send this afterwards" boxes have always also accepted
 	/// SendKeys notation, and settings saved years ago still hold "^{DEL}". Reading the
 	/// second form here is what puts it on the SendInput path, where a failure to deliver
-	/// can be seen (issue #325).
+	/// can be seen (PR #328).
 	/// </remarks>
 	internal static Hotkey? ResolveChord(string text)
 	{

--- a/Mutation.Ui/Services/KeyboardInput.cs
+++ b/Mutation.Ui/Services/KeyboardInput.cs
@@ -1,4 +1,4 @@
-#nullable enable
+﻿#nullable enable
 using System;
 using System.Runtime.InteropServices;
 
@@ -12,7 +12,7 @@ namespace Mutation.Ui.Services;
 /// <c>INPUT</c> — and the real one carries a union of MOUSEINPUT, KEYBDINPUT and
 /// HARDWAREINPUT, sized by the largest of the three. Declaring only the keyboard arm
 /// makes the struct 32 bytes on x64 where Windows wants 40, so every call returned
-/// zero events sent and nothing was ever typed (issue #325).
+/// zero events sent and nothing was ever typed (PR #328).
 /// </para>
 /// <para>
 /// Nothing said so. The keystrokes silently went nowhere and the app fell through to

--- a/Mutation.Ui/Services/SendKeysChord.cs
+++ b/Mutation.Ui/Services/SendKeysChord.cs
@@ -1,4 +1,4 @@
-#nullable enable
+﻿#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
@@ -16,7 +16,7 @@ namespace Mutation.Ui.Services;
 /// a setting saved in SendKeys notation could only ever reach
 /// <c>System.Windows.Forms.SendKeys.SendWait</c>, which answers nothing about whether the
 /// target window took them — so a shortcut that quietly stopped arriving looked exactly
-/// like one that worked (issue #325).
+/// like one that worked (PR #328).
 /// </para>
 /// <para>
 /// Deliberately narrow. Only modifier prefixes and a single key are recognised; anything


### PR DESCRIPTION
Comment-only follow-up to #328.

Eight comments in the code and tests added by #328 cite "issue #325". That number belongs to an unrelated PR that landed on main while the work was in flight — there was no issue for this bug, it came in as a report, and I picked a number rather than checking. They now cite #328, the PR that fixed it.

No behaviour change. Build clean, 1867 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)