### PR TITLE
Let a cold OCR read take longer on the retry, hear the hotkey box tidy itself, and read a shorthand key back

### DIFF
--- a/CognitiveSupport/OcrService.cs
+++ b/CognitiveSupport/OcrService.cs
@@ -81,7 +81,26 @@ public class OcrService : IOcrService, IDisposable
 	private static ImageAnalysisClient CreateImageAnalysisClient(string endpoint, string key) =>
 		 new(new Uri(endpoint), new AzureKeyCredential(key));
 
-	private TimeSpan GetPerRequestTimeout() => TimeSpan.FromSeconds(Math.Max(1, Math.Min(_timeoutSeconds, MaxTimeoutSeconds)));
+	/// <summary>
+	/// How long attempt <paramref name="attempt"/> waits: the configured timeout multiplied
+	/// by the attempt number, never more than <see cref="MaxTimeoutSeconds"/>.
+	/// <para>
+	/// The multiplication is the shape all five retrying services share, and it is here for
+	/// the reason it is there: the first call after a reboot pays for DNS, TLS and JIT warmup
+	/// all at once, and three more attempts of exactly the same length are no likelier to fit
+	/// than the first was. This one used to arm every attempt with the same flat value, which
+	/// issue #311 assumed was already false and issue #315 settled.
+	/// </para>
+	/// <para>
+	/// The ceiling is what keeps that from running away. It is a cap on each attempt rather
+	/// than on the first, so an OCR batch — many reads against a 20-a-minute limit — cannot
+	/// have one wedged image hold it up for longer and longer: with the default 30 seconds
+	/// the ladder is 30, 60, 60, 60, so the worst case is three and a half minutes rather
+	/// than the five an uncapped 30/60/90/120 would cost.
+	/// </para>
+	/// </summary>
+	private TimeSpan GetPerRequestTimeout(int attempt) =>
+		TimeSpan.FromSeconds(Math.Clamp((long)_timeoutSeconds * Math.Max(1, attempt), 1, MaxTimeoutSeconds));
 
 	/// <summary>
 	/// Arms this attempt's deadline. It is its own source rather than a <c>CancelAfter</c>
@@ -90,8 +109,8 @@ public class OcrService : IOcrService, IDisposable
 	/// the injected clock is what lets a test read the deadline back. The caller links it
 	/// to the overall token and disposes both.
 	/// </summary>
-	private CancellationTokenSource CreatePerRequestDeadline() =>
-		new(GetPerRequestTimeout(), _timeProvider);
+	private CancellationTokenSource CreatePerRequestDeadline(int attempt) =>
+		new(GetPerRequestTimeout(attempt), _timeProvider);
 
 
 	private async Task<string> ExecuteReadInternal(
@@ -106,7 +125,7 @@ public class OcrService : IOcrService, IDisposable
 
 		imageStream.Seek(0, SeekOrigin.Begin);
 
-		return await ReadInternal(ocrReadingOrder, imageStream, overallCancellationToken).ConfigureAwait(false);
+		return await ReadInternal(ocrReadingOrder, imageStream, attempt, overallCancellationToken).ConfigureAwait(false);
 	}
 
 
@@ -195,13 +214,14 @@ public class OcrService : IOcrService, IDisposable
 	private async Task<string> ReadInternal(
 		OcrReadingOrder ocrReadingOrder,
 		Stream imageStream,
+		int attempt,
 		CancellationToken overallCancellationToken)
 	{
 		imageStream = EnsureMinimumImageSize(imageStream);
 
 		await SharedRateLimiter.WaitAsync(overallCancellationToken).ConfigureAwait(false);
 
-		using var deadline = CreatePerRequestDeadline();
+		using var deadline = CreatePerRequestDeadline(attempt);
 		using var requestCts = CancellationTokenSource.CreateLinkedTokenSource(overallCancellationToken, deadline.Token);
 
 		var binaryData = BinaryData.FromStream(imageStream);

--- a/Documentation/UserGuide/html/accessibility.html
+++ b/Documentation/UserGuide/html/accessibility.html
@@ -201,6 +201,11 @@ status area was already open — so a run of updates like &quot;Recording…&quo
 they need you now. Routine progress updates wait their turn politely. If several
 updates arrive quickly, you hear the most recent one rather than a backlog of stale
 messages.</p>
+<p>The Settings window follows the same rule. A shortcut box that tidies up what you
+typed says so as you leave it — &quot;Speak clipboard now reads CTRL+SHIFT+A.&quot; — and waits
+its turn, so it never talks over a warning about the same box. A box that was already
+written Mutation's way stays quiet. See
+<a href="keyboard-shortcuts.html">Keyboard shortcuts</a> for what the tidying up does.</p>
 <h2 id="the-screenshot-overlay-talks-you-through-it">The screenshot overlay talks you through it</h2>
 <p>Grabbing part of a screen you cannot see sounds impossible. It is not.</p>
 <p>When the screen-capture overlay opens, it announces itself and tells you the keys:
@@ -230,6 +235,9 @@ was without you touching anything. Or set it to your screen reader's own &quot;r
 here&quot; shortcut, and the OCR result gets read to you the moment it is ready.</p>
 <p>You set it in <strong>Settings</strong>, under the shortcuts section: one box for &quot;after OCR&quot; and
 one for &quot;after transcription&quot;. Leave a box empty and nothing is sent.</p>
+<p>Pick a key that no Mutation shortcut already uses. Windows hands the key straight back
+to Mutation, so a clash sets the action off again. Mutation checks for you and shows a
+<strong>Duplicate hotkey</strong> note under both rows, whichever way round you wrote the key.</p>
 <h2 id="alongside-a-screen-reader-and-zoomtext">Alongside a screen reader and ZoomText</h2>
 <p>Mutation is designed to sit next to your existing tools, not replace them. Its global
 shortcuts are registered with Windows, so they work whichever app has focus. If your

--- a/Documentation/UserGuide/html/keyboard-shortcuts.html
+++ b/Documentation/UserGuide/html/keyboard-shortcuts.html
@@ -380,6 +380,10 @@ either way — Mutation just writes it one way everywhere, so two boxes holding 
 same combination look the same. That tidied version is what gets saved, so a
 shortcut you typed into the settings file by hand comes back tidied once Mutation
 has opened that page.</p>
+<p>When the box does change what you typed, Mutation says so, and a screen reader
+reads it out: &quot;Speak clipboard now reads CTRL+SHIFT+A&quot;. You get that only when
+something actually changed, so tabbing down a page of shortcuts that are already
+written Mutation's way stays quiet.</p>
 <p>The two optional &quot;send a key afterwards&quot; boxes are the exception: they keep
 whatever you type, exactly as you typed it, because what goes in them is not
 always a plain combination. There is more on them below. The <strong>Clear</strong> button
@@ -423,9 +427,11 @@ never need it — <strong>Ctrl+F5</strong> does the same job and reads better �
 you already know it.</li>
 </ul>
 <p>Because of those two, Mutation leaves these boxes exactly as you type them rather
-than tidying them up. They are also the one thing on this page not checked against
-your other shortcuts when you write them in the shorthand style, so if you do,
-check yourself that no Mutation shortcut already uses that key.</p>
+than tidying them up. Both spellings are still checked against your other
+shortcuts, so writing <code>^{F5}</code> while some Mutation shortcut is <strong>Ctrl+F5</strong> is
+flagged exactly as writing <strong>Ctrl+F5</strong> would be. Plain words are the exception:
+type <code>hello</code> into one of these boxes and Mutation types the word for you, so there
+is no shortcut there to clash with anything.</p>
 <h2 id="choosing-combinations-that-wont-clash">Choosing combinations that won't clash</h2>
 <ol>
 <li><strong>Use three modifiers.</strong> Combinations like <strong>Ctrl+Shift+Alt+Q</strong> are almost never

--- a/Documentation/UserGuide/html/keyboard-shortcuts.html
+++ b/Documentation/UserGuide/html/keyboard-shortcuts.html
@@ -380,14 +380,17 @@ either way — Mutation just writes it one way everywhere, so two boxes holding 
 same combination look the same. That tidied version is what gets saved, so a
 shortcut you typed into the settings file by hand comes back tidied once Mutation
 has opened that page.</p>
-<p>When the box does change what you typed, Mutation says so, and a screen reader
-reads it out: &quot;Speak clipboard now reads CTRL+SHIFT+A&quot;. You get that only when
-something actually changed, so tabbing down a page of shortcuts that are already
-written Mutation's way stays quiet.</p>
-<p>The two optional &quot;send a key afterwards&quot; boxes are the exception: they keep
-whatever you type, exactly as you typed it, because what goes in them is not
-always a plain combination. There is more on them below. The <strong>Clear</strong> button
-empties a box, which is what you want for those two.</p>
+<p>When a box does change what you typed, a short note appears under it and a screen
+reader reads it out: &quot;Speak clipboard now reads CTRL+SHIFT+A.&quot; You get that only
+when something actually changed, so tabbing down a page of shortcuts that are
+already written Mutation's way stays quiet. The note goes away when you come back
+to that box. The <strong>From</strong> and <strong>To</strong> boxes in the shortcut router further down the
+page still tidy up in silence.</p>
+<p>Two boxes are the exception: <strong>Send key after OCR (optional)</strong> and <strong>Send key
+after transcription (optional)</strong>. They keep whatever you type, exactly as you
+typed it, because what goes in them is not always a plain combination. There is
+more on them below. The <strong>Clear</strong> button empties a box, which is what you want for
+those two.</p>
 <p>Your changes are held until you press <strong>Save</strong> at the bottom of Settings. Press
 <strong>Cancel</strong> and nothing you changed is kept.</p>
 <h2 id="when-a-combination-is-taken-or-not-allowed">When a combination is taken or not allowed</h2>
@@ -405,10 +408,10 @@ you are editing. Give one of them a different combination, otherwise only one of
 two will ever fire.
 Mutation compares the keys, not the spelling, so writing one as
 <strong>Ctrl+Shift+A</strong> and the other as <strong>Shift+Ctrl+A</strong> is still caught.</li>
-<li><strong>The same combination in a &quot;send a key afterwards&quot; box and a real shortcut</strong> —
+<li><strong>The same combination in a &quot;send key after&quot; box and a real shortcut</strong> —
 also flagged, and worth fixing. Windows hands that key straight back to Mutation,
 so the action would set itself off again and again. Putting the same key in <em>both</em>
-&quot;send a key afterwards&quot; boxes is fine, though, and is not flagged: those keys go to
+&quot;send key after&quot; boxes is fine, though, and is not flagged: those keys go to
 whatever app you are in, so there is nothing for them to clash over.</li>
 <li><strong>Another app already owns it</strong> — Mutation cannot tell until it actually tries to
 claim the combination. When it fails, you get a beep and a message titled &quot;Some
@@ -416,8 +419,8 @@ hotkeys could not be registered&quot;, listing each action, its combination, and
 reason, usually &quot;The shortcut is already registered by another application.&quot;
 Go back to the Hotkeys page and pick something else.</li>
 </ul>
-<p>The two &quot;send a key afterwards&quot; boxes are a little more relaxed than the rest.
-They hold more than one plain combination can say:</p>
+<p>Those two &quot;send key after&quot; boxes are a little more relaxed than the rest. They
+hold more than one plain combination can say:</p>
 <ul>
 <li><strong>A run of keys, one after the other.</strong> Separate them with commas, like
 <code>Ctrl+V, Enter</code> to paste and then press Enter.</li>
@@ -427,11 +430,15 @@ never need it — <strong>Ctrl+F5</strong> does the same job and reads better �
 you already know it.</li>
 </ul>
 <p>Because of those two, Mutation leaves these boxes exactly as you type them rather
-than tidying them up. Both spellings are still checked against your other
-shortcuts, so writing <code>^{F5}</code> while some Mutation shortcut is <strong>Ctrl+F5</strong> is
-flagged exactly as writing <strong>Ctrl+F5</strong> would be. Plain words are the exception:
-type <code>hello</code> into one of these boxes and Mutation types the word for you, so there
-is no shortcut there to clash with anything.</p>
+than tidying them up.</p>
+<p>Both spellings are checked against your other shortcuts, so writing <code>^{F5}</code> while
+some Mutation shortcut is <strong>Ctrl+F5</strong> is flagged just as writing <strong>Ctrl+F5</strong> would
+be. Two things are not checked, and neither is a mistake. Plain words are not a
+shortcut at all — type <code>hello</code> and Mutation types the word for you. And anything
+in the shorthand that Mutation cannot read with certainty is passed over in
+silence rather than guessed at, because a wrong warning is worse than none. So no
+warning is good news, not a guarantee. If you want to be sure, write the key the
+plain way — <strong>Ctrl+F5</strong> rather than <code>^{F5}</code> — and it is always checked.</p>
 <h2 id="choosing-combinations-that-wont-clash">Choosing combinations that won't clash</h2>
 <ol>
 <li><strong>Use three modifiers.</strong> Combinations like <strong>Ctrl+Shift+Alt+Q</strong> are almost never

--- a/Documentation/UserGuide/html/troubleshooting.html
+++ b/Documentation/UserGuide/html/troubleshooting.html
@@ -288,6 +288,10 @@ at once, so forty PDFs still adds up to a lot of waiting.</p>
 <p>A page that does not get through first time is sent again, and each retry plays the end
 beep once more than the one before. Extra beeps during a batch are normal on a busy
 connection; they mean a page is being retried, not that anything has failed.</p>
+<p>Each try also waits longer than the one before it, up to a minute, so a page that is
+just being slow gets the room it needs. A page that never gets through is tried four
+times, which is why one stubborn page can hold things up for a few minutes before
+Mutation gives up on it and moves on.</p>
 <p><strong>What to do.</strong> Listen for the announcements — Mutation names each file as it finishes,
 and calls out the page count every ten pages inside a long PDF, so you can tell it is
 still working. If you picked the wrong files, or simply want it to stop, click <strong>Cancel

--- a/Documentation/UserGuide/markdown/accessibility.md
+++ b/Documentation/UserGuide/markdown/accessibility.md
@@ -71,6 +71,12 @@ they need you now. Routine progress updates wait their turn politely. If several
 updates arrive quickly, you hear the most recent one rather than a backlog of stale
 messages.
 
+The Settings window follows the same rule. A shortcut box that tidies up what you
+typed says so as you leave it — "Speak clipboard now reads CTRL+SHIFT+A." — and waits
+its turn, so it never talks over a warning about the same box. A box that was already
+written Mutation's way stays quiet. See
+[Keyboard shortcuts](keyboard-shortcuts.md) for what the tidying up does.
+
 ## The screenshot overlay talks you through it
 
 Grabbing part of a screen you cannot see sounds impossible. It is not.
@@ -110,6 +116,10 @@ here" shortcut, and the OCR result gets read to you the moment it is ready.
 
 You set it in **Settings**, under the shortcuts section: one box for "after OCR" and
 one for "after transcription". Leave a box empty and nothing is sent.
+
+Pick a key that no Mutation shortcut already uses. Windows hands the key straight back
+to Mutation, so a clash sets the action off again. Mutation checks for you and shows a
+**Duplicate hotkey** note under both rows, whichever way round you wrote the key.
 
 ## Alongside a screen reader and ZoomText
 

--- a/Documentation/UserGuide/markdown/keyboard-shortcuts.md
+++ b/Documentation/UserGuide/markdown/keyboard-shortcuts.md
@@ -115,15 +115,18 @@ same combination look the same. That tidied version is what gets saved, so a
 shortcut you typed into the settings file by hand comes back tidied once Mutation
 has opened that page.
 
-When the box does change what you typed, Mutation says so, and a screen reader
-reads it out: "Speak clipboard now reads CTRL+SHIFT+A". You get that only when
-something actually changed, so tabbing down a page of shortcuts that are already
-written Mutation's way stays quiet.
+When a box does change what you typed, a short note appears under it and a screen
+reader reads it out: "Speak clipboard now reads CTRL+SHIFT+A." You get that only
+when something actually changed, so tabbing down a page of shortcuts that are
+already written Mutation's way stays quiet. The note goes away when you come back
+to that box. The **From** and **To** boxes in the shortcut router further down the
+page still tidy up in silence.
 
-The two optional "send a key afterwards" boxes are the exception: they keep
-whatever you type, exactly as you typed it, because what goes in them is not
-always a plain combination. There is more on them below. The **Clear** button
-empties a box, which is what you want for those two.
+Two boxes are the exception: **Send key after OCR (optional)** and **Send key
+after transcription (optional)**. They keep whatever you type, exactly as you
+typed it, because what goes in them is not always a plain combination. There is
+more on them below. The **Clear** button empties a box, which is what you want for
+those two.
 
 Your changes are held until you press **Save** at the bottom of Settings. Press
 **Cancel** and nothing you changed is kept.
@@ -144,10 +147,10 @@ readers announce it straight away.
   two will ever fire.
   Mutation compares the keys, not the spelling, so writing one as
   **Ctrl+Shift+A** and the other as **Shift+Ctrl+A** is still caught.
-- **The same combination in a "send a key afterwards" box and a real shortcut** —
+- **The same combination in a "send key after" box and a real shortcut** —
   also flagged, and worth fixing. Windows hands that key straight back to Mutation,
   so the action would set itself off again and again. Putting the same key in *both*
-  "send a key afterwards" boxes is fine, though, and is not flagged: those keys go to
+  "send key after" boxes is fine, though, and is not flagged: those keys go to
   whatever app you are in, so there is nothing for them to clash over.
 - **Another app already owns it** — Mutation cannot tell until it actually tries to
   claim the combination. When it fails, you get a beep and a message titled "Some
@@ -155,8 +158,8 @@ readers announce it straight away.
   reason, usually "The shortcut is already registered by another application."
   Go back to the Hotkeys page and pick something else.
 
-The two "send a key afterwards" boxes are a little more relaxed than the rest.
-They hold more than one plain combination can say:
+Those two "send key after" boxes are a little more relaxed than the rest. They
+hold more than one plain combination can say:
 
 - **A run of keys, one after the other.** Separate them with commas, like
   `Ctrl+V, Enter` to paste and then press Enter.
@@ -166,11 +169,16 @@ They hold more than one plain combination can say:
   you already know it.
 
 Because of those two, Mutation leaves these boxes exactly as you type them rather
-than tidying them up. Both spellings are still checked against your other
-shortcuts, so writing `^{F5}` while some Mutation shortcut is **Ctrl+F5** is
-flagged exactly as writing **Ctrl+F5** would be. Plain words are the exception:
-type `hello` into one of these boxes and Mutation types the word for you, so there
-is no shortcut there to clash with anything.
+than tidying them up.
+
+Both spellings are checked against your other shortcuts, so writing `^{F5}` while
+some Mutation shortcut is **Ctrl+F5** is flagged just as writing **Ctrl+F5** would
+be. Two things are not checked, and neither is a mistake. Plain words are not a
+shortcut at all — type `hello` and Mutation types the word for you. And anything
+in the shorthand that Mutation cannot read with certainty is passed over in
+silence rather than guessed at, because a wrong warning is worse than none. So no
+warning is good news, not a guarantee. If you want to be sure, write the key the
+plain way — **Ctrl+F5** rather than `^{F5}` — and it is always checked.
 
 ## Choosing combinations that won't clash
 

--- a/Documentation/UserGuide/markdown/keyboard-shortcuts.md
+++ b/Documentation/UserGuide/markdown/keyboard-shortcuts.md
@@ -115,6 +115,11 @@ same combination look the same. That tidied version is what gets saved, so a
 shortcut you typed into the settings file by hand comes back tidied once Mutation
 has opened that page.
 
+When the box does change what you typed, Mutation says so, and a screen reader
+reads it out: "Speak clipboard now reads CTRL+SHIFT+A". You get that only when
+something actually changed, so tabbing down a page of shortcuts that are already
+written Mutation's way stays quiet.
+
 The two optional "send a key afterwards" boxes are the exception: they keep
 whatever you type, exactly as you typed it, because what goes in them is not
 always a plain combination. There is more on them below. The **Clear** button
@@ -161,9 +166,11 @@ They hold more than one plain combination can say:
   you already know it.
 
 Because of those two, Mutation leaves these boxes exactly as you type them rather
-than tidying them up. They are also the one thing on this page not checked against
-your other shortcuts when you write them in the shorthand style, so if you do,
-check yourself that no Mutation shortcut already uses that key.
+than tidying them up. Both spellings are still checked against your other
+shortcuts, so writing `^{F5}` while some Mutation shortcut is **Ctrl+F5** is
+flagged exactly as writing **Ctrl+F5** would be. Plain words are the exception:
+type `hello` into one of these boxes and Mutation types the word for you, so there
+is no shortcut there to clash with anything.
 
 ## Choosing combinations that won't clash
 

--- a/Documentation/UserGuide/markdown/troubleshooting.md
+++ b/Documentation/UserGuide/markdown/troubleshooting.md
@@ -173,6 +173,11 @@ A page that does not get through first time is sent again, and each retry plays 
 beep once more than the one before. Extra beeps during a batch are normal on a busy
 connection; they mean a page is being retried, not that anything has failed.
 
+Each try also waits longer than the one before it, up to a minute, so a page that is
+just being slow gets the room it needs. A page that never gets through is tried four
+times, which is why one stubborn page can hold things up for a few minutes before
+Mutation gives up on it and moves on.
+
 **What to do.** Listen for the announcements — Mutation names each file as it finishes,
 and calls out the page count every ten pages inside a long PDF, so you can tell it is
 still working. If you picked the wrong files, or simply want it to stop, click **Cancel

--- a/Mutation.Tests/HotkeyCommitAnnouncementTests.cs
+++ b/Mutation.Tests/HotkeyCommitAnnouncementTests.cs
@@ -1,0 +1,98 @@
+using Mutation.Ui.Core;
+
+namespace Mutation.Tests;
+
+/// <summary>
+/// Issue #327: leaving a hotkey box rewrites what is in it, and the rewrite happened in
+/// silence. These cover the two halves of getting that right — saying something when the box
+/// changed, and saying nothing the rest of the time.
+/// </summary>
+public class HotkeyCommitAnnouncementTests
+{
+	[Fact]
+	public void ARewrittenBoxSaysWhatItNowHolds()
+	{
+		// The case from the issue: typed one way, committed another. A sighted user sees it.
+		string? message = HotkeyCommitAnnouncement.For(
+			"Speak clipboard", "shift+ctrl+a", "CTRL+SHIFT+A", validationMessage: null);
+
+		Assert.Equal("Speak clipboard now reads CTRL+SHIFT+A.", message);
+	}
+
+	[Fact]
+	public void TheRowIsNamedSoTheUserKnowsWhichOneChanged()
+	{
+		// By the time a polite announcement lands the focus has moved to the next row, and
+		// seventeen hotkey rows sound identical without the label.
+		string? message = HotkeyCommitAnnouncement.For(
+			"Toggle microphone", "alt+m", "ALT+M", validationMessage: null);
+
+		Assert.StartsWith("Toggle microphone ", message);
+	}
+
+	[Theory]
+	[InlineData(null)]
+	[InlineData("")]
+	[InlineData("   ")]
+	public void ABoxWithNoLabelStillReportsTheRewrite(string? header)
+	{
+		string? message = HotkeyCommitAnnouncement.For(
+			header, "alt+m", "ALT+M", validationMessage: null);
+
+		Assert.Equal("Now reads ALT+M.", message);
+	}
+
+	[Fact]
+	public void AnAlreadyCanonicalRowStaysSilent()
+	{
+		// Commit runs on every LostFocus, so this is the case that happens seventeen times
+		// in a row while the user tabs down the Hotkeys page.
+		Assert.Null(HotkeyCommitAnnouncement.For(
+			"Speak clipboard", "CTRL+SHIFT+A", "CTRL+SHIFT+A", validationMessage: null));
+	}
+
+	[Fact]
+	public void AnEmptyBoxLeftEmptyStaysSilent()
+	{
+		Assert.Null(HotkeyCommitAnnouncement.For("Speak clipboard", "", "", validationMessage: null));
+	}
+
+	[Fact]
+	public void ClearingABoxIsNotAnnouncedAsARewrite()
+	{
+		// The Clear button did what it was asked to, and the box's own validation message
+		// already says the field is now empty.
+		Assert.Null(HotkeyCommitAnnouncement.For(
+			"Speak clipboard", "CTRL+SHIFT+A", "", validationMessage: null));
+	}
+
+	[Fact]
+	public void AValidationErrorIsNotTalkedOverByTheRewrite()
+	{
+		// Both messages sit under the same box. Being told the shortcut is unusable outranks
+		// being told how it is now spelled.
+		Assert.Null(HotkeyCommitAnnouncement.For(
+			"Speak clipboard", "ctrl+", "CTRL+", validationMessage: "Add a key after the modifiers."));
+	}
+
+	[Fact]
+	public void AWhitespaceOnlyValidationMessageIsNotTreatedAsAnError()
+	{
+		// A blank string means the validator had nothing to say, however it spelled "nothing".
+		string? message = HotkeyCommitAnnouncement.For(
+			"Speak clipboard", "shift+ctrl+a", "CTRL+SHIFT+A", validationMessage: "  ");
+
+		Assert.Equal("Speak clipboard now reads CTRL+SHIFT+A.", message);
+	}
+
+	[Fact]
+	public void TrimmingAloneCountsAsAChangeWorthReporting()
+	{
+		// The box really does hold something different afterwards, and a screen-reader user
+		// re-reading the field would otherwise find it disagreeing with what they typed.
+		string? message = HotkeyCommitAnnouncement.For(
+			"Send hotkey after OCR", "  ^{F5}  ", "^{F5}", validationMessage: null);
+
+		Assert.Equal("Send hotkey after OCR now reads ^{F5}.", message);
+	}
+}

--- a/Mutation.Tests/HotkeyCommitAnnouncementTests.cs
+++ b/Mutation.Tests/HotkeyCommitAnnouncementTests.cs
@@ -86,13 +86,53 @@ public class HotkeyCommitAnnouncementTests
 	}
 
 	[Fact]
-	public void TrimmingAloneCountsAsAChangeWorthReporting()
+	public void TrimmingAloneIsNotWorthReporting()
 	{
-		// The box really does hold something different afterwards, and a screen-reader user
-		// re-reading the field would otherwise find it disagreeing with what they typed.
-		string? message = HotkeyCommitAnnouncement.For(
-			"Send hotkey after OCR", "  ^{F5}  ", "^{F5}", validationMessage: null);
+		// Space either side is invisible to a screen reader, so the field does not disagree
+		// with what was typed. It also keeps SendKeys punctuation out of the announcement:
+		// "^{F5}" is spoken as bare "F5" at most default punctuation levels, which names a
+		// different shortcut from the one actually in the box.
+		Assert.Null(HotkeyCommitAnnouncement.For(
+			"Send key after OCR (optional)", "  ^{F5}  ", "^{F5}", validationMessage: null));
+	}
 
-		Assert.Equal("Send hotkey after OCR now reads ^{F5}.", message);
+	[Fact]
+	public void ARealRewriteIsStillReportedWhateverSpaceSurroundedIt()
+	{
+		string? message = HotkeyCommitAnnouncement.For(
+			"Speak clipboard", "  shift+ctrl+a  ", "CTRL+SHIFT+A", validationMessage: null);
+
+		Assert.Equal("Speak clipboard now reads CTRL+SHIFT+A.", message);
+	}
+
+	[Theory]
+	[InlineData("Send key after OCR (optional)", "Send key after OCR")]
+	[InlineData("Send key after transcription (optional)", "Send key after transcription")]
+	[InlineData("Send hotkey after OCR (optional)", "Send hotkey after OCR")]
+	public void ATrailingAsideInTheLabelIsNotReadOut(string header, string spoken)
+	{
+		// Four of the real labels end in "(optional)". It says nothing about what changed,
+		// and it is a mouthful in the middle of a spoken sentence.
+		Assert.Equal($"{spoken} now reads ALT+M.", HotkeyCommitAnnouncement.For(
+			header, "alt+m", "ALT+M", validationMessage: null));
+	}
+
+	[Theory]
+	[InlineData("Speak clipboard")]
+	[InlineData("Toggle microphone mute")]
+	[InlineData("Speech to text + process with LLM")]
+	public void AnOrdinaryLabelIsReadOutWhole(string header)
+	{
+		Assert.Equal($"{header} now reads ALT+M.", HotkeyCommitAnnouncement.For(
+			header, "alt+m", "ALT+M", validationMessage: null));
+	}
+
+	[Fact]
+	public void ALabelThatIsNothingButAnAsideIsNotStrippedToNothing()
+	{
+		// Dropping the whole label would leave a sentence with no subject; keeping it beats
+		// that, however odd a label it is.
+		Assert.Equal("(optional) now reads ALT+M.", HotkeyCommitAnnouncement.For(
+			"(optional)", "alt+m", "ALT+M", validationMessage: null));
 	}
 }

--- a/Mutation.Tests/HotkeyConflictFinderTests.cs
+++ b/Mutation.Tests/HotkeyConflictFinderTests.cs
@@ -147,10 +147,58 @@ public class HotkeyConflictFinderTests
 	}
 
 	[Fact]
-	public void SendKeys_syntax_in_a_sent_value_is_skipped_rather_than_misread()
+	public void SendKeys_syntax_in_a_sent_value_is_read_back_and_compared()
 	{
-		// The send-key boxes also accept SendKeys syntax, which is not a chord at all.
-		Assert.Empty(DuplicateIndexes(Configured(Claimed("CTRL+V"), Sent("^v"))));
+		// The send-key boxes accept both spellings of one shortcut. This one used to take no
+		// part in the comparison at all, so "^v" against Ctrl+V raised nothing while
+		// "Ctrl+V" against Ctrl+V was flagged (issue #326).
+		Assert.Equal(new[] { 0, 1 }, Sorted(DuplicateIndexes(Configured(
+			Claimed("CTRL+V"), Sent("^v")))));
+	}
+
+	[Fact]
+	public void The_case_from_the_issue_is_flagged_either_way_it_is_written()
+	{
+		Assert.Equal(new[] { 0, 1 }, Sorted(DuplicateIndexes(Configured(
+			Claimed("CTRL+F5"), Sent("^{F5}")))));
+	}
+
+	[Fact]
+	public void Every_chord_a_SendKeys_group_presses_is_compared()
+	{
+		Assert.Equal(new[] { 0, 1 }, Sorted(DuplicateIndexes(Configured(
+			Claimed("CTRL+SHIFT+B"), Sent("^+(ab)")))));
+	}
+
+	[Fact]
+	public void A_SendKeys_value_that_clashes_with_nothing_is_left_alone()
+	{
+		Assert.Empty(DuplicateIndexes(Configured(Claimed("CTRL+ALT+G"), Sent("^{F5}"))));
+	}
+
+	[Fact]
+	public void Two_send_boxes_holding_the_same_SendKeys_value_are_not_a_clash()
+	{
+		// Sending the same key after OCR and after transcription is an ordinary way to set
+		// the app up. Reading the shorthand must not turn that into a complaint.
+		Assert.Empty(DuplicateIndexes(Configured(Sent("^{F5}"), Sent("^{F5}"))));
+	}
+
+	[Fact]
+	public void Text_typed_out_by_a_send_box_is_not_mistaken_for_shortcuts()
+	{
+		// "hello" types five letters. Reading five one-key shortcuts out of it would flag a
+		// row that clashes with nothing at all.
+		Assert.Empty(DuplicateIndexes(Configured(Claimed("H"), Claimed("O"), Sent("hello"))));
+	}
+
+	[Fact]
+	public void A_plain_chord_still_wins_over_the_SendKeys_reading_of_the_same_text()
+	{
+		// The '+' in "Ctrl+F5" separates a chord; the one in "+{F5}" is SendKeys' Shift.
+		// Reading a chord first is what keeps the two apart.
+		Assert.Equal(new[] { 0, 1 }, Sorted(DuplicateIndexes(Configured(
+			Claimed("CTRL+F5"), Sent("Ctrl+F5")))));
 	}
 
 	// ----- Nothing to compare -----

--- a/Mutation.Tests/OcrServiceRetryTests.cs
+++ b/Mutation.Tests/OcrServiceRetryTests.cs
@@ -55,7 +55,11 @@ public class OcrServiceRetryTests : IDisposable
 	}
 
 	private (OcrService Service, ScriptedTransport Transport, RecordingClock Clock, List<int> Announced)
-		CreateService(params Func<int, HttpResponseMessage>[] replies)
+		CreateService(params Func<int, HttpResponseMessage>[] replies) =>
+		CreateService(TimeoutSeconds, replies);
+
+	private (OcrService Service, ScriptedTransport Transport, RecordingClock Clock, List<int> Announced)
+		CreateService(int timeoutSeconds, params Func<int, HttpResponseMessage>[] replies)
 	{
 		var transport = new ScriptedTransport(replies);
 		var httpClient = new HttpClient(transport);
@@ -76,7 +80,7 @@ public class OcrServiceRetryTests : IDisposable
 
 		var clock = new RecordingClock();
 		var announced = new List<int>();
-		var service = new OcrService("test-key", "https://example.cognitiveservices.azure.com/", TimeoutSeconds, client, clock, announced.Add);
+		var service = new OcrService("test-key", "https://example.cognitiveservices.azure.com/", timeoutSeconds, client, clock, announced.Add);
 		return (service, transport, clock, announced);
 	}
 
@@ -160,20 +164,35 @@ public class OcrServiceRetryTests : IDisposable
 	}
 
 	[Fact]
-	public async Task EveryAttemptGetsTheSamePerRequestDeadline()
+	public async Task EachAttemptGivesItselfLongerThanTheLastUpToTheCeiling()
 	{
-		// Unlike the other four callers, this one does not stretch its deadline by the
-		// attempt number: the read is capped at a flat 60 seconds, so a wedged call cannot
-		// hold up an OCR batch for longer each time round. Pinned here because issue #311
-		// assumed the opposite, and because a change of mind should have to edit a test.
-		// See issue #315.
+		// Issue #315 settled what issue #311 had assumed: this service stretches its
+		// deadline by the attempt number like the other four, so a slow cold start gets
+		// more room on the retry than it had on the first try. The 60-second ceiling caps
+		// each attempt rather than only the first, so a wedged read cannot hold an OCR
+		// batch up for longer and longer.
 		var (service, _, clock, _) = CreateService(Status(HttpStatusCode.ServiceUnavailable));
 
 		await Assert.ThrowsAsync<RequestFailedException>(() =>
 			service.ExtractText(OcrReadingOrder.TopToBottomColumnAware, Image(), CancellationToken.None));
 
-		Assert.Equal([30d, 30d, 30d, 30d], clock.DeadlineSeconds);
+		Assert.Equal([30d, 60d, 60d, 60d], clock.DeadlineSeconds);
 		Assert.Equal([500d, 1000d, 1500d], clock.BackoffMilliseconds);
+	}
+
+	[Fact]
+	public async Task AShortTimeoutStretchesAllTheWayUpTheLadder()
+	{
+		// With the ceiling well out of reach, every rung is longer than the one before —
+		// the point of stretching in the first place. Read alongside the test above, which
+		// is the same ladder run into the cap.
+		var (service, _, clock, _) = CreateService(
+			timeoutSeconds: 5, Status(HttpStatusCode.ServiceUnavailable));
+
+		await Assert.ThrowsAsync<RequestFailedException>(() =>
+			service.ExtractText(OcrReadingOrder.TopToBottomColumnAware, Image(), CancellationToken.None));
+
+		Assert.Equal([5d, 10d, 15d, 20d], clock.DeadlineSeconds);
 	}
 
 	[Fact]

--- a/Mutation.Tests/OcrServiceTests.cs
+++ b/Mutation.Tests/OcrServiceTests.cs
@@ -372,20 +372,28 @@ public class OcrServiceTests
 	// ---------------------------------------------------------------------
 
 	[Theory]
-	[InlineData(-5, 1)]   // floor at 1 second (Math.Max(1, …))
-	[InlineData(0, 1)]
-	[InlineData(1, 1)]
-	[InlineData(30, 30)]
-	[InlineData(60, 60)]
-	[InlineData(120, 60)] // ceiling at MaxTimeoutSeconds (60)
-	[InlineData(3600, 60)]
-	public void GetPerRequestTimeout_ClampsToValidRange(int configuredSeconds, int expectedSeconds)
+	[InlineData(-5, 1, 1)]   // floor at 1 second (Math.Max(1, …))
+	[InlineData(0, 1, 1)]
+	[InlineData(1, 1, 1)]
+	[InlineData(30, 1, 30)]
+	[InlineData(60, 1, 60)]
+	[InlineData(120, 1, 60)] // ceiling at MaxTimeoutSeconds (60)
+	[InlineData(3600, 1, 60)]
+	// The attempt number stretches the deadline, and the same ceiling caps every rung of
+	// the ladder rather than only the first (issue #315).
+	[InlineData(5, 2, 10)]
+	[InlineData(5, 4, 20)]
+	[InlineData(30, 2, 60)]
+	[InlineData(30, 4, 60)]
+	[InlineData(60, 3, 60)]
+	public void GetPerRequestTimeout_StretchesByAttemptAndClampsToValidRange(
+		int configuredSeconds, int attempt, int expectedSeconds)
 	{
 		var service = new OcrService("dummy-key", "https://example.com/", configuredSeconds);
 
 		MethodInfo? method = typeof(OcrService).GetMethod("GetPerRequestTimeout", BindingFlags.NonPublic | BindingFlags.Instance);
 		Assert.NotNull(method);
-		var timeout = (TimeSpan)method!.Invoke(service, null)!;
+		var timeout = (TimeSpan)method!.Invoke(service, [attempt])!;
 
 		Assert.Equal(TimeSpan.FromSeconds(expectedSeconds), timeout);
 	}
@@ -423,11 +431,11 @@ public class OcrServiceTests
 		Assert.Throws<ArgumentNullException>(() => new OcrService("key", null, 10));
 	}
 
-	private static CancellationTokenSource CreatePerRequestDeadline(OcrService service)
+	private static CancellationTokenSource CreatePerRequestDeadline(OcrService service, int attempt = 1)
 	{
 		MethodInfo? method = typeof(OcrService).GetMethod("CreatePerRequestDeadline", BindingFlags.NonPublic | BindingFlags.Instance);
 		Assert.NotNull(method);
-		return (CancellationTokenSource)method!.Invoke(service, null)!;
+		return (CancellationTokenSource)method!.Invoke(service, [attempt])!;
 	}
 
 	[Fact]

--- a/Mutation.Tests/SendKeysReaderTests.cs
+++ b/Mutation.Tests/SendKeysReaderTests.cs
@@ -1,0 +1,226 @@
+using Mutation.Ui.Services;
+using Windows.System;
+
+namespace Mutation.Tests;
+
+/// <summary>
+/// Issue #326: the "Send key after…" boxes accept Windows' SendKeys shorthand, and duplicate
+/// detection could only read the plain spelling. These cover the reader that closes that gap.
+/// <para>
+/// Two directions matter equally. Missing a clash leaves the user where they already were.
+/// Inventing one puts a "Duplicate hotkey" badge on a row that is perfectly fine, which is
+/// worse — so the "reads nothing" cases below are not an afterthought.
+/// </para>
+/// </summary>
+public class SendKeysReaderTests
+{
+	private static string[] Read(string? sendKeys) =>
+		SendKeysReader.ChordsIn(sendKeys).Select(c => c.ToString()).ToArray();
+
+	// ------------------------------------------------------------------
+	// What it reads
+	// ------------------------------------------------------------------
+
+	[Fact]
+	public void TheCaseFromTheIssueReadsBackAsTheChordItPresses()
+	{
+		Assert.Equal(["CTRL+F5"], Read("^{F5}"));
+	}
+
+	[Theory]
+	[InlineData("^v", "CTRL+V")]
+	[InlineData("%{TAB}", "ALT+TAB")]
+	[InlineData("+{F5}", "SHIFT+F5")]
+	[InlineData("^%{DEL}", "CTRL+ALT+DELETE")]
+	[InlineData("^+%a", "CTRL+SHIFT+ALT+A")]
+	[InlineData("^1", "CTRL+1")]
+	public void AModifiedKeyReadsBackAsThatChord(string sendKeys, string expected)
+	{
+		Assert.Equal([expected], Read(sendKeys));
+	}
+
+	[Theory]
+	[InlineData("{ENTER}", "ENTER")]
+	[InlineData("{RETURN}", "ENTER")]
+	[InlineData("{ESC}", "ESCAPE")]
+	[InlineData("{BACKSPACE}", "BACK")]
+	[InlineData("{PGDN}", "PAGEDOWN")]
+	[InlineData("{PGUP}", "PAGEUP")]
+	[InlineData("{APPS}", "APPLICATION")]
+	[InlineData("{F12}", "F12")]
+	[InlineData("{f12}", "F12")]
+	[InlineData("~", "ENTER")]
+	public void ANamedKeyIsAKeypressEvenWithNoModifier(string sendKeys, string expected)
+	{
+		// Unlike an ordinary character, a named key is never someone typing a word, so it
+		// counts on its own — a Mutation shortcut bound to plain F12 really would clash.
+		Assert.Equal([expected], Read(sendKeys));
+	}
+
+	[Fact]
+	public void ASequenceReadsBackAsEveryChordInIt()
+	{
+		// What "Ctrl+V, Enter" turns into when the user writes it the other way.
+		Assert.Equal(["CTRL+V", "ENTER"], Read("^v{ENTER}"));
+	}
+
+	[Fact]
+	public void ARepeatCountIsTheSameKeyAndIsReadOnce()
+	{
+		Assert.Equal(["CTRL+LEFT"], Read("^{LEFT 5}"));
+	}
+
+	// ------------------------------------------------------------------
+	// The group form
+	// ------------------------------------------------------------------
+
+	[Fact]
+	public void AGroupHoldsItsModifiersDownAcrossEveryKeyInIt()
+	{
+		// "^+(ab)" is Ctrl+Shift+A and then Ctrl+Shift+B — two chords, not one naming both.
+		Assert.Equal(["CTRL+SHIFT+A", "CTRL+SHIFT+B"], Read("^+(ab)"));
+	}
+
+	[Fact]
+	public void AGroupCanHoldNamedKeysToo()
+	{
+		Assert.Equal(["CTRL+HOME", "CTRL+END"], Read("^({HOME}{END})"));
+	}
+
+	[Fact]
+	public void AnUnmodifiedGroupIsJustTypingAndReadsNothing()
+	{
+		Assert.Empty(Read("(ab)"));
+	}
+
+	[Fact]
+	public void AnUnclosedGroupReadsNothingAtAll()
+	{
+		// Not even the part before it: a string this broken is not one anybody should be
+		// flagging rows from.
+		Assert.Empty(Read("^{F5}^(ab"));
+	}
+
+	[Fact]
+	public void ANestedGroupIsBeyondUsAndReadsNothing()
+	{
+		Assert.Empty(Read("^((ab))"));
+	}
+
+	// ------------------------------------------------------------------
+	// Escaped literals — the reserved characters, written to be typed
+	// ------------------------------------------------------------------
+
+	[Theory]
+	[InlineData("{+}")]
+	[InlineData("{^}")]
+	[InlineData("{%}")]
+	[InlineData("{~}")]
+	[InlineData("{(}")]
+	[InlineData("{)}")]
+	[InlineData("{{}")]
+	[InlineData("{}}")]
+	public void AnEscapedReservedCharacterIsATypedCharacterAndNotAModifier(string sendKeys)
+	{
+		// The whole point of the braces is that the character inside is not doing its
+		// reserved job. Reading "{+}" as a Shift modifier, or "{}}" as an empty pair
+		// followed by a stray brace, is how a fine row ends up flagged.
+		Assert.Empty(Read(sendKeys));
+	}
+
+	[Fact]
+	public void AnEscapedBraceDoesNotSwallowWhatFollowsIt()
+	{
+		Assert.Equal(["CTRL+F5"], Read("{}}^{F5}"));
+	}
+
+	[Fact]
+	public void AnEscapedCaretDoesNotModifyWhatFollowsIt()
+	{
+		// "{^}^a" types a caret and then presses Ctrl+A. Only the second caret is a modifier.
+		Assert.Equal(["CTRL+A"], Read("{^}^a"));
+	}
+
+	// ------------------------------------------------------------------
+	// What it refuses to read
+	// ------------------------------------------------------------------
+
+	[Theory]
+	[InlineData("hello")]
+	[InlineData("Yours sincerely")]
+	[InlineData("")]
+	[InlineData("   ")]
+	[InlineData(null)]
+	public void PlainTextIsSomethingBeingTypedAndReadsNothing(string? sendKeys)
+	{
+		Assert.Empty(Read(sendKeys));
+	}
+
+	[Fact]
+	public void OnlyTheModifiedKeysInAMixedRunAreRead()
+	{
+		// "hi^v" types two letters and then presses Ctrl+V. Only the last one is a shortcut.
+		Assert.Equal(["CTRL+V"], Read("hi^v"));
+	}
+
+	[Theory]
+	[InlineData("^")]
+	[InlineData("^+%")]
+	[InlineData("^{F5}%")]
+	public void AModifierWithNoKeyAfterItReadsNothingAtAll(string sendKeys)
+	{
+		Assert.Empty(Read(sendKeys));
+	}
+
+	[Theory]
+	[InlineData("^{F5")]
+	[InlineData("^{}")]
+	[InlineData("^)")]
+	[InlineData("^}")]
+	public void AStringThatDoesNotHoldTogetherReadsNothingAtAll(string sendKeys)
+	{
+		Assert.Empty(Read(sendKeys));
+	}
+
+	[Fact]
+	public void AnUnknownKeyNameIsSkippedWithoutLosingTheRest()
+	{
+		// The name is not one we can place, so it contributes nothing; the chord beside it
+		// is still perfectly readable.
+		Assert.Equal(["CTRL+F5"], Read("{NOTAKEY}^{F5}"));
+	}
+
+	[Fact]
+	public void AKeyWeCannotSpellAsAChordSimplyDropsOut()
+	{
+		// A semicolon is a token separator to the hotkey parser, so "CTRL+;" is not a chord
+		// it can express. Dropping out beats inventing something.
+		Assert.Empty(Read("^;"));
+	}
+
+	// ------------------------------------------------------------------
+	// Agreement with the rest of the app
+	// ------------------------------------------------------------------
+
+	[Fact]
+	public void WhatSendKeysMapperWritesIsWhatThisReadsBack()
+	{
+		// The two directions have to agree, or a value the app produced would come back as
+		// a different shortcut from the one the user asked for.
+		string mapped = SendKeysMapper.Map("Ctrl+Shift+F5");
+
+		Assert.Equal(["CTRL+SHIFT+F5"], Read(mapped));
+	}
+
+	[Fact]
+	public void AChordReadsBackToTheSameKeyTheEditorWouldRegister()
+	{
+		var chord = Assert.Single(SendKeysReader.ChordsIn("%{F4}"));
+
+		Assert.Equal(VirtualKey.F4, chord.Key);
+		Assert.True(chord.Alt);
+		Assert.False(chord.Control);
+		Assert.False(chord.Shift);
+		Assert.False(chord.Win);
+	}
+}

--- a/Mutation.Tests/SendKeysReaderTests.cs
+++ b/Mutation.Tests/SendKeysReaderTests.cs
@@ -215,6 +215,18 @@ public class SendKeysReaderTests
 		Assert.Equal(["CTRL+F5"], Read("{NOTAKEY}^{F5}"));
 	}
 
+	[Theory]
+	[InlineData("{F+5}")]
+	[InlineData("^{F+5}")]
+	[InlineData("{F-5}")]
+	public void ASignedFunctionKeyNumberIsNotAFunctionKey(string sendKeys)
+	{
+		// "F+5" is not F5. Read as one, it goes on to the chord parser, which splits it on
+		// the '+' and hands back the digit key 5 — a shortcut nobody wrote, ready to be
+		// flagged against any row registered as plain 5.
+		Assert.Empty(Read(sendKeys));
+	}
+
 	[Fact]
 	public void AKeyWeCannotSpellAsAChordSimplyDropsOut()
 	{

--- a/Mutation.Tests/SendKeysReaderTests.cs
+++ b/Mutation.Tests/SendKeysReaderTests.cs
@@ -182,6 +182,31 @@ public class SendKeysReaderTests
 		Assert.Empty(Read(sendKeys));
 	}
 
+	[Theory]
+	[InlineData("Ctrl+Alt")]
+	[InlineData("Ctrl+Shift")]
+	[InlineData("Shift+")]
+	[InlineData("Ctrl+F5")]
+	[InlineData("Ctrl+V, Enter")]
+	[InlineData("Ctrl+(AB)")]
+	public void ChordTextIsNotReadAsShorthandHoweverFinishedItIs(string chordText)
+	{
+		// A '+' is SendKeys' Shift and a chord's separator both. Read as shorthand,
+		// "Ctrl+Alt" on the way to "Ctrl+Alt+G" would report Shift+A and collide with any
+		// row genuinely holding Shift+A — a duplicate badge on a shortcut that is fine.
+		// The finished spellings are here too: those are the caller's job, read as chords
+		// before this reader is ever asked.
+		Assert.Empty(Read(chordText));
+	}
+
+	[Fact]
+	public void AShiftGroupAtTheStartIsStillShorthand()
+	{
+		// "+(" is the ambiguous one. Nothing precedes this '+', so it is not a chord
+		// separator and the group really is SendKeys' Shift.
+		Assert.Equal(["SHIFT+A", "SHIFT+B"], Read("+(ab)"));
+	}
+
 	[Fact]
 	public void AnUnknownKeyNameIsSkippedWithoutLosingTheRest()
 	{

--- a/Mutation.Ui/Core/HotkeyCommitAnnouncement.cs
+++ b/Mutation.Ui/Core/HotkeyCommitAnnouncement.cs
@@ -1,0 +1,58 @@
+using System;
+
+namespace Mutation.Ui.Core;
+
+/// <summary>
+/// What to say when a hotkey box rewrites itself, and when to say nothing at all.
+/// <para>
+/// Leaving a hotkey box canonicalises what is in it: <c>shift+ctrl+a</c> becomes
+/// <c>CTRL+SHIFT+A</c>. A sighted user watches that happen. Nothing announced it, so a
+/// screen-reader user heard only silence, and the next reading of the field disagreed with
+/// what they had typed (issue #327).
+/// </para>
+/// <para>
+/// Kept as a pure text-in, text-out unit because the alternative is a WinUI control that no
+/// test can reach: the whole defect was an announcement that never happened, which is exactly
+/// the kind of absence a running app does not complain about.
+/// </para>
+/// </summary>
+internal static class HotkeyCommitAnnouncement
+{
+	/// <summary>
+	/// The message for a commit, or null when there is nothing worth interrupting for.
+	/// </summary>
+	/// <param name="header">
+	/// The box's on-screen label, used to name which row this is about. Every hotkey row
+	/// looks the same to someone tabbing down seventeen of them, and by the time the
+	/// announcement lands the focus has already moved on. Blank for a box with no header,
+	/// which drops the name rather than inventing one.
+	/// </param>
+	/// <param name="typed">What was in the box when focus left it.</param>
+	/// <param name="committed">What the box holds now.</param>
+	/// <param name="validationMessage">
+	/// Whatever the validator has to say about <paramref name="committed"/>, or null when it
+	/// is happy. An error outranks this: being told the shortcut is unusable matters more
+	/// than being told how it is now spelled, and the two would otherwise talk over each
+	/// other in the same breath.
+	/// </param>
+	public static string? For(string? header, string? typed, string? committed, string? validationMessage)
+	{
+		if (!string.IsNullOrWhiteSpace(validationMessage))
+			return null;
+
+		// Nothing changed, so there is nothing to report. This is the common case by far —
+		// tabbing through rows that are already canonical has to stay silent, or the page
+		// talks over the user on every single row.
+		if (string.Equals(typed ?? string.Empty, committed ?? string.Empty, StringComparison.Ordinal))
+			return null;
+
+		// An emptied box is the Clear button doing exactly what it was asked to, and it
+		// carries its own "Enter a hotkey." message already.
+		if (string.IsNullOrEmpty(committed))
+			return null;
+
+		return string.IsNullOrWhiteSpace(header)
+			? $"Now reads {committed}."
+			: $"{header.Trim()} now reads {committed}.";
+	}
+}

--- a/Mutation.Ui/Core/HotkeyCommitAnnouncement.cs
+++ b/Mutation.Ui/Core/HotkeyCommitAnnouncement.cs
@@ -43,7 +43,15 @@ internal static class HotkeyCommitAnnouncement
 		// Nothing changed, so there is nothing to report. This is the common case by far —
 		// tabbing through rows that are already canonical has to stay silent, or the page
 		// talks over the user on every single row.
-		if (string.Equals(typed ?? string.Empty, committed ?? string.Empty, StringComparison.Ordinal))
+		//
+		// Space either side of the text does not count as a change. It is invisible to a
+		// screen reader, so the field does not disagree with what the user typed, and there
+		// is no shortcut in it either way. It matters most for the two "send key after"
+		// boxes, whose contents are kept exactly as typed: trimming is the only rewrite they
+		// ever get, and announcing it would read SendKeys punctuation aloud — "^{F5}" is
+		// spoken as bare "F5" at most screen readers' default punctuation level, naming a
+		// different shortcut from the one in the box.
+		if (string.Equals((typed ?? string.Empty).Trim(), committed ?? string.Empty, StringComparison.Ordinal))
 			return null;
 
 		// An emptied box is the Clear button doing exactly what it was asked to, and it
@@ -51,8 +59,27 @@ internal static class HotkeyCommitAnnouncement
 		if (string.IsNullOrEmpty(committed))
 			return null;
 
-		return string.IsNullOrWhiteSpace(header)
+		string name = SpokenName(header);
+		return name.Length == 0
 			? $"Now reads {committed}."
-			: $"{header.Trim()} now reads {committed}.";
+			: $"{name} now reads {committed}.";
+	}
+
+	/// <summary>
+	/// The row's label with any trailing aside dropped. Several rows are labelled
+	/// "Send key after OCR (optional)", and "Send key after OCR (optional) now reads ^{F5}"
+	/// is a mouthful to listen to for a word that says nothing about what changed.
+	/// </summary>
+	private static string SpokenName(string? header)
+	{
+		string name = header?.Trim() ?? string.Empty;
+		if (name.EndsWith(')'))
+		{
+			int open = name.LastIndexOf('(');
+			if (open > 0)
+				name = name[..open].TrimEnd();
+		}
+
+		return name;
 	}
 }

--- a/Mutation.Ui/Core/HotkeyConflictFinder.cs
+++ b/Mutation.Ui/Core/HotkeyConflictFinder.cs
@@ -93,10 +93,16 @@ internal static class HotkeyConflictFinder
 	/// compare.
 	/// <para>
 	/// A sent step is read as a chord first and as Windows' SendKeys shorthand only if that
-	/// fails, which is the order the ambiguity needs: the <c>+</c> in <c>Ctrl+F5</c> separates
-	/// a chord, while the one in <c>+{F5}</c> is SendKeys' Shift. Reading the shorthand at all
-	/// is new — it used to yield nothing, so <c>^{F5}</c> silently took no part in the
+	/// fails, because the two spellings collide on <c>+</c>: the one in <c>Ctrl+F5</c>
+	/// separates a chord, the one in <c>+{F5}</c> is SendKeys' Shift. Reading the shorthand at
+	/// all is new — it used to yield nothing, so <c>^{F5}</c> silently took no part in the
 	/// comparison while <c>Ctrl+F5</c> was flagged correctly (issue #326).
+	/// <para>
+	/// The order does not settle every case, and does not claim to. <c>+a</c> is SendKeys for
+	/// Shift+A, but <see cref="Hotkey.TryParse"/> reads it as plain A and so answers first.
+	/// That predates this and is a miss rather than a wrong flag; the reader is reached only
+	/// where the chord parser has already given up.
+	/// </para>
 	/// </para>
 	/// </summary>
 	private static IEnumerable<Hotkey> ChordsIn(ConfiguredHotkey entry)

--- a/Mutation.Ui/Core/HotkeyConflictFinder.cs
+++ b/Mutation.Ui/Core/HotkeyConflictFinder.cs
@@ -89,9 +89,15 @@ internal static class HotkeyConflictFinder
 
 	/// <summary>
 	/// Every chord one entry puts on the keyboard: one for a registered shortcut, and one per
-	/// step for a sent sequence. Anything that does not parse — half-typed text, or the
-	/// SendKeys syntax the "send key after" boxes also accept — yields nothing, because there
-	/// is no chord to compare.
+	/// step for a sent sequence. Half-typed text yields nothing, because there is no chord to
+	/// compare.
+	/// <para>
+	/// A sent step is read as a chord first and as Windows' SendKeys shorthand only if that
+	/// fails, which is the order the ambiguity needs: the <c>+</c> in <c>Ctrl+F5</c> separates
+	/// a chord, while the one in <c>+{F5}</c> is SendKeys' Shift. Reading the shorthand at all
+	/// is new — it used to yield nothing, so <c>^{F5}</c> silently took no part in the
+	/// comparison while <c>Ctrl+F5</c> was flagged correctly (issue #326).
+	/// </para>
 	/// </summary>
 	private static IEnumerable<Hotkey> ChordsIn(ConfiguredHotkey entry)
 	{
@@ -108,7 +114,13 @@ internal static class HotkeyConflictFinder
 		foreach (string step in entry.Text.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
 		{
 			if (Hotkey.TryParse(step, out var chord))
+			{
 				yield return chord;
+				continue;
+			}
+
+			foreach (var sent in SendKeysReader.ChordsIn(step))
+				yield return sent;
 		}
 	}
 }

--- a/Mutation.Ui/Services/SendKeysMapper.cs
+++ b/Mutation.Ui/Services/SendKeysMapper.cs
@@ -235,7 +235,10 @@ public static class SendKeysMapper
 		return prefix + "(" + body + ")";
 	}
 
-	private static bool LooksLikeSendKeys(string s)
+	// Internal rather than private so SendKeysReader can ask the same question before it
+	// reads anything. Two answers to "is this SendKeys?" would eventually disagree, and the
+	// place they would disagree is the '+(' case below — the one that already cost an issue.
+	internal static bool LooksLikeSendKeys(string s)
 	{
 		// Heuristic: any of these strongly implies SendKeys syntax
 		// '^', '%', '~', braces, or a group opened by SendKeys' Shift modifier.

--- a/Mutation.Ui/Services/SendKeysReader.cs
+++ b/Mutation.Ui/Services/SendKeysReader.cs
@@ -1,0 +1,307 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+
+namespace Mutation.Ui.Services;
+
+/// <summary>
+/// Reads a Windows SendKeys string back into the chords it puts on the keyboard —
+/// <c>^{F5}</c> into Ctrl+F5. The inverse of <see cref="SendKeysMapper"/>, which only ever
+/// went the other way.
+/// <para>
+/// The two "Send key after…" boxes accept both spellings of a shortcut, and duplicate
+/// detection understood only the plain one. Setting a sent key to <c>^{F5}</c> while a
+/// Mutation shortcut is Ctrl+F5 raised no badge, though Windows routes that synthesized
+/// keystroke straight back to Mutation and the action sets itself off again — the exact
+/// clash the sent-against-registered check exists to catch (issue #326).
+/// </para>
+/// <para>
+/// Everything here errs towards reading nothing. A missed clash leaves the user where they
+/// already were; a wrong one puts a "Duplicate hotkey" badge on a shortcut that is perfectly
+/// fine, which is a worse place to be. So a run of ordinary characters — text being typed,
+/// not a shortcut — yields nothing, an unrecognised key name yields nothing, and a string
+/// that does not hold together at all yields nothing whatsoever rather than a partial
+/// reading of a value nobody can be sure of.
+/// </para>
+/// </summary>
+public static class SendKeysReader
+{
+	private const char CtrlMod = '^';
+	private const char ShiftMod = '+';
+	private const char AltMod = '%';
+
+	/// <summary>
+	/// SendKeys' braced key names, spelled the way <see cref="Hotkey.Parse"/> wants them.
+	/// Only names this table knows are read back; anything else is a key we cannot name with
+	/// confidence, and guessing is what puts a badge on an innocent row.
+	/// <para>
+	/// The reserved single characters SendKeys escapes in braces — <c>{+}</c>, <c>{^}</c>,
+	/// <c>{%}</c>, <c>{~}</c>, <c>{(}</c>, <c>{)}</c>, <c>{{}</c>, <c>{}}</c> — are absent on
+	/// purpose. They are literal characters being typed, not named keys, and are treated as
+	/// the ordinary literals they are.
+	/// </para>
+	/// </summary>
+	private static readonly Dictionary<string, string> KeyNames = new(StringComparer.OrdinalIgnoreCase)
+	{
+		["ENTER"] = "Enter",
+		["RETURN"] = "Enter",
+		["TAB"] = "Tab",
+		["ESC"] = "Escape",
+		["ESCAPE"] = "Escape",
+		["BACKSPACE"] = "Back",
+		["BKSP"] = "Back",
+		["BS"] = "Back",
+		["DEL"] = "Delete",
+		["DELETE"] = "Delete",
+		["INS"] = "Insert",
+		["INSERT"] = "Insert",
+		["SPACE"] = "Space",
+		["UP"] = "Up",
+		["DOWN"] = "Down",
+		["LEFT"] = "Left",
+		["RIGHT"] = "Right",
+		["HOME"] = "Home",
+		["END"] = "End",
+		["PGUP"] = "PageUp",
+		["PGDN"] = "PageDown",
+		["APPS"] = "Application",
+		["BREAK"] = "Pause",
+		["HELP"] = "Help",
+		["CAPSLOCK"] = "CapitalLock",
+		["NUMLOCK"] = "NumberKeyLock",
+		["SCROLLLOCK"] = "Scroll",
+		["PRTSC"] = "Snapshot",
+		["ADD"] = "Add",
+		["SUBTRACT"] = "Subtract",
+		["MULTIPLY"] = "Multiply",
+		["DIVIDE"] = "Divide",
+		["DECIMAL"] = "Decimal",
+		["SEPARATOR"] = "Separator",
+	};
+
+	/// <summary>
+	/// The chords <paramref name="sendKeys"/> presses, in the order it presses them, or an
+	/// empty list when it cannot be read back.
+	/// </summary>
+	public static IReadOnlyList<Hotkey> ChordsIn(string? sendKeys)
+	{
+		var chords = new List<Hotkey>();
+		if (string.IsNullOrWhiteSpace(sendKeys))
+			return chords;
+
+		string s = sendKeys.Trim();
+		int i = 0;
+
+		while (i < s.Length)
+		{
+			var mods = ReadModifiers(s, ref i);
+			if (i >= s.Length)
+				return NothingAtAll(chords); // A modifier with no key after it: not a real value.
+
+			char c = s[i];
+
+			if (c == '(')
+			{
+				if (!TryReadGroup(s, ref i, mods, chords))
+					return NothingAtAll(chords);
+				continue;
+			}
+
+			if (c == '{')
+			{
+				if (!TryReadBraced(s, ref i, mods, chords))
+					return NothingAtAll(chords);
+				continue;
+			}
+
+			if (c == ')' || c == '}')
+				return NothingAtAll(chords); // A closer with nothing open: the string is broken.
+
+			// '~' is SendKeys' shorthand for Enter, and is a keypress however it is written.
+			if (c == '~')
+			{
+				Add(chords, mods, "Enter");
+				i++;
+				continue;
+			}
+
+			Add(chords, mods, c.ToString(), literal: true);
+			i++;
+		}
+
+		return chords;
+	}
+
+	/// <summary>
+	/// Consumes the run of modifier characters at <paramref name="i"/>. In SendKeys they bind
+	/// to whatever comes next and to nothing after that, so each pass round the loop starts
+	/// its own run.
+	/// </summary>
+	private static (bool Ctrl, bool Shift, bool Alt) ReadModifiers(string s, ref int i)
+	{
+		bool ctrl = false, shift = false, alt = false;
+		while (i < s.Length)
+		{
+			switch (s[i])
+			{
+				case CtrlMod: ctrl = true; break;
+				case ShiftMod: shift = true; break;
+				case AltMod: alt = true; break;
+				default: return (ctrl, shift, alt);
+			}
+			i++;
+		}
+		return (ctrl, shift, alt);
+	}
+
+	/// <summary>
+	/// The group form: <c>^+(ab)</c> holds Ctrl+Shift down across every key inside it, so it
+	/// is Ctrl+Shift+A and then Ctrl+Shift+B rather than one chord naming both.
+	/// </summary>
+	private static bool TryReadGroup(string s, ref int i, (bool Ctrl, bool Shift, bool Alt) mods, List<Hotkey> chords)
+	{
+		int close = s.IndexOf(')', i + 1);
+		if (close < 0)
+			return false;
+
+		string body = s[(i + 1)..close];
+		i = close + 1;
+
+		if (body.Length == 0)
+			return false;
+
+		// SendKeys neither nests groups nor re-applies modifiers inside one. Something in
+		// there doing either is a string we do not understand, and half-understanding it is
+		// how an innocent row gets flagged.
+		if (body.IndexOfAny([')', '(', CtrlMod, ShiftMod, AltMod]) >= 0)
+			return false;
+
+		int j = 0;
+		while (j < body.Length)
+		{
+			char c = body[j];
+
+			if (c == '{')
+			{
+				if (!TryReadBraced(body, ref j, mods, chords))
+					return false;
+				continue;
+			}
+
+			if (c == '}')
+				return false;
+
+			if (c == '~')
+			{
+				Add(chords, mods, "Enter");
+				j++;
+				continue;
+			}
+
+			Add(chords, mods, c.ToString(), literal: true);
+			j++;
+		}
+
+		return true;
+	}
+
+	/// <summary>
+	/// One braced piece: a named key such as <c>{F5}</c>, optionally with the repeat count
+	/// SendKeys allows (<c>{LEFT 5}</c>), or one of the reserved characters escaped into
+	/// braces so it can be typed literally.
+	/// </summary>
+	private static bool TryReadBraced(string s, ref int i, (bool Ctrl, bool Shift, bool Alt) mods, List<Hotkey> chords)
+	{
+		// "{}}" is the closing brace as a literal, and its first '}' is content rather than
+		// the closer. Spotted before the search below, which would otherwise stop on it and
+		// read an empty pair.
+		if (i + 2 < s.Length && s[i + 1] == '}' && s[i + 2] == '}')
+		{
+			Add(chords, mods, "}", literal: true);
+			i += 3;
+			return true;
+		}
+
+		int close = s.IndexOf('}', i + 1);
+		if (close < 0)
+			return false;
+
+		string body = s[(i + 1)..close].Trim();
+		i = close + 1;
+
+		if (body.Length == 0)
+			return false;
+
+		// A repeat count presses the same key again, which adds nothing to a comparison
+		// against other shortcuts, so only the key itself is kept.
+		int space = body.IndexOf(' ');
+		if (space > 0)
+			body = body[..space];
+
+		if (body.Length == 1)
+		{
+			// A single character in braces is an escaped literal — the key it types is the
+			// character, not a named key.
+			Add(chords, mods, body, literal: true);
+			return true;
+		}
+
+		if (KeyNames.TryGetValue(body, out string? named))
+		{
+			Add(chords, mods, named);
+			return true;
+		}
+
+		if (IsFunctionKey(body))
+		{
+			Add(chords, mods, body);
+			return true;
+		}
+
+		// A name we do not know. The piece yields nothing; the rest of the string still
+		// reads, the same way the finder skips one half-typed row without discarding the
+		// others.
+		return true;
+	}
+
+	private static bool IsFunctionKey(string body)
+	{
+		if (body.Length is < 2 or > 3) return false;
+		if (body[0] is not ('F' or 'f')) return false;
+		if (!int.TryParse(body.AsSpan(1), out int n)) return false;
+		return n is >= 1 and <= 24;
+	}
+
+	/// <summary>
+	/// Adds the chord for one keypress, or nothing when there is no chord in it.
+	/// <para>
+	/// An unmodified literal character is text being typed rather than a shortcut — a "send
+	/// key after" value of <c>hello</c> types a word, and reading five one-key shortcuts out
+	/// of it would flag rows that clash with nothing. With a modifier held it is a shortcut
+	/// again, so <c>^v</c> counts and the <c>v</c> in <c>hello</c> does not.
+	/// </para>
+	/// </summary>
+	private static void Add(List<Hotkey> chords, (bool Ctrl, bool Shift, bool Alt) mods, string keyToken, bool literal = false)
+	{
+		bool anyModifier = mods.Ctrl || mods.Shift || mods.Alt;
+		if (literal && !anyModifier)
+			return;
+
+		string text = string.Concat(
+			mods.Ctrl ? "CTRL+" : "",
+			mods.Shift ? "SHIFT+" : "",
+			mods.Alt ? "ALT+" : "",
+			keyToken);
+
+		// Parsed rather than assembled by hand so the key names agree with everywhere else
+		// in the app, and so a key this reader has no business naming simply drops out.
+		if (Hotkey.TryParse(text, out Hotkey? chord))
+			chords.Add(chord);
+	}
+
+	private static IReadOnlyList<Hotkey> NothingAtAll(List<Hotkey> chords)
+	{
+		chords.Clear();
+		return chords;
+	}
+}

--- a/Mutation.Ui/Services/SendKeysReader.cs
+++ b/Mutation.Ui/Services/SendKeysReader.cs
@@ -90,6 +90,16 @@ public static class SendKeysReader
 			return chords;
 
 		string s = sendKeys.Trim();
+
+		// Only text that is actually shorthand gets read as shorthand, and the question is
+		// put to the same judge the mapper uses so the two cannot drift apart. Without this,
+		// half-typed chord text is read as something it is not: "Ctrl+Alt" on the way to
+		// "Ctrl+Alt+G" has a '+' in it, and SendKeys' '+' is Shift, so the row would report
+		// Shift+A and collide with any row genuinely holding Shift+A. A duplicate badge on a
+		// shortcut that is fine is the one outcome worse than the silence this replaces.
+		if (!SendKeysMapper.LooksLikeSendKeys(s))
+			return chords;
+
 		int i = 0;
 
 		while (i < s.Length)

--- a/Mutation.Ui/Services/SendKeysReader.cs
+++ b/Mutation.Ui/Services/SendKeysReader.cs
@@ -1,6 +1,7 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace Mutation.Ui.Services;
 
@@ -18,10 +19,17 @@ namespace Mutation.Ui.Services;
 /// <para>
 /// Everything here errs towards reading nothing. A missed clash leaves the user where they
 /// already were; a wrong one puts a "Duplicate hotkey" badge on a shortcut that is perfectly
-/// fine, which is a worse place to be. So a run of ordinary characters — text being typed,
-/// not a shortcut — yields nothing, an unrecognised key name yields nothing, and a string
-/// that does not hold together at all yields nothing whatsoever rather than a partial
-/// reading of a value nobody can be sure of.
+/// fine, which is a worse place to be.
+/// </para>
+/// <para>
+/// It gives up at two different sizes, on purpose. A piece it cannot place — an unrecognised
+/// key name, a key the chord parser has no spelling for, a run of ordinary characters that is
+/// text being typed rather than a shortcut — drops out on its own and the rest of the value
+/// still reads. A value that does not hold together <em>structurally</em> — a modifier with
+/// no key after it, an unclosed brace or group, a nested group — yields nothing whatsoever,
+/// including whatever had already been read from earlier in it. Past a break like that the
+/// tokenizer no longer knows what it is looking at, and a partial reading of a value nobody
+/// can be sure of is how an innocent row gets flagged.
 /// </para>
 /// </summary>
 public static class SendKeysReader
@@ -278,7 +286,14 @@ public static class SendKeysReader
 	{
 		if (body.Length is < 2 or > 3) return false;
 		if (body[0] is not ('F' or 'f')) return false;
-		if (!int.TryParse(body.AsSpan(1), out int n)) return false;
+
+		// NumberStyles.None, matching SendKeysMapper. The default allows a leading sign, so
+		// "{F+5}" would pass as F5 and then be handed to Hotkey.Parse, which splits it on the
+		// '+' and comes back with the digit key 5 — a chord nobody wrote, on a row that would
+		// then be flagged against anything registered as plain 5.
+		if (!int.TryParse(body.AsSpan(1), NumberStyles.None, CultureInfo.InvariantCulture, out int n))
+			return false;
+
 		return n is >= 1 and <= 24;
 	}
 

--- a/Mutation.Ui/Views/Settings/Controls/HotkeyEditor.xaml
+++ b/Mutation.Ui/Views/Settings/Controls/HotkeyEditor.xaml
@@ -35,6 +35,7 @@
 					 PlaceholderText="e.g. CTRL+ALT+J"
 					 KeyDown="HotkeyTextBox_KeyDown"
 					 TextChanged="HotkeyTextBox_TextChanged"
+					 GotFocus="HotkeyTextBox_GotFocus"
 					 LostFocus="HotkeyTextBox_LostFocus"
 					 IsSpellCheckEnabled="False"
 					 IsTextPredictionEnabled="False" />
@@ -72,9 +73,12 @@
 		<!-- Its own region, and a polite one. Sharing the validation block would put a
 		     rewrite notice in critical red and let it overwrite an error the user still
 		     needs; polite means it waits its turn rather than cutting across the next
-		     field the user has already tabbed into (issue #327). -->
+		     field the user has already tabbed into (issue #327). Full-contrast text
+		     rather than the secondary brush a caption would normally take: this app's
+		     reader is low-vision, and a message worth showing at all is worth being able
+		     to read. -->
 		<TextBlock x:Name="CommitAnnouncement"
-				   Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+				   Foreground="{ThemeResource TextFillColorPrimaryBrush}"
 				   Visibility="Collapsed"
 				   AutomationProperties.LiveSetting="Polite"
 				   Style="{StaticResource CaptionTextBlockStyle}"

--- a/Mutation.Ui/Views/Settings/Controls/HotkeyEditor.xaml
+++ b/Mutation.Ui/Views/Settings/Controls/HotkeyEditor.xaml
@@ -69,5 +69,15 @@
 				   AutomationProperties.LiveSetting="Assertive"
 				   Style="{StaticResource CaptionTextBlockStyle}"
 				   TextWrapping="Wrap" />
+		<!-- Its own region, and a polite one. Sharing the validation block would put a
+		     rewrite notice in critical red and let it overwrite an error the user still
+		     needs; polite means it waits its turn rather than cutting across the next
+		     field the user has already tabbed into (issue #327). -->
+		<TextBlock x:Name="CommitAnnouncement"
+				   Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+				   Visibility="Collapsed"
+				   AutomationProperties.LiveSetting="Polite"
+				   Style="{StaticResource CaptionTextBlockStyle}"
+				   TextWrapping="Wrap" />
 	</StackPanel>
 </UserControl>

--- a/Mutation.Ui/Views/Settings/Controls/HotkeyEditor.xaml.cs
+++ b/Mutation.Ui/Views/Settings/Controls/HotkeyEditor.xaml.cs
@@ -130,6 +130,17 @@ public sealed partial class HotkeyEditor : UserControl
 		Commit();
 	}
 
+	/// <summary>
+	/// Takes down the last commit's notice on the way back in. It described something that
+	/// happened when the user left, and left standing it becomes a line of ordinary-looking
+	/// text under the row — read out as current content by anyone going down the page
+	/// afterwards, and one more thing between them and the next control. Clearing it also
+	/// means the same rewrite happening twice is announced twice, rather than the second one
+	/// being swallowed as an unchanged message.
+	/// </summary>
+	private void HotkeyTextBox_GotFocus(object sender, RoutedEventArgs e) =>
+		LiveMessage.Show(CommitAnnouncement, null);
+
 	private void HotkeyTextBox_KeyDown(object sender, KeyRoutedEventArgs e)
 	{
 		if (!_isRecording)
@@ -225,7 +236,8 @@ public sealed partial class HotkeyEditor : UserControl
 			? typed.Trim()
 			: Mutation.Ui.Services.Hotkey.Canonicalize(typed);
 
-		if (!string.Equals(committed, typed, StringComparison.Ordinal))
+		bool rewritten = !string.Equals(committed, typed, StringComparison.Ordinal);
+		if (rewritten)
 		{
 			_suppressTextChanged = true;
 			try { HotkeyTextBox.Text = committed; }
@@ -234,19 +246,29 @@ public sealed partial class HotkeyEditor : UserControl
 
 		// Suppressing TextChanged also suppressed everything downstream of it, so the box
 		// could rewrite its own contents in complete silence and leave the validation message
-		// describing text that is no longer there (issue #327). Both live regions are brought
-		// up to date against what the box now holds; each one stays quiet when its message has
-		// not changed, so a row that was already canonical says nothing.
+		// describing text that is no longer there (issue #327).
 		string? validation = ValidationMessageFor(committed);
-		LiveMessage.Show(ValidationText, validation);
-		LiveMessage.Show(
-			CommitAnnouncement,
-			HotkeyCommitAnnouncement.For(Header, typed, committed, validation));
+
+		// Only a rewrite can have left that message stale, and only a rewrite refreshes it.
+		// Doing it on every commit would newly complain at a required row that is empty and
+		// untouched — of which there are plenty — every single time the user tabbed past it.
+		if (rewritten)
+			LiveMessage.Show(ValidationText, validation);
 
 		if (!string.Equals(Hotkey, committed, StringComparison.Ordinal))
 			Hotkey = committed;
 
 		HotkeyCommitted?.Invoke(this, committed);
+
+		// Last, and deliberately so. The Hotkeys page recomputes duplicates off this event
+		// and puts "Duplicate hotkey" into an assertive live region of its own. Announced
+		// before that, a polite notice is cut off mid-sentence by the assertive one that
+		// follows it onto the same dispatcher pass — and the clash is precisely the case
+		// where both have something to say. Announced after, the urgent news goes first and
+		// this waits its turn.
+		LiveMessage.Show(
+			CommitAnnouncement,
+			HotkeyCommitAnnouncement.For(Header, typed, committed, validation));
 	}
 
 	private static VirtualKeyModifiers GetCurrentModifiers()

--- a/Mutation.Ui/Views/Settings/Controls/HotkeyEditor.xaml.cs
+++ b/Mutation.Ui/Views/Settings/Controls/HotkeyEditor.xaml.cs
@@ -2,6 +2,7 @@
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
+using Mutation.Ui.Core;
 using Mutation.Ui.Services;
 using Windows.System;
 
@@ -202,32 +203,45 @@ public sealed partial class HotkeyEditor : UserControl
 	/// #243).
 	/// </para>
 	/// </summary>
-	private void Validate(string text)
+	private void Validate(string text) => LiveMessage.Show(ValidationText, ValidationMessageFor(text));
+
+	/// <summary>What is wrong with <paramref name="text"/>, or null when nothing is.</summary>
+	private string? ValidationMessageFor(string? text)
 	{
 		string trimmed = text?.Trim() ?? string.Empty;
 		if (string.IsNullOrEmpty(trimmed))
-		{
-			LiveMessage.Show(ValidationText, AllowEmpty ? null : "Enter a hotkey.");
-			return;
-		}
+			return AllowEmpty ? null : "Enter a hotkey.";
 
-		LiveMessage.Show(ValidationText, HotkeyValidator.Validate(trimmed, AllowSendKeysSyntax));
+		return HotkeyValidator.Validate(trimmed, AllowSendKeysSyntax);
 	}
 
 	private void Commit()
 	{
+		string typed = HotkeyTextBox.Text ?? string.Empty;
+
 		// SendKeys syntax is not a chord, so it is kept exactly as typed. Anything else goes
 		// through the one canonical spelling the app uses everywhere (issue #323).
 		string committed = AllowSendKeysSyntax
-			? (HotkeyTextBox.Text ?? string.Empty).Trim()
-			: Mutation.Ui.Services.Hotkey.Canonicalize(HotkeyTextBox.Text);
+			? typed.Trim()
+			: Mutation.Ui.Services.Hotkey.Canonicalize(typed);
 
-		if (!string.Equals(committed, HotkeyTextBox.Text, StringComparison.Ordinal))
+		if (!string.Equals(committed, typed, StringComparison.Ordinal))
 		{
 			_suppressTextChanged = true;
 			try { HotkeyTextBox.Text = committed; }
 			finally { _suppressTextChanged = false; }
 		}
+
+		// Suppressing TextChanged also suppressed everything downstream of it, so the box
+		// could rewrite its own contents in complete silence and leave the validation message
+		// describing text that is no longer there (issue #327). Both live regions are brought
+		// up to date against what the box now holds; each one stays quiet when its message has
+		// not changed, so a row that was already canonical says nothing.
+		string? validation = ValidationMessageFor(committed);
+		LiveMessage.Show(ValidationText, validation);
+		LiveMessage.Show(
+			CommitAnnouncement,
+			HotkeyCommitAnnouncement.For(Header, typed, committed, validation));
 
 		if (!string.Equals(Hotkey, committed, StringComparison.Ordinal))
 			Hotkey = committed;


### PR DESCRIPTION
Three small stories from the Todo column, taken together because each is a
contained decision with tests beside it.

Closes #315
Closes #326
Closes #327

## #315 — the one retrying service that did not stretch its deadline

`OcrService.ReadInternal` armed every attempt with the same flat value while
the other four services multiply theirs by the attempt number. #311 assumed
they all did; `EveryAttemptGetsTheSamePerRequestDeadline` pinned the truth and
pointed here.

**Settled in favour of stretching.** A first read after a reboot pays for DNS,
TLS and JIT warmup at once, and three more attempts of exactly the same length
are no likelier to fit than the first was — the reason the other four stretch
is the reason this one should.

The 60-second ceiling stays, and now means something it did not before: a cap
on **each** attempt rather than on the first. With the default 30 seconds the
ladder is 30, 60, 60, 60, so an OCR batch's worst case is three and a half
minutes instead of the five an uncapped 30/60/90/120 would cost. The reasoning
sits next to the timeout, and the old test is replaced by one asserting the
ladder plus one showing a short timeout stretching all the way up.

## #326 — a shorthand "send key after" value now joins duplicate detection

`^{F5}` against a Mutation shortcut of **Ctrl+F5** raised no badge; writing the
same thing as `Ctrl+F5` was flagged correctly. Windows routes the synthesized
keystroke straight back to Mutation, so this is precisely the clash the
sent-against-registered check exists to catch.

New `Mutation.Ui/Services/SendKeysReader.cs` is the inverse `SendKeysMapper`
never had: modifier prefixes, braced key names with repeat counts, the group
form `^+(ab)`, `~` for Enter, and the escaped literals `{+}` `{^}` `{%}` `{~}`
`{(}` `{)}` `{{}` `{}}`. `HotkeyConflictFinder.ChordsIn` reads a sent step as a
chord first and as shorthand only if that fails, which is the order the
ambiguity needs — the `+` in `Ctrl+F5` separates a chord, the one in `+{F5}` is
SendKeys' Shift.

It errs towards reading nothing throughout, because a wrong badge on a fine row
is worse than the silence it replaces:

- a run of ordinary characters is text being typed, not shortcuts (`hello`
  yields nothing; `hi^v` yields only Ctrl+V);
- an unrecognised key name drops out and the rest still reads;
- a string that does not hold together — a dangling modifier, an unclosed
  brace or group, a nested group — yields nothing at all rather than a partial
  reading.

## #327 — the hotkey box rewrote itself in silence

`Commit` canonicalises the box under `_suppressTextChanged`, so `TextChanged`
never fired, `Validate` never ran, and nothing was announced. A sighted user
watched `shift+ctrl+a` become `CTRL+SHIFT+A`; a screen-reader user heard
nothing and found the field disagreeing with what they had typed.

`Commit` now brings both live regions up to date against what the box actually
holds. The rewrite notice gets its own **polite** region rather than sharing the
assertive, critical-red validation block — sharing it would put a routine notice
in error styling and let it overwrite an error the user still needs.

- A commit that changed the text says so, naming the row: "Speak clipboard now
  reads CTRL+SHIFT+A." The label matters because focus has moved on by the time
  a polite announcement lands, and seventeen rows sound identical without it.
- A row that was already canonical stays silent, which is the common case while
  tabbing down the page.
- A validation error wins; the rewrite says nothing.
- Clearing a box is not announced as a rewrite — the Clear button did what it
  was asked, and the empty-field message already covers it.

The decision is `Mutation.Ui/Core/HotkeyCommitAnnouncement`, a pure
text-in/text-out unit, because the defect was an announcement that never
happened and a running app does not complain about those.

## Not in this PR

**#316** was picked up alongside these and put back. Requiring 429 and 503 to be
retried while 401 and 400 are not cannot be met from what Deepgram 6.9.0 hands
us, and the reasons are worth recording — see the comment on the issue.

## Docs

`keyboard-shortcuts.md` gains the announcement, and loses the line stating that
a shorthand value is not checked against your other shortcuts. HTML rebuilt and
committed alongside.

## Testing

`dotnet test --configuration Release` — 1849 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
