### PR TITLE
Stop counting an outage twice, say the region size in one unit, and take one spelling of a key

### DIFF
--- a/CognitiveSupport/LlmService.cs
+++ b/CognitiveSupport/LlmService.cs
@@ -16,11 +16,6 @@ public class LlmService : ILlmService
 	/// <param name="transport">
 	/// Test seam only; null in production. See <see cref="OpenAiClientOptionsFactory.Create"/>.
 	/// </param>
-	/// <param name="sdkRetryCount">
-	/// Test seam only; null in production. Turns the OpenAI SDK's own retries down (0 off)
-	/// so the retries a test counts are the ones this class runs, not the SDK's underneath
-	/// them. See <see cref="OpenAiClientOptionsFactory.Create"/>.
-	/// </param>
 	/// <param name="timeProvider">
 	/// Test seam only; null in production. Drives both the retry backoff and each
 	/// attempt's deadline, so a test can read back the waits that were armed instead of
@@ -32,7 +27,6 @@ public class LlmService : ILlmService
 		int timeoutSeconds = 60,
 		int retryCount = 3,
 		PipelineTransport? transport = null,
-		int? sdkRetryCount = null,
 		TimeProvider? timeProvider = null)
 	{
 		if (string.IsNullOrEmpty(apiKey)) throw new ArgumentNullException(nameof(apiKey));
@@ -55,12 +49,13 @@ public class LlmService : ILlmService
 
 		foreach (var model in modelList)
 		{
-			// Options disable the SDK's 100 s default network timeout so the
-			// escalating per-attempt timeouts below are the real authority.
+			// Options disable the SDK's 100 s default network timeout so the escalating
+			// per-attempt timeouts below are the real authority, and its own retry loop so
+			// the pipeline above is the only one counting (issue #318).
 			_chatClients[model.Name] = new ChatClient(
 				model.Name,
 				new ApiKeyCredential(apiKey),
-				OpenAiClientOptionsFactory.Create(transport: transport, maxRetries: sdkRetryCount));
+				OpenAiClientOptionsFactory.Create(transport: transport));
 			_modelConfigs[model.Name] = model;
 		}
 	}
@@ -143,7 +138,7 @@ public class LlmService : ILlmService
 			// Only a rejected tier is handled here. Unlike Anthropic, OpenAI Fast mode has
 			// no capacity pool or rate limit of its own, so a 429 is the account's ordinary
 			// limit — dropping the tier would not get the user served any sooner, and the
-			// SDK's own retry policy already had a go at it.
+			// retry ladder around this send already had a go at it.
 			var reason = FastModeFailure.Classify(ex.Status, ex.Message);
 			if (reason is null)
 				throw; // Nothing to do with the service tier; report it as-is.

--- a/CognitiveSupport/OpenAiClientOptionsFactory.cs
+++ b/CognitiveSupport/OpenAiClientOptionsFactory.cs
@@ -20,8 +20,15 @@ namespace CognitiveSupport;
 /// <para>
 /// The one thing the SDK's loop did better was honour the <c>Retry-After</c> header a 429
 /// arrives with. That moved to <see cref="RetryAfterHint"/>, which
-/// <see cref="TransientRetry"/> consults on every retry — so it now benefits the Deepgram,
-/// Anthropic and OCR paths too, not just the two OpenAI-SDK ones.
+/// <see cref="TransientRetry"/> consults on every retry, so nothing was lost here.
+/// </para>
+/// <para>
+/// It reaches only the two OpenAI-SDK services, because a <c>Retry-After</c> can only be
+/// read off an exception that carries the response — <c>ClientResultException</c>. The
+/// Anthropic, Deepgram and OCR ladders throw exceptions that do not
+/// (<c>HttpRequestException</c>, Deepgram's own, Azure's <c>RequestFailedException</c>), so
+/// they keep the plain linear backoff they have always had. Widening it is a change to each
+/// of those services, not to this one.
 /// </para>
 /// </summary>
 public static class OpenAiClientOptionsFactory

--- a/CognitiveSupport/OpenAiClientOptionsFactory.cs
+++ b/CognitiveSupport/OpenAiClientOptionsFactory.cs
@@ -9,6 +9,20 @@ namespace CognitiveSupport;
 /// caps the configurable escalating per-attempt timeouts (e.g. 300 s file
 /// transcription). The transport timeout is disabled here; per-attempt
 /// CancellationTokenSources remain the sole timeout authority.
+/// <para>
+/// <b>The SDK's own retry loop is off, and this is why (issue #318).</b> It retried three
+/// times on 408, 429 and 5xx, inside the four attempts <see cref="TransientRetry"/> already
+/// runs — so one outage cost up to sixteen requests rather than four, and a rate-limited
+/// account was answered by asking sixteen more times. Two nested loops also make the
+/// escalating per-attempt deadline meaningless, because the SDK's retries all happen inside
+/// one of our attempts, sharing its deadline.
+/// </para>
+/// <para>
+/// The one thing the SDK's loop did better was honour the <c>Retry-After</c> header a 429
+/// arrives with. That moved to <see cref="RetryAfterHint"/>, which
+/// <see cref="TransientRetry"/> consults on every retry — so it now benefits the Deepgram,
+/// Anthropic and OCR paths too, not just the two OpenAI-SDK ones.
+/// </para>
 /// </summary>
 public static class OpenAiClientOptionsFactory
 {
@@ -19,27 +33,24 @@ public static class OpenAiClientOptionsFactory
 	/// </param>
 	/// <param name="maxRetries">
 	/// Caps the SDK's <em>own</em> retry policy, which is a separate loop from the one in
-	/// <see cref="TransientRetry"/>. Left null in production, where the SDK's default
-	/// three retries are wanted. A test that counts requests passes 0: otherwise a single
-	/// transient reply is retried by the SDK before the caller-level pipeline ever sees
-	/// it, and the request count measures two nested retry loops at once rather than the
-	/// one under test (issue #311).
+	/// <see cref="TransientRetry"/>. It defaults to none, in production as in tests, for the
+	/// reasons above. A caller that wants the SDK's loop back has to say so and had better
+	/// say why next to it, because the count it adds multiplies rather than adds.
 	/// </param>
 	public static OpenAIClientOptions Create(
 		Uri? endpoint = null,
 		PipelineTransport? transport = null,
-		int? maxRetries = null)
+		int maxRetries = 0)
 	{
 		var options = new OpenAIClientOptions
 		{
-			NetworkTimeout = Timeout.InfiniteTimeSpan
+			NetworkTimeout = Timeout.InfiniteTimeSpan,
+			RetryPolicy = new ClientRetryPolicy(maxRetries)
 		};
 		if (endpoint is not null)
 			options.Endpoint = endpoint;
 		if (transport is not null)
 			options.Transport = transport;
-		if (maxRetries is not null)
-			options.RetryPolicy = new ClientRetryPolicy(maxRetries.Value);
 		return options;
 	}
 }

--- a/CognitiveSupport/RetryAfterHint.cs
+++ b/CognitiveSupport/RetryAfterHint.cs
@@ -46,6 +46,14 @@ internal static class RetryAfterHint
 	/// <summary>
 	/// RFC 9110 allows either a count of seconds or an HTTP date; OpenAI sends seconds, but
 	/// a proxy in front of it need not. Anything else is ignored rather than guessed at.
+	/// <para>
+	/// Only a wait longer than nothing is answered with. Zero, a negative count, and a date
+	/// that has already passed all mean "no wait", and the caller reads null as "no opinion"
+	/// and keeps its own backoff — which is the whole point, because Polly treats a returned
+	/// <see cref="TimeSpan.Zero"/> as a real delay of no time at all. Honouring it would run
+	/// the entire ladder back-to-back in a few milliseconds, on the say-so of a header the
+	/// server controls: the exact hammering this change was made to stop.
+	/// </para>
 	/// </summary>
 	internal static TimeSpan? Parse(string? headerValue, DateTimeOffset now)
 	{
@@ -59,9 +67,16 @@ internal static class RetryAfterHint
 		// way round, so the numeric reading has to win to be reachable at all.
 		if (double.TryParse(text, NumberStyles.Float, CultureInfo.InvariantCulture, out double seconds))
 		{
-			if (double.IsNaN(seconds) || double.IsInfinity(seconds))
+			// "NaN" and "Infinity" are words double.TryParse accepts, and a number too big
+			// for a double overflows to infinity rather than failing to parse. None of them
+			// is a wait; they are unreadable, like "soon".
+			if (!double.IsFinite(seconds) || seconds <= 0d)
 				return null;
-			wait = TimeSpan.FromSeconds(Math.Clamp(seconds, 0d, Cap.TotalSeconds));
+			// Compared before converting: TimeSpan.FromSeconds overflows on a large enough
+			// finite number, and a header is free to carry one.
+			if (seconds >= Cap.TotalSeconds)
+				return Cap;
+			wait = TimeSpan.FromSeconds(seconds);
 		}
 		else if (DateTimeOffset.TryParse(
 			text,
@@ -76,9 +91,8 @@ internal static class RetryAfterHint
 			return null;
 		}
 
-		// A date already in the past means "you may go now", not "go back in time".
-		if (wait < TimeSpan.Zero)
-			return TimeSpan.Zero;
+		if (wait <= TimeSpan.Zero)
+			return null;
 
 		return wait > Cap ? Cap : wait;
 	}

--- a/CognitiveSupport/RetryAfterHint.cs
+++ b/CognitiveSupport/RetryAfterHint.cs
@@ -1,0 +1,85 @@
+using System.ClientModel;
+using System.Globalization;
+
+namespace CognitiveSupport;
+
+/// <summary>
+/// The wait a service asked for when it turned a request away, read off the
+/// <c>Retry-After</c> header it answered with.
+/// <para>
+/// This exists because <see cref="OpenAiClientOptionsFactory"/> turned the OpenAI SDK's own
+/// retry loop off (issue #318). That loop was the only part of the stack that listened to a
+/// rate limit, so the listening had to move here — otherwise answering a 429 would mean
+/// asking again on a flat 500 ms backoff, which is the wrong reply to being told to slow
+/// down.
+/// </para>
+/// </summary>
+internal static class RetryAfterHint
+{
+	/// <summary>
+	/// Longest wait honoured. A service asking for minutes is asking for more than a user
+	/// standing over a finished recording can give it; the ladder has a bounded number of
+	/// attempts either way, so the choice is between waiting this long and reporting the
+	/// failure, not between waiting this long and waiting the whole hour.
+	/// </summary>
+	internal static readonly TimeSpan Cap = TimeSpan.FromSeconds(60);
+
+	/// <summary>
+	/// The wait <paramref name="exception"/> asked for, or null when it asked for none —
+	/// which is every failure that is not an answered HTTP error, and most of those too.
+	/// Null leaves the caller's own backoff in charge.
+	/// </summary>
+	internal static TimeSpan? From(Exception? exception, DateTimeOffset now) =>
+		exception is ClientResultException answered
+			? Parse(HeaderOf(answered), now)
+			: null;
+
+	private static string? HeaderOf(ClientResultException answered)
+	{
+		var response = answered.GetRawResponse();
+		if (response is null)
+			return null;
+
+		return response.Headers.TryGetValue("Retry-After", out string? value) ? value : null;
+	}
+
+	/// <summary>
+	/// RFC 9110 allows either a count of seconds or an HTTP date; OpenAI sends seconds, but
+	/// a proxy in front of it need not. Anything else is ignored rather than guessed at.
+	/// </summary>
+	internal static TimeSpan? Parse(string? headerValue, DateTimeOffset now)
+	{
+		if (string.IsNullOrWhiteSpace(headerValue))
+			return null;
+
+		string text = headerValue.Trim();
+		TimeSpan wait;
+
+		// Seconds first: "120" parses as a date in some cultures' formats, never the other
+		// way round, so the numeric reading has to win to be reachable at all.
+		if (double.TryParse(text, NumberStyles.Float, CultureInfo.InvariantCulture, out double seconds))
+		{
+			if (double.IsNaN(seconds) || double.IsInfinity(seconds))
+				return null;
+			wait = TimeSpan.FromSeconds(Math.Clamp(seconds, 0d, Cap.TotalSeconds));
+		}
+		else if (DateTimeOffset.TryParse(
+			text,
+			CultureInfo.InvariantCulture,
+			DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal,
+			out var when))
+		{
+			wait = when - now;
+		}
+		else
+		{
+			return null;
+		}
+
+		// A date already in the past means "you may go now", not "go back in time".
+		if (wait < TimeSpan.Zero)
+			return TimeSpan.Zero;
+
+		return wait > Cap ? Cap : wait;
+	}
+}

--- a/CognitiveSupport/TransientRetry.cs
+++ b/CognitiveSupport/TransientRetry.cs
@@ -83,6 +83,10 @@ internal static class TransientRetry
 				// everything else returns null here and falls back to the linear backoff
 				// above. This is the only part of the stack that listens to a rate limit
 				// now that the OpenAI SDK's own retry loop is off (issue #318).
+				//
+				// Null is the fallback signal and TimeSpan.Zero is not — Polly reads zero as
+				// a real delay of no time — so RetryAfterHint answers null for every wait
+				// that is not longer than nothing.
 				DelayGenerator = args => ValueTask.FromResult(
 					RetryAfterHint.From(args.Outcome.Exception, clock.GetUtcNow())),
 				OnRetry = args =>

--- a/CognitiveSupport/TransientRetry.cs
+++ b/CognitiveSupport/TransientRetry.cs
@@ -6,9 +6,10 @@ namespace CognitiveSupport;
 
 /// <summary>
 /// The retry shape every remote-service call in this assembly shares: a linear 500 ms
-/// backoff, and the number of the attempt in flight, which the bodies use to stretch
-/// their per-attempt timeout and — in the three services that make a sound — to beep
-/// once more with each retry so the listener can hear how deep in it is.
+/// backoff — or the wait the service itself asked for, when it sent one — and the number of
+/// the attempt in flight, which the bodies use to stretch their per-attempt timeout and — in
+/// the three services that make a sound — to beep once more with each retry so the listener
+/// can hear how deep in it is.
 /// </summary>
 /// <remarks>
 /// The attempt number reaches the body as an argument, and lives for the rest of its
@@ -68,9 +69,8 @@ internal static class TransientRetry
 		if (retryCount <= 0)
 			return ResiliencePipeline.Empty;
 
-		var builder = new ResiliencePipelineBuilder();
-		if (timeProvider is not null)
-			builder.TimeProvider = timeProvider;
+		var clock = timeProvider ?? TimeProvider.System;
+		var builder = new ResiliencePipelineBuilder { TimeProvider = clock };
 
 		return builder
 			.AddRetry(new RetryStrategyOptions
@@ -79,6 +79,12 @@ internal static class TransientRetry
 				MaxRetryAttempts = retryCount,
 				BackoffType = DelayBackoffType.Linear,
 				Delay = FirstDelay,
+				// A service that answered with a Retry-After gets the wait it asked for;
+				// everything else returns null here and falls back to the linear backoff
+				// above. This is the only part of the stack that listens to a rate limit
+				// now that the OpenAI SDK's own retry loop is off (issue #318).
+				DelayGenerator = args => ValueTask.FromResult(
+					RetryAfterHint.From(args.Outcome.Exception, clock.GetUtcNow())),
 				OnRetry = args =>
 				{
 					// AttemptNumber counts the attempt that just failed, from zero, so the

--- a/Documentation/UserGuide/html/accessibility.html
+++ b/Documentation/UserGuide/html/accessibility.html
@@ -215,10 +215,12 @@ be finished in two keystrokes. <strong>Backspace</strong> clears the corner you 
 cancels.</p>
 <p>As you move, it reads your position out. Before you set a corner you hear the caret
 position. After you set one you hear the size of the region and where its top-left
-corner sits, so you always know where on the screen you are. Hold <strong>Ctrl</strong> for
-one-pixel steps or <strong>Shift</strong> for big hundred-pixel jumps. When the capture finishes it
-tells you the size of what it grabbed, in pixels. If you press Enter twice without
-moving, it tells you the region is empty rather than silently doing nothing.</p>
+corner sits, so you always know where on the screen you are. Hold <strong>Ctrl</strong> for the
+smallest step or <strong>Shift</strong> for big jumps. When the capture finishes it tells you the
+size of what it grabbed, in pixels. If you press Enter twice without moving, it tells
+you the region is empty rather than silently doing nothing.</p>
+<p>Every number you hear is in pixels of the picture being captured, so the size you hear
+while sizing the rectangle is the size you hear when it is captured.</p>
 <h2 id="reading-aloud-is-a-first-class-feature">Reading aloud is a first-class feature</h2>
 <p>Mutation can read the clipboard out loud, with its own voice, rate and volume, and its
 own pause, skip and rewind controls. It can announce roughly how long a piece of text

--- a/Documentation/UserGuide/html/keyboard-shortcuts.html
+++ b/Documentation/UserGuide/html/keyboard-shortcuts.html
@@ -386,6 +386,11 @@ when something actually changed, so tabbing down a page of shortcuts that are
 already written Mutation's way stays quiet. The note goes away when you come back
 to that box. The <strong>From</strong> and <strong>To</strong> boxes in the shortcut router further down the
 page still tidy up in silence.</p>
+<p>Short names for keys are fine. Write <strong>Alt+PgDn</strong> or <strong>Alt+PageDown</strong>, <strong>Ctrl+Esc</strong>
+or <strong>Ctrl+Escape</strong>, <strong>Bksp</strong> or <strong>Backspace</strong>, <strong>ArrowUp</strong> or <strong>Up</strong> — Mutation
+takes either, in any box on the page, and saves the full name. The one word to
+avoid is <strong>Menu</strong>, which means the Alt key in a shortcut but the context-menu key
+in a &quot;send key after&quot; box.</p>
 <p>Two boxes are the exception: <strong>Send key after OCR (optional)</strong> and <strong>Send key
 after transcription (optional)</strong>. They keep whatever you type, exactly as you
 typed it, because what goes in them is not always a plain combination. There is

--- a/Documentation/UserGuide/html/screen-capture-and-ocr.html
+++ b/Documentation/UserGuide/html/screen-capture-and-ocr.html
@@ -170,7 +170,8 @@ opposite corner, and let go. That is it. A right-click cancels instead.</p>
 <p>You never need to see the screen to do this. The overlay talks you through it. When it
 opens it says what it wants from you, then as you move it announces the position you
 are at, the size of the rectangle you have built so far, and finally the size of what
-was captured.</p>
+was captured. Those numbers are all in pixels of the picture, so the size you hear
+while sizing the rectangle matches the size you hear when it is captured.</p>
 <p>Think of it as a moving pointer that you park at one corner, pin down, and then drag to
 the other corner.</p>
 <div class="table-wrap"><table>

--- a/Documentation/UserGuide/html/troubleshooting.html
+++ b/Documentation/UserGuide/html/troubleshooting.html
@@ -196,6 +196,9 @@ than short ones.</p>
 before — two beeps, then three, then four. A burst of end beeps part way through a
 dictation means Mutation is still working, and how many you hear tells you how far into
 its retries it has got.</p>
+<p>If the service is busy and asks Mutation to wait a moment before asking again, Mutation
+waits as long as it was asked to, up to a minute. So a gap between beeps that is longer
+than usual is the service setting the pace, not something going wrong.</p>
 <p><strong>What to do.</strong></p>
 <ol>
 <li>Give it a moment — the retries are automatic and you will hear the result.</li>
@@ -232,6 +235,9 @@ that has gone down keeps Mutation waiting about <strong>ten minutes</strong> bef
 and up to twenty if the prompt asked for Fast mode and the service turns it away for being
 busy, because Mutation then tries the whole thing again at normal speed. Nothing is broken;
 it is still trying.</p>
+<p>If the AI service asks Mutation to wait a moment before asking again — which is what a
+busy service usually does — Mutation waits as long as it was asked to, up to a minute,
+rather than asking straight back.</p>
 <p>A prompt you started yourself puts &quot;Processing...&quot; in the <strong>Formatted Transcript</strong> box. The
 AI step after a dictation says &quot;Processing with LLM...&quot; in the <strong>Raw Transcript</strong> box
 instead.</p>

--- a/Documentation/UserGuide/markdown/accessibility.md
+++ b/Documentation/UserGuide/markdown/accessibility.md
@@ -89,10 +89,13 @@ cancels.
 
 As you move, it reads your position out. Before you set a corner you hear the caret
 position. After you set one you hear the size of the region and where its top-left
-corner sits, so you always know where on the screen you are. Hold **Ctrl** for
-one-pixel steps or **Shift** for big hundred-pixel jumps. When the capture finishes it
-tells you the size of what it grabbed, in pixels. If you press Enter twice without
-moving, it tells you the region is empty rather than silently doing nothing.
+corner sits, so you always know where on the screen you are. Hold **Ctrl** for the
+smallest step or **Shift** for big jumps. When the capture finishes it tells you the
+size of what it grabbed, in pixels. If you press Enter twice without moving, it tells
+you the region is empty rather than silently doing nothing.
+
+Every number you hear is in pixels of the picture being captured, so the size you hear
+while sizing the rectangle is the size you hear when it is captured.
 
 ## Reading aloud is a first-class feature
 

--- a/Documentation/UserGuide/markdown/keyboard-shortcuts.md
+++ b/Documentation/UserGuide/markdown/keyboard-shortcuts.md
@@ -122,6 +122,12 @@ already written Mutation's way stays quiet. The note goes away when you come bac
 to that box. The **From** and **To** boxes in the shortcut router further down the
 page still tidy up in silence.
 
+Short names for keys are fine. Write **Alt+PgDn** or **Alt+PageDown**, **Ctrl+Esc**
+or **Ctrl+Escape**, **Bksp** or **Backspace**, **ArrowUp** or **Up** — Mutation
+takes either, in any box on the page, and saves the full name. The one word to
+avoid is **Menu**, which means the Alt key in a shortcut but the context-menu key
+in a "send key after" box.
+
 Two boxes are the exception: **Send key after OCR (optional)** and **Send key
 after transcription (optional)**. They keep whatever you type, exactly as you
 typed it, because what goes in them is not always a plain combination. There is

--- a/Documentation/UserGuide/markdown/screen-capture-and-ocr.md
+++ b/Documentation/UserGuide/markdown/screen-capture-and-ocr.md
@@ -33,7 +33,8 @@ opposite corner, and let go. That is it. A right-click cancels instead.
 You never need to see the screen to do this. The overlay talks you through it. When it
 opens it says what it wants from you, then as you move it announces the position you
 are at, the size of the rectangle you have built so far, and finally the size of what
-was captured.
+was captured. Those numbers are all in pixels of the picture, so the size you hear
+while sizing the rectangle matches the size you hear when it is captured.
 
 Think of it as a moving pointer that you park at one corner, pin down, and then drag to
 the other corner.

--- a/Documentation/UserGuide/markdown/troubleshooting.md
+++ b/Documentation/UserGuide/markdown/troubleshooting.md
@@ -65,6 +65,10 @@ before — two beeps, then three, then four. A burst of end beeps part way throu
 dictation means Mutation is still working, and how many you hear tells you how far into
 its retries it has got.
 
+If the service is busy and asks Mutation to wait a moment before asking again, Mutation
+waits as long as it was asked to, up to a minute. So a gap between beeps that is longer
+than usual is the service setting the pace, not something going wrong.
+
 **What to do.**
 
 1. Give it a moment — the retries are automatic and you will hear the result.
@@ -104,6 +108,10 @@ that has gone down keeps Mutation waiting about **ten minutes** before it admits
 and up to twenty if the prompt asked for Fast mode and the service turns it away for being
 busy, because Mutation then tries the whole thing again at normal speed. Nothing is broken;
 it is still trying.
+
+If the AI service asks Mutation to wait a moment before asking again — which is what a
+busy service usually does — Mutation waits as long as it was asked to, up to a minute,
+rather than asking straight back.
 
 A prompt you started yourself puts "Processing..." in the **Formatted Transcript** box. The
 AI step after a dictation says "Processing with LLM..." in the **Raw Transcript** box

--- a/Mutation.Tests/FakeHttpMessageHandler.cs
+++ b/Mutation.Tests/FakeHttpMessageHandler.cs
@@ -12,15 +12,19 @@ namespace Mutation.Tests;
 /// </summary>
 internal sealed class FakeHttpMessageHandler : HttpMessageHandler
 {
-	private readonly Queue<(HttpStatusCode Status, string Body)> _replies = new();
-	private (HttpStatusCode Status, string Body) _lastReply = (HttpStatusCode.OK, "{}");
+	private readonly Queue<(HttpStatusCode Status, string Body, string? RetryAfter)> _replies = new();
+	private (HttpStatusCode Status, string Body, string? RetryAfter) _lastReply = (HttpStatusCode.OK, "{}", null);
 
 	/// <summary>Every request sent, in order, with its body already read.</summary>
 	internal List<CapturedRequest> Requests { get; } = new();
 
-	internal FakeHttpMessageHandler Respond(HttpStatusCode status, string body)
+	/// <param name="retryAfter">
+	/// The <c>Retry-After</c> header to answer with, when the reply is one that carries one.
+	/// Null sends no such header, which is the ordinary case.
+	/// </param>
+	internal FakeHttpMessageHandler Respond(HttpStatusCode status, string body, string? retryAfter = null)
 	{
-		_replies.Enqueue((status, body));
+		_replies.Enqueue((status, body, retryAfter));
 		return this;
 	}
 
@@ -42,10 +46,17 @@ internal sealed class FakeHttpMessageHandler : HttpMessageHandler
 		if (_replies.Count > 0)
 			_lastReply = _replies.Dequeue();
 
-		return new HttpResponseMessage(_lastReply.Status)
+		var response = new HttpResponseMessage(_lastReply.Status)
 		{
 			Content = new StringContent(_lastReply.Body, Encoding.UTF8, "application/json")
 		};
+		if (_lastReply.RetryAfter is not null)
+		{
+			// Without validation, so a deliberately malformed value can be sent to see what
+			// the reader makes of it.
+			response.Headers.TryAddWithoutValidation("Retry-After", _lastReply.RetryAfter);
+		}
+		return response;
 	}
 
 	internal sealed record CapturedRequest(string Body, IReadOnlyDictionary<string, string> Headers)

--- a/Mutation.Tests/KeyNameAliasesTests.cs
+++ b/Mutation.Tests/KeyNameAliasesTests.cs
@@ -1,0 +1,105 @@
+using Mutation.Ui.Services;
+using Windows.System;
+
+namespace Mutation.Tests;
+
+/// <summary>
+/// Issue #329: the short key names lived in <c>SendKeysMapper</c> alone, so the same key had
+/// one spelling that worked in the "send key after…" boxes and a different one that worked in
+/// the shortcut editors. These pin the single table both now read.
+/// </summary>
+public class KeyNameAliasesTests
+{
+	[Theory]
+	[InlineData("PgDn", VirtualKey.PageDown)]
+	[InlineData("PgUp", VirtualKey.PageUp)]
+	[InlineData("PageDn", VirtualKey.PageDown)]
+	[InlineData("Esc", VirtualKey.Escape)]
+	[InlineData("Bksp", VirtualKey.Back)]
+	[InlineData("BS", VirtualKey.Back)]
+	[InlineData("Backspace", VirtualKey.Back)]
+	[InlineData("Del", VirtualKey.Delete)]
+	[InlineData("Ins", VirtualKey.Insert)]
+	[InlineData("Return", VirtualKey.Enter)]
+	[InlineData("Spacebar", VirtualKey.Space)]
+	[InlineData("Caps", VirtualKey.CapitalLock)]
+	[InlineData("CapsLock", VirtualKey.CapitalLock)]
+	[InlineData("NumLock", VirtualKey.NumberKeyLock)]
+	[InlineData("ScrollLock", VirtualKey.Scroll)]
+	[InlineData("Break", VirtualKey.Pause)]
+	[InlineData("Apps", VirtualKey.Application)]
+	[InlineData("ContextMenu", VirtualKey.Application)]
+	[InlineData("ArrowUp", VirtualKey.Up)]
+	[InlineData("UpArrow", VirtualKey.Up)]
+	[InlineData("ArrowDown", VirtualKey.Down)]
+	[InlineData("ArrowLeft", VirtualKey.Left)]
+	[InlineData("ArrowRight", VirtualKey.Right)]
+	public void AShortcutEditorNowTakesTheShortSpellingToo(string alias, VirtualKey expected)
+	{
+		// The case from the issue: "Alt+PgDn" used to be rejected with "Unsupported key
+		// 'PGDN'" while a send-key box took it without complaint.
+		var parsed = Hotkey.Parse("Alt+" + alias);
+
+		Assert.Equal(expected, parsed.Key);
+		Assert.True(parsed.Alt);
+	}
+
+	[Fact]
+	public void EveryAliasMeansExactlyWhatItsFullSpellingMeans()
+	{
+		// One vocabulary means the two spellings are the same chord, not merely two spellings
+		// that both happen to parse.
+		foreach (var (alias, canonical) in KeyNameAliases.All)
+			Assert.Equal(Hotkey.Parse("Ctrl+" + canonical), Hotkey.Parse("Ctrl+" + alias));
+	}
+
+	[Fact]
+	public void NoAliasQuietlyRedefinesAKeyWindowsAlreadyNames()
+	{
+		// "Menu" is why this matters: VirtualKey.Menu is the Alt key, so aliasing it to the
+		// context-menu key would change what an already-saved shortcut means. Nothing in the
+		// table is allowed to shadow a name like that.
+		foreach (string alias in KeyNameAliases.All.Keys)
+			Assert.False(
+				Enum.TryParse<VirtualKey>(alias, ignoreCase: true, out _),
+				$"'{alias}' is already a VirtualKey name; aliasing it changes what it means.");
+	}
+
+	[Fact]
+	public void EveryAliasResolvesToANameWindowsKnows()
+	{
+		foreach (string canonical in KeyNameAliases.All.Values)
+			Assert.True(
+				Enum.TryParse<VirtualKey>(canonical, ignoreCase: true, out _),
+				$"'{canonical}' is not a VirtualKey name, so nothing can resolve to it.");
+	}
+
+	[Fact]
+	public void ANameThatIsNotAnAliasComesBackUnchanged()
+	{
+		Assert.Equal("PageDown", KeyNameAliases.Resolve("PageDown"));
+		Assert.Equal("NOSUCHKEY", KeyNameAliases.Resolve("NOSUCHKEY"));
+	}
+
+	[Theory]
+	[InlineData("PgDn")]
+	[InlineData("Esc")]
+	[InlineData("Bksp")]
+	[InlineData("ArrowUp")]
+	[InlineData("Caps")]
+	public void ASendKeyBoxStillTakesTheShortSpellingItAlwaysDid(string alias)
+	{
+		// The alias table moved; nothing was taken away from the boxes that had it.
+		Assert.Equal(SendKeysMapper.Map("Alt+" + alias), SendKeysMapper.Map("Alt+" + KeyNameAliases.Resolve(alias)));
+	}
+
+	[Fact]
+	public void MenuIsTheOneNameLeftMeaningTwoThings()
+	{
+		// Recorded rather than fixed: VirtualKey.Menu is Alt, and the send-key boxes have
+		// typed the context-menu key for "Menu" since they were written. Agreeing would have
+		// to break one of those, so neither was changed — see KeyNameAliases.
+		Assert.Equal(VirtualKey.Menu, Hotkey.Parse("Ctrl+Menu").Key);
+		Assert.Equal("^{APPS}", SendKeysMapper.Map("Ctrl+Menu"));
+	}
+}

--- a/Mutation.Tests/KeyNameAliasesTests.cs
+++ b/Mutation.Tests/KeyNameAliasesTests.cs
@@ -94,6 +94,24 @@ public class KeyNameAliasesTests
 	}
 
 	[Fact]
+	public void ReadingASendKeysBraceNameBackAgreesWithTheAliasTable()
+	{
+		// SendKeysReader (issue #326) keeps its own closed list of the brace names Windows'
+		// shorthand uses, and deliberately so — reading {SHIFT} back as a key is how an
+		// innocent row gets a duplicate badge. But the half of that list which is short
+		// spellings is this table again, so the two can drift. Where both know a name, they
+		// have to mean the same key.
+		foreach (var (alias, canonical) in KeyNameAliases.All)
+		{
+			var read = SendKeysReader.ChordsIn("^{" + alias + "}");
+			if (read.Count == 0)
+				continue; // Not one of SendKeys' brace names; nothing to agree about.
+
+			Assert.Equal(Hotkey.Parse("Ctrl+" + canonical), Assert.Single(read));
+		}
+	}
+
+	[Fact]
 	public void MenuIsTheOneNameLeftMeaningTwoThings()
 	{
 		// Recorded rather than fixed: VirtualKey.Menu is Alt, and the send-key boxes have

--- a/Mutation.Tests/KeyboardRegionSelectorTests.cs
+++ b/Mutation.Tests/KeyboardRegionSelectorTests.cs
@@ -247,4 +247,85 @@ public class KeyboardRegionSelectorTests
 		Assert.Equal(0, selector.SelectionWidth);
 		Assert.Equal(0, selector.SelectionHeight);
 	}
+
+	// Issue #265: what moving reads out and what the capture reads out were two different
+	// scales. On a 150% display a user sizing a region by the spoken numbers was told 400
+	// while moving and 600 on capture, for the same edge.
+	private static KeyboardRegionSelector ScaledSelector(double scale)
+	{
+		var selector = new KeyboardRegionSelector();
+		selector.SetBitmapSize(1000 * scale, 800 * scale);
+		selector.Reset(1000, 800, 0, 0);
+		return selector;
+	}
+
+	[Fact]
+	public void MovingReadsOutBitmapPixelsRatherThanOverlayUnits()
+	{
+		var selector = ScaledSelector(1.5);
+
+		var result = Press(selector, RegionSelectionKey.Right);
+
+		// One normal step is 10 overlay units, which is 15 pixels of the captured image.
+		Assert.Equal(KeyboardRegionSelector.NormalStep, selector.CaretX);
+		Assert.Equal("15, 0", result.Announcement);
+	}
+
+	[Fact]
+	public void TheSizeSaidWhileSizingIsTheSizeSaidOnCapture()
+	{
+		// The whole point: the running readout has to be the number the capture will
+		// confirm, or sizing by ear cannot work.
+		var selector = ScaledSelector(1.5);
+		Press(selector, RegionSelectionKey.Commit);
+		Press(selector, RegionSelectionKey.End);
+		var result = Press(selector, RegionSelectionKey.PageDown);
+
+		// The full 1000 x 800 overlay is a 1500 x 1200 capture.
+		Assert.StartsWith("1500 by 1200", result.Announcement);
+	}
+
+	[Fact]
+	public void TheWholeScreenIsReadOutInPixelsToo()
+	{
+		var selector = ScaledSelector(2);
+
+		var result = Press(selector, RegionSelectionKey.SelectAll, control: true);
+
+		Assert.Contains("2000 by 1600 pixels", result.Announcement);
+	}
+
+	[Fact]
+	public void ACornerIsReadOutInPixelsToo()
+	{
+		var selector = ScaledSelector(2);
+		Press(selector, RegionSelectionKey.Right);
+
+		var result = Press(selector, RegionSelectionKey.Commit);
+
+		Assert.Contains("20, 0 pixels", result.Announcement);
+	}
+
+	[Fact]
+	public void AnUnscaledDisplayReadsOutTheOverlayUnitsUnchanged()
+	{
+		// Nothing was told a bitmap size, and 100% is the common case anyway: the numbers
+		// are the ones this has always said.
+		var selector = NewSelector(width: 1000, height: 800);
+		selector.SyncCaret(0, 0);
+
+		Assert.Equal("10, 0", Press(selector, RegionSelectionKey.Right).Announcement);
+	}
+
+	[Fact]
+	public void ARidiculousBitmapSizeIsIgnoredRatherThanSpoken()
+	{
+		// Belt and braces: NaN divided into a coordinate would read out "NaN" to someone
+		// who cannot see that the number is nonsense.
+		var selector = new KeyboardRegionSelector();
+		selector.SetBitmapSize(double.NaN, double.PositiveInfinity);
+		selector.Reset(1000, 800, 0, 0);
+
+		Assert.Equal("10, 0", Press(selector, RegionSelectionKey.Right).Announcement);
+	}
 }

--- a/Mutation.Tests/LlmServiceRetryTests.cs
+++ b/Mutation.Tests/LlmServiceRetryTests.cs
@@ -8,9 +8,12 @@ namespace Mutation.Tests;
 
 /// <summary>
 /// Issue #311: every fast-mode test builds this service with a retry count of zero, so the
-/// pipeline is empty and no retry has ever run. These use a real one — and turn the OpenAI
-/// SDK's own retry policy off, so a request count is the number of times <em>this</em>
-/// service tried rather than the product of two nested loops.
+/// pipeline is empty and no retry has ever run. These use a real one.
+/// <para>
+/// A request count here is the number of times <em>this</em> service tried, not the product
+/// of two nested loops — and since issue #318 that is true of production too, because the
+/// SDK's own retry policy is off by default rather than turned off for the tests.
+/// </para>
 /// </summary>
 public class LlmServiceRetryTests : IDisposable
 {
@@ -42,7 +45,6 @@ public class LlmServiceRetryTests : IDisposable
 			timeoutSeconds: TimeoutSeconds,
 			retryCount: retryCount,
 			transport: new HttpClientPipelineTransport(httpClient),
-			sdkRetryCount: 0,
 			timeProvider: clock);
 		return (service, clock);
 	}
@@ -121,6 +123,53 @@ public class LlmServiceRetryTests : IDisposable
 	}
 
 	[Fact]
+	public async Task APersistentRateLimitCostsFourRequestsAndNotSixteen()
+	{
+		// The number issue #318 is about. Our four attempts used to wrap the SDK's own three
+		// retries, so a rate-limited account was answered by asking sixteen more times. This
+		// service is built exactly as App.xaml.cs builds it — no test-only cap — so the count
+		// is production's count.
+		var handler = new FakeHttpMessageHandler()
+			.Respond(HttpStatusCode.TooManyRequests, ErrorBody("slow down"));
+		var (service, _) = CreateService(handler);
+
+		await Assert.ThrowsAsync<ClientResultException>(() =>
+			service.CreateChatCompletion(Messages(), Model));
+
+		Assert.Equal(4, handler.Requests.Count);
+	}
+
+	[Fact]
+	public async Task ARateLimitThatAsksForAParticularWaitGetsIt()
+	{
+		// Honouring Retry-After was the one thing the SDK's retry loop did better than ours,
+		// and turning that loop off would have thrown it away. 2 s here, not the 500 ms the
+		// linear backoff would otherwise have picked.
+		var handler = new FakeHttpMessageHandler()
+			.Respond(HttpStatusCode.TooManyRequests, ErrorBody("slow down"), retryAfter: "2")
+			.Respond(HttpStatusCode.OK, SuccessBody);
+		var (service, clock) = CreateService(handler);
+
+		string result = await service.CreateChatCompletion(Messages(), Model);
+
+		Assert.Equal("done", result);
+		Assert.Equal([2000d], clock.BackoffMilliseconds);
+	}
+
+	[Fact]
+	public async Task AFailureThatAsksForNothingKeepsTheLinearBackoff()
+	{
+		var handler = new FakeHttpMessageHandler()
+			.Respond(HttpStatusCode.ServiceUnavailable, ErrorBody("still down"))
+			.Respond(HttpStatusCode.OK, SuccessBody);
+		var (service, clock) = CreateService(handler);
+
+		await service.CreateChatCompletion(Messages(), Model);
+
+		Assert.Equal([500d], clock.BackoffMilliseconds);
+	}
+
+	[Fact]
 	public async Task EachAttemptGivesItselfLongerThanTheLast()
 	{
 		var handler = new FakeHttpMessageHandler()
@@ -185,7 +234,6 @@ public class LlmServiceRetryTests : IDisposable
 			timeoutSeconds: TimeoutSeconds,
 			retryCount: 3,
 			transport: new HttpClientPipelineTransport(httpClient),
-			sdkRetryCount: 0,
 			timeProvider: new RecordingClock());
 
 		await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>

--- a/Mutation.Tests/LlmServiceRetryTests.cs
+++ b/Mutation.Tests/LlmServiceRetryTests.cs
@@ -156,6 +156,25 @@ public class LlmServiceRetryTests : IDisposable
 		Assert.Equal([2000d], clock.BackoffMilliseconds);
 	}
 
+	[Theory]
+	[InlineData("0")]
+	[InlineData("-1")]
+	public async Task ARateLimitAskingForNoWaitAtAllDoesNotCollapseTheLadder(string retryAfter)
+	{
+		// The header comes from the server, so a bad one must not be able to delete our own
+		// backoff and run all four attempts inside a few milliseconds — which is the
+		// hammering the whole change exists to stop.
+		var handler = new FakeHttpMessageHandler()
+			.Respond(HttpStatusCode.TooManyRequests, ErrorBody("slow down"), retryAfter: retryAfter);
+		var (service, clock) = CreateService(handler);
+
+		await Assert.ThrowsAsync<ClientResultException>(() =>
+			service.CreateChatCompletion(Messages(), Model));
+
+		Assert.Equal(4, handler.Requests.Count);
+		Assert.Equal([500d, 1000d, 1500d], clock.BackoffMilliseconds);
+	}
+
 	[Fact]
 	public async Task AFailureThatAsksForNothingKeepsTheLinearBackoff()
 	{

--- a/Mutation.Tests/OpenAiClientOptionsFactoryTests.cs
+++ b/Mutation.Tests/OpenAiClientOptionsFactoryTests.cs
@@ -31,6 +31,11 @@ public class OpenAiClientOptionsFactoryTests
 		// It used to be left alone, so the SDK's three retries ran inside our four and one
 		// outage cost up to sixteen requests. Production takes the same setting as the
 		// tests now, which is what makes a counted request count mean anything (issue #318).
+		//
+		// The count itself is not readable off the policy, so this says only that one is
+		// installed. What pins the number is behavioural, and lives where the requests can
+		// be counted: LlmServiceRetryTests and OpenAiSpeechToTextServiceRetryTests both have
+		// an APersistentRateLimitCostsFourRequestsAndNotSixteen.
 		Assert.IsType<ClientRetryPolicy>(OpenAiClientOptionsFactory.Create().RetryPolicy);
 	}
 

--- a/Mutation.Tests/OpenAiClientOptionsFactoryTests.cs
+++ b/Mutation.Tests/OpenAiClientOptionsFactoryTests.cs
@@ -26,17 +26,18 @@ public class OpenAiClientOptionsFactoryTests
 	}
 
 	[Fact]
-	public void Create_LeavesTheSdkSOwnRetryPolicyAlone_ByDefault()
+	public void Create_TurnsTheSdkSOwnRetryPolicyOff_ByDefault()
 	{
-		// Production wants the SDK's default retries. Only a test that counts requests
-		// turns them off, and it has to ask (issue #311).
-		Assert.Null(OpenAiClientOptionsFactory.Create().RetryPolicy);
+		// It used to be left alone, so the SDK's three retries ran inside our four and one
+		// outage cost up to sixteen requests. Production takes the same setting as the
+		// tests now, which is what makes a counted request count mean anything (issue #318).
+		Assert.IsType<ClientRetryPolicy>(OpenAiClientOptionsFactory.Create().RetryPolicy);
 	}
 
 	[Fact]
-	public void Create_CapsTheSdkSOwnRetries_WhenAsked()
+	public void Create_LetsACallerAskForTheSdkSRetriesBack()
 	{
-		var options = OpenAiClientOptionsFactory.Create(maxRetries: 0);
+		var options = OpenAiClientOptionsFactory.Create(maxRetries: 3);
 
 		Assert.IsType<ClientRetryPolicy>(options.RetryPolicy);
 	}

--- a/Mutation.Tests/OpenAiSpeechToTextServiceRetryTests.cs
+++ b/Mutation.Tests/OpenAiSpeechToTextServiceRetryTests.cs
@@ -8,9 +8,11 @@ using OpenAI.Audio;
 namespace Mutation.Tests;
 
 /// <summary>
-/// Issue #311: nothing drove a retry through this service. The SDK's own retry policy is
-/// turned off here — see <see cref="OpenAiClientOptionsFactory.Create"/> — so a call count
-/// means "this many times our pipeline tried", not "this many times two nested loops did".
+/// Issue #311: nothing drove a retry through this service. A call count here means "this
+/// many times our pipeline tried", not "this many times two nested loops did" — and since
+/// issue #318 that holds in production too, because
+/// <see cref="OpenAiClientOptionsFactory.Create"/> ships with the SDK's own retry policy
+/// off rather than leaving it on for everyone but the tests.
 /// </summary>
 public class OpenAiSpeechToTextServiceRetryTests : IDisposable
 {
@@ -48,8 +50,7 @@ public class OpenAiSpeechToTextServiceRetryTests : IDisposable
 			"whisper-1",
 			new ApiKeyCredential("test-key"),
 			OpenAiClientOptionsFactory.Create(
-				transport: new HttpClientPipelineTransport(httpClient),
-				maxRetries: 0));
+				transport: new HttpClientPipelineTransport(httpClient)));
 
 		var announced = new List<int>();
 		var service = new OpenAiSpeechToTextService("Whisper", audioClient, BaseTimeoutSeconds, clock, announced.Add);
@@ -62,10 +63,16 @@ public class OpenAiSpeechToTextServiceRetryTests : IDisposable
 			Content = new StringContent(body, System.Text.Encoding.UTF8, "application/json")
 		};
 
-	private static Func<int, HttpResponseMessage> Status(HttpStatusCode status) =>
-		_ => new HttpResponseMessage(status)
+	private static Func<int, HttpResponseMessage> Status(HttpStatusCode status, string? retryAfter = null) =>
+		_ =>
 		{
-			Content = new StringContent("""{"error":{"message":"nope"}}""", System.Text.Encoding.UTF8, "application/json")
+			var response = new HttpResponseMessage(status)
+			{
+				Content = new StringContent("""{"error":{"message":"nope"}}""", System.Text.Encoding.UTF8, "application/json")
+			};
+			if (retryAfter is not null)
+				response.Headers.TryAddWithoutValidation("Retry-After", retryAfter);
+			return response;
 		};
 
 	private static Func<int, HttpResponseMessage> Dropped() =>
@@ -139,6 +146,34 @@ public class OpenAiSpeechToTextServiceRetryTests : IDisposable
 			service.ConvertAudioToText("", WriteAudioFile(), CancellationToken.None));
 
 		Assert.Equal(1, handler.Calls);
+	}
+
+	[Fact]
+	public async Task APersistentRateLimitCostsFourRequestsAndNotSixteen()
+	{
+		// The number issue #318 is about: our four attempts used to wrap the SDK's own three
+		// retries. Nothing here caps the SDK any more, because the factory ships with it off.
+		var (service, handler, _, _) = CreateService(Status(HttpStatusCode.TooManyRequests));
+
+		await Assert.ThrowsAsync<ClientResultException>(() =>
+			service.ConvertAudioToText("", WriteAudioFile(), CancellationToken.None));
+
+		Assert.Equal(4, handler.Calls);
+	}
+
+	[Fact]
+	public async Task ARateLimitThatAsksForAParticularWaitGetsIt()
+	{
+		// Honouring Retry-After was the one thing the SDK's loop did better than ours, so it
+		// moved into TransientRetry rather than being lost with it (issue #318).
+		var (service, _, clock, _) = CreateService(
+			Status(HttpStatusCode.TooManyRequests, retryAfter: "2"),
+			Ok(TranscriptBody));
+
+		string text = await service.ConvertAudioToText("", WriteAudioFile(), CancellationToken.None);
+
+		Assert.Equal("the recovered transcript", text);
+		Assert.Equal([2000d], clock.BackoffMilliseconds);
 	}
 
 	[Fact]

--- a/Mutation.Tests/RetryAfterHintTests.cs
+++ b/Mutation.Tests/RetryAfterHintTests.cs
@@ -1,0 +1,80 @@
+using CognitiveSupport;
+
+namespace Mutation.Tests;
+
+/// <summary>
+/// Issue #318: turning the OpenAI SDK's own retry loop off took the only part of the stack
+/// that read <c>Retry-After</c> with it. These pin the reading that replaced it.
+/// </summary>
+public class RetryAfterHintTests
+{
+	private static readonly DateTimeOffset Now = new(2026, 8, 8, 12, 0, 0, TimeSpan.Zero);
+
+	[Fact]
+	public void A_count_of_seconds_is_the_wait()
+	{
+		// What OpenAI actually sends.
+		Assert.Equal(TimeSpan.FromSeconds(2), RetryAfterHint.Parse("2", Now));
+	}
+
+	[Fact]
+	public void Fractional_seconds_are_kept()
+	{
+		Assert.Equal(TimeSpan.FromSeconds(1.5), RetryAfterHint.Parse("1.5", Now));
+	}
+
+	[Fact]
+	public void Surrounding_space_does_not_hide_the_number()
+	{
+		Assert.Equal(TimeSpan.FromSeconds(3), RetryAfterHint.Parse("  3  ", Now));
+	}
+
+	[Fact]
+	public void An_http_date_is_read_as_the_wait_until_then()
+	{
+		Assert.Equal(TimeSpan.FromSeconds(30), RetryAfterHint.Parse("Sat, 08 Aug 2026 12:00:30 GMT", Now));
+	}
+
+	[Fact]
+	public void A_date_already_past_means_go_now_rather_than_go_back()
+	{
+		Assert.Equal(TimeSpan.Zero, RetryAfterHint.Parse("Sat, 08 Aug 2026 11:59:00 GMT", Now));
+	}
+
+	[Fact]
+	public void A_negative_count_means_go_now_too()
+	{
+		Assert.Equal(TimeSpan.Zero, RetryAfterHint.Parse("-5", Now));
+	}
+
+	[Theory]
+	[InlineData("3600")]
+	[InlineData("Sat, 08 Aug 2026 13:00:00 GMT")]
+	public void A_wait_longer_than_the_cap_is_cut_to_it(string header)
+	{
+		// A user is standing over a finished recording. An hour is not a wait; it is a
+		// failure that has not been reported yet.
+		Assert.Equal(RetryAfterHint.Cap, RetryAfterHint.Parse(header, Now));
+	}
+
+	[Theory]
+	[InlineData(null)]
+	[InlineData("")]
+	[InlineData("   ")]
+	[InlineData("soon")]
+	[InlineData("NaN")]
+	[InlineData("Infinity")]
+	public void Anything_unreadable_leaves_the_backoff_in_charge(string? header)
+	{
+		// Null is the "no opinion" answer, and it is what puts the caller's own linear
+		// backoff back in charge — not a zero wait, which would retry at once.
+		Assert.Null(RetryAfterHint.Parse(header, Now));
+	}
+
+	[Fact]
+	public void A_failure_that_is_not_an_answered_http_error_asks_for_nothing()
+	{
+		Assert.Null(RetryAfterHint.From(new HttpRequestException("connection reset"), Now));
+		Assert.Null(RetryAfterHint.From(null, Now));
+	}
+}

--- a/Mutation.Tests/RetryAfterHintTests.cs
+++ b/Mutation.Tests/RetryAfterHintTests.cs
@@ -35,16 +35,17 @@ public class RetryAfterHintTests
 		Assert.Equal(TimeSpan.FromSeconds(30), RetryAfterHint.Parse("Sat, 08 Aug 2026 12:00:30 GMT", Now));
 	}
 
-	[Fact]
-	public void A_date_already_past_means_go_now_rather_than_go_back()
+	[Theory]
+	[InlineData("0")]
+	[InlineData("-5")]
+	[InlineData("Sat, 08 Aug 2026 11:59:00 GMT")] // already past
+	[InlineData("Sat, 08 Aug 2026 12:00:00 GMT")] // exactly now
+	public void A_wait_of_no_time_at_all_leaves_the_backoff_in_charge(string header)
 	{
-		Assert.Equal(TimeSpan.Zero, RetryAfterHint.Parse("Sat, 08 Aug 2026 11:59:00 GMT", Now));
-	}
-
-	[Fact]
-	public void A_negative_count_means_go_now_too()
-	{
-		Assert.Equal(TimeSpan.Zero, RetryAfterHint.Parse("-5", Now));
+		// Never TimeSpan.Zero. Polly reads a returned zero as a real delay of no time, which
+		// would run the whole ladder back-to-back in a few milliseconds — on the say-so of a
+		// header the server sends. Null is what puts the linear backoff back in charge.
+		Assert.Null(RetryAfterHint.Parse(header, Now));
 	}
 
 	[Theory]
@@ -57,6 +58,14 @@ public class RetryAfterHintTests
 		Assert.Equal(RetryAfterHint.Cap, RetryAfterHint.Parse(header, Now));
 	}
 
+	[Fact]
+	public void A_number_too_big_for_a_TimeSpan_is_cut_to_the_cap_rather_than_overflowing()
+	{
+		// TimeSpan.FromSeconds throws on a number this size, so the cap has to be applied
+		// before the conversion rather than after it.
+		Assert.Equal(RetryAfterHint.Cap, RetryAfterHint.Parse("1000000000000000000", Now));
+	}
+
 	[Theory]
 	[InlineData(null)]
 	[InlineData("")]
@@ -64,6 +73,7 @@ public class RetryAfterHintTests
 	[InlineData("soon")]
 	[InlineData("NaN")]
 	[InlineData("Infinity")]
+	[InlineData("1E400")] // overflows a double, so it arrives as infinity rather than failing
 	public void Anything_unreadable_leaves_the_backoff_in_charge(string? header)
 	{
 		// Null is the "no opinion" answer, and it is what puts the caller's own linear

--- a/Mutation.Tests/SendKeysChordTests.cs
+++ b/Mutation.Tests/SendKeysChordTests.cs
@@ -169,13 +169,15 @@ public class SendKeysChordTests
 	[InlineData("Ctrl+PgDn", VirtualKey.PageDown)]
 	[InlineData("Ctrl+Bksp", VirtualKey.Back)]
 	[InlineData("Ctrl+Esc", VirtualKey.Escape)]
-	public void TheMappersOwnKeyAliasesAlsoReadBack(string chord, VirtualKey expected)
+	public void TheShortKeyNamesAlsoReadBack(string chord, VirtualKey expected)
 	{
-		// SendKeysMapper accepts short names Hotkey.Parse does not, so these round-trip
-		// through the mapped form rather than through a second Hotkey.Parse.
+		// These used to be spellings only SendKeysMapper accepted, so the round trip had to
+		// avoid Hotkey.Parse. Both surfaces take them now (issue #329), so the two readings
+		// are checked against each other as well as against the key.
 		var mapped = SendKeysMapper.Map(chord);
 
 		Assert.True(SendKeysChord.TryParse(mapped, out var readBack));
 		Assert.Equal(expected, readBack.Key);
+		Assert.Equal(Hotkey.Parse(chord), readBack);
 	}
 }

--- a/Mutation.Ui/Core/KeyboardRegionSelector.cs
+++ b/Mutation.Ui/Core/KeyboardRegionSelector.cs
@@ -49,6 +49,11 @@ internal readonly record struct RegionKeyResult(RegionKeyOutcome Outcome, string
 ///
 /// Coordinates are overlay-space DIPs, matching the pointer path, and all state is
 /// plain numbers so the behaviour is testable without a window.
+///
+/// What is *said* is in bitmap pixels, because that is the unit the capture is announced
+/// in. The two used to disagree: moving read out DIPs and the capture read out pixels, so
+/// on a 150% display a user sizing a region by the spoken numbers was fed two readings
+/// that did not agree (issue #265). See <see cref="SetBitmapSize"/>.
 /// </summary>
 internal sealed class KeyboardRegionSelector
 {
@@ -61,6 +66,8 @@ internal sealed class KeyboardRegionSelector
 
 	private double _width;
 	private double _height;
+	private double _bitmapWidth;
+	private double _bitmapHeight;
 
 	public double CaretX { get; private set; }
 	public double CaretY { get; private set; }
@@ -99,6 +106,23 @@ internal sealed class KeyboardRegionSelector
 		CaretY = Clamp(CaretY, _height);
 		AnchorX = Clamp(AnchorX, _width);
 		AnchorY = Clamp(AnchorY, _height);
+	}
+
+	/// <summary>
+	/// The size of the captured bitmap, which is what everything spoken is scaled to. The
+	/// overlay is measured in DIPs and the capture in bitmap pixels, and on any display
+	/// above 100% those are different numbers for the same edge.
+	/// <para>
+	/// Told as a size rather than as a ratio so a later <see cref="Resize"/> — the overlay
+	/// re-laid out across a changed set of monitors — cannot leave a stale scale behind.
+	/// Zero, or never calling this, leaves everything spoken in DIPs, which is what a 100%
+	/// display gives anyway.
+	/// </para>
+	/// </summary>
+	public void SetBitmapSize(double width, double height)
+	{
+		_bitmapWidth = double.IsFinite(width) ? Math.Max(0, width) : 0;
+		_bitmapHeight = double.IsFinite(height) ? Math.Max(0, height) : 0;
 	}
 
 	/// <summary>Moves the caret to where the pointer left it, so the two paths agree.</summary>
@@ -166,7 +190,7 @@ internal sealed class KeyboardRegionSelector
 		CaretY = _height;
 		return new RegionKeyResult(
 			RegionKeyOutcome.SelectedWholeScreen,
-			$"Whole screen selected, {Describe(_width)} by {Describe(_height)}. Press Enter to capture.");
+			$"Whole screen selected, {DescribeX(_width)} by {DescribeY(_height)} pixels. Press Enter to capture.");
 	}
 
 	private RegionKeyResult Commit()
@@ -178,7 +202,7 @@ internal sealed class KeyboardRegionSelector
 			AnchorY = CaretY;
 			return new RegionKeyResult(
 				RegionKeyOutcome.AnchorSet,
-				$"Region corner set at {Describe(CaretX)}, {Describe(CaretY)}. Move with the arrow keys, then press Enter to capture.");
+				$"Region corner set at {DescribeX(CaretX)}, {DescribeY(CaretY)} pixels. Move with the arrow keys, then press Enter to capture.");
 		}
 
 		// A zero-width or zero-height region is discarded further down the capture
@@ -211,8 +235,19 @@ internal sealed class KeyboardRegionSelector
 	// way to tell where on the screen the rectangle sits, and no way to recover it short
 	// of clearing the corner and starting again.
 	private string DescribePosition() => HasAnchor
-		? $"{Describe(SelectionWidth)} by {Describe(SelectionHeight)}, from {Describe(SelectionLeft)}, {Describe(SelectionTop)}"
-		: $"{Describe(CaretX)}, {Describe(CaretY)}";
+		? $"{DescribeX(SelectionWidth)} by {DescribeY(SelectionHeight)}, from {DescribeX(SelectionLeft)}, {DescribeY(SelectionTop)}"
+		: $"{DescribeX(CaretX)}, {DescribeY(CaretY)}";
+
+	// Said on every arrow press, so the unit is left off here and stated on the two
+	// announcements that are not a running readout. A number per keystroke is what makes
+	// sizing by ear bearable; "410 pixels, 250 pixels" ten times a second is not.
+	private string DescribeX(double dips) => Describe(dips * ScaleX);
+
+	private string DescribeY(double dips) => Describe(dips * ScaleY);
+
+	private double ScaleX => _bitmapWidth > 0 && _width > 0 ? _bitmapWidth / _width : 1;
+
+	private double ScaleY => _bitmapHeight > 0 && _height > 0 ? _bitmapHeight / _height : 1;
 
 	private static string Describe(double value) =>
 		Math.Round(value).ToString(System.Globalization.CultureInfo.CurrentCulture);

--- a/Mutation.Ui/Services/Hotkey.cs
+++ b/Mutation.Ui/Services/Hotkey.cs
@@ -166,20 +166,28 @@ public class Hotkey : IEquatable<Hotkey>
 				case "START":
 					hk.Win = true; break;
                                 default:
+                                        // The short names the "send key after…" boxes take — PgDn, Esc,
+                                        // Bksp — resolve to their full spelling here, so one key has one
+                                        // vocabulary across both surfaces (issue #329). A token that is
+                                        // not an alias comes back unchanged.
+                                        string keyName = KeyNameAliases.Resolve(token);
+
                                         // Try the "NumberN" alias first for purely-numeric tokens.
                                         // Otherwise Enum.TryParse would parse "5" as the integer value 5
                                         // and silently bind to VirtualKey.XButton1 (the int-5 enum member).
-                                        bool isAllDigits = token.Length > 0;
-                                        for (int i = 0; i < token.Length && isAllDigits; i++)
-                                                isAllDigits = char.IsDigit(token[i]);
+                                        bool isAllDigits = keyName.Length > 0;
+                                        for (int i = 0; i < keyName.Length && isAllDigits; i++)
+                                                isAllDigits = char.IsDigit(keyName[i]);
 
-                                        if (isAllDigits && Enum.TryParse<VirtualKey>("Number" + token, true, out var vk))
+                                        if (isAllDigits && Enum.TryParse<VirtualKey>("Number" + keyName, true, out var vk))
                                                 hk.Key = vk;
-                                        else if (Enum.TryParse<VirtualKey>(token, true, out vk))
+                                        else if (Enum.TryParse<VirtualKey>(keyName, true, out vk))
                                                 hk.Key = vk;
-                                        else if (Enum.TryParse<VirtualKey>("Number" + token, true, out vk))
+                                        else if (Enum.TryParse<VirtualKey>("Number" + keyName, true, out vk))
                                                 hk.Key = vk;
                                         else
+                                                // Quoted as the user wrote it, not as it was resolved: an
+                                                // alias that resolved to nothing is still their spelling.
                                                 throw new NotSupportedException($"Unsupported key '{token}'");
                                         break;
                         }

--- a/Mutation.Ui/Services/KeyNameAliases.cs
+++ b/Mutation.Ui/Services/KeyNameAliases.cs
@@ -1,0 +1,74 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+
+namespace Mutation.Ui.Services;
+
+/// <summary>
+/// The short names people write for keys, and the one spelling the app resolves each of them
+/// to. <see cref="Hotkey.Parse"/> and <see cref="SendKeysMapper"/> both go through here, so a
+/// key has one vocabulary across the shortcut editors and the "send key after…" boxes.
+/// <para>
+/// It used to have two. <c>Alt+PgDn</c> was accepted and sent by a send-key box and rejected
+/// by a shortcut editor with "Unsupported key 'PGDN'", and nothing on screen explained why
+/// (issue #329). That is the same second-vocabulary problem #306 removed for whole chords,
+/// one level down at key names.
+/// </para>
+/// </summary>
+internal static class KeyNameAliases
+{
+	/// <summary>
+	/// Alias to canonical name. Every value is a <see cref="Windows.System.VirtualKey"/>
+	/// member name, which is what makes it a spelling <see cref="Hotkey.Parse"/> can already
+	/// resolve; no key is one, which is what stops an alias quietly redefining a name that
+	/// means something else today. <c>KeyNameAliasesTests</c> pins both halves of that.
+	/// </summary>
+	private static readonly Dictionary<string, string> Aliases = new(StringComparer.OrdinalIgnoreCase)
+	{
+		// Control keys
+		["RETURN"] = "Enter",
+		["ESC"] = "Escape",
+		["BACKSPACE"] = "Back",
+		["BKSP"] = "Back",
+		["BS"] = "Back",
+		["DEL"] = "Delete",
+		["INS"] = "Insert",
+		["SPACEBAR"] = "Space",
+		["BREAK"] = "Pause",
+
+		// Navigation
+		["UPARROW"] = "Up",
+		["ARROWUP"] = "Up",
+		["DOWNARROW"] = "Down",
+		["ARROWDOWN"] = "Down",
+		["LEFTARROW"] = "Left",
+		["ARROWLEFT"] = "Left",
+		["RIGHTARROW"] = "Right",
+		["ARROWRIGHT"] = "Right",
+		["PGUP"] = "PageUp",
+		["PGDN"] = "PageDown",
+		["PAGEDN"] = "PageDown",
+
+		// Context menu
+		["APPS"] = "Application",
+		["CONTEXTMENU"] = "Application",
+
+		// Toggles
+		["CAPS"] = "CapitalLock",
+		["CAPSLOCK"] = "CapitalLock",
+		["NUMLOCK"] = "NumberKeyLock",
+		["SCROLLLOCK"] = "Scroll",
+	};
+
+	/// <summary>
+	/// The canonical name for <paramref name="keyName"/>, or <paramref name="keyName"/>
+	/// itself when it is not an alias — including when it is already canonical, and when it
+	/// is not a key name at all. Callers can therefore apply this to every token without
+	/// first asking whether it is one.
+	/// </summary>
+	internal static string Resolve(string keyName) =>
+		Aliases.TryGetValue(keyName, out string? canonical) ? canonical : keyName;
+
+	/// <summary>Every alias, for the tests that check the table's shape.</summary>
+	internal static IReadOnlyDictionary<string, string> All => Aliases;
+}

--- a/Mutation.Ui/Services/SendKeysMapper.cs
+++ b/Mutation.Ui/Services/SendKeysMapper.cs
@@ -22,59 +22,48 @@ public static class SendKeysMapper
 		"WIN", "WINDOWS", "CMD", "COMMAND", "META", "SUPER", "PRINTSCREEN", "PRTSC", "PRTSCR", "SYSRQ"
 	};
 
-	// Map of normalized tokens (letters/digits only, no spaces/dashes/underscores) to SendKeys pieces.
-	// Use braces for action keys; single-char literals returned as-is; reserved chars are escaped later.
+	// Map of key names to SendKeys pieces. Use braces for action keys; single-char literals
+	// returned as-is; reserved chars are escaped later.
+	//
+	// Keyed by the canonical name only — the short spellings people also write (PgDn, Esc,
+	// Bksp, ArrowUp) resolve to it through KeyNameAliases before the lookup, so this table
+	// and Hotkey.Parse take the same words. They used to be listed here and nowhere else,
+	// which is how "Alt+PgDn" came to be accepted by a send-key box and rejected by a
+	// shortcut editor (issue #329).
 	private static readonly Dictionary<string, string> KeyMap = new(StringComparer.OrdinalIgnoreCase)
 	{
 		// Control keys
 		["ENTER"] = "{ENTER}",
-		["RETURN"] = "{ENTER}",
 		["TAB"] = "{TAB}",
-		["ESC"] = "{ESC}",
 		["ESCAPE"] = "{ESC}",
-		["BACKSPACE"] = "{BACKSPACE}",
-		["BKSP"] = "{BACKSPACE}",
-		["BS"] = "{BACKSPACE}",
+		["BACK"] = "{BACKSPACE}",
 		["DELETE"] = "{DEL}",
-		["DEL"] = "{DEL}",
 		["INSERT"] = "{INS}",
-		["INS"] = "{INS}",
 		["SPACE"] = "{SPACE}",
-		["SPACEBAR"] = "{SPACE}",
 
 		// Navigation
 		["UP"] = "{UP}",
-		["UPARROW"] = "{UP}",
-		["ARROWUP"] = "{UP}",
 		["DOWN"] = "{DOWN}",
-		["DOWNARROW"] = "{DOWN}",
-		["ARROWDOWN"] = "{DOWN}",
 		["LEFT"] = "{LEFT}",
-		["LEFTARROW"] = "{LEFT}",
-		["ARROWLEFT"] = "{LEFT}",
 		["RIGHT"] = "{RIGHT}",
-		["RIGHTARROW"] = "{RIGHT}",
-		["ARROWRIGHT"] = "{RIGHT}",
 		["HOME"] = "{HOME}",
 		["END"] = "{END}",
-		["PGUP"] = "{PGUP}",
 		["PAGEUP"] = "{PGUP}",
 		["PAGEDOWN"] = "{PGDN}",
-		["PAGEDN"] = "{PGDN}",
-		["PGDN"] = "{PGDN}",
 
 		// Editing/context
-		["APPS"] = "{APPS}",
-		["CONTEXTMENU"] = "{APPS}",
+		["APPLICATION"] = "{APPS}",
+		// "Menu" is the one name the two surfaces still read differently, and deliberately
+		// so: VirtualKey.Menu is the Alt key, so aliasing it to the context-menu key would
+		// either change what an existing shortcut means or change what an existing send-key
+		// box types. Left as it has always behaved here, rather than broken either way.
 		["MENU"] = "{APPS}",
-		["BREAK"] = "{BREAK}",
+		["PAUSE"] = "{BREAK}",
 		["HELP"] = "{HELP}",
 
 		// Toggles
-		["CAPSLOCK"] = "{CAPSLOCK}",
-		["CAPS"] = "{CAPSLOCK}",
-		["NUMLOCK"] = "{NUMLOCK}",
-		["SCROLLLOCK"] = "{SCROLLLOCK}",
+		["CAPITALLOCK"] = "{CAPSLOCK}",
+		["NUMBERKEYLOCK"] = "{NUMLOCK}",
 		["SCROLL"] = "{SCROLLLOCK}",
 
 		// Numeric keypad (explicit names)
@@ -85,7 +74,9 @@ public static class SendKeysMapper
 		["DECIMAL"] = "{DECIMAL}",
 		["SEPARATOR"] = "{SEPARATOR}",
 
-		// Common symbol names → literals (escaped later if reserved)
+		// Common symbol names → literals (escaped later if reserved). These stay a
+		// send-key-only vocabulary: they name a character to type, and Windows has no
+		// virtual key for "the plus character" to register a shortcut against.
 		["PLUS"] = "+",
 		["MINUS"] = "-",
 		["DASH"] = "-",
@@ -350,7 +341,9 @@ public static class SendKeysMapper
 	private static bool TryResolveKey(string token, out string key)
 	{
 		key = "";
-		var norm = Normalize(token);
+		// Resolved through the shared alias table first, so "PgDn" and "PageDown" reach the
+		// same entry and this table needs only the one spelling (issue #329).
+		var norm = KeyNameAliases.Resolve(Normalize(token)).ToUpperInvariant();
 
 		if (TryMapFunctionKey(norm, out var fKey))
 		{

--- a/Mutation.Ui/Views/RegionSelectionWindow.xaml.cs
+++ b/Mutation.Ui/Views/RegionSelectionWindow.xaml.cs
@@ -33,6 +33,15 @@ public sealed partial class RegionSelectionWindow : Window
 	// without sight of the crosshair (issue #215).
 	private readonly KeyboardRegionSelector _keyboard = new();
 	private const string AnnouncementActivityId = "RegionSelection";
+	private const string CancelledAnnouncement = "Region selection cancelled.";
+
+	/// <summary>
+	/// Said only when the overlay could not take focus. Normally the Canvas's
+	/// <c>AutomationProperties.HelpText</c> carries the instructions and a reader reads them
+	/// out as focus lands — see <see cref="SelectRegionAsync"/>.
+	/// </summary>
+	private const string InstructionsAnnouncement =
+		"Select screen region. Move with the arrow keys, press Enter to set the first corner, move, then Enter again to capture. Control plus A selects the whole screen. Escape cancels.";
 
 	// Cache XAML elements to avoid reliance on generated fields
 	private Microsoft.UI.Xaml.Controls.Image? _img;
@@ -231,7 +240,7 @@ public sealed partial class RegionSelectionWindow : Window
 		// Show and activate for input (in case window was hidden for reuse)
 		try { this.AppWindow?.Show(); } catch { }
 		this.Activate();
-		TryFocusOverlay();
+		bool focused = TryFocusOverlay();
 		// Ensure TopMost without using SWP_SHOWWINDOW to avoid flicker
 		int left = GetSystemMetrics(SM_XVIRTUALSCREEN);
 		int top = GetSystemMetrics(SM_YVIRTUALSCREEN);
@@ -239,11 +248,16 @@ public sealed partial class RegionSelectionWindow : Window
 		int height = GetSystemMetrics(SM_CYVIRTUALSCREEN);
 		SetWindowPos(_hwnd, HWND_TOPMOST, left, top, width, height, SWP_NOMOVE | SWP_NOSIZE);
 		ResetKeyboardSelection();
-		// The overlay is full-screen and topmost: without this the reader just lands on
-		// an unnamed canvas with no hint that anything is expected of it (issue #215).
-		Announce(
-			"Select screen region. Move with the arrow keys, press Enter to set the first corner, move, then Enter again to capture. Control plus A selects the whole screen. Escape cancels.",
-			AutomationNotificationKind.Other);
+		// The overlay is full-screen and topmost, so it has to say what it wants (issue
+		// #215) — but the Canvas's AutomationProperties.HelpText already says it, and a
+		// reader reads that out as focus lands here. Announcing the same thing as well raced
+		// that: the focus-change announcement interrupted the notification part-way through
+		// the sentence, so the instructions were routinely heard cut off (issue #265).
+		//
+		// The notification is kept for the one case the HelpText cannot cover: focus that
+		// did not land on the overlay at all, where nothing would read it out.
+		if (!focused)
+			Announce(InstructionsAnnouncement, AutomationNotificationKind.Other);
 		return _tcs.Task;
 	}
 
@@ -255,11 +269,7 @@ public sealed partial class RegionSelectionWindow : Window
 		var pp = e.GetCurrentPoint(_overlay);
 		if (pp.Properties.IsRightButtonPressed)
 		{
-			_dragging = false;
-			_tcs?.TrySetResult(null);
-			Announce("Region selection cancelled.", AutomationNotificationKind.ActionAborted);
-			ResetSelection();
-			HideAndRestore();
+			CompleteSelection(null, CancelledAnnouncement, AutomationNotificationKind.ActionAborted);
 			return;
 		}
 		// Only start selection on left button
@@ -317,11 +327,7 @@ public sealed partial class RegionSelectionWindow : Window
 		// Right click cancels
 		if (e.GetCurrentPoint(_overlay).Properties.IsRightButtonPressed)
 		{
-			_dragging = false;
-			_tcs?.TrySetResult(null);
-			Announce("Region selection cancelled.", AutomationNotificationKind.ActionAborted);
-			ResetSelection();
-			HideAndRestore();
+			CompleteSelection(null, CancelledAnnouncement, AutomationNotificationKind.ActionAborted);
 			return;
 		}
 		if (!_dragging) return;
@@ -377,12 +383,47 @@ public sealed partial class RegionSelectionWindow : Window
 			Math.Max(0, x2 - x1),
 			Math.Max(0, y2 - y1)
 		);
-		Announce(
+		CompleteSelection(
+			rectPx,
 			$"Region captured, {Math.Round(rectPx.Width)} by {Math.Round(rectPx.Height)} pixels.",
 			AutomationNotificationKind.ActionCompleted);
-		_tcs?.TrySetResult(rectPx);
+	}
+
+	/// <summary>
+	/// Announces the outcome, then hides the overlay and reports the result on a later
+	/// dispatcher turn.
+	/// <para>
+	/// The order is the point. These two announcements — the capture and the cancel — are
+	/// the ones issue #215 asked for, and they were the least likely of any to be heard:
+	/// raised, and then in the same turn the window was hidden and another application put
+	/// back in front. A UIA notification reaches a screen reader asynchronously, and readers
+	/// commonly discard events whose source window is gone by the time they arrive
+	/// (issue #265). Hiding a turn later leaves the overlay visible and foreground while the
+	/// event is delivered.
+	/// </para>
+	/// <para>
+	/// The result is set last, after the restore, and that matters on its own: a
+	/// <see cref="TaskCompletionSource{T}"/> may run its continuation inline, so setting it
+	/// first let the caller's next step — clipboard, OCR, a paste — begin while this
+	/// full-screen topmost window was still in front.
+	/// </para>
+	/// </summary>
+	private void CompleteSelection(Rect? result, string announcement, AutomationNotificationKind kind)
+	{
+		_dragging = false;
+		Announce(announcement, kind);
 		ResetSelection();
-		HideAndRestore();
+
+		void Finish()
+		{
+			HideAndRestore();
+			_tcs?.TrySetResult(result);
+		}
+
+		// Falling straight through when there is no queue, or it refuses the work, is what
+		// keeps a capture from hanging for ever on a lost announcement.
+		if (_dispatcherQueue is null || !_dispatcherQueue.TryEnqueue(DispatcherQueuePriority.Low, Finish))
+			Finish();
 	}
 
 	private void InitializeCrosshairAtCursor(System.Drawing.Rectangle bounds)
@@ -419,10 +460,7 @@ public sealed partial class RegionSelectionWindow : Window
 	{
 		if (e.Key == Windows.System.VirtualKey.Escape)
 		{
-			_dragging = false;
-			_tcs?.TrySetResult(null);
-			Announce("Region selection cancelled.", AutomationNotificationKind.ActionAborted);
-			HideAndRestore();
+			CompleteSelection(null, CancelledAnnouncement, AutomationNotificationKind.ActionAborted);
 			e.Handled = true;
 			return;
 		}
@@ -521,6 +559,9 @@ public sealed partial class RegionSelectionWindow : Window
 		// Start where the pointer already is so mouse and keyboard agree, and so the
 		// caret matches the crosshair the mouse path draws on open.
 		var caret = _lastPointerPos ?? CursorInOverlayCoordinates(width, height);
+		// Everything the selector says is scaled to these, so it reads out the same unit
+		// FinishSelection announces the capture in (issue #265).
+		_keyboard.SetBitmapSize(_bmpW, _bmpH);
 		_keyboard.Reset(width, height, caret.X, caret.Y);
 	}
 
@@ -670,9 +711,14 @@ public sealed partial class RegionSelectionWindow : Window
 		}
 	}
 
-        private void TryFocusOverlay()
+        /// <summary>
+        /// True when focus landed on the overlay Canvas — which is what makes a reader read
+        /// out its name and HelpText, and so what decides whether the instructions have to be
+        /// announced separately (issue #265).
+        /// </summary>
+        private bool TryFocusOverlay()
         {
-                try { _overlay?.Focus(FocusState.Programmatic); } catch { }
+                try { return _overlay?.Focus(FocusState.Programmatic) == true; } catch { return false; }
         }
 
         private void RememberForegroundWindow()
@@ -829,15 +875,18 @@ public sealed partial class RegionSelectionWindow : Window
 			int vkCode = Marshal.ReadInt32(lParam);
 			if (vkCode == VK_ESCAPE)
 			{
-				// Cancel the selection on Escape key
+				// Cancel the selection on Escape key. The hook can run ahead of the UI
+				// thread's own message handling, so the work goes through the dispatcher;
+				// CompleteSelection then takes its own turn to hide, so the cancel is
+				// announced from a window that is still there to be announced from.
 				_dragging = false;
-				_tcs?.TrySetResult(null);
-				// Use dispatcher to ensure UI operations happen on the correct thread
-				_dispatcherQueue?.TryEnqueue(() =>
+				if (_dispatcherQueue is null || !_dispatcherQueue.TryEnqueue(
+					() => CompleteSelection(null, CancelledAnnouncement, AutomationNotificationKind.ActionAborted)))
 				{
-					Announce("Region selection cancelled.", AutomationNotificationKind.ActionAborted);
-					HideAndRestore();
-				});
+					// Nothing will run the cancel, so the caller has to be released here or
+					// it waits for a region that is never coming.
+					_tcs?.TrySetResult(null);
+				}
 				return (IntPtr)1; // Suppress the key
 			}
 		}

--- a/Mutation.Ui/Views/RegionSelectionWindow.xaml.cs
+++ b/Mutation.Ui/Views/RegionSelectionWindow.xaml.cs
@@ -883,9 +883,12 @@ public sealed partial class RegionSelectionWindow : Window
 				if (_dispatcherQueue is null || !_dispatcherQueue.TryEnqueue(
 					() => CompleteSelection(null, CancelledAnnouncement, AutomationNotificationKind.ActionAborted)))
 				{
-					// Nothing will run the cancel, so the caller has to be released here or
-					// it waits for a region that is never coming.
-					_tcs?.TrySetResult(null);
+					// Nothing will run the cancel on the queue, so it runs here — a
+					// low-level hook is delivered on the thread that installed it, which is
+					// this window's own. Merely releasing the caller instead would leave a
+					// full-screen topmost overlay on screen and a global keyboard hook
+					// installed, with the capture looking finished to everyone above.
+					CompleteSelection(null, CancelledAnnouncement, AutomationNotificationKind.ActionAborted);
 				}
 				return (IntPtr)1; // Suppress the key
 			}


### PR DESCRIPTION
Three small ones from the board, taken together because none of them touches
what the other two touch.

Closes #318
Closes #265
Closes #329

## #318 — one retry authority for the OpenAI-SDK clients

Every OpenAI SDK client the app builds kept the SDK's default `ClientRetryPolicy`:
three retries of its own on 408, 429 and 5xx. `TransientRetry` then wrapped that
with four more attempts, so a persistent 429 cost **up to sixteen requests**, and a
rate-limited account was answered by asking sixteen more times.

The SDK's loop is off now — `OpenAiClientOptionsFactory.Create` defaults
`maxRetries` to 0, in production as in the tests, with the reasoning written next
to it. Nested loops also made the escalating per-attempt deadline meaningless,
because the SDK's retries all ran inside one of ours, sharing its deadline.

The one thing the SDK's loop did better was honour the `Retry-After` header. That
moved into `RetryAfterHint`, which `TransientRetry` consults on every retry — so
the Deepgram, Anthropic and OCR paths get it too, not just the two OpenAI ones. A
wait longer than 60 s is cut to 60 s: a user is standing over a finished
recording, and an hour is not a wait, it is a failure that has not been reported
yet.

Pinned by tests: four requests for a persistent 429 through `LlmService` and
through `OpenAiSpeechToTextService`, both built the way `App.xaml.cs` builds them;
a `Retry-After: 2` waits 2 s rather than the linear 500 ms; a failure that asks
for nothing keeps the linear backoff.

`LlmService`'s `sdkRetryCount` parameter is gone — it existed only so a test could
turn off what production now turns off itself.

## #265 — three residual concerns from the region overlay

1. **The commit and cancel announcements were raised on a window hidden in the
   same turn.** UIA notifications reach a reader asynchronously, and readers
   commonly drop events whose source window is gone by the time they arrive — so
   the two announcements #215 specifically asked for were the least likely to be
   heard. `CompleteSelection` announces, then takes its own dispatcher turn to
   hide and restore. It also sets the result **after** the restore: a
   `TaskCompletionSource` may run its continuation inline, so setting it first let
   the caller's next step begin while a full-screen topmost window was still in
   front.
2. **The opening announcement raced window activation.** The Canvas's
   `AutomationProperties.HelpText` already carries the instructions and is read on
   focus, so the notification was both redundant and routinely cut off mid-sentence
   by the focus-change announcement. It is now raised only when focus did not land
   on the overlay, where nothing would read the HelpText out.
3. **Movement was announced in DIPs and the capture in bitmap pixels.** On a 150%
   display a user sizing a region by the spoken numbers was fed two readings that
   did not agree. `KeyboardRegionSelector.SetBitmapSize` puts everything it says on
   the capture's scale, and the two low-frequency announcements (whole screen, corner
   set) now say "pixels" outright. The per-keystroke readout stays terse on purpose.

Items 1 and 2 are the ones the issue said need a real screen reader to confirm.
The reasoning is written where the code is; the behaviour still wants a listen.

## #329 — one vocabulary for key names

`SendKeysMapper` accepted `PgDn`, `PgUp`, `Bksp`, `BS`, `Esc`, `Ins`, `Caps`,
`Scroll` and the arrow aliases; `Hotkey.Parse` did not. So `Alt+PgDn` was accepted
and sent by a send-key box and rejected by a shortcut editor with "Unsupported key
'PGDN'", with nothing on screen explaining why.

`KeyNameAliases` holds the one table, read by both. It resolves each alias to a
`VirtualKey` member name, which is the spelling `Hotkey.Parse` already understood
and the key `SendKeysMapper`'s table is now keyed by — so the mapper picked up the
full spellings (`Back`, `Application`, `Pause`, `CapitalLock`) it did not have,
in the same move. Tests assert no alias shadows a name Windows already uses, and
that every alias means exactly what its full spelling means.

`Menu` is left disagreeing, deliberately and in a comment: `VirtualKey.Menu` is the
Alt key, so aliasing it to the context-menu key would change either what an
existing shortcut means or what an existing send-key box types.

## Documentation

`keyboard-shortcuts.md` gains the short key names (and the `Menu` caveat),
`accessibility.md` and `screen-capture-and-ocr.md` say the overlay's numbers are
picture pixels throughout, and `troubleshooting.md` says a busy service that asks
Mutation to wait is now waited for. HTML rebuilt and committed alongside.

## Verification

`dotnet test --configuration Release` — 1926 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
