### PR TITLE
Point the board config at the option IDs the board actually has now

### DIFF
--- a/ClaudeProject.md
+++ b/ClaudeProject.md
@@ -176,12 +176,16 @@ write, so a stale id fails loudly instead of mutating the wrong board.
 
 | Status      | Purpose key       | Option ID  |
 | ----------- | ----------------- | ---------- |
-| Backlog     | `col-backlog`     | `f75ad846` |
-| Ready       | `col-ready`       | `6bff5a53` |
-| In Progress | `col-in-progress` | `47fc9ee4` |
-| In Review   | `col-in-review`   | `211e0ac6` |
-| Blocked     | `col-blocked`     | `311b4541` |
-| Done        | `col-done`        | `98236657` |
+| Backlog     | `col-backlog`     | `79aacfe5` |
+| Ready       | `col-ready`       | `e61d226b` |
+| In Progress | `col-in-progress` | `c74f4105` |
+| In Review   | `col-in-review`   | `75905803` |
+| Blocked     | `col-blocked`     | `8ebf6b74` |
+| Done        | `col-done`        | `751f4aa8` |
+
+Renaming or reordering a Status option regenerates **every** option ID and
+clears the Status value on every board item. If you rename one, re-read the
+IDs above and re-apply each item's Status afterwards.
 
 ## Reference Docs
 


### PR DESCRIPTION
## What

`ClaudeProject.md` listed the board's first Status option as `Backlog`, but on
the board it was actually named `Todo`. Renaming the option to `Backlog` fixed
the name — and regenerated all six option IDs, so every ID in the table went
stale in the same move.

`updateProjectV2Field` accepts no option `id`, only `{name, color, description}`,
so it cannot rename in place: it replaces the option set. Two consequences, both
worth knowing before anyone touches the board again:

- All six option IDs are new. Any board write using an old ID fails.
- Every item's Status value is cleared. All 129 items lost their column and were
  re-applied from a snapshot; the board is back to 124 Done, 4 Ready, 1 Backlog.

## Change

The Option ID table now holds the current IDs, and a short note below it says
what a rename costs so the next person snapshots first.

## Verification

Read back from the live board after the restore — the six IDs match, and every
issue's column matches its `status-*` label. `dotnet test` was not run: the
change is one Markdown table, and no compiled code is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)