### PR TITLE
Say what the router boxes rewrote, and check both hotkey lists against each other (#332, #321)

### DIFF
--- a/Documentation/UserGuide/html/accessibility.html
+++ b/Documentation/UserGuide/html/accessibility.html
@@ -204,7 +204,8 @@ messages.</p>
 <p>The Settings window follows the same rule. A shortcut box that tidies up what you
 typed says so as you leave it — &quot;Speak clipboard now reads CTRL+SHIFT+A.&quot; — and waits
 its turn, so it never talks over a warning about the same box. A box that was already
-written Mutation's way stays quiet. See
+written Mutation's way stays quiet. The &quot;From&quot; and &quot;To&quot; boxes in the shortcut router
+do the same, naming which of the two they mean. See
 <a href="keyboard-shortcuts.html">Keyboard shortcuts</a> for what the tidying up does.</p>
 <h2 id="the-screenshot-overlay-talks-you-through-it">The screenshot overlay talks you through it</h2>
 <p>Grabbing part of a screen you cannot see sounds impossible. It is not.</p>

--- a/Documentation/UserGuide/html/keyboard-shortcuts.html
+++ b/Documentation/UserGuide/html/keyboard-shortcuts.html
@@ -385,7 +385,9 @@ reader reads it out: &quot;Speak clipboard now reads CTRL+SHIFT+A.&quot; You get
 when something actually changed, so tabbing down a page of shortcuts that are
 already written Mutation's way stays quiet. The note goes away when you come back
 to that box. The <strong>From</strong> and <strong>To</strong> boxes in the shortcut router further down the
-page still tidy up in silence.</p>
+page do the same thing, and name the box they are talking about: &quot;Shortcut to
+listen for now reads CTRL+SHIFT+A.&quot; If the row has something wrong with it, you
+hear that instead — the problem matters more than the spelling.</p>
 <p>Short names for keys are fine. Write <strong>Alt+PgDn</strong> or <strong>Alt+PageDown</strong>, <strong>Ctrl+Esc</strong>
 or <strong>Ctrl+Escape</strong>, <strong>Bksp</strong> or <strong>Backspace</strong>, <strong>ArrowUp</strong> or <strong>Up</strong> — Mutation
 takes either, in any box on the page, and saves the full name. The one word to
@@ -412,7 +414,11 @@ hotkey</strong> note appears under both rows, and is read out the moment it turn
 you are editing. Give one of them a different combination, otherwise only one of the
 two will ever fire.
 Mutation compares the keys, not the spelling, so writing one as
-<strong>Ctrl+Shift+A</strong> and the other as <strong>Shift+Ctrl+A</strong> is still caught.</li>
+<strong>Ctrl+Shift+A</strong> and the other as <strong>Shift+Ctrl+A</strong> is still caught.
+The shortcuts at the top of the page and the router mappings at the bottom are
+checked against each other, not just each list against itself. Give <strong>Speak
+clipboard</strong> and a router mapping's &quot;From&quot; box the same combination and both rows
+are flagged, so you can see the two ends of the clash while you are still editing.</li>
 <li><strong>The same combination in a &quot;send key after&quot; box and a real shortcut</strong> —
 also flagged, and worth fixing. Windows hands that key straight back to Mutation,
 so the action would set itself off again and again. Putting the same key in <em>both</em>
@@ -477,8 +483,10 @@ down to the <strong>Hotkey Router</strong> section. Press <strong>Add mapping</s
 and &quot;To&quot; boxes, and press <strong>Save</strong>. Each row shows a small status marker: a tick
 once the mapping is live, or an error marker with a message if something is wrong.
 Two mappings listening for the same &quot;From&quot; combination get a &quot;Duplicate 'From'
-hotkey&quot; message — again comparing the keys rather than the spelling. <strong>Delete</strong>
-removes a mapping.</p>
+hotkey&quot; message — again comparing the keys rather than the spelling. So does a
+mapping whose &quot;From&quot; combination is already used by one of the shortcuts higher up
+the page: the two lists are checked together, because Mutation can only claim a
+combination once. <strong>Delete</strong> removes a mapping.</p>
 <blockquote>
 <p>As the in-app help puts it: map one shortcut to another so a single key press can
 trigger a more complex shortcut. Changes apply when you save settings.</p>

--- a/Documentation/UserGuide/markdown/accessibility.md
+++ b/Documentation/UserGuide/markdown/accessibility.md
@@ -74,7 +74,8 @@ messages.
 The Settings window follows the same rule. A shortcut box that tidies up what you
 typed says so as you leave it — "Speak clipboard now reads CTRL+SHIFT+A." — and waits
 its turn, so it never talks over a warning about the same box. A box that was already
-written Mutation's way stays quiet. See
+written Mutation's way stays quiet. The "From" and "To" boxes in the shortcut router
+do the same, naming which of the two they mean. See
 [Keyboard shortcuts](keyboard-shortcuts.md) for what the tidying up does.
 
 ## The screenshot overlay talks you through it

--- a/Documentation/UserGuide/markdown/keyboard-shortcuts.md
+++ b/Documentation/UserGuide/markdown/keyboard-shortcuts.md
@@ -120,7 +120,9 @@ reader reads it out: "Speak clipboard now reads CTRL+SHIFT+A." You get that only
 when something actually changed, so tabbing down a page of shortcuts that are
 already written Mutation's way stays quiet. The note goes away when you come back
 to that box. The **From** and **To** boxes in the shortcut router further down the
-page still tidy up in silence.
+page do the same thing, and name the box they are talking about: "Shortcut to
+listen for now reads CTRL+SHIFT+A." If the row has something wrong with it, you
+hear that instead — the problem matters more than the spelling.
 
 Short names for keys are fine. Write **Alt+PgDn** or **Alt+PageDown**, **Ctrl+Esc**
 or **Ctrl+Escape**, **Bksp** or **Backspace**, **ArrowUp** or **Up** — Mutation
@@ -153,6 +155,10 @@ readers announce it straight away.
   two will ever fire.
   Mutation compares the keys, not the spelling, so writing one as
   **Ctrl+Shift+A** and the other as **Shift+Ctrl+A** is still caught.
+  The shortcuts at the top of the page and the router mappings at the bottom are
+  checked against each other, not just each list against itself. Give **Speak
+  clipboard** and a router mapping's "From" box the same combination and both rows
+  are flagged, so you can see the two ends of the clash while you are still editing.
 - **The same combination in a "send key after" box and a real shortcut** —
   also flagged, and worth fixing. Windows hands that key straight back to Mutation,
   so the action would set itself off again and again. Putting the same key in *both*
@@ -222,8 +228,10 @@ down to the **Hotkey Router** section. Press **Add mapping**, fill in the "From"
 and "To" boxes, and press **Save**. Each row shows a small status marker: a tick
 once the mapping is live, or an error marker with a message if something is wrong.
 Two mappings listening for the same "From" combination get a "Duplicate 'From'
-hotkey" message — again comparing the keys rather than the spelling. **Delete**
-removes a mapping.
+hotkey" message — again comparing the keys rather than the spelling. So does a
+mapping whose "From" combination is already used by one of the shortcuts higher up
+the page: the two lists are checked together, because Mutation can only claim a
+combination once. **Delete** removes a mapping.
 
 > As the in-app help puts it: map one shortcut to another so a single key press can
 > trigger a more complex shortcut. Changes apply when you save settings.

--- a/Mutation.Tests/HotkeyConflictFinderTests.cs
+++ b/Mutation.Tests/HotkeyConflictFinderTests.cs
@@ -236,6 +236,119 @@ public class HotkeyConflictFinderTests
 		Assert.Throws<ArgumentNullException>(() => DuplicateIndexes(null!));
 	}
 
+	// ----- Across every list on the page (issue #321) -----
+	//
+	// HotkeyRegistrationTable is one table for the whole app: the Core, Router and Prompt
+	// groups exist only to decide what a refresh releases, and share one set of live chords.
+	// Each Settings list used to check only itself, so a core hotkey and a router mapping
+	// could claim the same chord with no badge on either row — and the user found out from
+	// "The shortcut is already registered." after saving.
+
+	[Fact]
+	public void A_shortcut_on_one_list_conflicts_with_the_same_one_on_another()
+	{
+		var across = DuplicateIndexesAcross(Lists(
+			Configured(Claimed("CTRL+ALT+G"), Claimed("CTRL+ALT+H")),
+			Configured(Claimed("CTRL+ALT+G"))));
+
+		// Both ends flagged, on whichever list they sit, so the user can find the pair.
+		Assert.Equal(new[] { 0 }, Sorted(across[0]));
+		Assert.Equal(new[] { 0 }, Sorted(across[1]));
+	}
+
+	[Fact]
+	public void Distinct_shortcuts_across_lists_do_not_conflict()
+	{
+		var across = DuplicateIndexesAcross(Lists(
+			Configured(Claimed("CTRL+ALT+G")),
+			Configured(Claimed("CTRL+ALT+H"), Claimed("SHIFT+F1"))));
+
+		Assert.Empty(across[0]);
+		Assert.Empty(across[1]);
+	}
+
+	[Fact]
+	public void Modifier_order_does_not_hide_a_clash_across_lists()
+	{
+		// The spellings differ and the chord does not, which is the whole reason this
+		// compares parsed chords rather than text (issue #306).
+		var across = DuplicateIndexesAcross(Lists(
+			Configured(Claimed("SHIFT+CTRL+A")),
+			Configured(Claimed("CTRL+SHIFT+A"))));
+
+		Assert.Equal(new[] { 0 }, Sorted(across[0]));
+		Assert.Equal(new[] { 0 }, Sorted(across[1]));
+	}
+
+	[Fact]
+	public void A_sent_key_still_clashes_with_a_registered_one_on_another_list()
+	{
+		// Windows routes the synthesized keystroke back to whoever registered the chord, so
+		// the action fires itself again — the exclusion #320 established survives the widening.
+		var across = DuplicateIndexesAcross(Lists(
+			Configured(Sent("CTRL+ALT+G")),
+			Configured(Claimed("CTRL+ALT+G"))));
+
+		Assert.Equal(new[] { 0 }, Sorted(across[0]));
+		Assert.Equal(new[] { 0 }, Sorted(across[1]));
+	}
+
+	[Fact]
+	public void Two_sent_keys_on_different_lists_are_still_not_a_conflict()
+	{
+		var across = DuplicateIndexesAcross(Lists(
+			Configured(Sent("^{F5}")),
+			Configured(Sent("^{F5}"))));
+
+		Assert.Empty(across[0]);
+		Assert.Empty(across[1]);
+	}
+
+	[Fact]
+	public void Half_typed_text_never_conflicts_across_lists_either()
+	{
+		// It cannot be registered at all, so it cannot collide — and the row already carries a
+		// validation message without a wrong duplicate badge on top of it.
+		var across = DuplicateIndexesAcross(Lists(
+			Configured(Claimed("CTRL+")),
+			Configured(Claimed("CTRL+"), Claimed(null))));
+
+		Assert.Empty(across[0]);
+		Assert.Empty(across[1]);
+	}
+
+	[Fact]
+	public void A_clash_inside_one_list_is_still_found_when_checked_alongside_others()
+	{
+		var across = DuplicateIndexesAcross(Lists(
+			Configured(Claimed("CTRL+ALT+G"), Claimed("CTRL+ALT+H"), Claimed("ctrl+alt+g")),
+			Configured(Claimed("SHIFT+F1"))));
+
+		Assert.Equal(new[] { 0, 2 }, Sorted(across[0]));
+		Assert.Empty(across[1]);
+	}
+
+	[Fact]
+	public void An_empty_list_alongside_a_populated_one_answers_for_both()
+	{
+		var across = DuplicateIndexesAcross(Lists(
+			Configured(),
+			Configured(Claimed("CTRL+ALT+G"), Claimed("CTRL+ALT+G"))));
+
+		Assert.Empty(across[0]);
+		Assert.Equal(new[] { 0, 1 }, Sorted(across[1]));
+	}
+
+	[Fact]
+	public void A_missing_set_of_lists_is_refused_rather_than_treated_as_empty()
+	{
+		Assert.Throws<ArgumentNullException>(() => DuplicateIndexesAcross(null!));
+		Assert.Throws<ArgumentNullException>(() => DuplicateIndexesAcross(Lists(Configured(), null!)));
+	}
+
+	private static IReadOnlyList<IReadOnlyList<ConfiguredHotkey>> Lists(
+		params IReadOnlyList<ConfiguredHotkey>[] lists) => lists;
+
 	private static int[] Sorted(IReadOnlySet<int> indexes)
 	{
 		var sorted = new List<int>(indexes);

--- a/Mutation.Tests/HotkeyRouterControllerTests.cs
+++ b/Mutation.Tests/HotkeyRouterControllerTests.cs
@@ -240,6 +240,69 @@ public class HotkeyRouterControllerTests
 		Assert.False(first.IsDuplicate);
 	}
 
+	// ----- One check across every list on the page (issue #321) -----
+
+	[Fact]
+	public void RecalculateDuplicates_HandsTheDecisionToTheHostWhenOneIsListening()
+	{
+		// The router shares one registration table with the core hotkeys and the per-prompt
+		// ones, so a route can collide with a row it cannot see. A host that shows both lists
+		// answers for both, and the router's own narrower check stands down.
+		var (controller, _, _, entries, _) = BuildController();
+		var first = new HotkeyRouterEntry(new HotKeyRouterSettings.HotKeyRouterMap("Ctrl+C", "Ctrl+V"));
+		var second = new HotkeyRouterEntry(new HotKeyRouterSettings.HotKeyRouterMap("Ctrl+C", "Ctrl+B"));
+		entries.Add(first);
+		entries.Add(second);
+
+		int calls = 0;
+		controller.CheckDuplicatesAcrossLists = () => calls++;
+
+		CallRecalculateDuplicates(controller);
+
+		Assert.Equal(1, calls);
+		// Left to the host, which in this test flagged nothing — the point being that the
+		// narrow check did not quietly run as well and flag them itself.
+		Assert.False(first.IsDuplicate);
+		Assert.False(second.IsDuplicate);
+	}
+
+	[Fact]
+	public void ConfiguredFromChords_ReportsEachRowsFromChordAsClaimed()
+	{
+		var (controller, _, _, entries, _) = BuildController();
+		entries.Add(new HotkeyRouterEntry(new HotKeyRouterSettings.HotKeyRouterMap("shift+ctrl+a", "Ctrl+V")));
+		// Half-typed: nothing to compare, so it is offered as no chord at all rather than as
+		// text that might accidentally match.
+		entries.Add(new HotkeyRouterEntry(new HotKeyRouterSettings.HotKeyRouterMap("Ctrl+", "Ctrl+B")));
+
+		var configured = controller.ConfiguredFromChords();
+
+		Assert.Equal(2, configured.Count);
+		Assert.Equal("CTRL+SHIFT+A", configured[0].Text);
+		Assert.True(configured[0].ClaimsTheChord);
+		Assert.Null(configured[1].Text);
+		Assert.True(configured[1].ClaimsTheChord);
+	}
+
+	[Fact]
+	public void ApplyDuplicates_FlagsExactlyTheRowsItIsGiven()
+	{
+		var (controller, _, _, entries, _) = BuildController();
+		var first = new HotkeyRouterEntry(new HotKeyRouterSettings.HotKeyRouterMap("Ctrl+C", "Ctrl+V"));
+		var second = new HotkeyRouterEntry(new HotKeyRouterSettings.HotKeyRouterMap("Ctrl+X", "Ctrl+B"));
+		entries.Add(first);
+		entries.Add(second);
+
+		controller.ApplyDuplicates(new HashSet<int> { 1 });
+
+		Assert.False(first.IsDuplicate);
+		Assert.True(second.IsDuplicate);
+
+		controller.ApplyDuplicates(new HashSet<int>());
+
+		Assert.False(second.IsDuplicate);
+	}
+
 	// ----- autoPersist=false (settings page editor mode) -----
 
 	[Fact]

--- a/Mutation.Tests/HotkeyRouterEntryTests.cs
+++ b/Mutation.Tests/HotkeyRouterEntryTests.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using CognitiveSupport;
 using Mutation.Ui;
 
@@ -194,5 +196,146 @@ public class HotkeyRouterEntryTests
 
 		Assert.False(entry.IsFromValid);
 		Assert.Equal("CTRL+SHIFT", entry.FromHotkey);
+	}
+
+	// ----- Announcing a rewrite (issue #332) -----
+	//
+	// These two boxes tidied up in silence, exactly as the hotkey editors did before #327:
+	// type "shift+ctrl+a", press Tab, and a sighted user watches it become "CTRL+SHIFT+A"
+	// while a screen-reader user hears nothing and reads back something they did not type.
+
+	[Fact]
+	public void Commit_ThatRewritesTheFromBox_SaysWhatItNowReads()
+	{
+		var entry = new HotkeyRouterEntry(Map("Ctrl+C", "Ctrl+V"));
+
+		entry.FromHotkey = "shift+ctrl+a";
+		entry.CommitFromHotkey();
+
+		Assert.Equal("Shortcut to listen for now reads CTRL+SHIFT+A.", entry.FromCommitAnnouncement);
+		Assert.Null(entry.ToCommitAnnouncement);
+	}
+
+	[Fact]
+	public void Commit_ThatRewritesTheToBox_SaysWhatItNowReads()
+	{
+		var entry = new HotkeyRouterEntry(Map("Ctrl+C", "Ctrl+V"));
+
+		entry.ToHotkey = "alt+ctrl+y";
+		entry.CommitToHotkey();
+
+		Assert.Equal("Shortcut to send when triggered now reads CTRL+ALT+Y.", entry.ToCommitAnnouncement);
+		Assert.Null(entry.FromCommitAnnouncement);
+	}
+
+	[Fact]
+	public void Commit_OfTextAlreadyWrittenCanonically_StaysSilent()
+	{
+		// The common case by far. Tabbing across a row that is already tidy has to say
+		// nothing, or the list talks over the user on every mapping they pass.
+		var entry = new HotkeyRouterEntry(Map("Ctrl+C", "Ctrl+V"));
+
+		entry.FromHotkey = "CTRL+SHIFT+A";
+		entry.CommitFromHotkey();
+
+		Assert.Null(entry.FromCommitAnnouncement);
+	}
+
+	[Fact]
+	public void Commit_OfHalfTypedText_LeavesTheRowErrorToSpeak()
+	{
+		// "CTRL+SHIFT" is a rewrite of what was typed, but the row already has something more
+		// important to say about it. Being told the shortcut is unusable outranks being told
+		// how it is now spelled, and the two would otherwise arrive in the same breath.
+		var entry = new HotkeyRouterEntry(Map("Ctrl+C", "Ctrl+V"));
+
+		entry.FromHotkey = "ctrl+shift+";
+		entry.CommitFromHotkey();
+
+		Assert.NotNull(entry.BindingErrorMessage);
+		Assert.Null(entry.FromCommitAnnouncement);
+	}
+
+	[Fact]
+	public void ADuplicateFoundAfterTheCommit_TakesDownTheRewriteNotice()
+	{
+		// Duplicates are recomputed after the commit that caused them, so the notice can
+		// already be standing by the time the clash is known. The clash is the more urgent
+		// news and must not have a tidy-up notice talking over it.
+		var entry = new HotkeyRouterEntry(Map("Ctrl+C", "Ctrl+V"));
+
+		entry.FromHotkey = "shift+ctrl+a";
+		entry.CommitFromHotkey();
+		Assert.NotNull(entry.FromCommitAnnouncement);
+
+		entry.SetDuplicate(true);
+
+		Assert.Null(entry.FromCommitAnnouncement);
+	}
+
+	[Fact]
+	public void BuildingARowFromSettings_SaysNothing()
+	{
+		// A settings file written before the app canonicalised these values would otherwise
+		// read every tidied row aloud at startup, about an edit nobody made.
+		var entry = new HotkeyRouterEntry(Map("shift+ctrl+a", "alt+ctrl+y"));
+
+		Assert.Equal("CTRL+SHIFT+A", entry.FromHotkey);
+		Assert.Null(entry.FromCommitAnnouncement);
+		Assert.Null(entry.ToCommitAnnouncement);
+	}
+
+	[Fact]
+	public void CommittingSilently_LeavesAStandingNoticeAlone()
+	{
+		// Saving the page re-commits every row. The row the user just left has already said
+		// what it rewrote, and a second commit of the same text must not wipe that.
+		var entry = new HotkeyRouterEntry(Map("Ctrl+C", "Ctrl+V"));
+
+		entry.FromHotkey = "shift+ctrl+a";
+		entry.CommitFromHotkey();
+
+		entry.CommitSilently();
+
+		Assert.Equal("Shortcut to listen for now reads CTRL+SHIFT+A.", entry.FromCommitAnnouncement);
+	}
+
+	[Fact]
+	public void ReturningToTheBox_TakesTheNoticeDown()
+	{
+		// Left standing it becomes an ordinary line of text under the row, read out as current
+		// content by anyone going down the page afterwards.
+		var entry = new HotkeyRouterEntry(Map("Ctrl+C", "Ctrl+V"));
+
+		entry.FromHotkey = "shift+ctrl+a";
+		entry.CommitFromHotkey();
+
+		entry.ClearFromCommitAnnouncement();
+
+		Assert.Null(entry.FromCommitAnnouncement);
+	}
+
+	[Fact]
+	public void TheSameRewriteTwiceIsAnnouncedTwice()
+	{
+		// Clearing on the way back in is what makes this work: an unchanged message would
+		// otherwise be swallowed as "nothing new to say".
+		var entry = new HotkeyRouterEntry(Map("Ctrl+C", "Ctrl+V"));
+		var announcements = new List<string?>();
+		entry.PropertyChanged += (_, e) =>
+		{
+			if (e.PropertyName == nameof(HotkeyRouterEntry.FromCommitAnnouncement))
+				announcements.Add(entry.FromCommitAnnouncement);
+		};
+
+		entry.FromHotkey = "shift+ctrl+a";
+		entry.CommitFromHotkey();
+		entry.ClearFromCommitAnnouncement();
+		entry.FromHotkey = "shift+ctrl+a";
+		entry.CommitFromHotkey();
+
+		Assert.Equal(
+			new[] { "Shortcut to listen for now reads CTRL+SHIFT+A.", null, "Shortcut to listen for now reads CTRL+SHIFT+A." },
+			announcements);
 	}
 }

--- a/Mutation.Ui/Core/HotkeyConflictFinder.cs
+++ b/Mutation.Ui/Core/HotkeyConflictFinder.cs
@@ -88,6 +88,58 @@ internal static class HotkeyConflictFinder
 	}
 
 	/// <summary>
+	/// The same answer for several lists at once: for each list in <paramref name="lists"/>,
+	/// the positions in it holding a shortcut that clashes with another one <em>anywhere</em>
+	/// in the set.
+	/// <para>
+	/// <see cref="HotkeyRegistrationTable"/> is one table for the whole app — the Core, Router
+	/// and Prompt groups exist only to decide what a refresh releases, and share one set of
+	/// live chords. So a core hotkey and a router mapping compete for the same chord, and
+	/// whichever registers second comes back as "The shortcut is already registered." after
+	/// the user saves. Each Settings list used to check only itself, which is how a clash
+	/// across two lists reached that dialog with no badge on either row (issue #321).
+	/// </para>
+	/// <para>
+	/// Every rule <see cref="DuplicateIndexes(IReadOnlyList{ConfiguredHotkey})"/> follows holds
+	/// here unchanged, because this is that same call over one concatenated list, with the
+	/// positions mapped back to the list each came from.
+	/// </para>
+	/// </summary>
+	public static IReadOnlyList<IReadOnlySet<int>> DuplicateIndexesAcross(
+		IReadOnlyList<IReadOnlyList<ConfiguredHotkey>> lists)
+	{
+		if (lists is null) throw new ArgumentNullException(nameof(lists));
+
+		var combined = new List<ConfiguredHotkey>();
+		var offsets = new int[lists.Count];
+		for (int list = 0; list < lists.Count; list++)
+		{
+			if (lists[list] is null)
+				throw new ArgumentNullException(nameof(lists), $"List {list} is null.");
+
+			offsets[list] = combined.Count;
+			combined.AddRange(lists[list]);
+		}
+
+		var duplicates = DuplicateIndexes(combined);
+
+		var perList = new IReadOnlySet<int>[lists.Count];
+		for (int list = 0; list < lists.Count; list++)
+		{
+			var mine = new HashSet<int>();
+			for (int i = 0; i < lists[list].Count; i++)
+			{
+				if (duplicates.Contains(offsets[list] + i))
+					mine.Add(i);
+			}
+
+			perList[list] = mine;
+		}
+
+		return perList;
+	}
+
+	/// <summary>
 	/// Every chord one entry puts on the keyboard: one for a registered shortcut, and one per
 	/// step for a sent sequence. Half-typed text yields nothing, because there is no chord to
 	/// compare.

--- a/Mutation.Ui/HotkeyRouterEntry.cs
+++ b/Mutation.Ui/HotkeyRouterEntry.cs
@@ -1,4 +1,5 @@
 ﻿using CognitiveSupport;
+using Mutation.Ui.Core;
 using Mutation.Ui.Services;
 using System;
 using System.Collections.Generic;
@@ -25,8 +26,20 @@ public sealed class HotkeyRouterEntry : INotifyPropertyChanged
         private static readonly Brush SuccessStatusBrush = ResolveThemeBrush("SystemFillColorSuccessBrush") ?? new SolidColorBrush(Color.FromArgb(0xFF, 0x0B, 0x8A, 0x00));
         private static readonly Brush FailureStatusBrush = ResolveThemeBrush("SystemFillColorCriticalBrush") ?? new SolidColorBrush(Color.FromArgb(0xFF, 0xD1, 0x42, 0x42));
 
+        /// <summary>
+        /// What each box is called when a rewrite is read out. These are the names the
+        /// screen reader already gives the two text boxes (<c>AutomationProperties.Name</c>
+        /// in the row template), so the notice names the field the same way the reader just
+        /// did. The visible column headers, "From" and "To", read as the start of a sentence
+        /// instead — "From now reads CTRL+SHIFT+A" is heard as "from now on".
+        /// </summary>
+        private const string FromBoxName = "Shortcut to listen for";
+        private const string ToBoxName = "Shortcut to send when triggered";
+
         private string _fromHotkeyText = string.Empty;
         private string _toHotkeyText = string.Empty;
+        private string? _fromCommitAnnouncement;
+        private string? _toCommitAnnouncement;
         private string? _formattedFrom;
         private string? _formattedTo;
         private bool _isFromValid;
@@ -49,8 +62,11 @@ public sealed class HotkeyRouterEntry : INotifyPropertyChanged
                 _fromHotkeyText = map.FromHotKey ?? string.Empty;
                 _toHotkeyText = map.ToHotKey ?? string.Empty;
 
-                EvaluateFrom(commit: true);
-                EvaluateTo(commit: true);
+                // Silent: a row being built from what is already on disk has not been edited
+                // by anyone, and a settings file written before the app canonicalised these
+                // values would otherwise read every tidied row aloud at startup.
+                EvaluateFrom(commit: true, announce: false);
+                EvaluateTo(commit: true, announce: false);
         }
 
         internal void ReplaceBackingMap(HotKeyRouterSettings.HotKeyRouterMap map)
@@ -60,8 +76,8 @@ public sealed class HotkeyRouterEntry : INotifyPropertyChanged
                 _fromHotkeyText = map.FromHotKey ?? string.Empty;
                 _toHotkeyText = map.ToHotKey ?? string.Empty;
 
-                EvaluateFrom(commit: true);
-                EvaluateTo(commit: true);
+                EvaluateFrom(commit: true, announce: false);
+                EvaluateTo(commit: true, announce: false);
         }
 
         public event PropertyChangedEventHandler? PropertyChanged;
@@ -73,7 +89,7 @@ public sealed class HotkeyRouterEntry : INotifyPropertyChanged
                 {
                         if (SetField(ref _fromHotkeyText, value ?? string.Empty, nameof(FromHotkey)))
                         {
-                                EvaluateFrom(commit: false);
+                                EvaluateFrom(commit: false, announce: false);
                                 SetBindingResult(HotkeyBindingState.Inactive, null);
                         }
                 }
@@ -86,7 +102,7 @@ public sealed class HotkeyRouterEntry : INotifyPropertyChanged
                 {
                         if (SetField(ref _toHotkeyText, value ?? string.Empty, nameof(ToHotkey)))
                         {
-                                EvaluateTo(commit: false);
+                                EvaluateTo(commit: false, announce: false);
                                 SetBindingResult(HotkeyBindingState.Inactive, null);
                         }
                 }
@@ -146,15 +162,49 @@ public sealed class HotkeyRouterEntry : INotifyPropertyChanged
 
         public string? BindingErrorMessage => _combinedError;
 
+        /// <summary>
+        /// What to read out after the "From" box tidied up what was typed into it, or null
+        /// when there is nothing worth interrupting for. Bound to a live region in the row
+        /// template, which is what turns it into something a screen reader says (issue #332).
+        /// </summary>
+        public string? FromCommitAnnouncement => _fromCommitAnnouncement;
+
+        /// <summary>The same, for the "To" box.</summary>
+        public string? ToCommitAnnouncement => _toCommitAnnouncement;
+
         public void CommitFromHotkey()
         {
-                EvaluateFrom(commit: true);
+                EvaluateFrom(commit: true, announce: true);
         }
 
         public void CommitToHotkey()
         {
-                EvaluateTo(commit: true);
+                EvaluateTo(commit: true, announce: true);
         }
+
+        /// <summary>
+        /// Commits without saying anything. Saving the page commits every row on the way out,
+        /// and the rows the user never touched have nothing to report — while the one they
+        /// were still in has already reported it on the way past.
+        /// </summary>
+        internal void CommitSilently()
+        {
+                EvaluateFrom(commit: true, announce: false);
+                EvaluateTo(commit: true, announce: false);
+        }
+
+        /// <summary>
+        /// Takes down the last commit's notice on the way back into a box. It described
+        /// something that happened when the user left, and left standing it becomes a line of
+        /// ordinary-looking text under the row — read out as current content by anyone going
+        /// down the page afterwards. Clearing it also means the same rewrite happening twice
+        /// is announced twice, rather than the second one being swallowed as an unchanged
+        /// message.
+        /// </summary>
+        public void ClearFromCommitAnnouncement() => SetFromCommitAnnouncement(null);
+
+        /// <summary>The same, for the "To" box.</summary>
+        public void ClearToCommitAnnouncement() => SetToCommitAnnouncement(null);
 
         public void SetDuplicate(bool isDuplicate)
         {
@@ -162,6 +212,12 @@ public sealed class HotkeyRouterEntry : INotifyPropertyChanged
                         return;
 
                 _isDuplicate = isDuplicate;
+                // The row error outranks a tidy-up notice. Duplicates are recomputed after the
+                // commit that caused them, so the notice can already be standing by the time
+                // the clash is known — take it down rather than let the two talk over each
+                // other about the same box.
+                if (isDuplicate)
+                        SetFromCommitAnnouncement(null);
                 OnPropertyChanged(nameof(IsDuplicate));
                 OnPropertyChanged(nameof(IsFromInputValid));
                 OnPropertyChanged(nameof(IsValid));
@@ -189,8 +245,9 @@ public sealed class HotkeyRouterEntry : INotifyPropertyChanged
                 UpdateCombinedError();
         }
 
-        private void EvaluateFrom(bool commit)
+        private void EvaluateFrom(bool commit, bool announce)
         {
+                string typed = _fromHotkeyText;
                 _formattedFrom = FormatHotkey(_fromHotkeyText);
                 (_isFromValid, _fromValidationMessage) = ValidateFormattedHotkey(_formattedFrom, true);
 
@@ -216,10 +273,15 @@ public sealed class HotkeyRouterEntry : INotifyPropertyChanged
                 OnPropertyChanged(nameof(IsValid));
                 OnPropertyChanged(nameof(FromBackgroundBrush));
                 UpdateCombinedError();
+
+                if (announce)
+                        SetFromCommitAnnouncement(HotkeyCommitAnnouncement.For(
+                                FromBoxName, typed, _fromHotkeyText, FromRowMessage));
         }
 
-        private void EvaluateTo(bool commit)
+        private void EvaluateTo(bool commit, bool announce)
         {
+                string typed = _toHotkeyText;
                 _formattedTo = FormatHotkey(_toHotkeyText);
                 (_isToValid, _toValidationMessage) = ValidateFormattedHotkey(_formattedTo, false);
 
@@ -240,6 +302,39 @@ public sealed class HotkeyRouterEntry : INotifyPropertyChanged
                 OnPropertyChanged(nameof(IsValid));
                 OnPropertyChanged(nameof(ToBackgroundBrush));
                 UpdateCombinedError();
+
+                if (announce)
+                        SetToCommitAnnouncement(HotkeyCommitAnnouncement.For(
+                                ToBoxName, typed, _toHotkeyText, _toValidationMessage));
+        }
+
+        /// <summary>
+        /// What the row has to say about its "From" box, in the order
+        /// <see cref="UpdateCombinedError"/> already arbitrates them. Passed to
+        /// <see cref="HotkeyCommitAnnouncement"/> as the thing a tidy-up notice must lose to:
+        /// being told the shortcut is unusable, or is already taken, matters more than being
+        /// told how it is now spelled.
+        /// </summary>
+        private string? FromRowMessage => IsFromInputValid
+                ? null
+                : _isDuplicate ? DuplicateFromMessage : _fromValidationMessage;
+
+        private void SetFromCommitAnnouncement(string? message)
+        {
+                if (string.Equals(_fromCommitAnnouncement, message, StringComparison.Ordinal))
+                        return;
+
+                _fromCommitAnnouncement = message;
+                OnPropertyChanged(nameof(FromCommitAnnouncement));
+        }
+
+        private void SetToCommitAnnouncement(string? message)
+        {
+                if (string.Equals(_toCommitAnnouncement, message, StringComparison.Ordinal))
+                        return;
+
+                _toCommitAnnouncement = message;
+                OnPropertyChanged(nameof(ToCommitAnnouncement));
         }
 
         private void ApplyFormattedValue(ref string storage, string? formatted, string propertyName)
@@ -277,15 +372,19 @@ public sealed class HotkeyRouterEntry : INotifyPropertyChanged
         /// </summary>
         private string? FormatHotkey(string? value) => Hotkey.Canonicalize(value);
 
+        private const string DuplicateFromMessage = "Duplicate 'From' hotkey.";
+
         private void UpdateCombinedError()
         {
-                string? message = null;
+                string? message;
                 if (!IsFromInputValid)
-                        message = _isDuplicate ? "Duplicate 'From' hotkey." : _fromValidationMessage;
+                        message = FromRowMessage;
                 else if (!_isToValid)
                         message = _toValidationMessage;
                 else if (_bindingState == HotkeyBindingState.Failed)
                         message = _bindingError;
+                else
+                        message = null;
 
                 if (!string.Equals(_combinedError, message, StringComparison.Ordinal))
                 {

--- a/Mutation.Ui/Services/HotkeyRouterController.cs
+++ b/Mutation.Ui/Services/HotkeyRouterController.cs
@@ -125,15 +125,32 @@ internal sealed class HotkeyRouterController
 		}
 	}
 
+	/// <summary>
+	/// Takes down the notice left by the last time this box tidied itself up, on the way back
+	/// into it (issue #332).
+	/// </summary>
+	public void ClearFromAnnouncement(object sender)
+	{
+		if (sender is FrameworkElement { DataContext: HotkeyRouterEntry entry })
+			entry.ClearFromCommitAnnouncement();
+	}
+
+	/// <summary>The same, for the "To" box.</summary>
+	public void ClearToAnnouncement(object sender)
+	{
+		if (sender is FrameworkElement { DataContext: HotkeyRouterEntry entry })
+			entry.ClearToCommitAnnouncement();
+	}
+
 	public List<(string From, string To)> SyncSettings()
 	{
 		_settings.HotKeyRouterSettings ??= new HotKeyRouterSettings();
 
+		// Silently: this runs on every commit and on save, over every row. The row the user
+		// just left has already said what it rewrote, and re-committing it here would only
+		// wipe that notice; the rows they never touched have nothing to report at all.
 		foreach (var entry in _entries)
-		{
-			entry.CommitFromHotkey();
-			entry.CommitToHotkey();
-		}
+			entry.CommitSilently();
 
 		var validEntries = _entries
 			.Where(e => e.IsValid && e.NormalizedFromHotkey is not null && e.NormalizedToHotkey is not null)
@@ -256,21 +273,52 @@ internal sealed class HotkeyRouterController
 	}
 
 	/// <summary>
-	/// Flags the routes whose "from" shortcut is already taken by another route. Compared as
-	/// chords rather than as text, so the answer is the one registration will give — the
-	/// screen used to compare the typed strings and could wave through a pair the hotkey
-	/// table then refused (issue #306).
+	/// The router's "From" chords as the conflict finder wants them. Handed out so a host that
+	/// shows more than one hotkey list can check them all against each other in one go — the
+	/// registration table is shared, so a route and a core hotkey do compete (issue #321).
 	/// </summary>
-	private void RecalculateDuplicates()
+	internal IReadOnlyList<HotkeyConflictFinder.ConfiguredHotkey> ConfiguredFromChords()
 	{
 		var configured = new List<HotkeyConflictFinder.ConfiguredHotkey>(_entries.Count);
 		foreach (var entry in _entries)
 			configured.Add(new(entry.IsFromValid ? entry.NormalizedFromHotkey : null, ClaimsTheChord: true));
+		return configured;
+	}
 
-		var duplicates = HotkeyConflictFinder.DuplicateIndexes(configured);
-
+	/// <summary>Flags the routes at <paramref name="duplicates"/> and clears the rest.</summary>
+	internal void ApplyDuplicates(IReadOnlySet<int> duplicates)
+	{
 		for (int i = 0; i < _entries.Count; i++)
 			_entries[i].SetDuplicate(duplicates.Contains(i));
+	}
+
+	/// <summary>
+	/// Set by a host that owns other hotkey lists on the same screen, to check every list at
+	/// once instead of this one alone (issue #321). It is expected to call back into
+	/// <see cref="ConfiguredFromChords"/> and <see cref="ApplyDuplicates"/>.
+	/// </summary>
+	internal Action? CheckDuplicatesAcrossLists { get; set; }
+
+	/// <summary>
+	/// Flags the routes whose "from" shortcut is already taken by another route. Compared as
+	/// chords rather than as text, so the answer is the one registration will give — the
+	/// screen used to compare the typed strings and could wave through a pair the hotkey
+	/// table then refused (issue #306).
+	/// <para>
+	/// This is the narrow answer, over the router list alone. A host that has set
+	/// <see cref="CheckDuplicatesAcrossLists"/> gets the wide one instead, because a route can
+	/// just as easily collide with a hotkey on another list.
+	/// </para>
+	/// </summary>
+	private void RecalculateDuplicates()
+	{
+		if (CheckDuplicatesAcrossLists is { } acrossLists)
+		{
+			acrossLists();
+			return;
+		}
+
+		ApplyDuplicates(HotkeyConflictFinder.DuplicateIndexes(ConfiguredFromChords()));
 	}
 
 	private void AttachEntry(HotkeyRouterEntry entry) =>

--- a/Mutation.Ui/Views/LiveRegion.cs
+++ b/Mutation.Ui/Views/LiveRegion.cs
@@ -1,0 +1,37 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace Mutation.Ui.Views;
+
+/// <summary>
+/// <see cref="LiveMessage"/> for a <see cref="TextBlock"/> that only a binding can reach.
+/// <para>
+/// A row inside a <c>DataTemplate</c> has no name to call it by from code-behind, so the
+/// hotkey router's rows could not use the one-line <c>LiveMessage.Show</c> the settings
+/// editors use. Binding <c>Text</c> directly is not enough on its own: WinUI raises nothing
+/// when a TextBlock's text changes, so a message bound into a live region is displayed and
+/// never spoken (issue #243). Binding this instead routes the same value through the same
+/// place, which sets the text, the visibility, and raises the event by hand.
+/// </para>
+/// </summary>
+public static class LiveRegion
+{
+	/// <summary>
+	/// The message to show and announce, or blank to take the last one down. Set it with a
+	/// binding — <c>views:LiveRegion.Text="{x:Bind SomeMessage, Mode=OneWay}"</c> — on a
+	/// TextBlock that also carries <c>AutomationProperties.LiveSetting</c>. Without the live
+	/// setting the block is announced by nothing; without this the text never changes.
+	/// </summary>
+	public static readonly DependencyProperty TextProperty = DependencyProperty.RegisterAttached(
+		"Text", typeof(string), typeof(LiveRegion), new PropertyMetadata(null, OnTextChanged));
+
+	public static string? GetText(DependencyObject element) => (string?)element.GetValue(TextProperty);
+
+	public static void SetText(DependencyObject element, string? value) => element.SetValue(TextProperty, value);
+
+	private static void OnTextChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+	{
+		if (d is TextBlock block)
+			LiveMessage.Show(block, e.NewValue as string);
+	}
+}

--- a/Mutation.Ui/Views/Settings/Pages/HotkeysSettingsPage.xaml
+++ b/Mutation.Ui/Views/Settings/Pages/HotkeysSettingsPage.xaml
@@ -5,6 +5,7 @@
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 	xmlns:controls="using:Mutation.Ui.Views.SettingsUi.Controls"
 	xmlns:local="using:Mutation.Ui"
+	xmlns:views="using:Mutation.Ui.Views"
 	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	mc:Ignorable="d">
@@ -53,6 +54,10 @@
 										<ColumnDefinition Width="2*" />
 										<ColumnDefinition Width="Auto" />
 									</Grid.ColumnDefinitions>
+									<Grid.RowDefinitions>
+										<RowDefinition Height="Auto" />
+										<RowDefinition Height="Auto" />
+									</Grid.RowDefinitions>
 
 									<Grid Grid.Column="0">
 										<Border Background="{x:Bind FromBackgroundBrush, Mode=OneWay}" CornerRadius="4">
@@ -63,6 +68,7 @@
 												HorizontalAlignment="Stretch"
 												AutomationProperties.Name="Shortcut to listen for"
 												ToolTipService.ToolTip="Shortcut to listen for"
+												GotFocus="HotkeyRouterFrom_GotFocus"
 												LostFocus="HotkeyRouterFrom_LostFocus" />
 										</Border>
 										<FontIcon
@@ -84,6 +90,7 @@
 											HorizontalAlignment="Stretch"
 											AutomationProperties.Name="Shortcut to send when triggered"
 											ToolTipService.ToolTip="Shortcut to send when triggered"
+											GotFocus="HotkeyRouterTo_GotFocus"
 											LostFocus="HotkeyRouterTo_LostFocus" />
 									</Border>
 
@@ -94,6 +101,31 @@
 										AutomationProperties.Name="Delete mapping"
 										Click="HotkeyRouterDelete_Click"
 										Tag="{x:Bind}" />
+
+									<!--
+										Says what the box rewrote itself to when leaving it tidied the
+										text up. Collapsed and silent until there is something to say;
+										LiveRegion sets the text and raises the event, the live setting
+										is what marks it worth announcing (issue #332).
+									-->
+									<TextBlock
+										Grid.Row="1"
+										Grid.Column="0"
+										TextWrapping="Wrap"
+										Visibility="Collapsed"
+										Style="{StaticResource CaptionTextBlockStyle}"
+										Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+										AutomationProperties.LiveSetting="Polite"
+										views:LiveRegion.Text="{x:Bind FromCommitAnnouncement, Mode=OneWay}" />
+									<TextBlock
+										Grid.Row="1"
+										Grid.Column="1"
+										TextWrapping="Wrap"
+										Visibility="Collapsed"
+										Style="{StaticResource CaptionTextBlockStyle}"
+										Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+										AutomationProperties.LiveSetting="Polite"
+										views:LiveRegion.Text="{x:Bind ToCommitAnnouncement, Mode=OneWay}" />
 								</Grid>
 							</DataTemplate>
 						</ListView.ItemTemplate>

--- a/Mutation.Ui/Views/Settings/Pages/HotkeysSettingsPage.xaml.cs
+++ b/Mutation.Ui/Views/Settings/Pages/HotkeysSettingsPage.xaml.cs
@@ -29,7 +29,6 @@ public sealed partial class HotkeysSettingsPage : UserControl
 		_settings = settings;
 		InitializeComponent();
 		BuildRows();
-		RecomputeDuplicates();
 
 		_routerController = new HotkeyRouterController(
 			HotkeyRouterEntries,
@@ -38,6 +37,10 @@ public sealed partial class HotkeysSettingsPage : UserControl
 			DispatcherQueue.GetForCurrentThread(),
 			HotkeyRouterList,
 			autoPersist: false);
+		// Both lists claim their chords from the same registration table, so they are checked
+		// against each other rather than each against itself (issue #321). Set before
+		// Initialize, which recomputes on its way out.
+		_routerController.CheckDuplicatesAcrossLists = RecomputeDuplicates;
 		_routerController.Initialize();
 	}
 
@@ -229,16 +232,31 @@ public sealed partial class HotkeysSettingsPage : UserControl
 		}
 	}
 
+	/// <summary>
+	/// Flags every row on the page that shares a chord with another one — the rows above and
+	/// the router mappings below, checked as one set rather than two.
+	/// <para>
+	/// They compete for real: <see cref="HotkeyRegistrationTable"/> is one table for the whole
+	/// app, so setting "Speak clipboard" and a route's "From" to the same chord used to pass
+	/// both lists and then fail at registration, reported in a dialog after saving with
+	/// nothing to say which two rows to compare (issue #321).
+	/// </para>
+	/// </summary>
 	private void RecomputeDuplicates()
 	{
-		var configured = new List<HotkeyConflictFinder.ConfiguredHotkey>(_rows.Count);
+		var core = new List<HotkeyConflictFinder.ConfiguredHotkey>(_rows.Count);
 		foreach (var row in _rows)
-			configured.Add(new(row.Spec.Getter(_settings), row.Spec.Registers));
+			core.Add(new(row.Spec.Getter(_settings), row.Spec.Registers));
 
-		var duplicates = HotkeyConflictFinder.DuplicateIndexes(configured);
+		var router = _routerController.ConfiguredFromChords();
+
+		var duplicates = HotkeyConflictFinder.DuplicateIndexesAcross(
+			new IReadOnlyList<HotkeyConflictFinder.ConfiguredHotkey>[] { core, router });
 
 		for (int i = 0; i < _rows.Count; i++)
-			ShowDuplicateBadge(_rows[i].DuplicateBadge, duplicates.Contains(i));
+			ShowDuplicateBadge(_rows[i].DuplicateBadge, duplicates[0].Contains(i));
+
+		_routerController.ApplyDuplicates(duplicates[1]);
 	}
 
 	private static void ShowDuplicateBadge(TextBlock badge, bool isDuplicate) =>
@@ -255,4 +273,10 @@ public sealed partial class HotkeysSettingsPage : UserControl
 
 	private void HotkeyRouterTo_LostFocus(object sender, RoutedEventArgs e) =>
 		_routerController.CommitToLostFocus(sender);
+
+	private void HotkeyRouterFrom_GotFocus(object sender, RoutedEventArgs e) =>
+		_routerController.ClearFromAnnouncement(sender);
+
+	private void HotkeyRouterTo_GotFocus(object sender, RoutedEventArgs e) =>
+		_routerController.ClearToAnnouncement(sender);
 }


### PR DESCRIPTION
Closes #332. Closes #321.

## #332 — the router boxes tidied up in silence

`HotkeyRouterEntry` canonicalises "From" and "To" on commit and writes the
result straight back through `OnPropertyChanged`. Type `shift+ctrl+a` into a
router **From** box and press Tab: a sighted user watches it become
`CTRL+SHIFT+A`, a screen-reader user hears nothing, and their next reading of
the field disagrees with what they typed. That is #327 word for word, on the
boxes #327 did not cover, one section down the same page.

Each row now carries an announcement per box, decided by the existing
`HotkeyCommitAnnouncement` rather than a second copy of the rule:

- Named after the boxes' own automation names — "Shortcut to listen for now
  reads CTRL+SHIFT+A." The visible column headers read as the start of a
  sentence instead: "From now reads…" is heard as "from now on".
- **The row error keeps priority.** No notice is raised while the box has a
  validation message, and a duplicate found *after* the commit — which is when
  duplicates are recomputed — takes a standing notice back down.
- **Silent where nobody edited anything.** Building a row from settings says
  nothing, so a file written before the app canonicalised these values does not
  read every tidied row aloud at startup. The save-time commit sweep is silent
  too; it runs over every row on every commit and would otherwise wipe the
  notice the user had just been handed.
- The notice comes down when focus returns to the box, so the same rewrite
  twice is announced twice rather than swallowed as an unchanged message.

A `DataTemplate` row has no name to reach from code-behind, so the one-line
`LiveMessage.Show` the editors use was not available. `Views/LiveRegion.cs` is
an attached property that routes a bound value through that same place — text,
visibility, and the automation event WinUI does not raise on its own (#243).

## #321 — two lists, one registration table

`HotkeyRegistrationTable` is one table for the whole app; the Core, Router and
Prompt groups exist only to decide what a refresh releases. Each Settings list
still only checked itself, so setting **Speak clipboard** and a mapping's
"From" to `CTRL+ALT+G` passed both checks, and whichever registered second came
back as "The shortcut is already registered." in the failure dialog after
saving — the wrong moment to find out, and with nothing to say which two rows
to compare.

`HotkeyConflictFinder.DuplicateIndexesAcross` runs the existing check over the
concatenated lists and maps the positions back, so every rule already in place
holds unchanged: parsed chords rather than text, half-typed text never clashes,
and two "Send key after…" entries still do not clash with each other. Both ends
of a clash are flagged, on whichever list they sit.

The Hotkeys page owns the combined check. The router controller hands over its
"From" chords and takes back the answer; its own narrower check remains as the
fallback for a host that has not widened it.

**Not covered:** per-prompt hotkeys are a third list, edited in a modal window
from another page, and the Hotkeys page has neither a live view of them nor
anywhere to put a badge for them. #321 asked for them "if they can be reached
from the same settings session" — filed as #336 rather than half-done, because
a "Duplicate hotkey" badge whose other end is on a page you cannot see is a
badge with no cause.

## Testing

`dotnet test --configuration Release` — 2046 passed, 0 failed.

- `HotkeyRouterEntryTests` — 10 new: both boxes announcing, an already-canonical
  box staying silent, the validation message and the after-the-fact duplicate
  each taking priority, construction and the silent sweep saying nothing, and
  the same rewrite twice being announced twice.
- `HotkeyConflictFinderTests` — 9 new on `DuplicateIndexesAcross`: a clash
  across lists flagging both ends, modifier order not hiding one, a sent key
  still clashing with a registered one on another list, two sent keys still not
  clashing, half-typed text still never clashing, and a within-list clash still
  found alongside others.
- `HotkeyRouterControllerTests` — 3 new on the hand-over: the host's check
  replacing the narrow one rather than running alongside it, the "From" chords
  handed out, and the answer applied.

Not covered by tests, same as #327: the XAML wiring itself — the live region in
the row template and the focus handlers. A WinUI `DataTemplate` needs a host to
build it (#304 tracks that seam).

## User guide

`keyboard-shortcuts.md` said outright that the router boxes still tidy up in
silence; that sentence is gone and describes what they now say. Duplicates are
described as covering both lists, in the shortcut-router section too.
`accessibility.md` extends the same paragraph to the router boxes. HTML rebuilt
and committed alongside.

🤖 Generated with [Claude Code](https://claude.com/claude-code)