### PR TITLE
Retry a busy Deepgram, say what a router box rewrote, and check one page's shortcuts as one list

### DIFF
--- a/CognitiveSupport/DeepgramFailure.cs
+++ b/CognitiveSupport/DeepgramFailure.cs
@@ -1,0 +1,87 @@
+using Deepgram.Models.Exceptions.v1;
+
+namespace CognitiveSupport;
+
+/// <summary>
+/// Whether a failure Deepgram answered with is worth another attempt.
+/// <para>
+/// Every failure Deepgram <em>answers</em> arrives as <see cref="DeepgramException"/> or its
+/// <see cref="DeepgramRESTException"/> subclass, neither of which the shared transient set
+/// handles. So a 429 rate limit or a 503 — exactly the failures another attempt would get
+/// past — used to be reported to the user on the first try, with the recording already made
+/// and the retry ladder never entered (issue #316).
+/// </para>
+/// <para>
+/// The exception carries no HTTP status. What it does carry is
+/// <see cref="DeepgramException.ErrCode"/>, which the SDK fills in from the <c>err_code</c>
+/// field of Deepgram's JSON error body — so the decision is made on that instead.
+/// </para>
+/// <para>
+/// Kept as a pure code-in, answer-out unit because the alternative is a decision buried in a
+/// Polly predicate that only a live rate limit would exercise.
+/// </para>
+/// </summary>
+internal static class DeepgramFailure
+{
+	/// <summary>
+	/// The error codes Deepgram documents for a request that will fail the same way however
+	/// many times it is sent: a rejected key, a malformed request, an unpayable account, audio
+	/// it cannot read. Retrying any of these makes the user wait out the whole ladder on a
+	/// lengthening timeout to be told what was already known on the first try.
+	/// <para>
+	/// Deepgram spells some of these twice — <c>PAYLOAD_TOO_LARGE</c> on one endpoint and
+	/// <c>Payload Too Large</c> on another — so the comparison strips the punctuation and case
+	/// rather than listing every spelling.
+	/// </para>
+	/// </summary>
+	private static readonly HashSet<string> Permanent = new(StringComparer.Ordinal)
+	{
+		Normalized("Bad Request"),                 // 400
+		Normalized("INVALID_QUERY_PARAMETER"),     // 400
+		Normalized("PAYLOAD_ERROR"),               // 400
+		Normalized("REMOTE_CONTENT_ERROR"),        // 400
+		Normalized("INVALID_AUTH"),                // 401
+		Normalized("ASR_PAYMENT_REQUIRED"),        // 402
+		Normalized("INSUFFICIENT_PERMISSIONS"),    // 401 or 403
+		Normalized("NOT_FOUND"),                   // 404
+		Normalized("PROJECT_NOT_FOUND"),           // 404
+		Normalized("PAYLOAD_TOO_LARGE"),           // 413
+		Normalized("UNSUPPORTED_MEDIA_TYPE"),      // 415
+		Normalized("UNPROCESSABLE_ENTITY"),        // 422
+		Normalized("ASR_UNPROCESSABLE_ENTITY"),    // 422
+	};
+
+	/// <summary>
+	/// True for a Deepgram failure another attempt could get past.
+	/// <para>
+	/// A list of what to give up on rather than a list of what to retry, and deliberately so.
+	/// The recording is already made by the time this is asked, and losing it to an error
+	/// Deepgram happened to spell in a way nobody here anticipated is a worse outcome than
+	/// three needless attempts. It also covers the two failures whose code does not reach us:
+	/// a 503 answers with <c>error_code</c> rather than <c>err_code</c>, which the SDK does
+	/// not read, and a gateway that answers with an HTML page at all gives the SDK nothing to
+	/// read, leaving its own "Unknown Error Code" placeholder behind. Both are transient, and
+	/// both would be lost by an allow-list.
+	/// </para>
+	/// <para>
+	/// The one documented client error this lets through is <c>INVALID_JSON</c> (400), whose
+	/// body carries <c>category</c> instead of <c>err_code</c>. It answers a malformed JSON
+	/// request body, and this app uploads audio bytes, so it is not a failure this caller can
+	/// provoke.
+	/// </para>
+	/// </summary>
+	public static bool IsWorthAnotherAttempt(DeepgramException failure) =>
+		!Permanent.Contains(Normalized(failure?.ErrCode));
+
+	/// <summary>
+	/// An error code with its case and separators taken off, so <c>TOO_MANY_REQUESTS</c> and
+	/// <c>Too Many Requests</c> are the one code they describe.
+	/// </summary>
+	private static string Normalized(string? errorCode)
+	{
+		if (string.IsNullOrWhiteSpace(errorCode))
+			return string.Empty;
+
+		return string.Concat(errorCode.Where(char.IsLetterOrDigit)).ToUpperInvariant();
+	}
+}

--- a/CognitiveSupport/DeepgramSpeechToTextService.cs
+++ b/CognitiveSupport/DeepgramSpeechToTextService.cs
@@ -44,7 +44,11 @@ public class DeepgramSpeechToTextService : ISpeechToTextService
 		_timeoutSeconds = timeoutSeconds > 0 ? timeoutSeconds : 10;
 		_timeProvider = timeProvider ?? TimeProvider.System;
 		_announceAttempt = announceAttempt ?? (attempt => this.Beep(attempt));
-		_retryPipeline = TransientRetry.Pipeline(retryCount: 3, TransientRetry.Transient(), timeProvider);
+		_retryPipeline = TransientRetry.Pipeline(
+			retryCount: 3,
+			TransientRetry.Transient()
+				.Handle<Deepgram.Models.Exceptions.v1.DeepgramException>(DeepgramFailure.IsWorthAnotherAttempt),
+			timeProvider);
 	}
 
 	public async Task<string> ConvertAudioToText(

--- a/Documentation/UserGuide/html/keyboard-shortcuts.html
+++ b/Documentation/UserGuide/html/keyboard-shortcuts.html
@@ -385,7 +385,8 @@ reader reads it out: &quot;Speak clipboard now reads CTRL+SHIFT+A.&quot; You get
 when something actually changed, so tabbing down a page of shortcuts that are
 already written Mutation's way stays quiet. The note goes away when you come back
 to that box. The <strong>From</strong> and <strong>To</strong> boxes in the shortcut router further down the
-page still tidy up in silence.</p>
+page do the same, and name themselves when they do: &quot;Shortcut to listen for now
+reads CTRL+SHIFT+A.&quot;</p>
 <p>Short names for keys are fine. Write <strong>Alt+PgDn</strong> or <strong>Alt+PageDown</strong>, <strong>Ctrl+Esc</strong>
 or <strong>Ctrl+Escape</strong>, <strong>Bksp</strong> or <strong>Backspace</strong>, <strong>ArrowUp</strong> or <strong>Up</strong> — Mutation
 takes either, in any box on the page, and saves the full name. The one word to
@@ -412,7 +413,13 @@ hotkey</strong> note appears under both rows, and is read out the moment it turn
 you are editing. Give one of them a different combination, otherwise only one of the
 two will ever fire.
 Mutation compares the keys, not the spelling, so writing one as
-<strong>Ctrl+Shift+A</strong> and the other as <strong>Shift+Ctrl+A</strong> is still caught.</li>
+<strong>Ctrl+Shift+A</strong> and the other as <strong>Shift+Ctrl+A</strong> is still caught. The check covers
+the whole page at once, so a shortcut at the top and a router mapping's &quot;From&quot; box at
+the bottom claiming the same keys are both flagged.</li>
+<li><strong>The same combination as one of your prompt shortcuts</strong> — a note reading <strong>Also
+used by an LLM prompt</strong> appears under the row. Prompt shortcuts are set in the prompt
+window rather than on this page, so there is no second row here to flag. Open
+<strong>AI prompts</strong> to see which one it is.</li>
 <li><strong>The same combination in a &quot;send key after&quot; box and a real shortcut</strong> —
 also flagged, and worth fixing. Windows hands that key straight back to Mutation,
 so the action would set itself off again and again. Putting the same key in <em>both</em>
@@ -476,9 +483,10 @@ are in, and the call mutes.</p>
 down to the <strong>Hotkey Router</strong> section. Press <strong>Add mapping</strong>, fill in the &quot;From&quot;
 and &quot;To&quot; boxes, and press <strong>Save</strong>. Each row shows a small status marker: a tick
 once the mapping is live, or an error marker with a message if something is wrong.
-Two mappings listening for the same &quot;From&quot; combination get a &quot;Duplicate 'From'
-hotkey&quot; message — again comparing the keys rather than the spelling. <strong>Delete</strong>
-removes a mapping.</p>
+A mapping whose &quot;From&quot; combination is already taken gets a &quot;Duplicate 'From'
+hotkey&quot; message — again comparing the keys rather than the spelling. That covers
+another mapping, any shortcut higher up the Hotkeys page, and any of your prompt
+shortcuts. <strong>Delete</strong> removes a mapping.</p>
 <blockquote>
 <p>As the in-app help puts it: map one shortcut to another so a single key press can
 trigger a more complex shortcut. Changes apply when you save settings.</p>

--- a/Documentation/UserGuide/html/troubleshooting.html
+++ b/Documentation/UserGuide/html/troubleshooting.html
@@ -199,6 +199,10 @@ its retries it has got.</p>
 <p>If the service is busy and asks Mutation to wait a moment before asking again, Mutation
 waits as long as it was asked to, up to a minute. So a gap between beeps that is longer
 than usual is the service setting the pace, not something going wrong.</p>
+<p>Not everything is worth another go. If the service turns the request down for a reason
+that will not change — your key was rejected, or the recording is bigger than it
+accepts — Mutation tells you straight away instead of working through the retries
+first. You hear one set of beeps, not four.</p>
 <p><strong>What to do.</strong></p>
 <ol>
 <li>Give it a moment — the retries are automatic and you will hear the result.</li>

--- a/Documentation/UserGuide/markdown/keyboard-shortcuts.md
+++ b/Documentation/UserGuide/markdown/keyboard-shortcuts.md
@@ -120,7 +120,8 @@ reader reads it out: "Speak clipboard now reads CTRL+SHIFT+A." You get that only
 when something actually changed, so tabbing down a page of shortcuts that are
 already written Mutation's way stays quiet. The note goes away when you come back
 to that box. The **From** and **To** boxes in the shortcut router further down the
-page still tidy up in silence.
+page do the same, and name themselves when they do: "Shortcut to listen for now
+reads CTRL+SHIFT+A."
 
 Short names for keys are fine. Write **Alt+PgDn** or **Alt+PageDown**, **Ctrl+Esc**
 or **Ctrl+Escape**, **Bksp** or **Backspace**, **ArrowUp** or **Up** — Mutation
@@ -152,7 +153,13 @@ readers announce it straight away.
   you are editing. Give one of them a different combination, otherwise only one of the
   two will ever fire.
   Mutation compares the keys, not the spelling, so writing one as
-  **Ctrl+Shift+A** and the other as **Shift+Ctrl+A** is still caught.
+  **Ctrl+Shift+A** and the other as **Shift+Ctrl+A** is still caught. The check covers
+  the whole page at once, so a shortcut at the top and a router mapping's "From" box at
+  the bottom claiming the same keys are both flagged.
+- **The same combination as one of your prompt shortcuts** — a note reading **Also
+  used by an LLM prompt** appears under the row. Prompt shortcuts are set in the prompt
+  window rather than on this page, so there is no second row here to flag. Open
+  **AI prompts** to see which one it is.
 - **The same combination in a "send key after" box and a real shortcut** —
   also flagged, and worth fixing. Windows hands that key straight back to Mutation,
   so the action would set itself off again and again. Putting the same key in *both*
@@ -221,9 +228,10 @@ To set one up, go to **Settings** (**Ctrl+Comma**), pick **Hotkeys**, and scroll
 down to the **Hotkey Router** section. Press **Add mapping**, fill in the "From"
 and "To" boxes, and press **Save**. Each row shows a small status marker: a tick
 once the mapping is live, or an error marker with a message if something is wrong.
-Two mappings listening for the same "From" combination get a "Duplicate 'From'
-hotkey" message — again comparing the keys rather than the spelling. **Delete**
-removes a mapping.
+A mapping whose "From" combination is already taken gets a "Duplicate 'From'
+hotkey" message — again comparing the keys rather than the spelling. That covers
+another mapping, any shortcut higher up the Hotkeys page, and any of your prompt
+shortcuts. **Delete** removes a mapping.
 
 > As the in-app help puts it: map one shortcut to another so a single key press can
 > trigger a more complex shortcut. Changes apply when you save settings.

--- a/Documentation/UserGuide/markdown/troubleshooting.md
+++ b/Documentation/UserGuide/markdown/troubleshooting.md
@@ -69,6 +69,11 @@ If the service is busy and asks Mutation to wait a moment before asking again, M
 waits as long as it was asked to, up to a minute. So a gap between beeps that is longer
 than usual is the service setting the pace, not something going wrong.
 
+Not everything is worth another go. If the service turns the request down for a reason
+that will not change — your key was rejected, or the recording is bigger than it
+accepts — Mutation tells you straight away instead of working through the retries
+first. You hear one set of beeps, not four.
+
 **What to do.**
 
 1. Give it a moment — the retries are automatic and you will hear the result.

--- a/Mutation.Tests/DeepgramErrorBodies.cs
+++ b/Mutation.Tests/DeepgramErrorBodies.cs
@@ -1,0 +1,32 @@
+namespace Mutation.Tests;
+
+/// <summary>
+/// The JSON Deepgram answers a failed request with, copied from its published error
+/// reference. Kept verbatim rather than paraphrased: the whole of issue #316 is what the
+/// service can tell from that answer, so a body invented here would prove nothing.
+/// </summary>
+internal static class DeepgramErrorBodies
+{
+	public const string BadRequest =
+		"""{"err_code":"Bad Request","err_msg":"Bad Request","request_id":"a1"}""";
+
+	public const string InvalidAuth =
+		"""{"err_code":"INVALID_AUTH","err_msg":"Invalid credentials.","request_id":"a2"}""";
+
+	public const string PayloadTooLarge =
+		"""{"err_code":"PAYLOAD_TOO_LARGE","err_msg":"Payload size exceeds limit of 2 MB.","request_id":"a3"}""";
+
+	public const string TooManyRequests =
+		"""{"err_code":"TOO_MANY_REQUESTS","err_msg":"Too many requests. Please try again later","request_id":"a4"}""";
+
+	/// <summary>The same 429, spelled the way Deepgram's text-to-speech side spells it.</summary>
+	public const string TooManyRequestsInWords =
+		"""{"err_code":"Too Many Requests","err_msg":"Please try again later.","request_id":"a5"}""";
+
+	/// <summary>
+	/// A 503. Note <c>error_code</c>, not <c>err_code</c> — the field Deepgram's own client
+	/// reads is missing, so nothing identifies this as a 503 by the time it reaches us.
+	/// </summary>
+	public const string ServiceUnavailable =
+		"""{"error_code":"Service Unavailable","err_msg":"Please try again later","request_id":"a6"}""";
+}

--- a/Mutation.Tests/DeepgramFailureTests.cs
+++ b/Mutation.Tests/DeepgramFailureTests.cs
@@ -1,0 +1,107 @@
+using System.Text.Json;
+using CognitiveSupport;
+using Deepgram.Models.Exceptions.v1;
+
+namespace Mutation.Tests;
+
+/// <summary>
+/// Covers <see cref="DeepgramFailure"/> — which of Deepgram's own answers earn another
+/// attempt.
+/// <para>
+/// Deepgram's exception carries no HTTP status, so the decision is made on the
+/// <c>err_code</c> its JSON error body carries. Everything here is built the way the SDK
+/// builds it, by deserializing a published error body into the exception; an exception
+/// constructed by hand has no error code on it and would agree with any rule at all
+/// (issue #316).
+/// </para>
+/// </summary>
+public class DeepgramFailureTests
+{
+	private static DeepgramException Answered(string errorBody) =>
+		JsonSerializer.Deserialize<DeepgramRESTException>(errorBody)!;
+
+	[Fact]
+	public void A_rate_limit_is_worth_another_attempt()
+	{
+		Assert.True(DeepgramFailure.IsWorthAnotherAttempt(Answered(DeepgramErrorBodies.TooManyRequests)));
+	}
+
+	[Fact]
+	public void A_rate_limit_spelled_in_words_is_the_same_rate_limit()
+	{
+		// Deepgram writes this code both ways depending on the endpoint. Listing one spelling
+		// and missing the other would retry half the rate limits and report the rest.
+		Assert.True(DeepgramFailure.IsWorthAnotherAttempt(Answered(DeepgramErrorBodies.TooManyRequestsInWords)));
+	}
+
+	[Fact]
+	public void An_unavailable_service_is_worth_another_attempt()
+	{
+		// The 503 body names its code in a field Deepgram's client does not read, so this
+		// arrives with no usable code at all. Giving up on it would abandon a finished
+		// recording over an outage that is over by the next attempt.
+		Assert.True(DeepgramFailure.IsWorthAnotherAttempt(Answered(DeepgramErrorBodies.ServiceUnavailable)));
+	}
+
+	[Fact]
+	public void An_answer_that_is_not_Deepgram_JSON_at_all_is_worth_another_attempt()
+	{
+		// What a gateway in front of Deepgram answers with when Deepgram is not answering.
+		// The client cannot read it, so it raises the base exception with its own placeholder
+		// code.
+		Assert.True(DeepgramFailure.IsWorthAnotherAttempt(
+			new DeepgramException("<html><body>502 Bad Gateway</body></html>")));
+	}
+
+	[Theory]
+	[InlineData("Bad Request")]
+	[InlineData("INVALID_QUERY_PARAMETER")]
+	[InlineData("PAYLOAD_ERROR")]
+	[InlineData("REMOTE_CONTENT_ERROR")]
+	[InlineData("INVALID_AUTH")]
+	[InlineData("ASR_PAYMENT_REQUIRED")]
+	[InlineData("INSUFFICIENT_PERMISSIONS")]
+	[InlineData("PROJECT_NOT_FOUND")]
+	[InlineData("PAYLOAD_TOO_LARGE")]
+	[InlineData("UNSUPPORTED_MEDIA_TYPE")]
+	[InlineData("UNPROCESSABLE_ENTITY")]
+	[InlineData("ASR_UNPROCESSABLE_ENTITY")]
+	public void A_request_that_will_fail_the_same_way_again_is_not_retried(string errorCode)
+	{
+		string body = $$"""{"err_code":"{{errorCode}}","err_msg":"no","request_id":"x"}""";
+
+		Assert.False(DeepgramFailure.IsWorthAnotherAttempt(Answered(body)));
+	}
+
+	[Fact]
+	public void A_rejected_key_is_reported_at_once_however_the_code_is_punctuated()
+	{
+		// The comparison strips case and separators, so a future spelling of a code already
+		// known to be permanent still fails fast.
+		Assert.False(DeepgramFailure.IsWorthAnotherAttempt(
+			Answered("""{"err_code":"invalid auth","err_msg":"no","request_id":"x"}""")));
+	}
+
+	[Fact]
+	public void A_payload_too_large_is_final_whichever_way_it_is_written()
+	{
+		Assert.False(DeepgramFailure.IsWorthAnotherAttempt(Answered(DeepgramErrorBodies.PayloadTooLarge)));
+		Assert.False(DeepgramFailure.IsWorthAnotherAttempt(
+			Answered("""{"err_code":"Payload Too Large","err_msg":"no","request_id":"x"}""")));
+	}
+
+	[Fact]
+	public void A_code_nobody_here_has_seen_is_given_another_attempt()
+	{
+		// The list says what to give up on, not what to retry. Losing a recording to a code
+		// nobody anticipated is worse than three needless attempts.
+		Assert.True(DeepgramFailure.IsWorthAnotherAttempt(
+			Answered("""{"err_code":"SOMETHING_NEW","err_msg":"?","request_id":"x"}""")));
+	}
+
+	[Fact]
+	public void A_missing_failure_is_not_treated_as_permanent()
+	{
+		Assert.True(DeepgramFailure.IsWorthAnotherAttempt(null!));
+	}
+}

--- a/Mutation.Tests/DeepgramSpeechToTextServiceRetryTests.cs
+++ b/Mutation.Tests/DeepgramSpeechToTextServiceRetryTests.cs
@@ -97,21 +97,58 @@ public class DeepgramSpeechToTextServiceRetryTests
 	}
 
 	[Fact]
-	public async Task AFailureDeepgramItselfReportsIsNotRetried()
+	public async Task ARateLimitIsRetriedUntilItSucceeds()
+	{
+		// The failure this ladder is most obviously for, and the one it used to miss: a 429
+		// is Deepgram asking to be asked again, and the recording is already made (issue
+		// #316).
+		var (service, client, _, _) = CreateService(
+			_ => throw AnsweredWith(DeepgramErrorBodies.TooManyRequests),
+			_ => throw AnsweredWith(DeepgramErrorBodies.TooManyRequests),
+			_ => Transcript("the recovered transcript"));
+
+		string path = WriteAudioFile();
+		try
+		{
+			string text = await service.ConvertAudioToText("", path, CancellationToken.None);
+
+			Assert.Equal("the recovered transcript", text);
+			Assert.Equal(3, client.Calls);
+		}
+		finally
+		{
+			File.Delete(path);
+		}
+	}
+
+	[Fact]
+	public async Task AnUnavailableServiceIsRetried()
+	{
+		var (service, client, _, _) = CreateService(
+			_ => throw AnsweredWith(DeepgramErrorBodies.ServiceUnavailable),
+			_ => Transcript("the recovered transcript"));
+
+		string path = WriteAudioFile();
+		try
+		{
+			string text = await service.ConvertAudioToText("", path, CancellationToken.None);
+
+			Assert.Equal("the recovered transcript", text);
+			Assert.Equal(2, client.Calls);
+		}
+		finally
+		{
+			File.Delete(path);
+		}
+	}
+
+	[Fact]
+	public async Task ARejectedApiKeyIsNotRetried()
 	{
 		// A rejected API key does not become valid on the second ask, so reporting it at
-		// once beats making the user wait out the whole ladder first.
-		//
-		// What actually decides it, though, is not the status — it is whether the error
-		// carried a body. Deepgram's client deserializes a JSON error into this exception,
-		// which nothing here handles; an error with an empty body falls through to
-		// EnsureSuccessStatusCode instead and arrives as the HttpRequestException the test
-		// above retries. So the real rule today is "an error with a body is final, one
-		// without gets four attempts", regardless of whether it was a 429 or a 401. That is
-		// stranger than any rule anyone chose, and DeepgramRESTException carries no status
-		// to fix it with. Recorded rather than papered over — see issue #316.
+		// once beats making the user wait out the whole ladder on a lengthening timeout.
 		var (service, client, _, _) = CreateService(
-			_ => throw new Deepgram.Models.Exceptions.v1.DeepgramRESTException("401 Unauthorized"));
+			_ => throw AnsweredWith(DeepgramErrorBodies.InvalidAuth));
 
 		string path = WriteAudioFile();
 		try
@@ -126,6 +163,35 @@ public class DeepgramSpeechToTextServiceRetryTests
 			File.Delete(path);
 		}
 	}
+
+	[Fact]
+	public async Task ARequestDeepgramCannotReadIsNotRetried()
+	{
+		var (service, client, _, _) = CreateService(
+			_ => throw AnsweredWith(DeepgramErrorBodies.BadRequest));
+
+		string path = WriteAudioFile();
+		try
+		{
+			await Assert.ThrowsAsync<Deepgram.Models.Exceptions.v1.DeepgramRESTException>(() =>
+				service.ConvertAudioToText("", path, CancellationToken.None));
+
+			Assert.Equal(1, client.Calls);
+		}
+		finally
+		{
+			File.Delete(path);
+		}
+	}
+
+	/// <summary>
+	/// The exception Deepgram's own client raises for <paramref name="errorBody"/>, built the
+	/// way the client builds it — by deserializing the answer into the exception. Constructing
+	/// one by hand would leave the error code unset and prove nothing about the real path.
+	/// </summary>
+	private static Exception AnsweredWith(string errorBody) =>
+		System.Text.Json.JsonSerializer
+			.Deserialize<Deepgram.Models.Exceptions.v1.DeepgramRESTException>(errorBody)!;
 
 	[Fact]
 	public async Task EachAttemptGivesItselfLongerThanTheLast()

--- a/Mutation.Tests/HotkeyConflictFinderTests.cs
+++ b/Mutation.Tests/HotkeyConflictFinderTests.cs
@@ -236,6 +236,130 @@ public class HotkeyConflictFinderTests
 		Assert.Throws<ArgumentNullException>(() => DuplicateIndexes(null!));
 	}
 
+	// ----- Several lists at once (issue #321) -----
+	//
+	// The hotkey table is one table for the whole app, so a chord one list holds is a chord no
+	// other list can also have. Each Settings list used to check only itself, and a core hotkey
+	// and a router mapping could both claim CTRL+ALT+G with no badge on either row — the user
+	// found out from the failure dialog after saving.
+
+	[Fact]
+	public void A_core_hotkey_and_a_route_claiming_one_chord_flag_each_other()
+	{
+		var perList = DuplicateIndexesAcross([
+			Configured(Claimed("CTRL+ALT+G"), Claimed("CTRL+ALT+H")),
+			Configured(Claimed("CTRL+ALT+G"))]);
+
+		Assert.Equal(new[] { 0 }, Sorted(perList[0]));
+		Assert.Equal(new[] { 0 }, Sorted(perList[1]));
+	}
+
+	[Fact]
+	public void A_clash_across_lists_is_found_however_each_side_spells_it()
+	{
+		var perList = DuplicateIndexesAcross([
+			Configured(Claimed("SHIFT+CTRL+A")),
+			Configured(Claimed("ctrl-shift-a"))]);
+
+		Assert.Equal(new[] { 0 }, Sorted(perList[0]));
+		Assert.Equal(new[] { 0 }, Sorted(perList[1]));
+	}
+
+	[Fact]
+	public void Each_list_gets_positions_within_itself()
+	{
+		// The lists are answered as one and handed back separately, so a screen can flag its
+		// own rows without knowing where its list sat in the queue.
+		var perList = DuplicateIndexesAcross([
+			Configured(Claimed("F1"), Claimed("F2"), Claimed("F3")),
+			Configured(Claimed("F9"), Claimed("F3"))]);
+
+		Assert.Equal(new[] { 2 }, Sorted(perList[0]));
+		Assert.Equal(new[] { 1 }, Sorted(perList[1]));
+	}
+
+	[Fact]
+	public void A_third_list_that_cannot_be_flagged_still_takes_part()
+	{
+		// Per-prompt shortcuts are edited in their own window, so the Hotkeys page has no row
+		// to flag for them — but they are registered from the same table, so a core hotkey that
+		// collides with one has to hear about it.
+		var perList = DuplicateIndexesAcross([
+			Configured(Claimed("CTRL+ALT+G")),
+			Configured(Claimed("CTRL+ALT+H")),
+			Configured(Claimed("CTRL+ALT+G"))]);
+
+		Assert.Equal(new[] { 0 }, Sorted(perList[0]));
+		Assert.Empty(perList[1]);
+		Assert.Equal(new[] { 0 }, Sorted(perList[2]));
+	}
+
+	[Fact]
+	public void A_sent_key_still_clashes_with_a_claimed_one_in_another_list()
+	{
+		var perList = DuplicateIndexesAcross([
+			Configured(Claimed("ALT+J"), Sent("ALT+J")),
+			Configured(Claimed("alt+j"))]);
+
+		Assert.Equal(new[] { 0, 1 }, Sorted(perList[0]));
+		Assert.Equal(new[] { 0 }, Sorted(perList[1]));
+	}
+
+	[Fact]
+	public void Two_sent_keys_in_different_lists_are_still_not_a_clash()
+	{
+		var perList = DuplicateIndexesAcross([
+			Configured(Sent("CTRL+V")),
+			Configured(Sent("CTRL+V"))]);
+
+		Assert.Empty(perList[0]);
+		Assert.Empty(perList[1]);
+	}
+
+	[Fact]
+	public void Half_typed_text_in_one_list_never_clashes_with_another()
+	{
+		var perList = DuplicateIndexesAcross([
+			Configured(Claimed("CTRL+")),
+			Configured(Claimed("CTRL+"))]);
+
+		Assert.Empty(perList[0]);
+		Assert.Empty(perList[1]);
+	}
+
+	[Fact]
+	public void An_empty_list_answers_with_an_empty_result_and_shifts_nothing()
+	{
+		var perList = DuplicateIndexesAcross([
+			Configured(Claimed("CTRL+ALT+G")),
+			Configured(),
+			Configured(Claimed("CTRL+ALT+G"))]);
+
+		Assert.Equal(3, perList.Count);
+		Assert.Equal(new[] { 0 }, Sorted(perList[0]));
+		Assert.Empty(perList[1]);
+		Assert.Equal(new[] { 0 }, Sorted(perList[2]));
+	}
+
+	[Fact]
+	public void No_lists_at_all_answers_with_no_results()
+	{
+		Assert.Empty(DuplicateIndexesAcross([]));
+	}
+
+	[Fact]
+	public void A_missing_set_of_lists_is_refused()
+	{
+		Assert.Throws<ArgumentNullException>(() => DuplicateIndexesAcross(null!));
+	}
+
+	[Fact]
+	public void A_missing_list_among_them_is_refused()
+	{
+		Assert.Throws<ArgumentNullException>(() =>
+			DuplicateIndexesAcross([Configured(Claimed("F1")), null!]));
+	}
+
 	private static int[] Sorted(IReadOnlySet<int> indexes)
 	{
 		var sorted = new List<int>(indexes);

--- a/Mutation.Tests/HotkeyRouterControllerTests.cs
+++ b/Mutation.Tests/HotkeyRouterControllerTests.cs
@@ -240,6 +240,65 @@ public class HotkeyRouterControllerTests
 		Assert.False(first.IsDuplicate);
 	}
 
+	// ----- Handing the check to an owner that sees more lists (issue #321) -----
+
+	[Fact]
+	public void RecalculateDuplicates_WithAWiderCheckAvailable_LeavesTheAnswerToIt()
+	{
+		// The router only sees its own routes. The Hotkeys page also holds the core hotkey
+		// rows, and a route can be taken by one of those just as easily as by another route,
+		// so on that page the router must not answer for itself.
+		var (controller, _, _, entries, _) = BuildController();
+		var first = new HotkeyRouterEntry(new HotKeyRouterSettings.HotKeyRouterMap("Ctrl+C", "Ctrl+V"));
+		var second = new HotkeyRouterEntry(new HotKeyRouterSettings.HotKeyRouterMap("Ctrl+C", "Ctrl+B"));
+		entries.Add(first);
+		entries.Add(second);
+		int widerChecks = 0;
+		SetField(controller, "_crossListDuplicateCheck", (Action)(() => widerChecks++));
+
+		CallRecalculateDuplicates(controller);
+
+		Assert.Equal(1, widerChecks);
+		Assert.False(first.IsDuplicate);
+		Assert.False(second.IsDuplicate);
+	}
+
+	[Fact]
+	public void ConfiguredFromHotkeys_OffersTheChordEachRouteClaims()
+	{
+		var (controller, _, _, entries, _) = BuildController();
+		entries.Add(new HotkeyRouterEntry(new HotKeyRouterSettings.HotKeyRouterMap("shift+ctrl+a", "Ctrl+V")));
+		// Half-typed text cannot be registered, so it is offered as nothing rather than as a
+		// row that might clash.
+		entries.Add(new HotkeyRouterEntry(new HotKeyRouterSettings.HotKeyRouterMap("Ctrl+", "Ctrl+B")));
+
+		var configured = controller.ConfiguredFromHotkeys();
+
+		Assert.Equal(2, configured.Count);
+		Assert.Equal("CTRL+SHIFT+A", configured[0].Text);
+		Assert.True(configured[0].ClaimsTheChord);
+		Assert.Null(configured[1].Text);
+	}
+
+	[Fact]
+	public void ApplyDuplicates_FlagsExactlyTheRowsItIsGiven()
+	{
+		var (controller, _, _, entries, _) = BuildController();
+		var first = new HotkeyRouterEntry(new HotKeyRouterSettings.HotKeyRouterMap("Ctrl+C", "Ctrl+V"));
+		var second = new HotkeyRouterEntry(new HotKeyRouterSettings.HotKeyRouterMap("Ctrl+X", "Ctrl+B"));
+		entries.Add(first);
+		entries.Add(second);
+
+		controller.ApplyDuplicates(new HashSet<int> { 1 });
+
+		Assert.False(first.IsDuplicate);
+		Assert.True(second.IsDuplicate);
+
+		controller.ApplyDuplicates(new HashSet<int>());
+
+		Assert.False(second.IsDuplicate);
+	}
+
 	// ----- autoPersist=false (settings page editor mode) -----
 
 	[Fact]

--- a/Mutation.Tests/HotkeyRouterEntryTests.cs
+++ b/Mutation.Tests/HotkeyRouterEntryTests.cs
@@ -195,4 +195,147 @@ public class HotkeyRouterEntryTests
 		Assert.False(entry.IsFromValid);
 		Assert.Equal("CTRL+SHIFT", entry.FromHotkey);
 	}
+
+	// ----- Saying out loud what the box rewrote itself to (issue #332) -----
+	//
+	// A sighted user watches "shift+ctrl+a" become "CTRL+SHIFT+A" on the way out of the box.
+	// A screen-reader user heard nothing, and the next reading of the field disagreed with
+	// what they had typed. The hotkey editor above this section was fixed for #327; these two
+	// boxes are the same defect on the same page.
+
+	[Fact]
+	public void CommittingAFromBoxThatTidiedItselfUpSaysSo()
+	{
+		var entry = new HotkeyRouterEntry(Map("Ctrl+C", "Ctrl+V"));
+
+		entry.FromHotkey = "shift+ctrl+a";
+		entry.CommitFromHotkey();
+
+		Assert.Equal("Shortcut to listen for now reads CTRL+SHIFT+A.", entry.CommitAnnouncement);
+	}
+
+	[Fact]
+	public void CommittingAToBoxThatTidiedItselfUpSaysSo()
+	{
+		// The row's two boxes are named apart, because the notice lands after the focus has
+		// moved on and "now reads CTRL+ALT+Y" alone would not say which one changed.
+		var entry = new HotkeyRouterEntry(Map("Ctrl+C", "Ctrl+V"));
+
+		entry.ToHotkey = "alt+ctrl+y";
+		entry.CommitToHotkey();
+
+		Assert.Equal("Shortcut to send when triggered now reads CTRL+ALT+Y.", entry.CommitAnnouncement);
+	}
+
+	[Fact]
+	public void ABoxAlreadyWrittenTheAppsOwnWayStaysSilent()
+	{
+		// Tabbing across a row that needs no tidying is the common case by far, and has to
+		// stay quiet or the page talks over the user on every row.
+		var entry = new HotkeyRouterEntry(Map("Ctrl+C", "Ctrl+V"));
+
+		entry.FromHotkey = "CTRL+X";
+		entry.CommitFromHotkey();
+		entry.ToHotkey = "CTRL+B";
+		entry.CommitToHotkey();
+
+		Assert.Null(entry.CommitAnnouncement);
+	}
+
+	[Fact]
+	public void HalfTypedTextIsLeftToTheErrorRatherThanAnnounced()
+	{
+		// The row already says the shortcut is unusable. Being told how it is now spelled on
+		// top of that is the less useful of the two, and both in one breath is neither.
+		var entry = new HotkeyRouterEntry(Map("Ctrl+C", "Ctrl+V"));
+
+		entry.FromHotkey = "ctrl+shift+";
+		entry.CommitFromHotkey();
+
+		Assert.Null(entry.CommitAnnouncement);
+	}
+
+	[Fact]
+	public void ADuplicateOutranksTheRewriteNotice()
+	{
+		var entry = new HotkeyRouterEntry(Map("Ctrl+C", "Ctrl+V"));
+		entry.SetDuplicate(true);
+
+		entry.FromHotkey = "shift+ctrl+a";
+		entry.CommitFromHotkey();
+
+		Assert.Null(entry.CommitAnnouncement);
+	}
+
+	[Fact]
+	public void AFromBoxIsStillAnnouncedWhileTheToBoxBesideItIsEmpty()
+	{
+		// Every newly added row starts with both boxes empty, so a notice that waited for the
+		// whole row to be valid would never be heard on the row most likely to need it.
+		var entry = new HotkeyRouterEntry(Map(string.Empty, string.Empty));
+
+		entry.FromHotkey = "shift+ctrl+a";
+		entry.CommitFromHotkey();
+
+		Assert.False(entry.IsToValid);
+		Assert.Equal("Shortcut to listen for now reads CTRL+SHIFT+A.", entry.CommitAnnouncement);
+	}
+
+	[Fact]
+	public void LoadingASettingsFileThatNeedsTidyingUpSaysNothing()
+	{
+		// The constructor canonicalises too. Announcing that would read every stored row aloud
+		// on the way into the page.
+		var entry = new HotkeyRouterEntry(Map("shift+ctrl+a", "alt+ctrl+y"));
+
+		Assert.Equal("CTRL+SHIFT+A", entry.FromHotkey);
+		Assert.Null(entry.CommitAnnouncement);
+	}
+
+	[Fact]
+	public void RebuildingTheRowLeavesAPendingNoticeStanding()
+	{
+		// Saving the page rewrites the backing maps and hands each row a new one. Treating
+		// that as a fresh silent load would swallow the notice for the very edit that
+		// triggered the save.
+		var entry = new HotkeyRouterEntry(Map("Ctrl+C", "Ctrl+V"));
+		entry.FromHotkey = "shift+ctrl+a";
+		entry.CommitFromHotkey();
+
+		entry.ReplaceBackingMap(Map("CTRL+SHIFT+A", "CTRL+V"));
+
+		Assert.Equal("Shortcut to listen for now reads CTRL+SHIFT+A.", entry.CommitAnnouncement);
+	}
+
+	[Fact]
+	public void ComingBackIntoTheBoxTakesTheNoticeDown()
+	{
+		var entry = new HotkeyRouterEntry(Map("Ctrl+C", "Ctrl+V"));
+		entry.FromHotkey = "shift+ctrl+a";
+		entry.CommitFromHotkey();
+
+		entry.ClearCommitAnnouncement();
+
+		Assert.Null(entry.CommitAnnouncement);
+	}
+
+	[Fact]
+	public void TheNoticeIsPublishedSoTheRowCanBind()
+	{
+		// The row is a data template with no code-behind to call LiveMessage.Show from, so the
+		// change notification is the whole delivery mechanism.
+		var entry = new HotkeyRouterEntry(Map("Ctrl+C", "Ctrl+V"));
+		var raised = new List<string?>();
+		entry.PropertyChanged += (_, e) =>
+		{
+			if (e.PropertyName == nameof(HotkeyRouterEntry.CommitAnnouncement))
+				raised.Add(entry.CommitAnnouncement);
+		};
+
+		entry.FromHotkey = "shift+ctrl+a";
+		entry.CommitFromHotkey();
+		entry.ClearCommitAnnouncement();
+
+		Assert.Equal(["Shortcut to listen for now reads CTRL+SHIFT+A.", null], raised);
+	}
 }

--- a/Mutation.Ui/Core/HotkeyConflictFinder.cs
+++ b/Mutation.Ui/Core/HotkeyConflictFinder.cs
@@ -88,6 +88,56 @@ internal static class HotkeyConflictFinder
 	}
 
 	/// <summary>
+	/// The same answer for several lists at once, one result set per list, each holding
+	/// positions within its own list.
+	/// <para>
+	/// <see cref="HotkeyRegistrationTable"/> is one table for the whole app: a chord any list
+	/// holds is a chord no other list can also have. The Settings screen used to check each of
+	/// its lists only against itself, so a core hotkey and a router mapping could both claim
+	/// <c>CTRL+ALT+G</c> with no badge on either row, and whichever registered second came back
+	/// as "The shortcut is already registered." in a dialog after saving — the after-the-fact
+	/// discovery the per-list check existed to remove, just across lists instead of within one
+	/// (issue #321).
+	/// </para>
+	/// <para>
+	/// The lists are laid end to end and answered as one, which is what makes a clash between
+	/// two of them visible at all; the positions are then handed back per list so each screen
+	/// can flag its own rows.
+	/// </para>
+	/// </summary>
+	public static IReadOnlyList<IReadOnlySet<int>> DuplicateIndexesAcross(
+		IReadOnlyList<IReadOnlyList<ConfiguredHotkey>> lists)
+	{
+		if (lists is null) throw new ArgumentNullException(nameof(lists));
+
+		var flattened = new List<ConfiguredHotkey>();
+		foreach (var list in lists)
+		{
+			if (list is null) throw new ArgumentNullException(nameof(lists), "No list may be null.");
+			flattened.AddRange(list);
+		}
+
+		var duplicates = DuplicateIndexes(flattened);
+
+		var perList = new List<IReadOnlySet<int>>(lists.Count);
+		int offset = 0;
+		foreach (var list in lists)
+		{
+			var mine = new HashSet<int>();
+			for (int i = 0; i < list.Count; i++)
+			{
+				if (duplicates.Contains(offset + i))
+					mine.Add(i);
+			}
+
+			perList.Add(mine);
+			offset += list.Count;
+		}
+
+		return perList;
+	}
+
+	/// <summary>
 	/// Every chord one entry puts on the keyboard: one for a registered shortcut, and one per
 	/// step for a sent sequence. Half-typed text yields nothing, because there is no chord to
 	/// compare.

--- a/Mutation.Ui/HotkeyRouterEntry.cs
+++ b/Mutation.Ui/HotkeyRouterEntry.cs
@@ -1,4 +1,5 @@
 ﻿using CognitiveSupport;
+using Mutation.Ui.Core;
 using Mutation.Ui.Services;
 using System;
 using System.Collections.Generic;
@@ -37,6 +38,18 @@ public sealed class HotkeyRouterEntry : INotifyPropertyChanged
         private HotkeyBindingState _bindingState = HotkeyBindingState.Inactive;
         private string? _bindingError;
         private string? _combinedError;
+        private string? _commitAnnouncement;
+
+        /// <summary>
+        /// What the two boxes are called to a screen reader, matching the
+        /// <c>AutomationProperties.Name</c> each one carries in the row template. The
+        /// announcement names the box it is about because by the time it lands the focus has
+        /// already moved on, and a router row holds two boxes that tidy up the same way.
+        /// </summary>
+        private const string FromBoxLabel = "Shortcut to listen for";
+        private const string ToBoxLabel = "Shortcut to send when triggered";
+
+        private const string DuplicateFromMessage = "Duplicate 'From' hotkey.";
 
         private HotKeyRouterSettings.HotKeyRouterMap _map;
 
@@ -49,8 +62,11 @@ public sealed class HotkeyRouterEntry : INotifyPropertyChanged
                 _fromHotkeyText = map.FromHotKey ?? string.Empty;
                 _toHotkeyText = map.ToHotKey ?? string.Empty;
 
-                EvaluateFrom(commit: true);
-                EvaluateTo(commit: true);
+                // Silently: this is settings arriving from disk, not the user leaving a box.
+                // A page that read seventeen rows' worth of tidying aloud on the way in would
+                // be unusable.
+                EvaluateFrom(commit: true, announce: false);
+                EvaluateTo(commit: true, announce: false);
         }
 
         internal void ReplaceBackingMap(HotKeyRouterSettings.HotKeyRouterMap map)
@@ -60,8 +76,11 @@ public sealed class HotkeyRouterEntry : INotifyPropertyChanged
                 _fromHotkeyText = map.FromHotKey ?? string.Empty;
                 _toHotkeyText = map.ToHotKey ?? string.Empty;
 
-                EvaluateFrom(commit: true);
-                EvaluateTo(commit: true);
+                // Silently: this is settings arriving from disk, not the user leaving a box.
+                // A page that read seventeen rows' worth of tidying aloud on the way in would
+                // be unusable.
+                EvaluateFrom(commit: true, announce: false);
+                EvaluateTo(commit: true, announce: false);
         }
 
         public event PropertyChangedEventHandler? PropertyChanged;
@@ -73,7 +92,7 @@ public sealed class HotkeyRouterEntry : INotifyPropertyChanged
                 {
                         if (SetField(ref _fromHotkeyText, value ?? string.Empty, nameof(FromHotkey)))
                         {
-                                EvaluateFrom(commit: false);
+                                EvaluateFrom(commit: false, announce: false);
                                 SetBindingResult(HotkeyBindingState.Inactive, null);
                         }
                 }
@@ -86,7 +105,7 @@ public sealed class HotkeyRouterEntry : INotifyPropertyChanged
                 {
                         if (SetField(ref _toHotkeyText, value ?? string.Empty, nameof(ToHotkey)))
                         {
-                                EvaluateTo(commit: false);
+                                EvaluateTo(commit: false, announce: false);
                                 SetBindingResult(HotkeyBindingState.Inactive, null);
                         }
                 }
@@ -146,15 +165,35 @@ public sealed class HotkeyRouterEntry : INotifyPropertyChanged
 
         public string? BindingErrorMessage => _combinedError;
 
+        /// <summary>
+        /// What to tell a screen-reader user about the box that just tidied itself up, or null
+        /// when there is nothing worth interrupting for.
+        /// <para>
+        /// Bound to a live region in the row template through
+        /// <see cref="Mutation.Ui.Views.LiveText"/>, because a row in a list has no code-behind
+        /// to call <c>LiveMessage.Show</c> from (issue #332).
+        /// </para>
+        /// </summary>
+        public string? CommitAnnouncement => _commitAnnouncement;
+
         public void CommitFromHotkey()
         {
-                EvaluateFrom(commit: true);
+                EvaluateFrom(commit: true, announce: true);
         }
 
         public void CommitToHotkey()
         {
-                EvaluateTo(commit: true);
+                EvaluateTo(commit: true, announce: true);
         }
+
+        /// <summary>
+        /// Takes down the last notice on the way back into either box. It described something
+        /// that happened when the user left, and left standing it becomes a line of
+        /// ordinary-looking text under the row — read out as current content by anyone going
+        /// down the page afterwards. Clearing it also means the same rewrite happening twice is
+        /// announced twice, rather than the second one being swallowed as an unchanged message.
+        /// </summary>
+        public void ClearCommitAnnouncement() => SetCommitAnnouncement(null);
 
         public void SetDuplicate(bool isDuplicate)
         {
@@ -189,18 +228,34 @@ public sealed class HotkeyRouterEntry : INotifyPropertyChanged
                 UpdateCombinedError();
         }
 
-        private void EvaluateFrom(bool commit)
+        /// <param name="announce">
+        /// True when the user has just left the box, false when the row is being rebuilt from
+        /// settings. Only the first is worth saying out loud, and only the first clears a
+        /// notice that is no longer true — a rebuild must leave the last one standing, because
+        /// saving the page rebuilds every row and would otherwise swallow the notice for the
+        /// very edit that triggered the save.
+        /// </param>
+        private void EvaluateFrom(bool commit, bool announce)
         {
+                string typedBeforeCommit = _fromHotkeyText;
+
                 _formattedFrom = FormatHotkey(_fromHotkeyText);
                 (_isFromValid, _fromValidationMessage) = ValidateFormattedHotkey(_formattedFrom, true);
 
                 if (commit)
                 {
                         ApplyFormattedValue(ref _fromHotkeyText, _formattedFrom, nameof(FromHotkey));
-                                // Only update underlying map if valid; do NOT clear an existing persisted value here
-                                // to avoid wiping settings when a parse hiccup occurs (e.g., at startup before full init).
-                                if (_isFromValid)
-                                        _map.FromHotKey = _formattedFrom;
+
+                        if (announce)
+                        {
+                                SetCommitAnnouncement(HotkeyCommitAnnouncement.For(
+                                        FromBoxLabel, typedBeforeCommit, _fromHotkeyText, FromErrorMessage));
+                        }
+
+                        // Only update underlying map if valid; do NOT clear an existing persisted value here
+                        // to avoid wiping settings when a parse hiccup occurs (e.g., at startup before full init).
+                        if (_isFromValid)
+                                _map.FromHotKey = _formattedFrom;
                 }
                 else if (!_isFromValid)
                 {
@@ -218,17 +273,27 @@ public sealed class HotkeyRouterEntry : INotifyPropertyChanged
                 UpdateCombinedError();
         }
 
-        private void EvaluateTo(bool commit)
+        /// <param name="announce">See <see cref="EvaluateFrom"/>.</param>
+        private void EvaluateTo(bool commit, bool announce)
         {
+                string typedBeforeCommit = _toHotkeyText;
+
                 _formattedTo = FormatHotkey(_toHotkeyText);
                 (_isToValid, _toValidationMessage) = ValidateFormattedHotkey(_formattedTo, false);
 
                 if (commit)
                 {
                         ApplyFormattedValue(ref _toHotkeyText, _formattedTo, nameof(ToHotkey));
-                                // Only update underlying map if valid; avoid clearing persisted value on transient invalid state.
-                                if (_isToValid)
-                                        _map.ToHotKey = _formattedTo;
+
+                        if (announce)
+                        {
+                                SetCommitAnnouncement(HotkeyCommitAnnouncement.For(
+                                        ToBoxLabel, typedBeforeCommit, _toHotkeyText, _toValidationMessage));
+                        }
+
+                        // Only update underlying map if valid; avoid clearing persisted value on transient invalid state.
+                        if (_isToValid)
+                                _map.ToHotKey = _formattedTo;
                 }
                 else if (!_isToValid)
                 {
@@ -240,6 +305,25 @@ public sealed class HotkeyRouterEntry : INotifyPropertyChanged
                 OnPropertyChanged(nameof(IsValid));
                 OnPropertyChanged(nameof(ToBackgroundBrush));
                 UpdateCombinedError();
+        }
+
+        /// <summary>
+        /// What is wrong with the "From" box, or null when nothing is. The rewrite notice loses
+        /// to this, the way it already loses to a validation message in the hotkey editor: being
+        /// told the shortcut is unusable matters more than being told how it is now spelled.
+        /// It is answered per box rather than from the row's combined error, so a "From" that
+        /// tidied up is still announced while the "To" beside it is empty — which is every
+        /// newly added row.
+        /// </summary>
+        private string? FromErrorMessage => _isDuplicate ? DuplicateFromMessage : _fromValidationMessage;
+
+        private void SetCommitAnnouncement(string? message)
+        {
+                if (string.Equals(_commitAnnouncement, message, StringComparison.Ordinal))
+                        return;
+
+                _commitAnnouncement = message;
+                OnPropertyChanged(nameof(CommitAnnouncement));
         }
 
         private void ApplyFormattedValue(ref string storage, string? formatted, string propertyName)
@@ -281,7 +365,7 @@ public sealed class HotkeyRouterEntry : INotifyPropertyChanged
         {
                 string? message = null;
                 if (!IsFromInputValid)
-                        message = _isDuplicate ? "Duplicate 'From' hotkey." : _fromValidationMessage;
+                        message = FromErrorMessage;
                 else if (!_isToValid)
                         message = _toValidationMessage;
                 else if (_bindingState == HotkeyBindingState.Failed)

--- a/Mutation.Ui/Services/HotkeyRouterController.cs
+++ b/Mutation.Ui/Services/HotkeyRouterController.cs
@@ -23,18 +23,31 @@ internal sealed class HotkeyRouterController
 	private readonly ObservableCollection<HotkeyRouterEntry> _entries;
 	private readonly List<(string From, string To)> _persistedSnapshot = new();
 	private readonly bool _autoPersist;
+	private readonly Action? _crossListDuplicateCheck;
 
 	private bool _initialized;
 	private HotkeyManager? _hotkeyManager;
 
+	/// <param name="crossListDuplicateCheck">
+	/// Runs the duplicate check on an owner that has more lists to compare than this one — the
+	/// Hotkeys page, which holds the core hotkey rows as well. Null leaves the router checking
+	/// its own "From" chords against each other, which is all it can see by itself.
+	/// <para>
+	/// The owner is expected to call back into <see cref="ConfiguredFromHotkeys"/> and
+	/// <see cref="ApplyDuplicates"/>: this list still owns its own rows, it just no longer
+	/// decides on its own which of them clash (issue #321).
+	/// </para>
+	/// </param>
 	public HotkeyRouterController(
 		ObservableCollection<HotkeyRouterEntry> entries,
 		Settings settings,
 		ISettingsManager? settingsManager,
 		DispatcherQueue dispatcherQueue,
 		ListView routerListView,
-		bool autoPersist = true)
+		bool autoPersist = true,
+		Action? crossListDuplicateCheck = null)
 	{
+		_crossListDuplicateCheck = crossListDuplicateCheck;
 		_entries = entries ?? throw new ArgumentNullException(nameof(entries));
 		_settings = settings ?? throw new ArgumentNullException(nameof(settings));
 		_dispatcherQueue = dispatcherQueue ?? throw new ArgumentNullException(nameof(dispatcherQueue));
@@ -105,6 +118,17 @@ internal sealed class HotkeyRouterController
 		DetachEntry(entry);
 		_entries.Remove(entry);
 		RefreshRegistrations();
+	}
+
+	/// <summary>
+	/// Takes down the row's rewrite notice as the user comes back into either of its boxes.
+	/// See <see cref="HotkeyRouterEntry.ClearCommitAnnouncement"/> for why it does not simply
+	/// stay put.
+	/// </summary>
+	public void ClearCommitAnnouncement(object sender)
+	{
+		if (sender is FrameworkElement { DataContext: HotkeyRouterEntry entry })
+			entry.ClearCommitAnnouncement();
 	}
 
 	public void CommitFromLostFocus(object sender)
@@ -256,21 +280,51 @@ internal sealed class HotkeyRouterController
 	}
 
 	/// <summary>
-	/// Flags the routes whose "from" shortcut is already taken by another route. Compared as
-	/// chords rather than as text, so the answer is the one registration will give — the
-	/// screen used to compare the typed strings and could wave through a pair the hotkey
-	/// table then refused (issue #306).
+	/// The "From" chord of every route, in row order. Each one is claimed from Windows, and
+	/// text that does not parse yet is offered as nothing at all — it cannot be registered, so
+	/// it cannot clash.
 	/// </summary>
-	private void RecalculateDuplicates()
+	public IReadOnlyList<HotkeyConflictFinder.ConfiguredHotkey> ConfiguredFromHotkeys()
 	{
 		var configured = new List<HotkeyConflictFinder.ConfiguredHotkey>(_entries.Count);
 		foreach (var entry in _entries)
 			configured.Add(new(entry.IsFromValid ? entry.NormalizedFromHotkey : null, ClaimsTheChord: true));
 
-		var duplicates = HotkeyConflictFinder.DuplicateIndexes(configured);
+		return configured;
+	}
+
+	/// <summary>
+	/// Flags the rows at <paramref name="duplicateRows"/> and clears the rest. The positions
+	/// are those of <see cref="ConfiguredFromHotkeys"/>, whoever worked them out.
+	/// </summary>
+	public void ApplyDuplicates(IReadOnlySet<int> duplicateRows)
+	{
+		if (duplicateRows is null) throw new ArgumentNullException(nameof(duplicateRows));
 
 		for (int i = 0; i < _entries.Count; i++)
-			_entries[i].SetDuplicate(duplicates.Contains(i));
+			_entries[i].SetDuplicate(duplicateRows.Contains(i));
+	}
+
+	/// <summary>
+	/// Flags the routes whose "from" shortcut is already taken. Compared as chords rather than
+	/// as text, so the answer is the one registration will give — the screen used to compare
+	/// the typed strings and could wave through a pair the hotkey table then refused (issue
+	/// #306).
+	/// <para>
+	/// Handed to the owner when it has more lists to compare than this one, because the hotkey
+	/// table is one table for the whole app and a route can be taken by a core hotkey just as
+	/// easily as by another route (issue #321).
+	/// </para>
+	/// </summary>
+	private void RecalculateDuplicates()
+	{
+		if (_crossListDuplicateCheck is not null)
+		{
+			_crossListDuplicateCheck();
+			return;
+		}
+
+		ApplyDuplicates(HotkeyConflictFinder.DuplicateIndexes(ConfiguredFromHotkeys()));
 	}
 
 	private void AttachEntry(HotkeyRouterEntry entry) =>

--- a/Mutation.Ui/Views/LiveText.cs
+++ b/Mutation.Ui/Views/LiveText.cs
@@ -1,0 +1,36 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace Mutation.Ui.Views;
+
+/// <summary>
+/// <see cref="LiveMessage"/> for a <see cref="TextBlock"/> that lives inside a data template.
+/// <para>
+/// Every other live region in this app is a named part of a control, so its code-behind can
+/// call <see cref="LiveMessage.Show"/> on it directly. A row in a <c>ListView</c> has no code-
+/// behind and no name to reach it by — binding <c>Text</c> is the only way in, and a bound
+/// <c>Text</c> is exactly the case WinUI announces nothing for (issue #332). Binding this
+/// instead routes the same value through the same one place that shows a message and then
+/// raises the event that makes it heard.
+/// </para>
+/// <para>
+/// Public because XAML markup has to reach it, unlike the internal helper behind it.
+/// </para>
+/// </summary>
+public static class LiveText
+{
+	public static readonly DependencyProperty MessageProperty = DependencyProperty.RegisterAttached(
+		"Message", typeof(string), typeof(LiveText), new PropertyMetadata(null, OnMessageChanged));
+
+	public static string? GetMessage(DependencyObject element) =>
+		(string?)element.GetValue(MessageProperty);
+
+	public static void SetMessage(DependencyObject element, string? value) =>
+		element.SetValue(MessageProperty, value);
+
+	private static void OnMessageChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+	{
+		if (d is TextBlock block)
+			LiveMessage.Show(block, e.NewValue as string);
+	}
+}

--- a/Mutation.Ui/Views/Settings/Pages/HotkeysSettingsPage.xaml
+++ b/Mutation.Ui/Views/Settings/Pages/HotkeysSettingsPage.xaml
@@ -5,6 +5,7 @@
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 	xmlns:controls="using:Mutation.Ui.Views.SettingsUi.Controls"
 	xmlns:local="using:Mutation.Ui"
+	xmlns:views="using:Mutation.Ui.Views"
 	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	mc:Ignorable="d">
@@ -47,54 +48,74 @@
 						IsTabStop="False">
 						<ListView.ItemTemplate>
 							<DataTemplate x:DataType="local:HotkeyRouterEntry">
-								<Grid ColumnSpacing="12" Padding="0,4">
-									<Grid.ColumnDefinitions>
-										<ColumnDefinition Width="2*" />
-										<ColumnDefinition Width="2*" />
-										<ColumnDefinition Width="Auto" />
-									</Grid.ColumnDefinitions>
+								<StackPanel Spacing="2" Padding="0,4">
+									<Grid ColumnSpacing="12">
+										<Grid.ColumnDefinitions>
+											<ColumnDefinition Width="2*" />
+											<ColumnDefinition Width="2*" />
+											<ColumnDefinition Width="Auto" />
+										</Grid.ColumnDefinitions>
 
-									<Grid Grid.Column="0">
-										<Border Background="{x:Bind FromBackgroundBrush, Mode=OneWay}" CornerRadius="4">
+										<Grid Grid.Column="0">
+											<Border Background="{x:Bind FromBackgroundBrush, Mode=OneWay}" CornerRadius="4">
+												<TextBox
+													Text="{x:Bind FromHotkey, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+													PlaceholderText="CTRL+ALT+H"
+													Background="Transparent"
+													HorizontalAlignment="Stretch"
+													AutomationProperties.Name="Shortcut to listen for"
+													ToolTipService.ToolTip="Shortcut to listen for"
+													GotFocus="HotkeyRouterBox_GotFocus"
+													LostFocus="HotkeyRouterFrom_LostFocus" />
+											</Border>
+											<FontIcon
+												Glyph="&#xE783;"
+												Foreground="{ThemeResource SystemFillColorCriticalBrush}"
+												HorizontalAlignment="Right"
+												VerticalAlignment="Center"
+												Margin="0,0,8,0"
+												Visibility="{x:Bind BindingErrorVisibility, Mode=OneWay}"
+												AutomationProperties.Name="{x:Bind BindingErrorMessage, Mode=OneWay}"
+												ToolTipService.ToolTip="{x:Bind BindingErrorMessage, Mode=OneWay}" />
+										</Grid>
+
+										<Border Grid.Column="1" Background="{x:Bind ToBackgroundBrush, Mode=OneWay}" CornerRadius="4">
 											<TextBox
-												Text="{x:Bind FromHotkey, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-												PlaceholderText="CTRL+ALT+H"
+												Text="{x:Bind ToHotkey, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+												PlaceholderText="CTRL+SHIFT+H"
 												Background="Transparent"
 												HorizontalAlignment="Stretch"
-												AutomationProperties.Name="Shortcut to listen for"
-												ToolTipService.ToolTip="Shortcut to listen for"
-												LostFocus="HotkeyRouterFrom_LostFocus" />
+												AutomationProperties.Name="Shortcut to send when triggered"
+												ToolTipService.ToolTip="Shortcut to send when triggered"
+												GotFocus="HotkeyRouterBox_GotFocus"
+												LostFocus="HotkeyRouterTo_LostFocus" />
 										</Border>
-										<FontIcon
-											Glyph="&#xE783;"
-											Foreground="{ThemeResource SystemFillColorCriticalBrush}"
-											HorizontalAlignment="Right"
-											VerticalAlignment="Center"
-											Margin="0,0,8,0"
-											Visibility="{x:Bind BindingErrorVisibility, Mode=OneWay}"
-											AutomationProperties.Name="{x:Bind BindingErrorMessage, Mode=OneWay}"
-											ToolTipService.ToolTip="{x:Bind BindingErrorMessage, Mode=OneWay}" />
+
+										<Button
+											Grid.Column="2"
+											Style="{StaticResource SubtleButtonStyle}"
+											Content="Delete"
+											AutomationProperties.Name="Delete mapping"
+											Click="HotkeyRouterDelete_Click"
+											Tag="{x:Bind}" />
 									</Grid>
 
-									<Border Grid.Column="1" Background="{x:Bind ToBackgroundBrush, Mode=OneWay}" CornerRadius="4">
-										<TextBox
-											Text="{x:Bind ToHotkey, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-											PlaceholderText="CTRL+SHIFT+H"
-											Background="Transparent"
-											HorizontalAlignment="Stretch"
-											AutomationProperties.Name="Shortcut to send when triggered"
-											ToolTipService.ToolTip="Shortcut to send when triggered"
-											LostFocus="HotkeyRouterTo_LostFocus" />
-									</Border>
-
-									<Button
-										Grid.Column="2"
-										Style="{StaticResource SubtleButtonStyle}"
-										Content="Delete"
-										AutomationProperties.Name="Delete mapping"
-										Click="HotkeyRouterDelete_Click"
-										Tag="{x:Bind}" />
-								</Grid>
+									<!-- Says what a box rewrote itself to when the user left it. A polite
+									     region of its own, so it waits its turn rather than cutting across
+									     the next field, and so it cannot overwrite the row's error. Bound
+									     through LiveText because a row in a list has no code-behind to call
+									     LiveMessage.Show from (issue #332). Full-contrast text rather than
+									     the secondary brush a caption would normally take: this app's
+									     reader is low-vision, and a message worth showing at all is worth
+									     being able to read. -->
+									<TextBlock
+										views:LiveText.Message="{x:Bind CommitAnnouncement, Mode=OneWay}"
+										Foreground="{ThemeResource TextFillColorPrimaryBrush}"
+										Visibility="Collapsed"
+										AutomationProperties.LiveSetting="Polite"
+										Style="{StaticResource CaptionTextBlockStyle}"
+										TextWrapping="Wrap" />
+								</StackPanel>
 							</DataTemplate>
 						</ListView.ItemTemplate>
 					</ListView>

--- a/Mutation.Ui/Views/Settings/Pages/HotkeysSettingsPage.xaml.cs
+++ b/Mutation.Ui/Views/Settings/Pages/HotkeysSettingsPage.xaml.cs
@@ -18,6 +18,14 @@ public sealed partial class HotkeysSettingsPage : UserControl
 {
 	private const string DuplicateBadgeText = "Duplicate hotkey";
 
+	/// <summary>
+	/// For a row whose only clash is with a prompt's own shortcut. The prompt is edited in its
+	/// own window rather than in a list on this page, so there is no second row here to look
+	/// at — saying "Duplicate hotkey" and leaving every visible row unflagged would send the
+	/// user hunting down the page for a partner that is not on it.
+	/// </summary>
+	private const string PromptClashBadgeText = "Also used by an LLM prompt";
+
 	private readonly Settings _settings;
 	private readonly List<HotkeyRow> _rows = new();
 	private readonly HotkeyRouterController _routerController;
@@ -29,7 +37,6 @@ public sealed partial class HotkeysSettingsPage : UserControl
 		_settings = settings;
 		InitializeComponent();
 		BuildRows();
-		RecomputeDuplicates();
 
 		_routerController = new HotkeyRouterController(
 			HotkeyRouterEntries,
@@ -37,7 +44,12 @@ public sealed partial class HotkeysSettingsPage : UserControl
 			settingsManager: null,
 			DispatcherQueue.GetForCurrentThread(),
 			HotkeyRouterList,
-			autoPersist: false);
+			autoPersist: false,
+			// This page holds both lists, so it is the only place that can see a core hotkey
+			// and a route claiming the same chord (issue #321).
+			crossListDuplicateCheck: RecomputeDuplicates);
+
+		// Also runs the first duplicate check, once the router rows exist to take part in it.
 		_routerController.Initialize();
 	}
 
@@ -229,26 +241,69 @@ public sealed partial class HotkeysSettingsPage : UserControl
 		}
 	}
 
+	/// <summary>
+	/// One duplicate check for every shortcut this settings session can reach, not one per
+	/// list. <see cref="HotkeyRegistrationTable"/> is a single table for the whole app, so a
+	/// chord any list holds is a chord no other list can also have; checking each list only
+	/// against itself let a core hotkey and a route both claim <c>CTRL+ALT+G</c> with no badge
+	/// on either row, and the user found out from the failure dialog after saving (issue #321).
+	/// </summary>
 	private void RecomputeDuplicates()
 	{
-		var configured = new List<HotkeyConflictFinder.ConfiguredHotkey>(_rows.Count);
+		var coreRows = new List<HotkeyConflictFinder.ConfiguredHotkey>(_rows.Count);
 		foreach (var row in _rows)
-			configured.Add(new(row.Spec.Getter(_settings), row.Spec.Registers));
+			coreRows.Add(new(row.Spec.Getter(_settings), row.Spec.Registers));
 
-		var duplicates = HotkeyConflictFinder.DuplicateIndexes(configured);
+		var routerRows = _routerController.ConfiguredFromHotkeys();
+
+		// Two passes rather than one, so a row can say which kind of clash it has. The prompt
+		// shortcuts take part in the check but have no rows on this page to flag, and a badge
+		// reading "Duplicate hotkey" beside seventeen unflagged rows would be a hunt with no
+		// quarry.
+		var onThisPage = HotkeyConflictFinder.DuplicateIndexesAcross([coreRows, routerRows]);
+		var everywhere = HotkeyConflictFinder.DuplicateIndexesAcross(
+			[coreRows, routerRows, ConfiguredPromptHotkeys()]);
 
 		for (int i = 0; i < _rows.Count; i++)
-			ShowDuplicateBadge(_rows[i].DuplicateBadge, duplicates.Contains(i));
+		{
+			LiveMessage.Show(
+				_rows[i].DuplicateBadge,
+				onThisPage[0].Contains(i) ? DuplicateBadgeText
+					: everywhere[0].Contains(i) ? PromptClashBadgeText
+					: null);
+		}
+
+		// A route says "Duplicate 'From' hotkey." either way. The wording is true of a prompt
+		// clash too, and the row has one message to spend.
+		_routerController.ApplyDuplicates(everywhere[1]);
 	}
 
-	private static void ShowDuplicateBadge(TextBlock badge, bool isDuplicate) =>
-		LiveMessage.Show(badge, isDuplicate ? DuplicateBadgeText : null);
+	/// <summary>
+	/// The shortcut on each LLM prompt. They are registered from the same table as everything
+	/// on this page, so they clash with it, but they are edited in the prompt window rather
+	/// than here — they take part in the check without being flagged by it.
+	/// </summary>
+	private IReadOnlyList<HotkeyConflictFinder.ConfiguredHotkey> ConfiguredPromptHotkeys()
+	{
+		var prompts = _settings.LlmSettings?.Prompts;
+		if (prompts is null)
+			return Array.Empty<HotkeyConflictFinder.ConfiguredHotkey>();
+
+		var configured = new List<HotkeyConflictFinder.ConfiguredHotkey>(prompts.Count);
+		foreach (var prompt in prompts)
+			configured.Add(new(prompt.Hotkey, ClaimsTheChord: true));
+
+		return configured;
+	}
 
 	private void BtnAddHotkeyRoute_Click(object sender, RoutedEventArgs e) =>
 		_routerController.AddNewMapping();
 
 	private void HotkeyRouterDelete_Click(object sender, RoutedEventArgs e) =>
 		_routerController.DeleteMapping(sender);
+
+	private void HotkeyRouterBox_GotFocus(object sender, RoutedEventArgs e) =>
+		_routerController.ClearCommitAnnouncement(sender);
 
 	private void HotkeyRouterFrom_LostFocus(object sender, RoutedEventArgs e) =>
 		_routerController.CommitFromLostFocus(sender);


### PR DESCRIPTION
Closes #316. Closes #321. Closes #332.

Three fixes on the same theme: something the app already knew, but did not act on or did not say out loud.

## Deepgram never retried a failure it answered with (#316)

Every failure Deepgram *answers* rather than drops the connection on arrives as `DeepgramException` (or its `DeepgramRESTException` subclass), neither of which `TransientRetry.Transient()` handles. A 429 or a 503 — exactly the failures another attempt would get past — was reported on the first try, with the recording already made.

The issue assumed the exception carries nothing but a message. It does not: `DeepgramException.ErrCode` is filled in by the SDK from the `err_code` field of Deepgram's JSON error body. Verified against the SDK's own `AbstractRestClient.ThrowException`, which deserializes the answer straight into the exception.

`CognitiveSupport/DeepgramFailure.cs` decides on that code. It is a list of what to give up on, not a list of what to retry:

- The recording is already made by the time this is asked, so losing it to a code nobody here anticipated is worse than three needless attempts.
- Deepgram's 503 body names its code in `error_code`, which the SDK does not read — an allow-list would never see it.
- A gateway that answers with an HTML page gives the SDK nothing to read at all, leaving its own "Unknown Error Code" placeholder. Also transient, also invisible to an allow-list.

Codes are compared with case and separators stripped, because Deepgram spells the same code both `TOO_MANY_REQUESTS` and `Too Many Requests` depending on the endpoint.

`AFailureDeepgramItselfReportsIsNotRetried` is replaced by four narrower cases — 429 retried, 503 retried, 401 not, 400 not — plus `DeepgramFailureTests` over the unit itself. Every exception in those tests is built the way the SDK builds it, by deserializing a published error body; one constructed by hand has no error code on it and would agree with any rule at all.

## The router's From and To boxes rewrote themselves in silence (#332)

The same defect #327 fixed for `HotkeyEditor`, still live one section down the same page. Type `shift+ctrl+a` into a router **From** box and tab away: a sighted user sees `CTRL+SHIFT+A`, a screen-reader user heard nothing.

The row is MVVM-bound with no code-behind to call `LiveMessage.Show` from, so `HotkeyRouterEntry.CommitAnnouncement` carries the notice and the new `Views/LiveText.cs` attached property routes a bound value through the same `LiveMessage` that makes every other live region heard. The decision itself is the existing `HotkeyCommitAnnouncement`, not a second copy.

- Each box names itself — "Shortcut to listen for now reads CTRL+SHIFT+A." — because the notice lands after the focus has moved on and a row holds two boxes that tidy up the same way.
- Its own polite region under the row, so it cannot overwrite the row's error and does not cut across the next field.
- Arbitrated per box, not per row: a "From" that tidied up is still announced while the "To" beside it is empty, which is every newly added row.
- Silent when the row is loaded from disk, and left standing when saving rebuilds the row — otherwise the save would swallow the notice for the edit that triggered it.

## A core hotkey and a route could claim the same chord (#321)

`HotkeyRegistrationTable` is one table for the whole app, but each Settings list checked only itself. **Speak clipboard** on `CTRL+ALT+G` and a router mapping's "From" on `CTRL+ALT+G` got no badge on either row, and whichever registered second came back as "The shortcut is already registered." after saving.

`HotkeyConflictFinder.DuplicateIndexesAcross` answers several lists as one and hands back positions per list. The page is now the single arbiter: the router keeps its rows and its own check when it stands alone, but on this page it defers through `crossListDuplicateCheck` and takes the answer back via `ApplyDuplicates`.

Per-prompt shortcuts take part in the check as well. They are edited in the prompt window rather than in a list here, so there is no row to flag for them — a row whose only clash is with one says **Also used by an LLM prompt** rather than "Duplicate hotkey", which would send the user hunting down the page for a partner that is not on it.

Both #320 exclusions are kept: text that does not parse cannot clash, and two "Send key after…" entries holding the same key are not a conflict.

**Not covered:** two prompt shortcuts clashing with *each other* still go unflagged. Neither has a row on this page, and the prompt window has no duplicate check of its own. Worth its own issue.

## Documentation

`keyboard-shortcuts.md` loses the sentence saying the router boxes tidy up in silence, gains the new badge, and says the duplicate check now spans the page. `troubleshooting.md` says a failure the service will repeat is reported at once rather than after four attempts. HTML rebuilt.

## Testing

`dotnet test --configuration Release` — 2072 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)