### PR TITLE
Give an injected shortcut a place on the keyboard, and send it after the two runs that never did

### DIFF
--- a/Documentation/UserGuide/html/dictation.html
+++ b/Documentation/UserGuide/html/dictation.html
@@ -304,6 +304,8 @@ if you don't need it.</p>
 <p>If the transcript could not be delivered — you hear the failure beep — the shortcut is
 not sent. It usually acts on the text, and sending it when nothing arrived would aim it
 at whatever was there before.</p>
+<p>It is sent after every way of finishing a transcript: dictating, running a prompt over
+one, and the <strong>Format transcript</strong> button, which used to be the one that stayed silent.</p>
 <p>Write the shortcut the ordinary way, like <strong>Ctrl+V</strong> or <strong>Ctrl+Shift+Delete</strong>. You can
 list more than one, separated by commas, and they are sent in turn.</p>
 <h2 id="choosing-a-transcription-service">Choosing a transcription service</h2>

--- a/Documentation/UserGuide/html/screen-capture-and-ocr.html
+++ b/Documentation/UserGuide/html/screen-capture-and-ocr.html
@@ -317,6 +317,8 @@ remove the limit.</li>
 your choosing once the text is ready — handy for kicking off your screen reader
 automatically. It is sent whether the run found text or failed, so a screen-reader
 shortcut in that box reads out the error just as readily as the result.</p>
+<p>It now fires after a batch of documents too, not only after a screenshot or a clipboard
+image. It does not fire if you cancel a batch, since nothing is copied then.</p>
 <p>The rest of the options are covered in <a href="settings.html">The Settings window</a>.</p>
 <h2 id="where-to-next">Where to next</h2>
 <ul>

--- a/Documentation/UserGuide/html/troubleshooting.html
+++ b/Documentation/UserGuide/html/troubleshooting.html
@@ -360,7 +360,8 @@ after OCR</strong> boxes in <strong>Settings</strong>. There are two reasons one
 failure beep, the shortcut is deliberately skipped — it is usually something that acts
 on the text, and running it when the text never landed would aim it at the wrong thing.
 OCR is different: it sends the shortcut either way, so a screen-reader command in that
-box reads out the error as readily as the result.</p>
+box reads out the error as readily as the result. The one exception is a batch of
+documents you cancelled — nothing is copied then, so nothing is sent.</p>
 <p>The second is how the shortcut is written. Write it the ordinary way — modifier names
 joined with plus signs, like <strong>Ctrl+V</strong>, <strong>Alt+F4</strong> or <strong>Ctrl+Shift+Delete</strong>. Mutation
 still understands the older shorthand some settings files hold, such as <code>^{DEL}</code> for

--- a/Documentation/UserGuide/markdown/dictation.md
+++ b/Documentation/UserGuide/markdown/dictation.md
@@ -180,6 +180,9 @@ If the transcript could not be delivered — you hear the failure beep — the s
 not sent. It usually acts on the text, and sending it when nothing arrived would aim it
 at whatever was there before.
 
+It is sent after every way of finishing a transcript: dictating, running a prompt over
+one, and the **Format transcript** button, which used to be the one that stayed silent.
+
 Write the shortcut the ordinary way, like **Ctrl+V** or **Ctrl+Shift+Delete**. You can
 list more than one, separated by commas, and they are sent in turn.
 

--- a/Documentation/UserGuide/markdown/screen-capture-and-ocr.md
+++ b/Documentation/UserGuide/markdown/screen-capture-and-ocr.md
@@ -148,6 +148,9 @@ your choosing once the text is ready — handy for kicking off your screen reade
 automatically. It is sent whether the run found text or failed, so a screen-reader
 shortcut in that box reads out the error just as readily as the result.
 
+It now fires after a batch of documents too, not only after a screenshot or a clipboard
+image. It does not fire if you cancel a batch, since nothing is copied then.
+
 The rest of the options are covered in [The Settings window](settings.md).
 
 ## Where to next

--- a/Documentation/UserGuide/markdown/troubleshooting.md
+++ b/Documentation/UserGuide/markdown/troubleshooting.md
@@ -261,7 +261,8 @@ The first is that dictation only sends it when the text was delivered. If you he
 failure beep, the shortcut is deliberately skipped — it is usually something that acts
 on the text, and running it when the text never landed would aim it at the wrong thing.
 OCR is different: it sends the shortcut either way, so a screen-reader command in that
-box reads out the error as readily as the result.
+box reads out the error as readily as the result. The one exception is a batch of
+documents you cancelled — nothing is copied then, so nothing is sent.
 
 The second is how the shortcut is written. Write it the ordinary way — modifier names
 joined with plus signs, like **Ctrl+V**, **Alt+F4** or **Ctrl+Shift+Delete**. Mutation

--- a/Mutation.Tests/KeyboardInputLayoutTests.cs
+++ b/Mutation.Tests/KeyboardInputLayoutTests.cs
@@ -96,4 +96,54 @@ public class KeyboardInputLayoutTests
 	{
 		Assert.Equal(0u, KeyboardInput.Send(Array.Empty<KeyboardInput.INPUT>()));
 	}
+
+	[Theory]
+	[InlineData((ushort)0x11)] // Ctrl
+	[InlineData((ushort)0x10)] // Shift
+	[InlineData((ushort)0x12)] // Alt
+	[InlineData((ushort)0x56)] // V
+	[InlineData((ushort)0x2E)] // Delete
+	[InlineData((ushort)0x24)] // Home
+	[InlineData((ushort)0x70)] // F1
+	public void KeyDown_CarriesTheScanCodeTheKeyboardWouldReport(ushort virtualKey)
+	{
+		// Issue #335. A chord injected with a scan code of zero carries no key position, and
+		// a screen reader or magnifier watching the keyboard through a low-level hook reads
+		// the position. It sees a key that is at no place on the keyboard, decides this is
+		// not its shortcut, and does nothing — while SendInput reports every event accepted,
+		// so nothing anywhere says the shortcut was ignored.
+		var input = KeyboardInput.KeyDown(virtualKey);
+
+		Assert.NotEqual(0, input.U.ki.wScan);
+		Assert.Equal(KeyboardInput.ScanCode(virtualKey), input.U.ki.wScan);
+	}
+
+	[Fact]
+	public void KeyUp_CarriesTheSameScanCodeAsItsKeyDown()
+	{
+		// A press and its release have to name the same physical key, or a watcher that
+		// pairs them by position never sees the release and holds the chord down.
+		const ushort delete = 0x2E;
+
+		Assert.Equal(KeyboardInput.KeyDown(delete).U.ki.wScan, KeyboardInput.KeyUp(delete).U.ki.wScan);
+	}
+
+	[Fact]
+	public void ExtendedKeys_KeepBothTheScanCodeAndTheExtendedFlag()
+	{
+		// Delete's scan code is the keypad period's; the extended flag is the only thing
+		// telling the two apart. Adding the scan code must not cost the flag.
+		var input = KeyboardInput.KeyDown(0x2E);
+
+		Assert.NotEqual(0, input.U.ki.wScan);
+		Assert.Equal(KeyboardInput.KeyEventExtendedKey, input.U.ki.dwFlags & KeyboardInput.KeyEventExtendedKey);
+	}
+
+	[Fact]
+	public void ScanCode_ForAKeyTheLayoutHasNoPositionFor_IsZeroRatherThanAThrow()
+	{
+		// There is no key for VK_PROCESSKEY. Zero is what the struct held before this was
+		// filled in at all, so an unmappable key is no worse off than it used to be.
+		Assert.Equal(0, KeyboardInput.ScanCode(0xE5));
+	}
 }

--- a/Mutation.Tests/PostOperationHotkeyCoverageTests.cs
+++ b/Mutation.Tests/PostOperationHotkeyCoverageTests.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Mutation.Tests;
+
+/// <summary>
+/// Every operation that publishes a result to the user also sends the shortcut the user
+/// configured to run afterwards.
+/// <para>
+/// Batch OCR of documents did not. It wrote the combined text to the clipboard, filled the
+/// OCR box, and announced "Results copied to the clipboard" — and then sent nothing, on the
+/// one OCR path where the user has waited longest for an answer they cannot see. The eight
+/// sibling paths all sent it, which is exactly why the gap survived: nothing looked wrong
+/// anywhere except the one handler nobody compared (issue #335).
+/// </para>
+/// <para>
+/// Pinned by reading the handler source rather than by running it, because MainWindow needs
+/// a WinUI host that the test project cannot start (issue #304). That makes this a weaker
+/// test than a behavioural one — it proves the call is written, not that it fires — so it is
+/// deliberately narrow: it asks only the question the bug was, which is whether a result
+/// reaches the user with no shortcut behind it.
+/// </para>
+/// </summary>
+public class PostOperationHotkeyCoverageTests
+{
+	private const string OcrSetting = "SendHotkeyAfterOcrOperation";
+	private const string TranscriptionSetting = "SendHotkeyAfterTranscriptionOperation";
+	private const string Send = "SendHotkeyAfterDelay";
+
+	/// <summary>
+	/// How far after the result is published the send may sit. Wide enough for the status
+	/// branches an OCR handler ends with, narrow enough that a send belonging to the next
+	/// handler cannot be mistaken for this one's.
+	/// </summary>
+	private const int WindowLines = 25;
+
+	private static string[] MainWindowSource()
+	{
+		string relative = Path.Combine("Mutation.Ui", "MainWindow.xaml.cs");
+
+		var directory = new DirectoryInfo(AppContext.BaseDirectory);
+		while (directory is not null && !File.Exists(Path.Combine(directory.FullName, relative)))
+			directory = directory.Parent;
+
+		Assert.True(directory is not null, $"{relative} not found above {AppContext.BaseDirectory}");
+		return File.ReadAllLines(Path.Combine(directory!.FullName, relative));
+	}
+
+	private static IEnumerable<int> LinesCalling(string[] source, string fragment) =>
+		source.Select((line, index) => (line, index))
+			.Where(entry => entry.line.Contains(fragment, StringComparison.Ordinal))
+			.Select(entry => entry.index);
+
+	private static bool SendsWithin(string[] source, int from, string setting)
+	{
+		int last = Math.Min(source.Length - 1, from + WindowLines);
+		for (int i = from; i <= last; i++)
+		{
+			if (!source[i].Contains(Send, StringComparison.Ordinal))
+				continue;
+
+			// The setting can sit on the call's own line or on the next one, since these
+			// calls are written both ways.
+			string call = string.Join(' ', source.Skip(i).Take(3));
+			if (call.Contains(setting, StringComparison.Ordinal))
+				return true;
+		}
+
+		return false;
+	}
+
+	[Fact]
+	public void Every_OCR_result_shown_to_the_user_is_followed_by_the_configured_shortcut()
+	{
+		var source = MainWindowSource();
+
+		// SetOcrText is how an OCR result reaches the user: it fills the OCR box and enables
+		// the download button. Its own declaration is not a call, so it is excluded by the
+		// parenthesis-and-argument shape.
+		var publishes = LinesCalling(source, "SetOcrText(result.")
+			.ToList();
+
+		Assert.Equal(9, publishes.Count);
+
+		var unsent = publishes
+			.Where(line => !SendsWithin(source, line, OcrSetting))
+			.Select(line => $"MainWindow.xaml.cs:{line + 1}: {source[line].Trim()}")
+			.ToList();
+
+		Assert.True(unsent.Count == 0,
+			"An OCR result is shown to the user with no configured shortcut sent after it:\n" +
+			string.Join("\n", unsent));
+	}
+
+	[Fact]
+	public void Every_transcript_delivery_is_followed_by_the_configured_shortcut()
+	{
+		var source = MainWindowSource();
+
+		// The planner is what decides a transcript run is finished, and all three delivery
+		// sites — dictation, an LLM prompt run, and formatting — go through it.
+		var plans = LinesCalling(source, "TranscriptCompletionPlanner.Plan(").ToList();
+
+		Assert.Equal(3, plans.Count);
+
+		var unsent = plans
+			.Where(line => !SendsWithin(source, line, TranscriptionSetting))
+			.Select(line => $"MainWindow.xaml.cs:{line + 1}: {source[line].Trim()}")
+			.ToList();
+
+		Assert.True(unsent.Count == 0,
+			"A transcript is delivered with no configured shortcut sent after it:\n" +
+			string.Join("\n", unsent));
+	}
+
+	[Fact]
+	public void The_shortcut_is_sent_before_the_beep_and_the_status_that_can_throw()
+	{
+		var source = MainWindowSource();
+
+		// Ordering, not presence. The send used to be the last statement of each block, after
+		// BeepPlayer.Play and ShowStatus — and ShowStatus builds an automation peer and starts
+		// a timer, the operation issue #234 was filed about throwing. A throw there took the
+		// shortcut with it, after the text had already reached the clipboard.
+		foreach (int plan in LinesCalling(source, "TranscriptCompletionPlanner.Plan("))
+		{
+			int send = Enumerable.Range(plan, Math.Min(WindowLines, source.Length - plan))
+				.First(i => source[i].Contains(Send, StringComparison.Ordinal));
+			int beep = Enumerable.Range(plan, Math.Min(WindowLines, source.Length - plan))
+				.First(i => source[i].Contains("BeepPlayer.Play(plan.Beep)", StringComparison.Ordinal));
+
+			Assert.True(send < beep,
+				$"MainWindow.xaml.cs:{plan + 1}: the shortcut is sent after the beep and status, " +
+				"so a throw from either loses it.");
+		}
+	}
+}

--- a/Mutation.Ui/MainWindow.xaml.cs
+++ b/Mutation.Ui/MainWindow.xaml.cs
@@ -1061,7 +1061,7 @@ public sealed partial class MainWindow : Window, IDisposable
 			if (!await EnsureOcrConfiguredAsync()) return;
 			var result = await _ocrManager.ExtractTextFromClipboardImageAsync(OcrReadingOrder.TopToBottomColumnAware);
 			SetOcrText(result.Message);
-			HotkeyManager.SendHotkeyAfterDelay(_settings.AzureComputerVisionSettings?.SendHotkeyAfterOcrOperation ?? string.Empty, PostOperationHotkey.OcrDelay(result.Success));
+			HotkeyManager.SendHotkeyAfterDelay(_settings.AzureComputerVisionSettings?.SendHotkeyAfterOcrOperation, PostOperationHotkey.OcrDelay(result.Success));
 			if (result.Success)
 				ShowStatus("OCR", "Clipboard image converted to text.", InfoBarSeverity.Success);
 			else
@@ -1147,6 +1147,15 @@ public sealed partial class MainWindow : Window, IDisposable
 
                         var result = await _ocrManager.ExtractTextFromFilesAsync(paths, OcrReadingOrder.TopToBottomColumnAware, run.Token, progress);
 			SetOcrText(result.Text);
+
+			// The one OCR path that never sent the configured shortcut, though it is the
+			// path where the user has waited longest and most wants to hear the answer.
+			// Sent here rather than after the branches below, and only once the run has
+			// reached a result: a cancelled batch never gets this far, so the shortcut is
+			// not aimed at whatever the OCR box still held from last time (issue #335).
+			HotkeyManager.SendHotkeyAfterDelay(
+				_settings.AzureComputerVisionSettings?.SendHotkeyAfterOcrOperation,
+				PostOperationHotkey.OcrDelay(result.Success));
 
 			if (result.SuccessCount == 0)
 			{
@@ -1422,7 +1431,7 @@ public sealed partial class MainWindow : Window, IDisposable
 			if (!await EnsureOcrConfiguredAsync()) return;
 			var result = await _ocrManager.ExtractTextFromClipboardImageAsync(OcrReadingOrder.LeftToRightTopToBottom);
 			SetOcrText(result.Message);
-			HotkeyManager.SendHotkeyAfterDelay(_settings.AzureComputerVisionSettings?.SendHotkeyAfterOcrOperation ?? string.Empty, PostOperationHotkey.OcrDelay(result.Success));
+			HotkeyManager.SendHotkeyAfterDelay(_settings.AzureComputerVisionSettings?.SendHotkeyAfterOcrOperation, PostOperationHotkey.OcrDelay(result.Success));
 			if (result.Success)
 				ShowStatus("OCR (left-to-right)", "Clipboard image converted using left-to-right reading order.", InfoBarSeverity.Success);
 			else
@@ -2365,17 +2374,25 @@ public sealed partial class MainWindow : Window, IDisposable
 		TxtFormatTranscript.Text = formatted;
 		bool copied = await _clipboard.TrySetTextAsync(formatted);
 		var outcome = await TryInsertIntoActiveApplicationAsync(formatted, clipboardAvailable: copied);
-		string? failure = TranscriptDeliveryMessages.Failure(copied, outcome, "formatted transcript");
-		if (failure is null)
-		{
-			BeepPlayer.Play(BeepType.Success);
-			ShowStatus("Formatting", "Transcript formatted and copied.", InfoBarSeverity.Success);
-		}
-		else
-		{
-			BeepPlayer.Play(BeepType.Failure);
-			ShowStatus("Formatting", failure, InfoBarSeverity.Error);
-		}
+
+		// Through the planner like the other two delivery sites. This one kept its own
+		// copy of the beep-and-message half and had no idea the shortcut was the third
+		// part of the same decision, so formatting a transcript delivered the text and
+		// then did nothing the user had asked for afterwards (issue #335).
+		var plan = TranscriptCompletionPlanner.Plan(copied, outcome, "formatted transcript");
+
+		// Before the beep and the status, either of which can throw — a status builds an
+		// automation peer and starts a timer (issue #234). The text has already landed by
+		// this point, so the shortcut that acts on it should not be the thing that is lost.
+		if (plan.SendConfiguredHotkey)
+			HotkeyManager.SendHotkeyAfterDelay(
+				_settings.SpeechToTextSettings?.SendHotkeyAfterTranscriptionOperation,
+				PostOperationHotkey.SuccessDelayMs);
+
+		BeepPlayer.Play(plan.Beep);
+		ShowStatus("Formatting",
+			plan.FailureMessage ?? "Transcript formatted and copied.",
+			plan.Succeeded ? InfoBarSeverity.Success : InfoBarSeverity.Error);
 	}
 
 	public async void BtnProcessLlm_Click(object? sender, RoutedEventArgs? e)
@@ -2501,17 +2518,21 @@ public sealed partial class MainWindow : Window, IDisposable
 			// once however the delivery turns out.
 			FastModeFallbackReason? fastModeNotice = ClaimFastModeNotice(prompt.Id, fastModeFallback);
 
+			// Ahead of the beep and the status rather than after them. Both can throw —
+			// ShowStatus builds an automation peer and starts a timer, which is what
+			// issue #234 was about — and the catch below would then swallow the shortcut
+			// as well, after the text had already been delivered (issue #335).
+			if (plan.SendConfiguredHotkey)
+				HotkeyManager.SendHotkeyAfterDelay(
+					_settings.SpeechToTextSettings?.SendHotkeyAfterTranscriptionOperation,
+					PostOperationHotkey.SuccessDelayMs);
+
 			BeepPlayer.Play(plan.Beep);
 			ShowStatus("Processing",
 				FastModeMessages.AppendTo(
 					plan.FailureMessage ?? $"Applied prompt '{prompt.Name}' with the language model.",
 					fastModeNotice),
 				plan.Succeeded ? InfoBarSeverity.Success : InfoBarSeverity.Error);
-
-			if (plan.SendConfiguredHotkey)
-				HotkeyManager.SendHotkeyAfterDelay(
-					_settings.SpeechToTextSettings?.SendHotkeyAfterTranscriptionOperation,
-					PostOperationHotkey.SuccessDelayMs);
         }
         catch (OperationCanceledException) when (_isClosing || _shutdownCts.IsCancellationRequested)
         {
@@ -2786,15 +2807,19 @@ public sealed partial class MainWindow : Window, IDisposable
 				var outcome = await TryInsertIntoActiveApplicationAsync(formatted, clipboardAvailable: copied);
 				var plan = TranscriptCompletionPlanner.Plan(copied, outcome, "transcript");
 
-				BeepPlayer.Play(plan.Beep);
-				ShowStatus("Speech to Text",
-					FastModeMessages.AppendTo(plan.FailureMessage ?? successMessage, fastModeNotice),
-					plan.Succeeded ? InfoBarSeverity.Success : InfoBarSeverity.Error);
-
+				// Ahead of the beep and the status rather than after them. A throw from
+				// either lands in onFailure below, which announces that the delivery went
+				// wrong — but the transcript is on the clipboard and already pasted by
+				// then, and the user's shortcut would have been lost with it (issue #335).
 				if (plan.SendConfiguredHotkey)
 					HotkeyManager.SendHotkeyAfterDelay(
 						_settings.SpeechToTextSettings?.SendHotkeyAfterTranscriptionOperation,
 						PostOperationHotkey.SuccessDelayMs);
+
+				BeepPlayer.Play(plan.Beep);
+				ShowStatus("Speech to Text",
+					FastModeMessages.AppendTo(plan.FailureMessage ?? successMessage, fastModeNotice),
+					plan.Succeeded ? InfoBarSeverity.Success : InfoBarSeverity.Error);
 			},
 			onFailure: ex =>
 			{

--- a/Mutation.Ui/Services/KeyboardInput.cs
+++ b/Mutation.Ui/Services/KeyboardInput.cs
@@ -20,6 +20,16 @@ namespace Mutation.Ui.Services;
 /// pasted into another window was announced as a failure it had not had, and the
 /// shortcut configured to run afterwards was skipped along with it.
 /// </para>
+/// <para>
+/// The contents matter for the same reason the size does. A key press describes both
+/// what the key means (the virtual key) and where it is (the scan code), and this sent
+/// only the first. Ordinary applications read the meaning and were content; screen
+/// readers and magnifiers watch the keyboard through a low-level hook and read the
+/// position, so a shortcut arriving from nowhere on the keyboard was not the shortcut
+/// they were waiting for and they let it pass. Once PR #328 made SendInput work, that
+/// became the whole of the "send this shortcut afterwards" feature failing — quietly,
+/// because Windows accepted every event (issue #335).
+/// </para>
 /// </summary>
 internal static class KeyboardInput
 {
@@ -94,6 +104,12 @@ internal static class KeyboardInput
 	[DllImport("user32.dll", SetLastError = true)]
 	private static extern uint SendInput(uint nInputs, INPUT[] pInputs, int cbSize);
 
+	/// <summary>MAPVK_VK_TO_VSC — a virtual key to the scan code of the key that carries it.</summary>
+	private const uint MapVkToScanCode = 0;
+
+	[DllImport("user32.dll")]
+	private static extern uint MapVirtualKey(uint code, uint mapType);
+
 	/// <summary>
 	/// Submits <paramref name="inputs"/> and reports how many Windows accepted. Fewer than
 	/// were submitted means the foreground application refused them — usually because it
@@ -117,6 +133,13 @@ internal static class KeyboardInput
 
 	public static INPUT UnicodeUp(char character) => Unicode(character, KeyEventUnicode | KeyEventKeyUp);
 
+	/// <summary>
+	/// The scan code the keyboard itself would report for <paramref name="virtualKey"/> —
+	/// what the key's physical position is, as opposed to what it means. Zero when the
+	/// current layout has no position for it.
+	/// </summary>
+	public static ushort ScanCode(ushort virtualKey) => (ushort)MapVirtualKey(virtualKey, MapVkToScanCode);
+
 	private static INPUT Key(ushort virtualKey, uint flags) => new()
 	{
 		type = InputKeyboard,
@@ -125,7 +148,13 @@ internal static class KeyboardInput
 			ki = new KEYBDINPUT
 			{
 				wVk = virtualKey,
-				wScan = 0,
+				// Filled, not left at zero. A real key press carries both the virtual key
+				// and the position it came from, and anything reading the keyboard through
+				// a low-level hook — screen readers and magnifiers above all — is entitled
+				// to look at the position. A chord injected with a scan code of zero is
+				// simply not the shortcut they are watching for, so it is discarded without
+				// a word, while SendInput reports every event accepted (issue #335).
+				wScan = ScanCode(virtualKey),
 				dwFlags = flags,
 				time = 0,
 				dwExtraInfo = IntPtr.Zero,


### PR DESCRIPTION
Fixes #335.

## The shortcut had no place on the keyboard

A key press says two things: what the key means (its virtual key) and where it is
(its scan code). `KeyboardInput` filled in the meaning and left the position at zero.

Ordinary applications read the meaning and were satisfied — which is why pasting with
Ctrl+V kept working, and why this looked like an OCR problem rather than a keyboard one.
Screen readers and magnifiers watch the keyboard through a low-level hook and read the
position. A chord that comes from nowhere on the keyboard is not the shortcut they are
waiting for, so they let it pass without a word.

Measured with a `WH_KEYBOARD_LL` hook rather than reasoned about — Ctrl+Home injected
both ways:

| | Ctrl | Home |
| --- | --- | --- |
| As sent before this | `vk=0xA2 scan=0x00` | `vk=0x24 scan=0x00 extended=True` |
| As sent now | `vk=0xA2 scan=0x1D` | `vk=0x24 scan=0x47 extended=True` |
| A real key press | `vk=0xA2 scan=0x1D` | `vk=0x24 scan=0x47 extended=True` |

`wScan` now comes from `MapVirtualKey(vk, MAPVK_VK_TO_VSC)`. The extended flag stays, so
Delete does not become the keypad's full stop.

### Why it appeared in the last two days

Until #328 every `SendInput` call was rejected outright and the WinForms `SendKeys`
fallback did the work — and that path produces a real scan code. Repairing SendInput
moved these chords onto a path Windows accepts and the screen reader ignores, and it
reports success at every step. `%TEMP%\Mutation.Hotkey.log` shows the send going out
with nothing under it:

```
18:12:30.273 WM_HOTKEY received: id=6
18:12:34.506 SendHotkeyAfterDelay firing: '^{DEL}'
18:12:34.508 Sending via SendInput: '^{DEL}'
```

## Then every place the shortcut belongs

A fix to the mechanism is worth little where the call was never written, so all of them
were audited.

- **OCR of documents** copied a whole batch to the clipboard, filled the OCR box,
  announced "Results copied to the clipboard" — and sent nothing. The path where the
  user has waited longest for an answer they cannot see. It sends now, once the run
  reaches a result, so a cancelled batch does not aim the shortcut at whatever the box
  held before.
- **Format transcript** delivered its text and sent nothing. It was the one delivery
  site that kept its own copy of the beep-and-message half rather than going through
  `TranscriptCompletionPlanner`, so it never saw that the shortcut is the third part of
  the same decision. It goes through the planner now.
- **All three transcript sites** had the send as the last statement, after the beep and
  the status — and a status builds an automation peer and starts a timer, the operation
  #234 was filed about throwing. A throw there took the shortcut with it, after the text
  had already landed. The send now goes first.

The eight OCR sites that were already correct are unchanged apart from two that spelled
the same argument `?? string.Empty`.

## Tests

The scan code is pinned per key, a press and its release are pinned to the same one, and
the extended flag is pinned alongside it, so filling one cannot cost the other.

MainWindow needs a WinUI host the test project cannot start (#304), so the two coverage
tests read the handler source. That is a weaker test than a behavioural one — it proves
the call is written, not that it fires — which the file says plainly, and it is narrowed
to the one question the bug was. Checked falsifiable: removing the batch-OCR send fails
the OCR test by file and line.

2038 passing, 0 warnings.

## Guide

The OCR chapter on the batch, the dictation chapter on Format transcript, and the
troubleshooting entry on the cancelled-batch exception. Markdown and HTML committed
together.

## What to test

1. Set **Send hotkey after OCR** to a shortcut your screen reader owns. OCR a screenshot
   and a clipboard image, both reading orders, and hear the shortcut act on the result.
2. Do the same with **OCR documents** on a couple of files. Then cancel a batch and
   confirm nothing is sent.
3. Set **Send hotkey after transcription** and check it after dictation, after a prompt
   run, and after **Format transcript**.
4. Confirm a hotkey router mapping still delivers its target chord.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
