### PR TITLE
Ask Windows which keys are extended, and make the coverage tests able to fail

### DIFF
--- a/Documentation/UserGuide/html/dictation.html
+++ b/Documentation/UserGuide/html/dictation.html
@@ -305,7 +305,7 @@ if you don't need it.</p>
 not sent. It usually acts on the text, and sending it when nothing arrived would aim it
 at whatever was there before.</p>
 <p>It is sent after every way of finishing a transcript: dictating, running a prompt over
-one, and the <strong>Format transcript</strong> button, which used to be the one that stayed silent.</p>
+one, and the <strong>Format transcript</strong> button.</p>
 <p>Write the shortcut the ordinary way, like <strong>Ctrl+V</strong> or <strong>Ctrl+Shift+Delete</strong>. You can
 list more than one, separated by commas, and they are sent in turn.</p>
 <h2 id="choosing-a-transcription-service">Choosing a transcription service</h2>

--- a/Documentation/UserGuide/html/screen-capture-and-ocr.html
+++ b/Documentation/UserGuide/html/screen-capture-and-ocr.html
@@ -317,8 +317,8 @@ remove the limit.</li>
 your choosing once the text is ready — handy for kicking off your screen reader
 automatically. It is sent whether the run found text or failed, so a screen-reader
 shortcut in that box reads out the error just as readily as the result.</p>
-<p>It now fires after a batch of documents too, not only after a screenshot or a clipboard
-image. It does not fire if you cancel a batch, since nothing is copied then.</p>
+<p>It is sent after a batch of documents as well, not only after a screenshot or a
+clipboard image. It is not sent if you cancel a batch, since nothing is copied then.</p>
 <p>The rest of the options are covered in <a href="settings.html">The Settings window</a>.</p>
 <h2 id="where-to-next">Where to next</h2>
 <ul>

--- a/Documentation/UserGuide/markdown/dictation.md
+++ b/Documentation/UserGuide/markdown/dictation.md
@@ -181,7 +181,7 @@ not sent. It usually acts on the text, and sending it when nothing arrived would
 at whatever was there before.
 
 It is sent after every way of finishing a transcript: dictating, running a prompt over
-one, and the **Format transcript** button, which used to be the one that stayed silent.
+one, and the **Format transcript** button.
 
 Write the shortcut the ordinary way, like **Ctrl+V** or **Ctrl+Shift+Delete**. You can
 list more than one, separated by commas, and they are sent in turn.

--- a/Documentation/UserGuide/markdown/screen-capture-and-ocr.md
+++ b/Documentation/UserGuide/markdown/screen-capture-and-ocr.md
@@ -148,8 +148,8 @@ your choosing once the text is ready — handy for kicking off your screen reade
 automatically. It is sent whether the run found text or failed, so a screen-reader
 shortcut in that box reads out the error just as readily as the result.
 
-It now fires after a batch of documents too, not only after a screenshot or a clipboard
-image. It does not fire if you cancel a batch, since nothing is copied then.
+It is sent after a batch of documents as well, not only after a screenshot or a
+clipboard image. It is not sent if you cancel a batch, since nothing is copied then.
 
 The rest of the options are covered in [The Settings window](settings.md).
 

--- a/Mutation.Tests/KeyboardInputLayoutTests.cs
+++ b/Mutation.Tests/KeyboardInputLayoutTests.cs
@@ -139,6 +139,47 @@ public class KeyboardInputLayoutTests
 		Assert.Equal(KeyboardInput.KeyEventExtendedKey, input.U.ki.dwFlags & KeyboardInput.KeyEventExtendedKey);
 	}
 
+	[Theory]
+	[InlineData((ushort)0x5B)] // Left Windows
+	[InlineData((ushort)0x5C)] // Right Windows
+	[InlineData((ushort)0xA3)] // Right Ctrl
+	[InlineData((ushort)0xA5)] // Right Alt
+	[InlineData((ushort)0x5D)] // Context menu
+	[InlineData((ushort)0x6F)] // Keypad divide
+	public void KeysWindowsCallsExtended_AreMarkedExtended(ushort virtualKey)
+	{
+		// The last two were missing from the hand-written list, and both are reachable by
+		// name from the "send key after…" boxes. Windows is asked as well as the list now.
+		Assert.True(KeyboardInput.IsExtended(virtualKey));
+	}
+
+	[Theory]
+	[InlineData((ushort)0xA1)] // Right Shift — scan 0x36, and genuinely not extended
+	[InlineData((ushort)0xA0)] // Left Shift
+	[InlineData((ushort)0xA2)] // Left Ctrl
+	[InlineData((ushort)0x90)] // Num Lock
+	[InlineData((ushort)0x56)] // V
+	public void KeysWindowsDoesNotCallExtended_AreNotMarkedExtended(ushort virtualKey)
+	{
+		// Right Shift was on the list and should never have been. Prefixing it produces the
+		// filler keystroke Windows emits around keypad sequences, which hooks discard.
+		Assert.False(KeyboardInput.IsExtended(virtualKey));
+	}
+
+	[Theory]
+	[InlineData((ushort)0x2E)] // Delete
+	[InlineData((ushort)0x24)] // Home
+	[InlineData((ushort)0x21)] // Page Up
+	[InlineData((ushort)0x25)] // Left
+	[InlineData((ushort)0x2D)] // Insert
+	public void TheNavigationCluster_StaysExtendedThoughWindowsWillNotSaySo(ushort virtualKey)
+	{
+		// MapVirtualKey answers these with the keypad's scan code and no prefix, because a
+		// virtual key alone does not say which of the twinned keys was pressed. Deferring to
+		// it here would turn Delete back into the keypad's full stop.
+		Assert.True(KeyboardInput.IsExtended(virtualKey));
+	}
+
 	[Fact]
 	public void ScanCode_ForAKeyTheLayoutHasNoPositionFor_IsZeroRatherThanAThrow()
 	{

--- a/Mutation.Tests/PostOperationHotkeyCoverageTests.cs
+++ b/Mutation.Tests/PostOperationHotkeyCoverageTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 
 namespace Mutation.Tests;
 
@@ -30,32 +31,53 @@ public class PostOperationHotkeyCoverageTests
 	private const string Send = "SendHotkeyAfterDelay";
 
 	/// <summary>
-	/// How far after the result is published the send may sit. Wide enough for the status
-	/// branches an OCR handler ends with, narrow enough that a send belonging to the next
-	/// handler cannot be mistaken for this one's.
+	/// How far after a result is published the send may sit — enough for the status branches
+	/// an OCR handler ends with. A search is additionally stopped at the next publish, so a
+	/// send belonging to the following handler can never stand in for a missing one: the four
+	/// hotkey handlers sit about thirteen lines apart, well inside this.
 	/// </summary>
 	private const int WindowLines = 25;
 
+	/// <summary>
+	/// Resolved by the compiler from this file's own location, so it cannot drift when the
+	/// tests are run from a published or copied output directory.
+	/// </summary>
+	private static string MainWindowPath([CallerFilePath] string thisFile = "") =>
+		Path.Combine(Path.GetDirectoryName(thisFile)!, "..", "Mutation.Ui", "MainWindow.xaml.cs");
+
 	private static string[] MainWindowSource()
 	{
-		string relative = Path.Combine("Mutation.Ui", "MainWindow.xaml.cs");
-
-		var directory = new DirectoryInfo(AppContext.BaseDirectory);
-		while (directory is not null && !File.Exists(Path.Combine(directory.FullName, relative)))
-			directory = directory.Parent;
-
-		Assert.True(directory is not null, $"{relative} not found above {AppContext.BaseDirectory}");
-		return File.ReadAllLines(Path.Combine(directory!.FullName, relative));
+		string path = Path.GetFullPath(MainWindowPath());
+		Assert.True(File.Exists(path), $"MainWindow.xaml.cs not found at {path}");
+		return File.ReadAllLines(path);
 	}
 
-	private static IEnumerable<int> LinesCalling(string[] source, string fragment) =>
+	private static List<int> LinesCalling(string[] source, Func<string, bool> matches) =>
 		source.Select((line, index) => (line, index))
-			.Where(entry => entry.line.Contains(fragment, StringComparison.Ordinal))
-			.Select(entry => entry.index);
+			.Where(entry => matches(entry.line))
+			.Select(entry => entry.index)
+			.ToList();
 
-	private static bool SendsWithin(string[] source, int from, string setting)
+	/// <summary>
+	/// Where an OCR result reaches the user: <c>SetOcrText</c> fills the OCR box and enables
+	/// the download button. Matched by call shape rather than by argument name, so a new
+	/// handler naming its result something else is still seen. The declaration is excluded.
+	/// </summary>
+	private static List<int> OcrPublishes(string[] source) =>
+		LinesCalling(source, line =>
+			line.Contains("SetOcrText(", StringComparison.Ordinal) &&
+			!line.Contains("void SetOcrText(", StringComparison.Ordinal));
+
+	/// <summary>
+	/// Where a transcript run is decided finished. All three delivery sites — dictation, an
+	/// LLM prompt run, and formatting — go through the planner.
+	/// </summary>
+	private static List<int> TranscriptPlans(string[] source) =>
+		LinesCalling(source, line => line.Contains("TranscriptCompletionPlanner.Plan(", StringComparison.Ordinal));
+
+	private static bool SendsWithin(string[] source, int from, int stopBefore, string setting)
 	{
-		int last = Math.Min(source.Length - 1, from + WindowLines);
+		int last = Math.Min(Math.Min(source.Length - 1, from + WindowLines), stopBefore - 1);
 		for (int i = from; i <= last; i++)
 		{
 			if (!source[i].Contains(Send, StringComparison.Ordinal))
@@ -71,23 +93,31 @@ public class PostOperationHotkeyCoverageTests
 		return false;
 	}
 
+	private static List<string> Unsent(string[] source, List<int> publishes, string setting)
+	{
+		var missing = new List<string>();
+		for (int n = 0; n < publishes.Count; n++)
+		{
+			int stopBefore = n + 1 < publishes.Count ? publishes[n + 1] : source.Length;
+			if (!SendsWithin(source, publishes[n], stopBefore, setting))
+				missing.Add($"MainWindow.xaml.cs:{publishes[n] + 1}: {source[publishes[n]].Trim()}");
+		}
+
+		return missing;
+	}
+
 	[Fact]
 	public void Every_OCR_result_shown_to_the_user_is_followed_by_the_configured_shortcut()
 	{
 		var source = MainWindowSource();
+		var publishes = OcrPublishes(source);
 
-		// SetOcrText is how an OCR result reaches the user: it fills the OCR box and enables
-		// the download button. Its own declaration is not a call, so it is excluded by the
-		// parenthesis-and-argument shape.
-		var publishes = LinesCalling(source, "SetOcrText(result.")
-			.ToList();
+		// Not an exact count: a tenth OCR handler that does send is a correct change and
+		// should not fail here. This only catches the search itself matching nothing after
+		// a rename, which would make the test pass by asking nothing.
+		Assert.NotEmpty(publishes);
 
-		Assert.Equal(9, publishes.Count);
-
-		var unsent = publishes
-			.Where(line => !SendsWithin(source, line, OcrSetting))
-			.Select(line => $"MainWindow.xaml.cs:{line + 1}: {source[line].Trim()}")
-			.ToList();
+		var unsent = Unsent(source, publishes, OcrSetting);
 
 		Assert.True(unsent.Count == 0,
 			"An OCR result is shown to the user with no configured shortcut sent after it:\n" +
@@ -98,17 +128,11 @@ public class PostOperationHotkeyCoverageTests
 	public void Every_transcript_delivery_is_followed_by_the_configured_shortcut()
 	{
 		var source = MainWindowSource();
+		var plans = TranscriptPlans(source);
 
-		// The planner is what decides a transcript run is finished, and all three delivery
-		// sites — dictation, an LLM prompt run, and formatting — go through it.
-		var plans = LinesCalling(source, "TranscriptCompletionPlanner.Plan(").ToList();
+		Assert.NotEmpty(plans);
 
-		Assert.Equal(3, plans.Count);
-
-		var unsent = plans
-			.Where(line => !SendsWithin(source, line, TranscriptionSetting))
-			.Select(line => $"MainWindow.xaml.cs:{line + 1}: {source[line].Trim()}")
-			.ToList();
+		var unsent = Unsent(source, plans, TranscriptionSetting);
 
 		Assert.True(unsent.Count == 0,
 			"A transcript is delivered with no configured shortcut sent after it:\n" +
@@ -119,17 +143,23 @@ public class PostOperationHotkeyCoverageTests
 	public void The_shortcut_is_sent_before_the_beep_and_the_status_that_can_throw()
 	{
 		var source = MainWindowSource();
+		var plans = TranscriptPlans(source);
+
+		Assert.NotEmpty(plans);
 
 		// Ordering, not presence. The send used to be the last statement of each block, after
 		// BeepPlayer.Play and ShowStatus — and ShowStatus builds an automation peer and starts
 		// a timer, the operation issue #234 was filed about throwing. A throw there took the
 		// shortcut with it, after the text had already reached the clipboard.
-		foreach (int plan in LinesCalling(source, "TranscriptCompletionPlanner.Plan("))
+		foreach (int plan in plans)
 		{
-			int send = Enumerable.Range(plan, Math.Min(WindowLines, source.Length - plan))
-				.First(i => source[i].Contains(Send, StringComparison.Ordinal));
-			int beep = Enumerable.Range(plan, Math.Min(WindowLines, source.Length - plan))
-				.First(i => source[i].Contains("BeepPlayer.Play(plan.Beep)", StringComparison.Ordinal));
+			var window = Enumerable.Range(plan, Math.Min(WindowLines, source.Length - plan)).ToList();
+			int send = window.FirstOrDefault(i => source[i].Contains(Send, StringComparison.Ordinal), -1);
+			int beep = window.FirstOrDefault(i => source[i].Contains("BeepPlayer.Play(plan.Beep)", StringComparison.Ordinal), -1);
+
+			Assert.True(send >= 0 && beep >= 0,
+				$"MainWindow.xaml.cs:{plan + 1}: expected both a send and a beep within " +
+				$"{WindowLines} lines of the plan, found send={send + 1} beep={beep + 1}.");
 
 			Assert.True(send < beep,
 				$"MainWindow.xaml.cs:{plan + 1}: the shortcut is sent after the beep and status, " +

--- a/Mutation.Ui/MainWindow.xaml.cs
+++ b/Mutation.Ui/MainWindow.xaml.cs
@@ -2384,6 +2384,13 @@ public sealed partial class MainWindow : Window, IDisposable
 		// Before the beep and the status, either of which can throw — a status builds an
 		// automation peer and starts a timer (issue #234). The text has already landed by
 		// this point, so the shortcut that acts on it should not be the thing that is lost.
+		//
+		// This button is the one delivery site with no hotkey of its own, so Mutation is
+		// always the foreground window when it runs — which is why the insert above
+		// deliberately typed nothing. The shortcut is still sent, on purpose: it is normally
+		// a screen-reader command, which is global and wants running wherever the user is.
+		// A shortcut that only means something in another application will land here instead,
+		// and that is the same bargain the eight OCR buttons already make (PR #339).
 		if (plan.SendConfiguredHotkey)
 			HotkeyManager.SendHotkeyAfterDelay(
 				_settings.SpeechToTextSettings?.SendHotkeyAfterTranscriptionOperation,

--- a/Mutation.Ui/Services/KeyboardInput.cs
+++ b/Mutation.Ui/Services/KeyboardInput.cs
@@ -107,6 +107,14 @@ internal static class KeyboardInput
 	/// <summary>MAPVK_VK_TO_VSC — a virtual key to the scan code of the key that carries it.</summary>
 	private const uint MapVkToScanCode = 0;
 
+	/// <summary>
+	/// MAPVK_VK_TO_VSC_EX — the same, with the prefix byte in the high byte: 0xE0 for an
+	/// extended key. Consulted only for the flag; the scan code itself still comes from
+	/// <see cref="MapVkToScanCode"/>, because the low byte of the two agrees everywhere the
+	/// extended one answers at all.
+	/// </summary>
+	private const uint MapVkToScanCodeEx = 4;
+
 	[DllImport("user32.dll")]
 	private static extern uint MapVirtualKey(uint code, uint mapType);
 
@@ -179,13 +187,35 @@ internal static class KeyboardInput
 	};
 
 	/// <summary>
-	/// The navigation cluster and the right-hand modifiers, which share their virtual-key
-	/// code with a numeric-keypad key and are told apart by this flag. Delete without it
-	/// arrives as the keypad's period.
+	/// Whether the key needs the 0xE0 prefix that tells it apart from the numeric-keypad key
+	/// sharing its scan code. Delete without it arrives as the keypad's full stop.
 	/// </summary>
+	/// <remarks>
+	/// Asked of Windows and of the list below, because neither knows all of it.
+	/// <para>
+	/// The list cannot be dropped: <c>MapVirtualKey</c> answers the navigation cluster with
+	/// the keypad's own scan code and no prefix — Delete is 0x0053, Home 0x0047 — because a
+	/// virtual key alone does not say which of the two keys was pressed. Believing it there
+	/// would put the full stop back.
+	/// </para>
+	/// <para>
+	/// And the list is not enough on its own: it was written by hand and had never been
+	/// checked against Windows. It was missing the context-menu key and the keypad's divide,
+	/// both of which the "send key after…" boxes accept by name, and it claimed right Shift
+	/// is extended when it is not — that one is scan 0x36 with no prefix, and prefixing it
+	/// produces the filler keystroke Windows emits around keypad sequences, which hooks throw
+	/// away (PR #339).
+	/// </para>
+	/// </remarks>
 	public static bool IsExtended(ushort virtualKey) =>
+		NamedExtendedKeys(virtualKey) || (MapVirtualKey(virtualKey, MapVkToScanCodeEx) & 0xFF00) == 0xE000;
+
+	/// <summary>
+	/// The keys Windows will not admit are extended, because their virtual key is shared with
+	/// a keypad key and it cannot tell which was meant.
+	/// </summary>
+	private static bool NamedExtendedKeys(ushort virtualKey) =>
 		virtualKey is 0x21 /*PGUP*/ or 0x22 /*PGDN*/ or 0x23 /*END*/ or 0x24 /*HOME*/
 			or 0x25 /*LEFT*/ or 0x26 /*UP*/ or 0x27 /*RIGHT*/ or 0x28 /*DOWN*/
-			or 0x2D /*INSERT*/ or 0x2E /*DELETE*/ or 0x5B /*LWIN*/ or 0x5C /*RWIN*/
-			or 0xA1 /*RSHIFT*/ or 0xA3 /*RCONTROL*/ or 0xA5 /*RMENU(ALT)*/;
+			or 0x2D /*INSERT*/ or 0x2E /*DELETE*/;
 }


### PR DESCRIPTION
Follow-up to #339, which auto-merged before the review findings could be pushed to it.
Same work, on top of current `main`.

## The extended-key list was wrong three ways, and the obvious fix would have broken Delete

The hand-written `IsExtended` list had never been checked against Windows. The review
proposed replacing it with `MAPVK_VK_TO_VSC_EX`. I measured first:

| key | `VK_TO_VSC` | `VK_TO_VSC_EX` | Windows says extended |
| --- | --- | --- | --- |
| Delete | `0x53` | `0x0053` | **no** |
| Home | `0x47` | `0x0047` | **no** |
| Insert | `0x52` | `0x0052` | **no** |
| Context menu | `0x5D` | `0xE05D` | yes |
| Keypad divide | `0x35` | `0xE035` | yes |
| Right Shift | `0x36` | `0x0036` | no |
| Right Ctrl | `0x1D` | `0xE01D` | yes |

Windows answers the whole navigation cluster with the keypad's scan code and no prefix,
because a virtual key alone does not say which of the twinned keys was meant. Deferring
to it would have put the keypad's full stop back where Delete belongs — the exact
regression the list exists to prevent.

So it is the union of the two. The list keeps only the keys Windows will not admit to,
with the reason written beside it, and Windows supplies the rest:

- **Context menu** and **keypad divide** were missing. Both are reachable by name from
  the "send key after…" boxes, and the context menu key is a plausible thing for a
  screen-reader user to send.
- **Right Shift** was on the list and should never have been. It is scan `0x36` with no
  prefix; prefixing it produces the filler keystroke Windows emits around keypad
  sequences, which hooks routinely discard.

## The coverage tests could not fail for four of the nine OCR sites

The 25-line window reached into the next handler, and the four hotkey handlers sit
about thirteen lines apart — so the send belonging to the *next* handler stood in for a
missing one. Deleting the send at line 509 left the test green.

The search now stops at the next publish. Verified by removing each of the nine sends in
turn:

```
removed send at line 509:  test FAILS (good)
removed send at line 522:  test FAILS (good)
removed send at line 535:  test FAILS (good)
removed send at line 548:  test FAILS (good)
removed send at line 1024: test FAILS (good)
removed send at line 1044: test FAILS (good)
removed send at line 1064: test FAILS (good)
removed send at line 1156: test FAILS (good)
removed send at line 1434: test FAILS (good)
```

Nine of nine, where five did before.

## The rest of the review

- The exact counts of 9 and 3 would have failed on a correct tenth handler while saying
  nothing about the property under test. `NotEmpty` does the job they were really for,
  which is catching a search that matches nothing after a rename.
- The publish search matched only handlers whose variable is named `result`. It matches
  the call shape now, so a new handler is seen whatever it calls its result.
- Path discovery walked up from `AppContext.BaseDirectory` and would have broken as soon
  as tests ran from a published output, or under CI. `[CallerFilePath]` cannot drift.
- Two bare `First()` calls threw `InvalidOperationException` over the diagnostic message
  built underneath them.
- **Format transcript** is the one delivery site with no hotkey of its own, so Mutation
  is always foreground and the insert above it deliberately types nothing. The send stays
  — a screen-reader command is global and wants running wherever the user is — but the
  reasoning is now written next to it rather than inherited from the site above.
- Two guide sentences described the patch rather than the product. A reader installing
  this next year has no "now".

Not acted on, deliberately: scan codes for *letter* keys are layout-specific and read
from the sending thread's layout, which cannot affect the modifier, function and
navigation keys these shortcuts use; and `LLKHF_INJECTED` is still set on every event,
which is why the acceptance test below still needs a human at the keyboard.

2101 passing, 0 warnings.

## What to test

1. Set **Send key after OCR** to a shortcut your screen reader owns and confirm it still
   fires after a screenshot, a clipboard image, and a batch of documents.
2. If you have anything bound to the context-menu key or the keypad's divide, those now
   arrive with the prefix a real press carries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
