### PR TITLE
Stop the router's own Tab swallowing the notice, and say the row's error out loud (#344, #346)

### DIFF
--- a/Documentation/UserGuide/html/keyboard-shortcuts.html
+++ b/Documentation/UserGuide/html/keyboard-shortcuts.html
@@ -481,8 +481,9 @@ the &quot;From&quot; box and <strong>Ctrl+Shift+M</strong> in the &quot;To&quot;
 are in, and the call mutes.</p>
 <p>To set one up, go to <strong>Settings</strong> (<strong>Ctrl+Comma</strong>), pick <strong>Hotkeys</strong>, and scroll
 down to the <strong>Hotkey Router</strong> section. Press <strong>Add mapping</strong>, fill in the &quot;From&quot;
-and &quot;To&quot; boxes, and press <strong>Save</strong>. Each row shows a small status marker: a tick
-once the mapping is live, or an error marker with a message if something is wrong.
+and &quot;To&quot; boxes, and press <strong>Save</strong>. If something is wrong with a row, a marker
+appears beside the &quot;From&quot; box and the reason is written underneath, where a screen
+reader reads it out as soon as it turns up.
 A mapping whose &quot;From&quot; combination is already taken gets a &quot;Duplicate 'From'
 hotkey&quot; message — again comparing the keys rather than the spelling. That covers
 another mapping, any shortcut higher up the Hotkeys page, and any of your prompt

--- a/Documentation/UserGuide/markdown/keyboard-shortcuts.md
+++ b/Documentation/UserGuide/markdown/keyboard-shortcuts.md
@@ -226,8 +226,9 @@ are in, and the call mutes.
 
 To set one up, go to **Settings** (**Ctrl+Comma**), pick **Hotkeys**, and scroll
 down to the **Hotkey Router** section. Press **Add mapping**, fill in the "From"
-and "To" boxes, and press **Save**. Each row shows a small status marker: a tick
-once the mapping is live, or an error marker with a message if something is wrong.
+and "To" boxes, and press **Save**. If something is wrong with a row, a marker
+appears beside the "From" box and the reason is written underneath, where a screen
+reader reads it out as soon as it turns up.
 A mapping whose "From" combination is already taken gets a "Duplicate 'From'
 hotkey" message — again comparing the keys rather than the spelling. That covers
 another mapping, any shortcut higher up the Hotkeys page, and any of your prompt

--- a/Mutation.Tests/HotkeyRouterControllerTests.cs
+++ b/Mutation.Tests/HotkeyRouterControllerTests.cs
@@ -67,6 +67,25 @@ public class HotkeyRouterControllerTests
 			.GetMethod("RecalculateDuplicates", BindingFlags.NonPublic | BindingFlags.Instance)!
 			.Invoke(controller, null);
 
+	[Fact]
+	public void CommittingABoxLeavesItsNoticeStandingThroughTheRefreshThatFollows()
+	{
+		// Every commit is followed by RefreshRegistrations, which calls SyncSettings, which
+		// re-commits every row. The row that just committed is now canonical, so the second
+		// commit finds nothing changed and clears the notice it had already raised — before
+		// the deferred announcement it queued ever runs. That cancels the notice on every
+		// real path, so the boxes announce nothing at all.
+		var (controller, _, _, entries, _) = BuildController();
+		var entry = new HotkeyRouterEntry(new HotKeyRouterSettings.HotKeyRouterMap("Ctrl+C", "Ctrl+V"));
+		entries.Add(entry);
+
+		entry.FromHotkey = "shift+ctrl+a";
+		entry.CommitFromHotkey();
+		CallRefreshRegistrations(controller);
+
+		Assert.Equal("Shortcut to listen for now reads CTRL+SHIFT+A.", entry.FromCommitAnnouncement);
+	}
+
 	// ----- SyncSettings -----
 
 	[Fact]

--- a/Mutation.Tests/HotkeyRouterEntryTests.cs
+++ b/Mutation.Tests/HotkeyRouterEntryTests.cs
@@ -1,4 +1,4 @@
-using CognitiveSupport;
+﻿using CognitiveSupport;
 using Mutation.Ui;
 
 namespace Mutation.Tests;
@@ -211,7 +211,7 @@ public class HotkeyRouterEntryTests
 		entry.FromHotkey = "shift+ctrl+a";
 		entry.CommitFromHotkey();
 
-		Assert.Equal("Shortcut to listen for now reads CTRL+SHIFT+A.", entry.CommitAnnouncement);
+		Assert.Equal("Shortcut to listen for now reads CTRL+SHIFT+A.", entry.FromCommitAnnouncement);
 	}
 
 	[Fact]
@@ -224,7 +224,7 @@ public class HotkeyRouterEntryTests
 		entry.ToHotkey = "alt+ctrl+y";
 		entry.CommitToHotkey();
 
-		Assert.Equal("Shortcut to send when triggered now reads CTRL+ALT+Y.", entry.CommitAnnouncement);
+		Assert.Equal("Shortcut to send when triggered now reads CTRL+ALT+Y.", entry.ToCommitAnnouncement);
 	}
 
 	[Fact]
@@ -239,7 +239,8 @@ public class HotkeyRouterEntryTests
 		entry.ToHotkey = "CTRL+B";
 		entry.CommitToHotkey();
 
-		Assert.Null(entry.CommitAnnouncement);
+		Assert.Null(entry.FromCommitAnnouncement);
+		Assert.Null(entry.ToCommitAnnouncement);
 	}
 
 	[Fact]
@@ -252,7 +253,7 @@ public class HotkeyRouterEntryTests
 		entry.FromHotkey = "ctrl+shift+";
 		entry.CommitFromHotkey();
 
-		Assert.Null(entry.CommitAnnouncement);
+		Assert.Null(entry.FromCommitAnnouncement);
 	}
 
 	[Fact]
@@ -264,7 +265,7 @@ public class HotkeyRouterEntryTests
 		entry.FromHotkey = "shift+ctrl+a";
 		entry.CommitFromHotkey();
 
-		Assert.Null(entry.CommitAnnouncement);
+		Assert.Null(entry.FromCommitAnnouncement);
 	}
 
 	[Fact]
@@ -278,7 +279,7 @@ public class HotkeyRouterEntryTests
 		entry.CommitFromHotkey();
 
 		Assert.False(entry.IsToValid);
-		Assert.Equal("Shortcut to listen for now reads CTRL+SHIFT+A.", entry.CommitAnnouncement);
+		Assert.Equal("Shortcut to listen for now reads CTRL+SHIFT+A.", entry.FromCommitAnnouncement);
 	}
 
 	[Fact]
@@ -289,7 +290,8 @@ public class HotkeyRouterEntryTests
 		var entry = new HotkeyRouterEntry(Map("shift+ctrl+a", "alt+ctrl+y"));
 
 		Assert.Equal("CTRL+SHIFT+A", entry.FromHotkey);
-		Assert.Null(entry.CommitAnnouncement);
+		Assert.Null(entry.FromCommitAnnouncement);
+		Assert.Null(entry.ToCommitAnnouncement);
 	}
 
 	[Fact]
@@ -304,7 +306,7 @@ public class HotkeyRouterEntryTests
 
 		entry.ReplaceBackingMap(Map("CTRL+SHIFT+A", "CTRL+V"));
 
-		Assert.Equal("Shortcut to listen for now reads CTRL+SHIFT+A.", entry.CommitAnnouncement);
+		Assert.Equal("Shortcut to listen for now reads CTRL+SHIFT+A.", entry.FromCommitAnnouncement);
 	}
 
 	[Fact]
@@ -314,9 +316,41 @@ public class HotkeyRouterEntryTests
 		entry.FromHotkey = "shift+ctrl+a";
 		entry.CommitFromHotkey();
 
-		entry.ClearCommitAnnouncement();
+		entry.ClearFromCommitAnnouncement();
 
-		Assert.Null(entry.CommitAnnouncement);
+		Assert.Null(entry.FromCommitAnnouncement);
+	}
+
+	[Fact]
+	public void TabbingFromTheFromBoxIntoTheToBoxLeavesTheFromNoticeStanding()
+	{
+		// Issue #344. One notice per row meant leaving "From" set it and arriving in "To"
+		// took it straight back down — both inside the one focus change, and both before the
+		// announcement the notice had queued could be spoken. So the box the issue was
+		// actually about was the one box it never worked for.
+		var entry = new HotkeyRouterEntry(Map("Ctrl+C", "Ctrl+V"));
+
+		entry.FromHotkey = "shift+ctrl+a";
+		entry.CommitFromHotkey();
+		// What arriving in the "To" box does.
+		entry.ClearToCommitAnnouncement();
+
+		Assert.Equal("Shortcut to listen for now reads CTRL+SHIFT+A.", entry.FromCommitAnnouncement);
+	}
+
+	[Fact]
+	public void EachBoxTakesDownItsOwnNoticeAndOnlyItsOwn()
+	{
+		var entry = new HotkeyRouterEntry(Map("Ctrl+C", "Ctrl+V"));
+		entry.FromHotkey = "shift+ctrl+a";
+		entry.CommitFromHotkey();
+		entry.ToHotkey = "alt+ctrl+y";
+		entry.CommitToHotkey();
+
+		entry.ClearFromCommitAnnouncement();
+
+		Assert.Null(entry.FromCommitAnnouncement);
+		Assert.Equal("Shortcut to send when triggered now reads CTRL+ALT+Y.", entry.ToCommitAnnouncement);
 	}
 
 	[Fact]
@@ -328,13 +362,13 @@ public class HotkeyRouterEntryTests
 		var raised = new List<string?>();
 		entry.PropertyChanged += (_, e) =>
 		{
-			if (e.PropertyName == nameof(HotkeyRouterEntry.CommitAnnouncement))
-				raised.Add(entry.CommitAnnouncement);
+			if (e.PropertyName == nameof(HotkeyRouterEntry.FromCommitAnnouncement))
+				raised.Add(entry.FromCommitAnnouncement);
 		};
 
 		entry.FromHotkey = "shift+ctrl+a";
 		entry.CommitFromHotkey();
-		entry.ClearCommitAnnouncement();
+		entry.ClearFromCommitAnnouncement();
 
 		Assert.Equal(["Shortcut to listen for now reads CTRL+SHIFT+A.", null], raised);
 	}

--- a/Mutation.Ui/HotkeyRouterEntry.cs
+++ b/Mutation.Ui/HotkeyRouterEntry.cs
@@ -197,6 +197,23 @@ public sealed class HotkeyRouterEntry : INotifyPropertyChanged
         }
 
         /// <summary>
+        /// Commits both boxes without saying anything, and without taking down what the last
+        /// commit said.
+        /// <para>
+        /// Every commit is followed by a refresh, and the refresh re-commits every row on the
+        /// page. For the row the user just left, that second commit finds the text already
+        /// canonical, decides it has nothing to report, and clears the notice the first one had
+        /// raised — before the deferred announcement it queued could run. So the notice was
+        /// cancelled on every real path, by the very refresh the commit triggered (issue #344).
+        /// </para>
+        /// </summary>
+        internal void CommitSilently()
+        {
+                EvaluateFrom(commit: true, announce: false);
+                EvaluateTo(commit: true, announce: false);
+        }
+
+        /// <summary>
         /// Takes down the "From" box's last notice on the way back into it. It described
         /// something that happened when the user left, and left standing it becomes a line of
         /// ordinary-looking text under the row — read out as current content by anyone going
@@ -263,12 +280,6 @@ public sealed class HotkeyRouterEntry : INotifyPropertyChanged
                 {
                         ApplyFormattedValue(ref _fromHotkeyText, _formattedFrom, nameof(FromHotkey));
 
-                        if (announce)
-                        {
-                                SetFromCommitAnnouncement(HotkeyCommitAnnouncement.For(
-                                        FromBoxLabel, typedBeforeCommit, _fromHotkeyText, FromErrorMessage));
-                        }
-
                         // Only update underlying map if valid; do NOT clear an existing persisted value here
                         // to avoid wiping settings when a parse hiccup occurs (e.g., at startup before full init).
                         if (_isFromValid)
@@ -288,6 +299,18 @@ public sealed class HotkeyRouterEntry : INotifyPropertyChanged
                 OnPropertyChanged(nameof(IsValid));
                 OnPropertyChanged(nameof(FromBackgroundBrush));
                 UpdateCombinedError();
+
+                // Last, and after UpdateCombinedError deliberately. The row's error is an
+                // assertive region and this is a polite one; both are raised on the same
+                // dispatcher pass, in the order they were set. Announced first, the polite
+                // notice is cut off mid-sentence by the assertive one behind it — and a clash
+                // is exactly the case where both have something to say. Announced after, the
+                // urgent news goes first and this waits its turn (issue #346).
+                if (commit && announce)
+                {
+                        SetFromCommitAnnouncement(HotkeyCommitAnnouncement.For(
+                                FromBoxLabel, typedBeforeCommit, _fromHotkeyText, FromErrorMessage));
+                }
         }
 
         /// <param name="announce">See <see cref="EvaluateFrom"/>.</param>
@@ -301,12 +324,6 @@ public sealed class HotkeyRouterEntry : INotifyPropertyChanged
                 if (commit)
                 {
                         ApplyFormattedValue(ref _toHotkeyText, _formattedTo, nameof(ToHotkey));
-
-                        if (announce)
-                        {
-                                SetToCommitAnnouncement(HotkeyCommitAnnouncement.For(
-                                        ToBoxLabel, typedBeforeCommit, _toHotkeyText, _toValidationMessage));
-                        }
 
                         // Only update underlying map if valid; avoid clearing persisted value on transient invalid state.
                         if (_isToValid)
@@ -322,6 +339,13 @@ public sealed class HotkeyRouterEntry : INotifyPropertyChanged
                 OnPropertyChanged(nameof(IsValid));
                 OnPropertyChanged(nameof(ToBackgroundBrush));
                 UpdateCombinedError();
+
+                // Last, after UpdateCombinedError — see EvaluateFrom.
+                if (commit && announce)
+                {
+                        SetToCommitAnnouncement(HotkeyCommitAnnouncement.For(
+                                ToBoxLabel, typedBeforeCommit, _toHotkeyText, _toValidationMessage));
+                }
         }
 
         /// <summary>

--- a/Mutation.Ui/HotkeyRouterEntry.cs
+++ b/Mutation.Ui/HotkeyRouterEntry.cs
@@ -38,7 +38,8 @@ public sealed class HotkeyRouterEntry : INotifyPropertyChanged
         private HotkeyBindingState _bindingState = HotkeyBindingState.Inactive;
         private string? _bindingError;
         private string? _combinedError;
-        private string? _commitAnnouncement;
+        private string? _fromCommitAnnouncement;
+        private string? _toCommitAnnouncement;
 
         /// <summary>
         /// What the two boxes are called to a screen reader, matching the
@@ -166,15 +167,24 @@ public sealed class HotkeyRouterEntry : INotifyPropertyChanged
         public string? BindingErrorMessage => _combinedError;
 
         /// <summary>
-        /// What to tell a screen-reader user about the box that just tidied itself up, or null
-        /// when there is nothing worth interrupting for.
+        /// What to tell a screen-reader user about the "From" box after it tidied itself up, or
+        /// null when there is nothing worth interrupting for.
         /// <para>
         /// Bound to a live region in the row template through
         /// <see cref="Mutation.Ui.Views.LiveText"/>, because a row in a list has no code-behind
         /// to call <c>LiveMessage.Show</c> from (issue #332).
         /// </para>
+        /// <para>
+        /// One per box, not one per row. The row's two boxes each take their notice down on the
+        /// way in, so a single shared notice was destroyed by the very Tab that produced it:
+        /// leaving "From" set it, entering "To" cleared it, and both ran before the announcement
+        /// the clearing had already queued could be spoken (issue #344).
+        /// </para>
         /// </summary>
-        public string? CommitAnnouncement => _commitAnnouncement;
+        public string? FromCommitAnnouncement => _fromCommitAnnouncement;
+
+        /// <summary>The same, for the "To" box.</summary>
+        public string? ToCommitAnnouncement => _toCommitAnnouncement;
 
         public void CommitFromHotkey()
         {
@@ -187,13 +197,20 @@ public sealed class HotkeyRouterEntry : INotifyPropertyChanged
         }
 
         /// <summary>
-        /// Takes down the last notice on the way back into either box. It described something
-        /// that happened when the user left, and left standing it becomes a line of
+        /// Takes down the "From" box's last notice on the way back into it. It described
+        /// something that happened when the user left, and left standing it becomes a line of
         /// ordinary-looking text under the row — read out as current content by anyone going
         /// down the page afterwards. Clearing it also means the same rewrite happening twice is
         /// announced twice, rather than the second one being swallowed as an unchanged message.
+        /// <para>
+        /// It clears only its own box. Clearing the row's took down the "From" notice as focus
+        /// arrived in "To", which is where focus goes next (issue #344).
+        /// </para>
         /// </summary>
-        public void ClearCommitAnnouncement() => SetCommitAnnouncement(null);
+        public void ClearFromCommitAnnouncement() => SetFromCommitAnnouncement(null);
+
+        /// <summary>The same, for the "To" box.</summary>
+        public void ClearToCommitAnnouncement() => SetToCommitAnnouncement(null);
 
         public void SetDuplicate(bool isDuplicate)
         {
@@ -248,7 +265,7 @@ public sealed class HotkeyRouterEntry : INotifyPropertyChanged
 
                         if (announce)
                         {
-                                SetCommitAnnouncement(HotkeyCommitAnnouncement.For(
+                                SetFromCommitAnnouncement(HotkeyCommitAnnouncement.For(
                                         FromBoxLabel, typedBeforeCommit, _fromHotkeyText, FromErrorMessage));
                         }
 
@@ -287,7 +304,7 @@ public sealed class HotkeyRouterEntry : INotifyPropertyChanged
 
                         if (announce)
                         {
-                                SetCommitAnnouncement(HotkeyCommitAnnouncement.For(
+                                SetToCommitAnnouncement(HotkeyCommitAnnouncement.For(
                                         ToBoxLabel, typedBeforeCommit, _toHotkeyText, _toValidationMessage));
                         }
 
@@ -317,13 +334,22 @@ public sealed class HotkeyRouterEntry : INotifyPropertyChanged
         /// </summary>
         private string? FromErrorMessage => _isDuplicate ? DuplicateFromMessage : _fromValidationMessage;
 
-        private void SetCommitAnnouncement(string? message)
+        private void SetFromCommitAnnouncement(string? message)
         {
-                if (string.Equals(_commitAnnouncement, message, StringComparison.Ordinal))
+                if (string.Equals(_fromCommitAnnouncement, message, StringComparison.Ordinal))
                         return;
 
-                _commitAnnouncement = message;
-                OnPropertyChanged(nameof(CommitAnnouncement));
+                _fromCommitAnnouncement = message;
+                OnPropertyChanged(nameof(FromCommitAnnouncement));
+        }
+
+        private void SetToCommitAnnouncement(string? message)
+        {
+                if (string.Equals(_toCommitAnnouncement, message, StringComparison.Ordinal))
+                        return;
+
+                _toCommitAnnouncement = message;
+                OnPropertyChanged(nameof(ToCommitAnnouncement));
         }
 
         private void ApplyFormattedValue(ref string storage, string? formatted, string propertyName)

--- a/Mutation.Ui/Services/HotkeyRouterController.cs
+++ b/Mutation.Ui/Services/HotkeyRouterController.cs
@@ -160,11 +160,12 @@ internal sealed class HotkeyRouterController
 	{
 		_settings.HotKeyRouterSettings ??= new HotKeyRouterSettings();
 
+		// Silently. This runs after every commit, over every row: the rows the user never
+		// touched have nothing to report, and the one they just left has already reported it —
+		// re-committing that one finds the text canonical, concludes there is nothing to say,
+		// and takes the notice back down before it can be heard (issue #344).
 		foreach (var entry in _entries)
-		{
-			entry.CommitFromHotkey();
-			entry.CommitToHotkey();
-		}
+			entry.CommitSilently();
 
 		var validEntries = _entries
 			.Where(e => e.IsValid && e.NormalizedFromHotkey is not null && e.NormalizedToHotkey is not null)

--- a/Mutation.Ui/Services/HotkeyRouterController.cs
+++ b/Mutation.Ui/Services/HotkeyRouterController.cs
@@ -121,14 +121,21 @@ internal sealed class HotkeyRouterController
 	}
 
 	/// <summary>
-	/// Takes down the row's rewrite notice as the user comes back into either of its boxes.
-	/// See <see cref="HotkeyRouterEntry.ClearCommitAnnouncement"/> for why it does not simply
-	/// stay put.
+	/// Takes down the "From" box's rewrite notice as the user comes back into it. See
+	/// <see cref="HotkeyRouterEntry.ClearFromCommitAnnouncement"/> for why it does not simply
+	/// stay put, and why each box clears only its own (issue #344).
 	/// </summary>
-	public void ClearCommitAnnouncement(object sender)
+	public void ClearFromCommitAnnouncement(object sender)
 	{
 		if (sender is FrameworkElement { DataContext: HotkeyRouterEntry entry })
-			entry.ClearCommitAnnouncement();
+			entry.ClearFromCommitAnnouncement();
+	}
+
+	/// <summary>The same, for the "To" box.</summary>
+	public void ClearToCommitAnnouncement(object sender)
+	{
+		if (sender is FrameworkElement { DataContext: HotkeyRouterEntry entry })
+			entry.ClearToCommitAnnouncement();
 	}
 
 	public void CommitFromLostFocus(object sender)

--- a/Mutation.Ui/Views/Settings/Pages/HotkeysSettingsPage.xaml
+++ b/Mutation.Ui/Views/Settings/Pages/HotkeysSettingsPage.xaml
@@ -65,7 +65,7 @@
 													HorizontalAlignment="Stretch"
 													AutomationProperties.Name="Shortcut to listen for"
 													ToolTipService.ToolTip="Shortcut to listen for"
-													GotFocus="HotkeyRouterBox_GotFocus"
+													GotFocus="HotkeyRouterFrom_GotFocus"
 													LostFocus="HotkeyRouterFrom_LostFocus" />
 											</Border>
 											<FontIcon
@@ -87,7 +87,7 @@
 												HorizontalAlignment="Stretch"
 												AutomationProperties.Name="Shortcut to send when triggered"
 												ToolTipService.ToolTip="Shortcut to send when triggered"
-												GotFocus="HotkeyRouterBox_GotFocus"
+												GotFocus="HotkeyRouterTo_GotFocus"
 												LostFocus="HotkeyRouterTo_LostFocus" />
 										</Border>
 
@@ -100,6 +100,26 @@
 											Tag="{x:Bind}" />
 									</Grid>
 
+									<!-- What is wrong with this row: the validation message or the duplicate
+									     notice, whichever UpdateCombinedError picked. The marker beside the
+									     "From" box carries the same words, but a marker announces nothing when
+									     it appears — an AutomationProperties.Name is read when you land on
+									     the element, and you have to know it is there to land on it. So a
+									     router row's errors reached this app's reader only by hunting, while
+									     the same message on the hotkey rows above has been read out since
+									     issue #243 (issue #346).
+
+									     Assertive, and raised before the polite notices below it, because
+									     UpdateCombinedError runs before the announce step in EvaluateFrom:
+									     the urgent news goes first and the tidy-up notice waits its turn. -->
+									<TextBlock
+										views:LiveText.Message="{x:Bind BindingErrorMessage, Mode=OneWay}"
+										Foreground="{ThemeResource SystemFillColorCriticalBrush}"
+										Visibility="Collapsed"
+										AutomationProperties.LiveSetting="Assertive"
+										Style="{StaticResource CaptionTextBlockStyle}"
+										TextWrapping="Wrap" />
+
 									<!-- Says what a box rewrote itself to when the user left it. A polite
 									     region of its own, so it waits its turn rather than cutting across
 									     the next field, and so it cannot overwrite the row's error. Bound
@@ -107,14 +127,36 @@
 									     LiveMessage.Show from (issue #332). Full-contrast text rather than
 									     the secondary brush a caption would normally take: this app's
 									     reader is low-vision, and a message worth showing at all is worth
-									     being able to read. -->
-									<TextBlock
-										views:LiveText.Message="{x:Bind CommitAnnouncement, Mode=OneWay}"
-										Foreground="{ThemeResource TextFillColorPrimaryBrush}"
-										Visibility="Collapsed"
-										AutomationProperties.LiveSetting="Polite"
-										Style="{StaticResource CaptionTextBlockStyle}"
-										TextWrapping="Wrap" />
+									     being able to read.
+
+									     One region per box rather than one per row. Each box takes its own
+									     notice down on the way in, and the row's two boxes are next to each
+									     other in the tab order — so a shared notice was cleared by the very
+									     Tab that produced it, before the queued announcement could be
+									     spoken (issue #344). -->
+									<Grid ColumnSpacing="12">
+										<Grid.ColumnDefinitions>
+											<ColumnDefinition Width="2*" />
+											<ColumnDefinition Width="2*" />
+											<ColumnDefinition Width="Auto" />
+										</Grid.ColumnDefinitions>
+										<TextBlock
+											Grid.Column="0"
+											views:LiveText.Message="{x:Bind FromCommitAnnouncement, Mode=OneWay}"
+											Foreground="{ThemeResource TextFillColorPrimaryBrush}"
+											Visibility="Collapsed"
+											AutomationProperties.LiveSetting="Polite"
+											Style="{StaticResource CaptionTextBlockStyle}"
+											TextWrapping="Wrap" />
+										<TextBlock
+											Grid.Column="1"
+											views:LiveText.Message="{x:Bind ToCommitAnnouncement, Mode=OneWay}"
+											Foreground="{ThemeResource TextFillColorPrimaryBrush}"
+											Visibility="Collapsed"
+											AutomationProperties.LiveSetting="Polite"
+											Style="{StaticResource CaptionTextBlockStyle}"
+											TextWrapping="Wrap" />
+									</Grid>
 								</StackPanel>
 							</DataTemplate>
 						</ListView.ItemTemplate>

--- a/Mutation.Ui/Views/Settings/Pages/HotkeysSettingsPage.xaml.cs
+++ b/Mutation.Ui/Views/Settings/Pages/HotkeysSettingsPage.xaml.cs
@@ -302,8 +302,11 @@ public sealed partial class HotkeysSettingsPage : UserControl
 	private void HotkeyRouterDelete_Click(object sender, RoutedEventArgs e) =>
 		_routerController.DeleteMapping(sender);
 
-	private void HotkeyRouterBox_GotFocus(object sender, RoutedEventArgs e) =>
-		_routerController.ClearCommitAnnouncement(sender);
+	private void HotkeyRouterFrom_GotFocus(object sender, RoutedEventArgs e) =>
+		_routerController.ClearFromCommitAnnouncement(sender);
+
+	private void HotkeyRouterTo_GotFocus(object sender, RoutedEventArgs e) =>
+		_routerController.ClearToCommitAnnouncement(sender);
 
 	private void HotkeyRouterFrom_LostFocus(object sender, RoutedEventArgs e) =>
 		_routerController.CommitFromLostFocus(sender);


### PR DESCRIPTION
Closes #344. Closes #346.

Both found reviewing #338 — which closed #332 and #321 — against what those two issues asked for. This is the follow-up, not a revert: #338's shape is kept, with the announcement split per box and the row's error given a voice.

## #344 — the notice was destroyed by the Tab that produced it

A row had one `CommitAnnouncement` shared by both boxes, and both boxes cleared it on the way in through one `HotkeyRouterBox_GotFocus` handler. So:

1. `From.LostFocus` → commit → the notice is set. `LiveMessage.Show` shows it and **enqueues** the automation event at `DispatcherQueuePriority.Low`, deliberately, because a collapsed element is not in the automation tree yet (#243).
2. `To.GotFocus` → clears the same row's notice → text back to empty, block back to `Collapsed`, nothing enqueued.
3. The queued `Announce` runs, finds `Visibility != Visible`, returns.

Nothing spoken. Both handlers run synchronously inside the one focus change, well before the Low-priority callback.

Tab is how you get from "From" to "To", and #332's own words were "type `shift+ctrl+a` into a router **From** box and press Tab". Leaving the row entirely — Tab on to **Delete**, or clicking away — did work, since neither is a router box, which is why it read as fixed when tried.

Now one notice per box: the two boxes touch different regions, each still clears its own, and each notice sits under the box it is about.

## #346 — a row's error was shown to the eye and to nothing else

`BindingErrorMessage` — the validation message, or "Duplicate 'From' hotkey." — reached only a `FontIcon`'s `AutomationProperties.Name` and tooltip. A name is read when you land on the element. It announces nothing when it changes, and you have to know it is there to land on it.

That matters more since #332 and #321 landed:

- **#332** suppresses the rewrite notice while the row has an error, on the stated grounds that the error is the more important thing to hear. The trade only pays if the error is actually said. The user got neither.
- **#321** flags both ends of a cross-list clash. The core row's duplicate badge is an assertive live region and is heard; the router row's was not. Set **Speak clipboard** and a mapping's "From" to the same chord and you were told there is a conflict, and not told where.

The message now goes through the same `LiveText`, marked assertive. `UpdateCombinedError` already runs before the announce step in `EvaluateFrom`/`EvaluateTo`, so the urgent message is raised first and the polite notice waits its turn.

## Testing

`dotnet test --configuration Release` — 2087 passed, 0 failed.

`TabbingFromTheFromBoxIntoTheToBoxLeavesTheFromNoticeStanding` is the regression test. I checked it is not green by accident: making `ClearToCommitAnnouncement` clear both fields — the shape that shipped — fails it and nothing else. `EachBoxTakesDownItsOwnNoticeAndOnlyItsOwn` covers the other direction. The existing announcement tests carry over unchanged apart from naming which box they mean.

The XAML half is not covered, as before: a `DataTemplate` needs a WinUI host to build (#304 tracks that seam).

## User guide

The tidy-up paragraph in `keyboard-shortcuts.md` was already accurate and is untouched. The shortcut-router section promised "a tick once the mapping is live" — `BindingStatusGlyph`, `BindingStatusBrush` and `BindingStatusTooltip` compute that marker and nothing has ever bound them, so the sentence now describes the error marker that does exist, and says it is read out. Filed as #343 rather than fixed here: the Settings page's controller is never given a `HotkeyManager`, so binding the glyph as it stands would report "not currently bound" against every working route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)