### PR TITLE
Stop the bookkeeping commit swallowing the router's rewrite notice, and give each box its own

### DIFF
--- a/Documentation/UserGuide/html/troubleshooting.html
+++ b/Documentation/UserGuide/html/troubleshooting.html
@@ -196,9 +196,11 @@ than short ones.</p>
 before — two beeps, then three, then four. A burst of end beeps part way through a
 dictation means Mutation is still working, and how many you hear tells you how far into
 its retries it has got.</p>
-<p>If the service is busy and asks Mutation to wait a moment before asking again, Mutation
-waits as long as it was asked to, up to a minute. So a gap between beeps that is longer
-than usual is the service setting the pace, not something going wrong.</p>
+<p>Some services answer a busy moment by telling Mutation how long to wait before asking
+again. When Mutation is told, it waits that long, up to a minute — so a gap between
+beeps that is longer than usual is the service setting the pace, not something going
+wrong. Deepgram does not tell Mutation, so its retries come at the usual short
+intervals.</p>
 <p>Not everything is worth another go. If the service turns the request down for a reason
 that will not change — your key was rejected, or the recording is bigger than it
 accepts — Mutation tells you straight away instead of working through the retries

--- a/Documentation/UserGuide/markdown/troubleshooting.md
+++ b/Documentation/UserGuide/markdown/troubleshooting.md
@@ -65,9 +65,11 @@ before — two beeps, then three, then four. A burst of end beeps part way throu
 dictation means Mutation is still working, and how many you hear tells you how far into
 its retries it has got.
 
-If the service is busy and asks Mutation to wait a moment before asking again, Mutation
-waits as long as it was asked to, up to a minute. So a gap between beeps that is longer
-than usual is the service setting the pace, not something going wrong.
+Some services answer a busy moment by telling Mutation how long to wait before asking
+again. When Mutation is told, it waits that long, up to a minute — so a gap between
+beeps that is longer than usual is the service setting the pace, not something going
+wrong. Deepgram does not tell Mutation, so its retries come at the usual short
+intervals.
 
 Not everything is worth another go. If the service turns the request down for a reason
 that will not change — your key was rejected, or the recording is bigger than it

--- a/Mutation.Tests/HotkeyRouterControllerTests.cs
+++ b/Mutation.Tests/HotkeyRouterControllerTests.cs
@@ -240,6 +240,42 @@ public class HotkeyRouterControllerTests
 		Assert.False(first.IsDuplicate);
 	}
 
+	// ----- The rewrite notice surviving the refresh that follows it (issue #332) -----
+
+	[Fact]
+	public void RefreshRegistrations_LeavesTheNoticeFromTheCommitThatTriggeredItStanding()
+	{
+		// The real sequence when the user tabs out of a "From" box: the box commits and
+		// announces, and the controller then refreshes — which re-commits every row, including
+		// this one. That second pass finds nothing left to change, and an announcing one would
+		// take the notice back down again before it had been spoken.
+		var (controller, _, _, entries, _) = BuildController(autoPersist: false, injectSettingsManager: false);
+		var entry = new HotkeyRouterEntry(new HotKeyRouterSettings.HotKeyRouterMap("Ctrl+C", "Ctrl+V"));
+		entries.Add(entry);
+
+		entry.FromHotkey = "shift+ctrl+a";
+		entry.CommitFromHotkey();
+		CallRefreshRegistrations(controller);
+
+		Assert.Equal("Shortcut to listen for now reads CTRL+SHIFT+A.", entry.FromCommitAnnouncement);
+	}
+
+	[Fact]
+	public void RefreshRegistrations_DoesNotInventANoticeForRowsTheUserDidNotTouch()
+	{
+		// The bookkeeping commit runs over every row. A row loaded from a settings file that
+		// needs tidying up would otherwise announce itself the first time anything on the page
+		// changed.
+		var (controller, _, _, entries, _) = BuildController(autoPersist: false, injectSettingsManager: false);
+		var untouched = new HotkeyRouterEntry(new HotKeyRouterSettings.HotKeyRouterMap("Ctrl+C", "Ctrl+V"));
+		entries.Add(untouched);
+
+		CallRefreshRegistrations(controller);
+
+		Assert.Null(untouched.FromCommitAnnouncement);
+		Assert.Null(untouched.ToCommitAnnouncement);
+	}
+
 	// ----- Handing the check to an owner that sees more lists (issue #321) -----
 
 	[Fact]

--- a/Mutation.Tests/HotkeyRouterEntryTests.cs
+++ b/Mutation.Tests/HotkeyRouterEntryTests.cs
@@ -211,7 +211,7 @@ public class HotkeyRouterEntryTests
 		entry.FromHotkey = "shift+ctrl+a";
 		entry.CommitFromHotkey();
 
-		Assert.Equal("Shortcut to listen for now reads CTRL+SHIFT+A.", entry.CommitAnnouncement);
+		Assert.Equal("Shortcut to listen for now reads CTRL+SHIFT+A.", entry.FromCommitAnnouncement);
 	}
 
 	[Fact]
@@ -224,7 +224,35 @@ public class HotkeyRouterEntryTests
 		entry.ToHotkey = "alt+ctrl+y";
 		entry.CommitToHotkey();
 
-		Assert.Equal("Shortcut to send when triggered now reads CTRL+ALT+Y.", entry.CommitAnnouncement);
+		Assert.Equal("Shortcut to send when triggered now reads CTRL+ALT+Y.", entry.ToCommitAnnouncement);
+	}
+
+	[Fact]
+	public void EachBoxKeepsItsOwnNotice()
+	{
+		// Tabbing from "From" to "To" is how a mapping gets filled in. One notice for the row
+		// would mean the second box's commit — which usually changes nothing — took down the
+		// first box's notice before it had been read out.
+		var entry = new HotkeyRouterEntry(Map("Ctrl+C", "Ctrl+V"));
+
+		entry.FromHotkey = "shift+ctrl+a";
+		entry.CommitFromHotkey();
+		entry.CommitToHotkey();
+
+		Assert.Equal("Shortcut to listen for now reads CTRL+SHIFT+A.", entry.FromCommitAnnouncement);
+		Assert.Null(entry.ToCommitAnnouncement);
+	}
+
+	[Fact]
+	public void ComingBackIntoOneBoxLeavesTheOtherBoxsNoticeAlone()
+	{
+		var entry = new HotkeyRouterEntry(Map("Ctrl+C", "Ctrl+V"));
+		entry.FromHotkey = "shift+ctrl+a";
+		entry.CommitFromHotkey();
+
+		entry.ClearToCommitAnnouncement();
+
+		Assert.Equal("Shortcut to listen for now reads CTRL+SHIFT+A.", entry.FromCommitAnnouncement);
 	}
 
 	[Fact]
@@ -239,7 +267,8 @@ public class HotkeyRouterEntryTests
 		entry.ToHotkey = "CTRL+B";
 		entry.CommitToHotkey();
 
-		Assert.Null(entry.CommitAnnouncement);
+		Assert.Null(entry.FromCommitAnnouncement);
+		Assert.Null(entry.ToCommitAnnouncement);
 	}
 
 	[Fact]
@@ -252,7 +281,7 @@ public class HotkeyRouterEntryTests
 		entry.FromHotkey = "ctrl+shift+";
 		entry.CommitFromHotkey();
 
-		Assert.Null(entry.CommitAnnouncement);
+		Assert.Null(entry.FromCommitAnnouncement);
 	}
 
 	[Fact]
@@ -264,7 +293,27 @@ public class HotkeyRouterEntryTests
 		entry.FromHotkey = "shift+ctrl+a";
 		entry.CommitFromHotkey();
 
-		Assert.Null(entry.CommitAnnouncement);
+		Assert.Null(entry.FromCommitAnnouncement);
+	}
+
+	[Fact]
+	public void ADuplicateFoundDuringTheCommitStillOutranksTheNotice()
+	{
+		// The real ordering on the page: typing raises FromHotkey, the controller recalculates
+		// duplicates from that, and the flag is already set by the time the commit decides
+		// whether to announce.
+		var entry = new HotkeyRouterEntry(Map("Ctrl+C", "Ctrl+V"));
+		entry.PropertyChanged += (_, e) =>
+		{
+			if (e.PropertyName == nameof(HotkeyRouterEntry.FromHotkey))
+				entry.SetDuplicate(true);
+		};
+
+		entry.FromHotkey = "shift+ctrl+a";
+		entry.CommitFromHotkey();
+
+		Assert.True(entry.IsDuplicate);
+		Assert.Null(entry.FromCommitAnnouncement);
 	}
 
 	[Fact]
@@ -278,7 +327,7 @@ public class HotkeyRouterEntryTests
 		entry.CommitFromHotkey();
 
 		Assert.False(entry.IsToValid);
-		Assert.Equal("Shortcut to listen for now reads CTRL+SHIFT+A.", entry.CommitAnnouncement);
+		Assert.Equal("Shortcut to listen for now reads CTRL+SHIFT+A.", entry.FromCommitAnnouncement);
 	}
 
 	[Fact]
@@ -289,7 +338,23 @@ public class HotkeyRouterEntryTests
 		var entry = new HotkeyRouterEntry(Map("shift+ctrl+a", "alt+ctrl+y"));
 
 		Assert.Equal("CTRL+SHIFT+A", entry.FromHotkey);
-		Assert.Null(entry.CommitAnnouncement);
+		Assert.Null(entry.FromCommitAnnouncement);
+		Assert.Null(entry.ToCommitAnnouncement);
+	}
+
+	[Fact]
+	public void TheBookkeepingCommitLeavesAPendingNoticeStanding()
+	{
+		// The controller re-commits every row on every refresh, including the one the user has
+		// just edited and which has just announced. An announcing pass there finds nothing left
+		// to change and would take the notice straight back down again.
+		var entry = new HotkeyRouterEntry(Map("Ctrl+C", "Ctrl+V"));
+		entry.FromHotkey = "shift+ctrl+a";
+		entry.CommitFromHotkey();
+
+		entry.CommitSilently();
+
+		Assert.Equal("Shortcut to listen for now reads CTRL+SHIFT+A.", entry.FromCommitAnnouncement);
 	}
 
 	[Fact]
@@ -304,7 +369,7 @@ public class HotkeyRouterEntryTests
 
 		entry.ReplaceBackingMap(Map("CTRL+SHIFT+A", "CTRL+V"));
 
-		Assert.Equal("Shortcut to listen for now reads CTRL+SHIFT+A.", entry.CommitAnnouncement);
+		Assert.Equal("Shortcut to listen for now reads CTRL+SHIFT+A.", entry.FromCommitAnnouncement);
 	}
 
 	[Fact]
@@ -314,9 +379,9 @@ public class HotkeyRouterEntryTests
 		entry.FromHotkey = "shift+ctrl+a";
 		entry.CommitFromHotkey();
 
-		entry.ClearCommitAnnouncement();
+		entry.ClearFromCommitAnnouncement();
 
-		Assert.Null(entry.CommitAnnouncement);
+		Assert.Null(entry.FromCommitAnnouncement);
 	}
 
 	[Fact]
@@ -328,13 +393,13 @@ public class HotkeyRouterEntryTests
 		var raised = new List<string?>();
 		entry.PropertyChanged += (_, e) =>
 		{
-			if (e.PropertyName == nameof(HotkeyRouterEntry.CommitAnnouncement))
-				raised.Add(entry.CommitAnnouncement);
+			if (e.PropertyName == nameof(HotkeyRouterEntry.FromCommitAnnouncement))
+				raised.Add(entry.FromCommitAnnouncement);
 		};
 
 		entry.FromHotkey = "shift+ctrl+a";
 		entry.CommitFromHotkey();
-		entry.ClearCommitAnnouncement();
+		entry.ClearFromCommitAnnouncement();
 
 		Assert.Equal(["Shortcut to listen for now reads CTRL+SHIFT+A.", null], raised);
 	}

--- a/Mutation.Ui/HotkeyRouterEntry.cs
+++ b/Mutation.Ui/HotkeyRouterEntry.cs
@@ -38,7 +38,8 @@ public sealed class HotkeyRouterEntry : INotifyPropertyChanged
         private HotkeyBindingState _bindingState = HotkeyBindingState.Inactive;
         private string? _bindingError;
         private string? _combinedError;
-        private string? _commitAnnouncement;
+        private string? _fromCommitAnnouncement;
+        private string? _toCommitAnnouncement;
 
         /// <summary>
         /// What the two boxes are called to a screen reader, matching the
@@ -166,15 +167,23 @@ public sealed class HotkeyRouterEntry : INotifyPropertyChanged
         public string? BindingErrorMessage => _combinedError;
 
         /// <summary>
-        /// What to tell a screen-reader user about the box that just tidied itself up, or null
-        /// when there is nothing worth interrupting for.
+        /// What to tell a screen-reader user about the "From" box after it tidied itself up, or
+        /// null when there is nothing worth interrupting for.
         /// <para>
         /// Bound to a live region in the row template through
         /// <see cref="Mutation.Ui.Views.LiveText"/>, because a row in a list has no code-behind
         /// to call <c>LiveMessage.Show</c> from (issue #332).
         /// </para>
+        /// <para>
+        /// One per box rather than one per row. The two boxes are tabbed through one after the
+        /// other, so a shared notice would be taken down by entering the second box before the
+        /// first box's notice had been read out at all.
+        /// </para>
         /// </summary>
-        public string? CommitAnnouncement => _commitAnnouncement;
+        public string? FromCommitAnnouncement => _fromCommitAnnouncement;
+
+        /// <summary>The same, for the "To" box. See <see cref="FromCommitAnnouncement"/>.</summary>
+        public string? ToCommitAnnouncement => _toCommitAnnouncement;
 
         public void CommitFromHotkey()
         {
@@ -187,13 +196,34 @@ public sealed class HotkeyRouterEntry : INotifyPropertyChanged
         }
 
         /// <summary>
-        /// Takes down the last notice on the way back into either box. It described something
-        /// that happened when the user left, and left standing it becomes a line of
+        /// Commits both boxes without saying anything about it. This is the bookkeeping commit
+        /// the controller runs over every row whenever anything on the page changes — it is
+        /// idempotent for the row the user actually edited, and for the rest of them it is not
+        /// about anything the user just did.
+        /// <para>
+        /// It also has to stay silent to leave the notice from the real commit standing: the
+        /// row the user edited is committed once by them and then again by this, and an
+        /// announcing second pass sees nothing left to change and would take the first one's
+        /// notice down before it had been spoken.
+        /// </para>
+        /// </summary>
+        internal void CommitSilently()
+        {
+                EvaluateFrom(commit: true, announce: false);
+                EvaluateTo(commit: true, announce: false);
+        }
+
+        /// <summary>
+        /// Takes down the "From" box's last notice on the way back into it. It described
+        /// something that happened when the user left, and left standing it becomes a line of
         /// ordinary-looking text under the row — read out as current content by anyone going
         /// down the page afterwards. Clearing it also means the same rewrite happening twice is
         /// announced twice, rather than the second one being swallowed as an unchanged message.
         /// </summary>
-        public void ClearCommitAnnouncement() => SetCommitAnnouncement(null);
+        public void ClearFromCommitAnnouncement() => SetFromCommitAnnouncement(null);
+
+        /// <summary>The same, for the "To" box.</summary>
+        public void ClearToCommitAnnouncement() => SetToCommitAnnouncement(null);
 
         public void SetDuplicate(bool isDuplicate)
         {
@@ -229,11 +259,11 @@ public sealed class HotkeyRouterEntry : INotifyPropertyChanged
         }
 
         /// <param name="announce">
-        /// True when the user has just left the box, false when the row is being rebuilt from
-        /// settings. Only the first is worth saying out loud, and only the first clears a
-        /// notice that is no longer true — a rebuild must leave the last one standing, because
-        /// saving the page rebuilds every row and would otherwise swallow the notice for the
-        /// very edit that triggered the save.
+        /// True only when the user has just left this box. False for the row being built or
+        /// rebuilt from settings, and false for <see cref="CommitSilently"/>: those are not
+        /// about anything the user just did, and announcing them would read every stored row
+        /// aloud on the way into the page. It is also the only thing that clears a notice, so a
+        /// silent pass leaves the last one standing rather than swallowing it.
         /// </param>
         private void EvaluateFrom(bool commit, bool announce)
         {
@@ -248,7 +278,7 @@ public sealed class HotkeyRouterEntry : INotifyPropertyChanged
 
                         if (announce)
                         {
-                                SetCommitAnnouncement(HotkeyCommitAnnouncement.For(
+                                SetFromCommitAnnouncement(HotkeyCommitAnnouncement.For(
                                         FromBoxLabel, typedBeforeCommit, _fromHotkeyText, FromErrorMessage));
                         }
 
@@ -287,7 +317,7 @@ public sealed class HotkeyRouterEntry : INotifyPropertyChanged
 
                         if (announce)
                         {
-                                SetCommitAnnouncement(HotkeyCommitAnnouncement.For(
+                                SetToCommitAnnouncement(HotkeyCommitAnnouncement.For(
                                         ToBoxLabel, typedBeforeCommit, _toHotkeyText, _toValidationMessage));
                         }
 
@@ -317,13 +347,22 @@ public sealed class HotkeyRouterEntry : INotifyPropertyChanged
         /// </summary>
         private string? FromErrorMessage => _isDuplicate ? DuplicateFromMessage : _fromValidationMessage;
 
-        private void SetCommitAnnouncement(string? message)
+        private void SetFromCommitAnnouncement(string? message)
         {
-                if (string.Equals(_commitAnnouncement, message, StringComparison.Ordinal))
+                if (string.Equals(_fromCommitAnnouncement, message, StringComparison.Ordinal))
                         return;
 
-                _commitAnnouncement = message;
-                OnPropertyChanged(nameof(CommitAnnouncement));
+                _fromCommitAnnouncement = message;
+                OnPropertyChanged(nameof(FromCommitAnnouncement));
+        }
+
+        private void SetToCommitAnnouncement(string? message)
+        {
+                if (string.Equals(_toCommitAnnouncement, message, StringComparison.Ordinal))
+                        return;
+
+                _toCommitAnnouncement = message;
+                OnPropertyChanged(nameof(ToCommitAnnouncement));
         }
 
         private void ApplyFormattedValue(ref string storage, string? formatted, string propertyName)

--- a/Mutation.Ui/Services/HotkeyRouterController.cs
+++ b/Mutation.Ui/Services/HotkeyRouterController.cs
@@ -121,14 +121,23 @@ internal sealed class HotkeyRouterController
 	}
 
 	/// <summary>
-	/// Takes down the row's rewrite notice as the user comes back into either of its boxes.
-	/// See <see cref="HotkeyRouterEntry.ClearCommitAnnouncement"/> for why it does not simply
-	/// stay put.
+	/// Takes down the "From" box's rewrite notice as the user comes back into it. See
+	/// <see cref="HotkeyRouterEntry.ClearFromCommitAnnouncement"/> for why it does not simply
+	/// stay put — and note that entering one box leaves the other box's notice alone, because
+	/// tabbing from "From" to "To" is how a mapping is filled in and would otherwise wipe the
+	/// first notice before it had been read out.
 	/// </summary>
-	public void ClearCommitAnnouncement(object sender)
+	public void ClearFromCommitAnnouncement(object sender)
 	{
 		if (sender is FrameworkElement { DataContext: HotkeyRouterEntry entry })
-			entry.ClearCommitAnnouncement();
+			entry.ClearFromCommitAnnouncement();
+	}
+
+	/// <summary>The same, for the "To" box.</summary>
+	public void ClearToCommitAnnouncement(object sender)
+	{
+		if (sender is FrameworkElement { DataContext: HotkeyRouterEntry entry })
+			entry.ClearToCommitAnnouncement();
 	}
 
 	public void CommitFromLostFocus(object sender)
@@ -153,11 +162,12 @@ internal sealed class HotkeyRouterController
 	{
 		_settings.HotKeyRouterSettings ??= new HotKeyRouterSettings();
 
+		// Silently. This runs over every row on every refresh, including the one the user
+		// just edited — which has already committed and announced. An announcing pass here
+		// finds nothing left to change and would take that notice straight back down again
+		// (issue #332).
 		foreach (var entry in _entries)
-		{
-			entry.CommitFromHotkey();
-			entry.CommitToHotkey();
-		}
+			entry.CommitSilently();
 
 		var validEntries = _entries
 			.Where(e => e.IsValid && e.NormalizedFromHotkey is not null && e.NormalizedToHotkey is not null)

--- a/Mutation.Ui/Views/Settings/Pages/HotkeysSettingsPage.xaml
+++ b/Mutation.Ui/Views/Settings/Pages/HotkeysSettingsPage.xaml
@@ -48,74 +48,91 @@
 						IsTabStop="False">
 						<ListView.ItemTemplate>
 							<DataTemplate x:DataType="local:HotkeyRouterEntry">
-								<StackPanel Spacing="2" Padding="0,4">
-									<Grid ColumnSpacing="12">
-										<Grid.ColumnDefinitions>
-											<ColumnDefinition Width="2*" />
-											<ColumnDefinition Width="2*" />
-											<ColumnDefinition Width="Auto" />
-										</Grid.ColumnDefinitions>
+								<Grid ColumnSpacing="12" RowSpacing="2" Padding="0,4">
+									<Grid.ColumnDefinitions>
+										<ColumnDefinition Width="2*" />
+										<ColumnDefinition Width="2*" />
+										<ColumnDefinition Width="Auto" />
+									</Grid.ColumnDefinitions>
+									<Grid.RowDefinitions>
+										<RowDefinition Height="Auto" />
+										<RowDefinition Height="Auto" />
+									</Grid.RowDefinitions>
 
-										<Grid Grid.Column="0">
-											<Border Background="{x:Bind FromBackgroundBrush, Mode=OneWay}" CornerRadius="4">
-												<TextBox
-													Text="{x:Bind FromHotkey, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-													PlaceholderText="CTRL+ALT+H"
-													Background="Transparent"
-													HorizontalAlignment="Stretch"
-													AutomationProperties.Name="Shortcut to listen for"
-													ToolTipService.ToolTip="Shortcut to listen for"
-													GotFocus="HotkeyRouterBox_GotFocus"
-													LostFocus="HotkeyRouterFrom_LostFocus" />
-											</Border>
-											<FontIcon
-												Glyph="&#xE783;"
-												Foreground="{ThemeResource SystemFillColorCriticalBrush}"
-												HorizontalAlignment="Right"
-												VerticalAlignment="Center"
-												Margin="0,0,8,0"
-												Visibility="{x:Bind BindingErrorVisibility, Mode=OneWay}"
-												AutomationProperties.Name="{x:Bind BindingErrorMessage, Mode=OneWay}"
-												ToolTipService.ToolTip="{x:Bind BindingErrorMessage, Mode=OneWay}" />
-										</Grid>
-
-										<Border Grid.Column="1" Background="{x:Bind ToBackgroundBrush, Mode=OneWay}" CornerRadius="4">
+									<Grid Grid.Row="0" Grid.Column="0">
+										<Border Background="{x:Bind FromBackgroundBrush, Mode=OneWay}" CornerRadius="4">
 											<TextBox
-												Text="{x:Bind ToHotkey, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-												PlaceholderText="CTRL+SHIFT+H"
+												Text="{x:Bind FromHotkey, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+												PlaceholderText="CTRL+ALT+H"
 												Background="Transparent"
 												HorizontalAlignment="Stretch"
-												AutomationProperties.Name="Shortcut to send when triggered"
-												ToolTipService.ToolTip="Shortcut to send when triggered"
-												GotFocus="HotkeyRouterBox_GotFocus"
-												LostFocus="HotkeyRouterTo_LostFocus" />
+												AutomationProperties.Name="Shortcut to listen for"
+												ToolTipService.ToolTip="Shortcut to listen for"
+												GotFocus="HotkeyRouterFrom_GotFocus"
+												LostFocus="HotkeyRouterFrom_LostFocus" />
 										</Border>
-
-										<Button
-											Grid.Column="2"
-											Style="{StaticResource SubtleButtonStyle}"
-											Content="Delete"
-											AutomationProperties.Name="Delete mapping"
-											Click="HotkeyRouterDelete_Click"
-											Tag="{x:Bind}" />
+										<FontIcon
+											Glyph="&#xE783;"
+											Foreground="{ThemeResource SystemFillColorCriticalBrush}"
+											HorizontalAlignment="Right"
+											VerticalAlignment="Center"
+											Margin="0,0,8,0"
+											Visibility="{x:Bind BindingErrorVisibility, Mode=OneWay}"
+											AutomationProperties.Name="{x:Bind BindingErrorMessage, Mode=OneWay}"
+											ToolTipService.ToolTip="{x:Bind BindingErrorMessage, Mode=OneWay}" />
 									</Grid>
 
-									<!-- Says what a box rewrote itself to when the user left it. A polite
-									     region of its own, so it waits its turn rather than cutting across
-									     the next field, and so it cannot overwrite the row's error. Bound
-									     through LiveText because a row in a list has no code-behind to call
-									     LiveMessage.Show from (issue #332). Full-contrast text rather than
-									     the secondary brush a caption would normally take: this app's
-									     reader is low-vision, and a message worth showing at all is worth
-									     being able to read. -->
+									<Border Grid.Row="0" Grid.Column="1" Background="{x:Bind ToBackgroundBrush, Mode=OneWay}" CornerRadius="4">
+										<TextBox
+											Text="{x:Bind ToHotkey, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+											PlaceholderText="CTRL+SHIFT+H"
+											Background="Transparent"
+											HorizontalAlignment="Stretch"
+											AutomationProperties.Name="Shortcut to send when triggered"
+											ToolTipService.ToolTip="Shortcut to send when triggered"
+											GotFocus="HotkeyRouterTo_GotFocus"
+											LostFocus="HotkeyRouterTo_LostFocus" />
+									</Border>
+
+									<Button
+										Grid.Row="0"
+										Grid.Column="2"
+										Style="{StaticResource SubtleButtonStyle}"
+										Content="Delete"
+										AutomationProperties.Name="Delete mapping"
+										Click="HotkeyRouterDelete_Click"
+										Tag="{x:Bind}" />
+
+									<!-- Says what the box above it rewrote itself to when the user left it.
+									     One region per box, under that box: the two are tabbed through one
+									     after the other, so a shared one would be taken down by entering
+									     the second box before the first had been read out. Polite, so it
+									     waits its turn rather than cutting across the next field, and so it
+									     cannot overwrite the row's error. Bound through LiveText because a
+									     row in a list has no code-behind to call LiveMessage.Show from
+									     (issue #332). Full-contrast text rather than the secondary brush a
+									     caption would normally take: this app's reader is low-vision, and a
+									     message worth showing at all is worth being able to read. -->
 									<TextBlock
-										views:LiveText.Message="{x:Bind CommitAnnouncement, Mode=OneWay}"
+										Grid.Row="1"
+										Grid.Column="0"
+										views:LiveText.Message="{x:Bind FromCommitAnnouncement, Mode=OneWay}"
 										Foreground="{ThemeResource TextFillColorPrimaryBrush}"
 										Visibility="Collapsed"
 										AutomationProperties.LiveSetting="Polite"
 										Style="{StaticResource CaptionTextBlockStyle}"
 										TextWrapping="Wrap" />
-								</StackPanel>
+
+									<TextBlock
+										Grid.Row="1"
+										Grid.Column="1"
+										views:LiveText.Message="{x:Bind ToCommitAnnouncement, Mode=OneWay}"
+										Foreground="{ThemeResource TextFillColorPrimaryBrush}"
+										Visibility="Collapsed"
+										AutomationProperties.LiveSetting="Polite"
+										Style="{StaticResource CaptionTextBlockStyle}"
+										TextWrapping="Wrap" />
+								</Grid>
 							</DataTemplate>
 						</ListView.ItemTemplate>
 					</ListView>

--- a/Mutation.Ui/Views/Settings/Pages/HotkeysSettingsPage.xaml.cs
+++ b/Mutation.Ui/Views/Settings/Pages/HotkeysSettingsPage.xaml.cs
@@ -302,8 +302,11 @@ public sealed partial class HotkeysSettingsPage : UserControl
 	private void HotkeyRouterDelete_Click(object sender, RoutedEventArgs e) =>
 		_routerController.DeleteMapping(sender);
 
-	private void HotkeyRouterBox_GotFocus(object sender, RoutedEventArgs e) =>
-		_routerController.ClearCommitAnnouncement(sender);
+	private void HotkeyRouterFrom_GotFocus(object sender, RoutedEventArgs e) =>
+		_routerController.ClearFromCommitAnnouncement(sender);
+
+	private void HotkeyRouterTo_GotFocus(object sender, RoutedEventArgs e) =>
+		_routerController.ClearToCommitAnnouncement(sender);
 
 	private void HotkeyRouterFrom_LostFocus(object sender, RoutedEventArgs e) =>
 		_routerController.CommitFromLostFocus(sender);


### PR DESCRIPTION
Follow-up to [#338](https://github.com/Subverting-complexity/Mutation/pull/338), which closed [#332](https://github.com/Subverting-complexity/Mutation/issues/332). Two defects found by the independent review of that branch, caught after it had already merged. #332 was not actually fixed by it.

## The notice never survived long enough to be spoken

`HotkeyRouterController.CommitFromLostFocus` commits the box and then calls `RefreshRegistrations`, which calls `SyncSettings`, which re-commits **every** row. On that second pass the text has already been canonicalised, so `HotkeyCommitAnnouncement.For` sees nothing changed, answers null, and the notice is cleared — before the queued `LiveRegionChanged` event has run. `LiveMessage.Announce` then finds the block collapsed and returns.

Net effect: the router box still rewrote itself in silence, which is the whole of #332.

`SyncSettings` now uses a new `HotkeyRouterEntry.CommitSilently()`. `HotkeyEditor` already had this ordering right — it announces last, after the duplicate recompute — and the router path was the inverse.

The test that pins it drives the real sequence through the controller rather than the entry alone, and fails against the merged code:

```
RefreshRegistrations_LeavesTheNoticeFromTheCommitThatTriggeredItStanding
  Assert.Equal() Failure: Strings differ
```

`RebuildingTheRowLeavesAPendingNoticeStanding` passed on the merged code only because it exercised `ReplaceBackingMap` in isolation — in production that is reached from `SyncSettings`, five lines after the loop that had already nulled the notice. The guard was on the wrong call.

## One notice per row was the wrong unit

`GotFocus` was wired to both boxes and cleared the row's single notice. Tabbing **From** → **To** is how a mapping gets filled in, so the overwhelmingly common next action destroyed the From box's notice before it could be read out — and, because `Announce` is queued at `Low` priority, before it was spoken either.

Each box now has its own notice (`FromCommitAnnouncement`, `ToCommitAnnouncement`), its own polite live region in the row's second grid row directly under it, and its own `GotFocus` handler. Entering one box leaves the other's notice alone. That also makes the guide's existing sentence true — "the note goes away when you come back to that box".

New tests: `EachBoxKeepsItsOwnNotice`, `ComingBackIntoOneBoxLeavesTheOtherBoxsNoticeAlone`, `TheBookkeepingCommitLeavesAPendingNoticeStanding`, `RefreshRegistrations_DoesNotInventANoticeForRowsTheUserDidNotTouch`, and `ADuplicateFoundDuringTheCommitStillOutranksTheNotice` (which pins the real ordering — the duplicate flag is set from the `FromHotkey` change during the commit, not before it).

## One documentation claim was not true

`troubleshooting.md` said Mutation honours a "wait this long" answer from a busy service. `RetryAfterHint.From` only reads that header off `ClientResultException`, the OpenAI SDK's type; `DeepgramException` carries no HTTP response. #338 is what brought Deepgram into the retry ladder at all, so the sentence now says which services it holds for.

## Filed rather than fixed here

[#347](https://github.com/Subverting-complexity/Mutation/issues/347) — opening the Hotkeys page raises one assertive interruption per pre-existing duplicate badge. The mechanism predates #338, which widened what it fires for. Fixing it means giving `LiveMessage` a way to show without announcing, which is its own change.

## Testing

`dotnet test --configuration Release` — 2107 passed, 0 failed. User guide HTML rebuilt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)