### PR TITLE
Say what took the shortcut, retry a busy clipboard, and hold a keystroke aimed at nothing

### DIFF
--- a/Documentation/UserGuide/html/ai-prompts.html
+++ b/Documentation/UserGuide/html/ai-prompts.html
@@ -207,6 +207,7 @@ footer{margin-top:3rem; padding-top:1rem; border-top:1px solid var(--rule); colo
 <h2 id="giving-a-prompt-its-own-shortcut">Giving a prompt its own shortcut</h2>
 <p>The <strong>Hotkey</strong> box in the prompt editor is optional. Fill it in and that key combination runs this prompt from anywhere — no need to switch to Mutation first. Copy some text in Outlook, press your shortcut, and the cleaned-up version lands back in Outlook.</p>
 <p>Pick combinations that nothing else is using. <strong>Ctrl+Alt</strong> plus a letter is usually safe. If a shortcut cannot be claimed because another program already has it, Mutation tells you.</p>
+<p>If something inside Mutation already has it, you find out sooner: a note appears under the <strong>Hotkey</strong> box as you type, saying what has it — another prompt by name, one of Mutation's own shortcuts, or a hotkey route. You can still save, but only one of the two will fire, so it is worth changing while you are here.</p>
 <hr />
 <h2 id="the-auto-run-prompt">The Auto-Run prompt</h2>
 <p>One prompt in your list can be marked <strong>Run automatically after transcription</strong>. That prompt then runs on its own as soon as a recording has been turned into text, without you pressing anything.</p>

--- a/Documentation/UserGuide/html/keyboard-shortcuts.html
+++ b/Documentation/UserGuide/html/keyboard-shortcuts.html
@@ -330,6 +330,10 @@ it can only be added by editing the settings file by hand — see
 </div>
 <p>Each prompt you create can have its own shortcut. You set it in the prompt editor
 on the main window, not on the Hotkeys page. None are filled in for you.</p>
+<p>If the combination you type is already taken, the prompt editor tells you straight
+away, under the <strong>Hotkey</strong> box, and says what has it — another prompt by name, one of
+Mutation's own shortcuts, or a hotkey route. You can still save it, but only one of
+the two will ever fire, so it is worth picking something else while you are there.</p>
 <h3 id="app">App</h3>
 <div class="table-wrap"><table>
 <thead>
@@ -416,10 +420,11 @@ Mutation compares the keys, not the spelling, so writing one as
 <strong>Ctrl+Shift+A</strong> and the other as <strong>Shift+Ctrl+A</strong> is still caught. The check covers
 the whole page at once, so a shortcut at the top and a router mapping's &quot;From&quot; box at
 the bottom claiming the same keys are both flagged.</li>
-<li><strong>The same combination as one of your prompt shortcuts</strong> — a note reading <strong>Also
-used by an LLM prompt</strong> appears under the row. Prompt shortcuts are set in the prompt
-window rather than on this page, so there is no second row here to flag. Open
-<strong>AI prompts</strong> to see which one it is.</li>
+<li><strong>The same combination as one of your prompt shortcuts</strong> — a note appears under
+the row naming the prompt, for example <strong>Also used by the LLM prompt &quot;Summarize&quot;</strong>.
+Prompt shortcuts are set in the prompt window rather than on this page, so there is
+no second row here to flag — the note names it instead, so you know which prompt to
+open.</li>
 <li><strong>The same combination in a &quot;send key after&quot; box and a real shortcut</strong> —
 also flagged, and worth fixing. Windows hands that key straight back to Mutation,
 so the action would set itself off again and again. Putting the same key in <em>both</em>

--- a/Documentation/UserGuide/html/screen-capture-and-ocr.html
+++ b/Documentation/UserGuide/html/screen-capture-and-ocr.html
@@ -277,6 +277,12 @@ end beep is the first thing you hear, and it says your picture has been sent off
 read.</p>
 <p>Either way, the success beep then says the text is on your clipboard — or the failure
 beep says something went wrong, and the status area tells you what.</p>
+<p>Now and then another program has the clipboard open at the moment Mutation wants to
+copy to it — a clipboard manager, or your screen reader taking a look at the
+screenshot that went there a second earlier. Mutation waits a moment and tries again a
+few times. If it still cannot get in, the reading itself is not lost: the text is in
+the <strong>OCR result</strong> box as usual, and a message says it could not be copied to the
+clipboard. That way you know to copy it out of the box yourself.</p>
 <h2 id="reading-a-batch-of-files-at-once">Reading a batch of files at once</h2>
 <p>The <strong>OCR documents</strong> button handles whole files rather than screenshots. Click it,
 pick one or more files, and Mutation reads them all.</p>
@@ -319,6 +325,16 @@ automatically. It is sent whether the run found text or failed, so a screen-read
 shortcut in that box reads out the error just as readily as the result.</p>
 <p>It is sent after a batch of documents as well, not only after a screenshot or a
 clipboard image. It is not sent if you cancel a batch, since nothing is copied then.</p>
+<p>Two more times it holds back rather than firing:</p>
+<ul>
+<li><strong>You press an OCR shortcut while a capture is already on screen.</strong> Nothing has
+happened, so there is nothing new to read. Mutation brings the capture you already
+have back to the front and sends nothing — otherwise the keystroke would land in the
+capture overlay.</li>
+<li><strong>You cancel a capture.</strong> The keystroke is still sent, so a screen-reader shortcut
+reads out the &quot;cancelled&quot; message. It just waits until the window you were in has
+the keyboard back, so it goes where you meant it to.</li>
+</ul>
 <p>The rest of the options are covered in <a href="settings.html">The Settings window</a>.</p>
 <h2 id="where-to-next">Where to next</h2>
 <ul>

--- a/Documentation/UserGuide/html/troubleshooting.html
+++ b/Documentation/UserGuide/html/troubleshooting.html
@@ -279,6 +279,20 @@ page, which is better for columns and tables. <strong>Basic</strong> layout read
 to right, top to bottom, which is better for a plain block of text that Natural has
 scrambled. Each has its own shortcut, so you can just try the other one.</li>
 </ol>
+<h3 id="ocr-read-the-text-but-could-not-copy-it-to-the-clipboard">OCR read the text but could not copy it to the clipboard</h3>
+<p><strong>What's happening.</strong> Only one program can have the clipboard open at a time. Just
+after a screenshot, a clipboard manager or your screen reader often opens it to look at
+the picture that arrived — and for that moment nothing else can write to it. Mutation
+waits and tries again a few times, which is usually enough. When it is not, you hear
+the message &quot;The text was recognised, but it could not be copied to the clipboard. It
+is in the OCR results box.&quot;</p>
+<p>This is not a failed reading. The text is there, in the <strong>OCR result</strong> box on the
+<strong>Visual Capture</strong> card, and any shortcut you set to run afterwards still fires, so a
+screen reader can read it out of the box as usual.</p>
+<p><strong>What to do.</strong> Copy the text out of the <strong>OCR result</strong> box, or press the OCR shortcut
+again — the second attempt almost always gets in. If it happens every time, a clipboard
+manager or clipboard-history tool is the usual culprit; closing it or turning off its
+monitoring settles it.</p>
 <h3 id="ocr-skipped-a-file-for-being-too-large">OCR skipped a file for being too large</h3>
 <p><strong>What's happening.</strong> There is a maximum size for a file or page sent for OCR, so a
 huge file cannot be uploaded by accident. Anything over it is skipped before upload,
@@ -366,8 +380,14 @@ after OCR</strong> boxes in <strong>Settings</strong>. There are two reasons one
 failure beep, the shortcut is deliberately skipped — it is usually something that acts
 on the text, and running it when the text never landed would aim it at the wrong thing.
 OCR is different: it sends the shortcut either way, so a screen-reader command in that
-box reads out the error as readily as the result. The one exception is a batch of
-documents you cancelled — nothing is copied then, so nothing is sent.</p>
+box reads out the error as readily as the result. There are two exceptions. A batch of
+documents you cancelled sends nothing, because nothing is copied then. And an OCR
+shortcut pressed while a capture is already on screen sends nothing either — nothing
+happened, so there is nothing new to read, and the keystroke would land in the capture
+overlay rather than where you aimed it.</p>
+<p>Cancelling a capture does still send it, so a screen-reader shortcut reads out the
+&quot;cancelled&quot; message. It waits a moment first, until the window you were in has the
+keyboard back.</p>
 <p>The second is how the shortcut is written. Write it the ordinary way — modifier names
 joined with plus signs, like <strong>Ctrl+V</strong>, <strong>Alt+F4</strong> or <strong>Ctrl+Shift+Delete</strong>. Mutation
 still understands the older shorthand some settings files hold, such as <code>^{DEL}</code> for

--- a/Documentation/UserGuide/markdown/ai-prompts.md
+++ b/Documentation/UserGuide/markdown/ai-prompts.md
@@ -65,6 +65,8 @@ The **Hotkey** box in the prompt editor is optional. Fill it in and that key com
 
 Pick combinations that nothing else is using. **Ctrl+Alt** plus a letter is usually safe. If a shortcut cannot be claimed because another program already has it, Mutation tells you.
 
+If something inside Mutation already has it, you find out sooner: a note appears under the **Hotkey** box as you type, saying what has it — another prompt by name, one of Mutation's own shortcuts, or a hotkey route. You can still save, but only one of the two will fire, so it is worth changing while you are here.
+
 ---
 
 ## The Auto-Run prompt

--- a/Documentation/UserGuide/markdown/keyboard-shortcuts.md
+++ b/Documentation/UserGuide/markdown/keyboard-shortcuts.md
@@ -76,6 +76,11 @@ to happen a second time.
 Each prompt you create can have its own shortcut. You set it in the prompt editor
 on the main window, not on the Hotkeys page. None are filled in for you.
 
+If the combination you type is already taken, the prompt editor tells you straight
+away, under the **Hotkey** box, and says what has it — another prompt by name, one of
+Mutation's own shortcuts, or a hotkey route. You can still save it, but only one of
+the two will ever fire, so it is worth picking something else while you are there.
+
 ### App
 
 | What it does | Default shortcut | More about it |
@@ -156,10 +161,11 @@ readers announce it straight away.
   **Ctrl+Shift+A** and the other as **Shift+Ctrl+A** is still caught. The check covers
   the whole page at once, so a shortcut at the top and a router mapping's "From" box at
   the bottom claiming the same keys are both flagged.
-- **The same combination as one of your prompt shortcuts** — a note reading **Also
-  used by an LLM prompt** appears under the row. Prompt shortcuts are set in the prompt
-  window rather than on this page, so there is no second row here to flag. Open
-  **AI prompts** to see which one it is.
+- **The same combination as one of your prompt shortcuts** — a note appears under
+  the row naming the prompt, for example **Also used by the LLM prompt "Summarize"**.
+  Prompt shortcuts are set in the prompt window rather than on this page, so there is
+  no second row here to flag — the note names it instead, so you know which prompt to
+  open.
 - **The same combination in a "send key after" box and a real shortcut** —
   also flagged, and worth fixing. Windows hands that key straight back to Mutation,
   so the action would set itself off again and again. Putting the same key in *both*

--- a/Documentation/UserGuide/markdown/screen-capture-and-ocr.md
+++ b/Documentation/UserGuide/markdown/screen-capture-and-ocr.md
@@ -95,6 +95,13 @@ read.
 Either way, the success beep then says the text is on your clipboard — or the failure
 beep says something went wrong, and the status area tells you what.
 
+Now and then another program has the clipboard open at the moment Mutation wants to
+copy to it — a clipboard manager, or your screen reader taking a look at the
+screenshot that went there a second earlier. Mutation waits a moment and tries again a
+few times. If it still cannot get in, the reading itself is not lost: the text is in
+the **OCR result** box as usual, and a message says it could not be copied to the
+clipboard. That way you know to copy it out of the box yourself.
+
 ## Reading a batch of files at once
 
 The **OCR documents** button handles whole files rather than screenshots. Click it,
@@ -150,6 +157,16 @@ shortcut in that box reads out the error just as readily as the result.
 
 It is sent after a batch of documents as well, not only after a screenshot or a
 clipboard image. It is not sent if you cancel a batch, since nothing is copied then.
+
+Two more times it holds back rather than firing:
+
+- **You press an OCR shortcut while a capture is already on screen.** Nothing has
+  happened, so there is nothing new to read. Mutation brings the capture you already
+  have back to the front and sends nothing — otherwise the keystroke would land in the
+  capture overlay.
+- **You cancel a capture.** The keystroke is still sent, so a screen-reader shortcut
+  reads out the "cancelled" message. It just waits until the window you were in has
+  the keyboard back, so it goes where you meant it to.
 
 The rest of the options are covered in [The Settings window](settings.md).
 

--- a/Documentation/UserGuide/markdown/troubleshooting.md
+++ b/Documentation/UserGuide/markdown/troubleshooting.md
@@ -158,6 +158,24 @@ different pages.
    to right, top to bottom, which is better for a plain block of text that Natural has
    scrambled. Each has its own shortcut, so you can just try the other one.
 
+### OCR read the text but could not copy it to the clipboard
+
+**What's happening.** Only one program can have the clipboard open at a time. Just
+after a screenshot, a clipboard manager or your screen reader often opens it to look at
+the picture that arrived — and for that moment nothing else can write to it. Mutation
+waits and tries again a few times, which is usually enough. When it is not, you hear
+the message "The text was recognised, but it could not be copied to the clipboard. It
+is in the OCR results box."
+
+This is not a failed reading. The text is there, in the **OCR result** box on the
+**Visual Capture** card, and any shortcut you set to run afterwards still fires, so a
+screen reader can read it out of the box as usual.
+
+**What to do.** Copy the text out of the **OCR result** box, or press the OCR shortcut
+again — the second attempt almost always gets in. If it happens every time, a clipboard
+manager or clipboard-history tool is the usual culprit; closing it or turning off its
+monitoring settles it.
+
 ### OCR skipped a file for being too large
 
 **What's happening.** There is a maximum size for a file or page sent for OCR, so a
@@ -268,8 +286,15 @@ The first is that dictation only sends it when the text was delivered. If you he
 failure beep, the shortcut is deliberately skipped — it is usually something that acts
 on the text, and running it when the text never landed would aim it at the wrong thing.
 OCR is different: it sends the shortcut either way, so a screen-reader command in that
-box reads out the error as readily as the result. The one exception is a batch of
-documents you cancelled — nothing is copied then, so nothing is sent.
+box reads out the error as readily as the result. There are two exceptions. A batch of
+documents you cancelled sends nothing, because nothing is copied then. And an OCR
+shortcut pressed while a capture is already on screen sends nothing either — nothing
+happened, so there is nothing new to read, and the keystroke would land in the capture
+overlay rather than where you aimed it.
+
+Cancelling a capture does still send it, so a screen-reader shortcut reads out the
+"cancelled" message. It waits a moment first, until the window you were in has the
+keyboard back.
 
 The second is how the shortcut is written. Write it the ordinary way — modifier names
 joined with plus signs, like **Ctrl+V**, **Alt+F4** or **Ctrl+Shift+Delete**. Mutation

--- a/Mutation.Tests/ClaimedHotkeysTests.cs
+++ b/Mutation.Tests/ClaimedHotkeysTests.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Linq;
+using CognitiveSupport;
+using Mutation.Ui.Core;
+
+namespace Mutation.Tests;
+
+/// <summary>
+/// The three lists that fill one registration table, gathered as one so a screen that shows
+/// none of them can still say what a shortcut is already taken by (issue #340).
+/// </summary>
+public class ClaimedHotkeysTests
+{
+	private static Settings SettingsWith(params LlmSettings.LlmPrompt[] prompts)
+	{
+		var settings = new Settings
+		{
+			TextToSpeechSettings = new TextToSpeechSettings { SpeakClipboard = "CTRL+ALT+G" },
+			LlmSettings = new LlmSettings(),
+			HotKeyRouterSettings = new HotKeyRouterSettings(),
+		};
+
+		settings.LlmSettings.Prompts.AddRange(prompts);
+		return settings;
+	}
+
+	private static LlmSettings.LlmPrompt Prompt(string name, string? hotkey) =>
+		new() { Name = name, Hotkey = hotkey };
+
+	[Fact]
+	public void The_app_s_own_shortcuts_are_in_it_under_the_names_the_page_shows()
+	{
+		var claimed = ClaimedHotkeys.Excluding(SettingsWith(), excludedPrompt: null);
+
+		Assert.Contains(claimed, entry => entry.Name == "Speak clipboard" && entry.Text == "CTRL+ALT+G");
+	}
+
+	[Fact]
+	public void A_send_key_row_is_carried_as_one_that_is_not_claimed_from_Windows()
+	{
+		var claimed = ClaimedHotkeys.Excluding(SettingsWith(), excludedPrompt: null);
+
+		var sent = claimed.Single(entry => entry.Name == "Send key after OCR");
+		Assert.False(sent.ClaimsTheChord);
+	}
+
+	[Fact]
+	public void A_row_header_s_parenthesised_aside_is_dropped_before_it_is_read_out()
+	{
+		// "Send key after OCR (optional)" is the right header for a box that may be left blank,
+		// and the wrong thing to hear inside "Already used by …".
+		Assert.DoesNotContain(
+			ClaimedHotkeys.Excluding(SettingsWith(), excludedPrompt: null),
+			entry => entry.Name.Contains("(optional)", StringComparison.Ordinal));
+	}
+
+	[Fact]
+	public void Every_route_and_every_prompt_is_in_it()
+	{
+		var settings = SettingsWith(Prompt("Summarize", "CTRL+ALT+P"));
+		settings.HotKeyRouterSettings.Mappings.Add(new HotKeyRouterSettings.HotKeyRouterMap("CTRL+ALT+R", "F5"));
+
+		var claimed = ClaimedHotkeys.Excluding(settings, excludedPrompt: null);
+
+		Assert.Contains(claimed, entry => entry.Name == ClaimedHotkeys.RouteName && entry.Text == "CTRL+ALT+R");
+		Assert.Contains(claimed, entry => entry.Text == "CTRL+ALT+P" && entry.Name.Contains("Summarize", StringComparison.Ordinal));
+	}
+
+	[Fact]
+	public void The_prompt_being_edited_is_left_out_so_it_cannot_clash_with_itself()
+	{
+		var edited = Prompt("Summarize", "CTRL+ALT+P");
+		var settings = SettingsWith(edited, Prompt("Tidy up", "CTRL+ALT+T"));
+
+		var claimed = ClaimedHotkeys.Excluding(settings, edited);
+
+		Assert.DoesNotContain(claimed, entry => entry.Text == "CTRL+ALT+P");
+		Assert.Contains(claimed, entry => entry.Text == "CTRL+ALT+T");
+	}
+
+	[Fact]
+	public void A_namesake_of_the_prompt_being_edited_is_still_in_it()
+	{
+		// By reference, not by name. Two prompts may be called the same thing, and dropping
+		// both would hide a real clash behind a coincidence.
+		var edited = Prompt("Summarize", "CTRL+ALT+P");
+		var namesake = Prompt("Summarize", "CTRL+ALT+S");
+		var settings = SettingsWith(edited, namesake);
+
+		var claimed = ClaimedHotkeys.Excluding(settings, edited);
+
+		Assert.Contains(claimed, entry => entry.Text == "CTRL+ALT+S");
+	}
+
+	[Fact]
+	public void A_prompt_with_no_name_yet_is_still_referred_to_as_something()
+	{
+		Assert.Equal("an unnamed LLM prompt", ClaimedHotkeys.NameOf(Prompt("  ", "CTRL+ALT+P")));
+	}
+
+	[Fact]
+	public void A_prompt_name_is_quoted_so_the_sentence_keeps_its_shape()
+	{
+		// A prompt's name is the user's own words and could be an ordinary phrase. Unquoted,
+		// "Already used by the LLM prompt do the thing." reads as a sentence that lost its end.
+		Assert.Equal("the LLM prompt \"do the thing\"", ClaimedHotkeys.NameOf(Prompt("do the thing", null)));
+	}
+
+	[Fact]
+	public void Settings_with_no_prompts_and_no_routes_still_answers()
+	{
+		var bare = new Settings();
+
+		var claimed = ClaimedHotkeys.Excluding(bare, excludedPrompt: null);
+
+		Assert.Equal(CoreHotkeys.All.Length, claimed.Count);
+	}
+
+	[Fact]
+	public void A_null_settings_object_is_a_mistake_rather_than_an_empty_answer()
+	{
+		Assert.Throws<ArgumentNullException>(() => ClaimedHotkeys.Excluding(null!, excludedPrompt: null));
+	}
+}

--- a/Mutation.Tests/CoreHotkeysTests.cs
+++ b/Mutation.Tests/CoreHotkeysTests.cs
@@ -1,6 +1,6 @@
-using System.Linq;
+﻿using System.Linq;
 using Mutation.Ui.Services;
-using Mutation.Ui.Views.SettingsUi.Pages;
+using Mutation.Ui.Core;
 
 namespace Mutation.Tests;
 
@@ -20,14 +20,14 @@ namespace Mutation.Tests;
 /// gap is one property assignment in <c>BuildRows</c>.
 /// </para>
 /// </summary>
-public class HotkeysSettingsPageSpecsTests
+public class CoreHotkeysTests
 {
 	private const string SendKeyAfterOcr = "Send key after OCR (optional)";
 	private const string SendKeyAfterTranscription = "Send key after transcription (optional)";
 	private const string SendKeysValue = "^{F5}";
 
-	private static HotkeysSettingsPage.HotkeySpec SpecFor(string label) =>
-		HotkeysSettingsPage.Specs.Single(s => s.Label == label);
+	private static HotkeySpec SpecFor(string label) =>
+		CoreHotkeys.All.Single(s => s.Label == label);
 
 	[Theory]
 	[InlineData(SendKeyAfterOcr)]
@@ -60,20 +60,20 @@ public class HotkeysSettingsPageSpecsTests
 	{
 		Assert.Equal(
 			new[] { SendKeyAfterOcr, SendKeyAfterTranscription },
-			HotkeysSettingsPage.Specs.Where(s => s.AllowsSendKeysSyntax).Select(s => s.Label).ToArray());
+			CoreHotkeys.All.Where(s => s.AllowsSendKeysSyntax).Select(s => s.Label).ToArray());
 	}
 
 	[Fact]
 	public void A_row_accepts_SendKeys_syntax_when_and_only_when_it_is_not_registered()
 	{
-		Assert.All(HotkeysSettingsPage.Specs,
+		Assert.All(CoreHotkeys.All,
 			spec => Assert.Equal(!spec.Registers, spec.AllowsSendKeysSyntax));
 	}
 
 	[Fact]
 	public void An_ordinary_chord_is_still_accepted_on_every_row()
 	{
-		Assert.All(HotkeysSettingsPage.Specs,
+		Assert.All(CoreHotkeys.All,
 			spec => Assert.Null(HotkeyValidator.Validate("Ctrl+V", spec.AllowsSendKeysSyntax)));
 	}
 
@@ -84,6 +84,6 @@ public class HotkeysSettingsPageSpecsTests
 		// are the only ones the Clear button is meant for.
 		Assert.Equal(
 			new[] { SendKeyAfterOcr, SendKeyAfterTranscription },
-			HotkeysSettingsPage.Specs.Where(s => s.AllowEmpty).Select(s => s.Label).ToArray());
+			CoreHotkeys.All.Where(s => s.AllowEmpty).Select(s => s.Label).ToArray());
 	}
 }

--- a/Mutation.Tests/HotkeyClashDescriptionTests.cs
+++ b/Mutation.Tests/HotkeyClashDescriptionTests.cs
@@ -130,6 +130,24 @@ public class HotkeyClashDescriptionTests
 			HotkeyClashDescription.For("CTRL+ALT+P", sent));
 	}
 
+	[Theory]
+	[InlineData("^{F5}")]
+	[InlineData("CTRL+A, CTRL+ALT+P")]
+	public void A_send_key_row_is_asked_about_the_way_a_send_key_row_is_read(string configured)
+	{
+		// The Hotkeys page asks this for its rows too, and two of them are not claimed from
+		// Windows: their value may be a comma-separated sequence, and it may be spelled in
+		// SendKeys shorthand. Asked as though it were one claimed chord, "^{F5}" parses as
+		// nothing and the badge would have no name to show.
+		var prompts = new[]
+		{
+			SummarizePrompt with { Text = "CTRL+F5" },
+			SummarizePrompt with { Name = "the LLM prompt \"Tidy up\"", Text = "CTRL+ALT+P" },
+		};
+
+		Assert.NotEmpty(HotkeyClashDescription.NamesHolding(configured, prompts, claimsTheChord: false));
+	}
+
 	[Fact]
 	public void Two_other_prompts_clashing_with_each_other_are_not_this_prompt_s_problem()
 	{

--- a/Mutation.Tests/HotkeyClashDescriptionTests.cs
+++ b/Mutation.Tests/HotkeyClashDescriptionTests.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Collections.Generic;
+using Mutation.Ui.Core;
+
+namespace Mutation.Tests;
+
+/// <summary>
+/// What a prompt editor says when the shortcut being typed is already spoken for.
+/// <para>
+/// Two prompts could claim <c>CTRL+ALT+P</c> and both editors looked perfectly happy; the user
+/// saved, and whichever registered second came back in the "Some hotkeys could not be
+/// registered" dialog. That was the last list where a clash was still found out after the
+/// fact, which is what #306 and #321 set out to remove everywhere else (issue #340).
+/// </para>
+/// <para>
+/// The Hotkeys page can get away with a bare "Duplicate hotkey" because both rows are on the
+/// screen in front of the user. Neither end of a prompt clash is, so what is pinned here is
+/// mostly the naming: a warning that does not say what took the shortcut leaves the user with
+/// nowhere to go (issue #336).
+/// </para>
+/// </summary>
+public class HotkeyClashDescriptionTests
+{
+	private static readonly NamedHotkey SpeakClipboard = new("Speak clipboard", "CTRL+ALT+G", ClaimsTheChord: true);
+	private static readonly NamedHotkey SummarizePrompt = new("the LLM prompt \"Summarize\"", "CTRL+ALT+P", ClaimsTheChord: true);
+	private static readonly NamedHotkey Route = new(ClaimedHotkeys.RouteName, "CTRL+ALT+R", ClaimsTheChord: true);
+
+	private static readonly NamedHotkey[] Everything = { SpeakClipboard, SummarizePrompt, Route };
+
+	[Fact]
+	public void A_free_shortcut_says_nothing()
+	{
+		Assert.Null(HotkeyClashDescription.For("CTRL+ALT+Z", Everything));
+	}
+
+	[Fact]
+	public void A_shortcut_another_prompt_holds_names_that_prompt()
+	{
+		// The case nothing caught before this: neither end has a row on the Hotkeys page, so
+		// neither screen had anything to flag.
+		Assert.Equal(
+			"Already used by the LLM prompt \"Summarize\".",
+			HotkeyClashDescription.For("CTRL+ALT+P", Everything));
+	}
+
+	[Fact]
+	public void A_shortcut_the_app_itself_holds_names_that_shortcut()
+	{
+		Assert.Equal(
+			"Already used by Speak clipboard.",
+			HotkeyClashDescription.For("CTRL+ALT+G", Everything));
+	}
+
+	[Fact]
+	public void A_shortcut_a_route_listens_for_says_so()
+	{
+		Assert.Equal(
+			$"Already used by {ClaimedHotkeys.RouteName}.",
+			HotkeyClashDescription.For("CTRL+ALT+R", Everything));
+	}
+
+	[Fact]
+	public void A_different_spelling_of_the_same_chord_is_the_same_chord()
+	{
+		// The reason the finder is reused rather than the text compared: Settings used to check
+		// spellings and registration checked chords, so the two disagreed (issue #306).
+		Assert.Equal(
+			"Already used by Speak clipboard.",
+			HotkeyClashDescription.For("alt+ctrl+g", Everything));
+	}
+
+	[Fact]
+	public void Everything_holding_it_is_named_and_the_last_pair_is_joined_with_a_word()
+	{
+		var both = new[]
+		{
+			SpeakClipboard,
+			SummarizePrompt with { Text = "CTRL+ALT+G" },
+			Route with { Text = "CTRL+ALT+G" },
+		};
+
+		Assert.Equal(
+			$"Already used by Speak clipboard, the LLM prompt \"Summarize\" and {ClaimedHotkeys.RouteName}.",
+			HotkeyClashDescription.For("CTRL+ALT+G", both));
+	}
+
+	[Fact]
+	public void Two_routes_on_one_chord_are_said_once()
+	{
+		var routes = new[] { Route, Route };
+
+		Assert.Equal(
+			$"Already used by {ClaimedHotkeys.RouteName}.",
+			HotkeyClashDescription.For("CTRL+ALT+R", routes));
+	}
+
+	[Theory]
+	[InlineData(null)]
+	[InlineData("")]
+	[InlineData("   ")]
+	public void A_shortcut_that_is_not_there_yet_cannot_be_taken(string? typed)
+	{
+		var blanks = new[] { SpeakClipboard with { Text = typed } };
+
+		Assert.Null(HotkeyClashDescription.For(typed, blanks));
+	}
+
+	[Fact]
+	public void Half_typed_text_is_not_a_chord_and_so_clashes_with_nothing()
+	{
+		// Both #320 exclusions, kept: text that cannot be registered cannot be claimed, and
+		// reporting two unparseable values as duplicates of each other would be a second, wrong
+		// complaint on top of the validation message they already carry.
+		var halfTyped = new[] { SpeakClipboard with { Text = "CTRL+" } };
+
+		Assert.Null(HotkeyClashDescription.For("CTRL+", halfTyped));
+	}
+
+	[Fact]
+	public void A_key_that_is_only_sent_onward_still_counts_against_a_prompt()
+	{
+		// The other #320 exclusion is narrower than it looks. Two "Send key after…" values
+		// holding the same key are not a conflict, because neither is claimed from Windows. A
+		// prompt's shortcut is claimed — and Windows routes the synthesized keystroke straight
+		// back to whoever claimed it, so the prompt would run itself.
+		var sent = new[] { new NamedHotkey("Send key after OCR", "CTRL+ALT+P", ClaimsTheChord: false) };
+
+		Assert.Equal(
+			"Already used by Send key after OCR.",
+			HotkeyClashDescription.For("CTRL+ALT+P", sent));
+	}
+
+	[Fact]
+	public void Two_other_prompts_clashing_with_each_other_are_not_this_prompt_s_problem()
+	{
+		// The reason each candidate is asked about on its own. Answering the whole set at once
+		// reports every entry that clashes with anything, which here would name two prompts the
+		// shortcut in the box has nothing to do with.
+		var others = new[]
+		{
+			SummarizePrompt with { Name = "the LLM prompt \"One\"", Text = "CTRL+ALT+1" },
+			SummarizePrompt with { Name = "the LLM prompt \"Two\"", Text = "CTRL+ALT+1" },
+		};
+
+		Assert.Null(HotkeyClashDescription.For("CTRL+ALT+9", others));
+	}
+
+	[Fact]
+	public void A_null_list_is_a_mistake_rather_than_an_empty_answer()
+	{
+		Assert.Throws<ArgumentNullException>(() =>
+			HotkeyClashDescription.For("CTRL+ALT+G", (IReadOnlyList<NamedHotkey>)null!));
+	}
+}

--- a/Mutation.Tests/OcrManagerTests.cs
+++ b/Mutation.Tests/OcrManagerTests.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using CognitiveSupport;
+using Mutation.Ui.Core;
 using Mutation.Ui.Services;
 using PdfSharp.Pdf;
 using PdfSharp.Pdf.IO;
@@ -93,6 +94,121 @@ public class OcrManagerTests
 		Assert.Equal(0, manager.RunOnDispatcherCalls);
 		WaitForBeep(manager, 1);
 		Assert.Contains(BeepType.Success, manager.Beeps);
+	}
+
+	/// <summary>
+	/// A clipboard held open by something else is retried, not reported. The window for it is
+	/// widest right after a screenshot puts the image on the clipboard, which is exactly when a
+	/// clipboard manager or a screen reader opens it to see what arrived — and the copy that
+	/// followed had no retry at all, so a perfectly good read came back as a COM error where the
+	/// text should have been (issue #341).
+	/// </summary>
+	[Fact]
+	public async Task A_clipboard_that_is_briefly_busy_is_retried_and_the_text_still_lands()
+	{
+		using var image = new SoftwareBitmap(BitmapPixelFormat.Bgra8, 2, 2, BitmapAlphaMode.Premultiplied);
+		var clipboard = new TestClipboard { Image = image, FailWrites = 2 };
+		var manager = new TestableOcrManager(CreateValidSettings(), new StubOcrService("recognised text"), clipboard);
+
+		var result = await manager.ExtractTextFromClipboardImageAsync(DefaultOrder);
+
+		Assert.True(result.Success);
+		Assert.False(result.ClipboardCopyFailed);
+		Assert.Equal(3, clipboard.SetTextCalls);
+		Assert.Equal("recognised text", clipboard.LastText);
+	}
+
+	/// <summary>
+	/// And when it never lets go, the run says the copy failed rather than that the OCR did.
+	/// The recognised text is the thing the user waited for and it is returned either way — the
+	/// caller puts it in the OCR box, where the shortcut that runs next can read it.
+	/// </summary>
+	[Fact]
+	public async Task A_clipboard_that_never_opens_is_a_failed_copy_and_not_a_failed_read()
+	{
+		using var image = new SoftwareBitmap(BitmapPixelFormat.Bgra8, 2, 2, BitmapAlphaMode.Premultiplied);
+		var clipboard = new TestClipboard { Image = image, FailWrites = int.MaxValue };
+		var manager = new TestableOcrManager(CreateValidSettings(), new StubOcrService("recognised text"), clipboard);
+
+		var result = await manager.ExtractTextFromClipboardImageAsync(DefaultOrder);
+
+		// The read succeeded, so the run did. The recognised text is still what comes back, and
+		// the caller still puts it in the OCR box where the shortcut that runs next can read it
+		// — the copy failing is a separate thing to say, not a reason to throw the text away and
+		// show a COM error in its place.
+		Assert.True(result.Success);
+		Assert.True(result.ClipboardCopyFailed);
+		Assert.Equal("recognised text", result.Message);
+		Assert.Equal(ClipboardRetry.DefaultAttempts, clipboard.SetTextCalls);
+	}
+
+	/// <summary>
+	/// A run that recognised nothing had nothing to copy, and must not report the copy that
+	/// never happened as one that failed.
+	/// </summary>
+	[Fact]
+	public async Task A_run_with_no_text_does_not_claim_the_copy_failed()
+	{
+		using var image = new SoftwareBitmap(BitmapPixelFormat.Bgra8, 2, 2, BitmapAlphaMode.Premultiplied);
+		var clipboard = new TestClipboard { Image = image, FailWrites = int.MaxValue };
+		var manager = new TestableOcrManager(CreateValidSettings(), new StubOcrService(string.Empty), clipboard);
+
+		var result = await manager.ExtractTextFromClipboardImageAsync(DefaultOrder);
+
+		Assert.False(result.ClipboardCopyFailed);
+		Assert.Equal(0, clipboard.SetTextCalls);
+	}
+
+	/// <summary>
+	/// A batch says so too. Forty pages announced as "Results copied to the clipboard" when
+	/// they are not is the same lie, told to the user who waited longest for them.
+	/// </summary>
+	[Fact]
+	public async Task A_batch_that_could_not_be_copied_says_so_as_well()
+	{
+		var clipboard = new TestClipboard { FailWrites = int.MaxValue };
+		using var file = new TempFile(".png");
+		var manager = new TestableOcrManager(CreateValidSettings(), new StubOcrService("recognised text"), clipboard);
+
+		var result = await manager.ExtractTextFromFilesAsync(new[] { file.Path }, DefaultOrder, CancellationToken.None);
+
+		Assert.True(result.Success);
+		Assert.True(result.ClipboardCopyFailed);
+		Assert.Contains("recognised text", result.Text, StringComparison.Ordinal);
+	}
+
+	/// <summary>
+	/// Pressing an OCR shortcut while a capture is already on screen is refused rather than
+	/// failed. The distinction is the whole fix: the caller reads it to decide whether to send
+	/// the configured shortcut, and used to have nothing to read but the message text
+	/// (issue #342).
+	/// </summary>
+	[Fact]
+	public void A_second_capture_while_one_is_open_is_refused_rather_than_failed()
+	{
+		var result = OcrManager.CaptureAlreadyInProgress();
+
+		Assert.False(result.Success);
+		Assert.Equal(OcrRunOutcome.Refused, result.Outcome);
+		Assert.False(PostOperationHotkey.ShouldSendAfterOcr(result.Outcome));
+	}
+
+	/// <summary>
+	/// Every other unsuccessful run still sends it. An error in the OCR box wants reading as
+	/// much as a result does, and narrowing that to "only successes" would be a worse bug than
+	/// the one being fixed.
+	/// </summary>
+	[Fact]
+	public async Task An_ordinary_OCR_failure_still_gets_the_shortcut()
+	{
+		var settings = CreateValidSettings();
+		var manager = new TestableOcrManager(settings, new StubOcrService(), new TestClipboard());
+
+		var result = await manager.ExtractTextFromClipboardImageAsync(DefaultOrder);
+
+		Assert.False(result.Success);
+		Assert.Equal(OcrRunOutcome.Answered, result.Outcome);
+		Assert.True(PostOperationHotkey.ShouldSendAfterOcr(result.Outcome));
 	}
 
 	[Fact]
@@ -989,6 +1105,12 @@ public class OcrManagerTests
 		public string? LastText { get; private set; }
 		public int SetTextCalls { get; private set; }
 
+		/// <summary>
+		/// How many of the next writes throw the way a clipboard held open by another process
+		/// does. <see cref="int.MaxValue"/> for one that never lets go.
+		/// </summary>
+		public int FailWrites { get; set; }
+
 		// The image ExtractTextFromClipboardImageAsync will find. Null means "no image
 		// on the clipboard", which is the path that beeps failure.
 		public SoftwareBitmap? Image { get; set; }
@@ -996,6 +1118,16 @@ public class OcrManagerTests
 		public override void SetText(string text)
 		{
 			SetTextCalls++;
+			if (FailWrites > 0)
+			{
+				if (FailWrites != int.MaxValue)
+					FailWrites--;
+
+				// The real one is a COMException carrying CLIPBRD_E_CANT_OPEN. What matters
+				// here is only that the write throws, which is all the retry looks at.
+				throw new InvalidOperationException("OpenClipboard Failed (0x800401D0)");
+			}
+
 			LastText = text;
 		}
 

--- a/Mutation.Tests/PostOperationHotkeyCoverageTests.cs
+++ b/Mutation.Tests/PostOperationHotkeyCoverageTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -122,6 +122,20 @@ public class PostOperationHotkeyCoverageTests
 		Assert.True(unsent.Count == 0,
 			"An OCR result is shown to the user with no configured shortcut sent after it:\n" +
 			string.Join("\n", unsent));
+	}
+
+	[Fact]
+	public void Every_single_image_OCR_handler_publishes_through_the_one_method_that_sends()
+	{
+		var source = MainWindowSource();
+
+		// The four hotkey handlers and the four button handlers. Counted so that a ninth path
+		// added without going through PublishOcrResult is a failure here rather than a shortcut
+		// that silently never fires.
+		int publishes = LinesCalling(source,
+			line => line.Contains("PublishOcrResult(result", StringComparison.Ordinal)).Count;
+
+		Assert.Equal(8, publishes);
 	}
 
 	[Fact]

--- a/Mutation.Tests/PostOperationHotkeyTests.cs
+++ b/Mutation.Tests/PostOperationHotkeyTests.cs
@@ -30,4 +30,21 @@ public class PostOperationHotkeyTests
 		// one with text settling in it — has to be the longer of the two.
 		Assert.True(PostOperationHotkey.SuccessDelayMs > PostOperationHotkey.FailureDelayMs);
 	}
+
+	[Fact]
+	public void ARunThatWasRefusedSendsNothing()
+	{
+		// Pressing an OCR shortcut while a capture is already on screen changes nothing: the
+		// OCR box still holds the last run's answer, and what is in front of the user is a
+		// full-screen capture overlay. The shortcut would be typed into it (issue #342).
+		Assert.False(PostOperationHotkey.ShouldSendAfterOcr(OcrRunOutcome.Refused));
+	}
+
+	[Fact]
+	public void ARunThatReachedAnAnswerStillSendsIt()
+	{
+		// Including a failed one. Narrowing the send to successes would be a worse bug than
+		// the one being fixed — see the test above on the failure delay.
+		Assert.True(PostOperationHotkey.ShouldSendAfterOcr(OcrRunOutcome.Answered));
+	}
 }

--- a/Mutation.Ui/Core/ClaimedHotkeys.cs
+++ b/Mutation.Ui/Core/ClaimedHotkeys.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+using CognitiveSupport;
+
+namespace Mutation.Ui.Core;
+
+/// <summary>
+/// Every shortcut the app has been configured with, named, gathered from one settings object.
+/// <para>
+/// <see cref="Services.HotkeyRegistrationTable"/> is a single table for the whole app, so the
+/// three lists that fill it — the built-in shortcuts, the router's "From" chords, and the
+/// shortcut on each LLM prompt — compete for the same chords. Anything asking "is this one
+/// taken" has to see all three, and the prompt editor can see none of them on its own screen
+/// (issue #340).
+/// </para>
+/// </summary>
+internal static class ClaimedHotkeys
+{
+	/// <summary>
+	/// What one router mapping is called in a sentence. A route has no name of its own, and it
+	/// does not need one: its "From" chord is the chord being complained about, and the row
+	/// holding it is on the Hotkeys page where the user is being sent anyway.
+	/// </summary>
+	public const string RouteName = "a hotkey route";
+
+	/// <summary>
+	/// Everything except <paramref name="excludedPrompt"/>, which is the prompt being edited —
+	/// left out so its own saved shortcut is not reported as a clash with itself.
+	/// </summary>
+	public static IReadOnlyList<NamedHotkey> Excluding(Settings settings, LlmSettings.LlmPrompt? excludedPrompt)
+	{
+		if (settings is null) throw new ArgumentNullException(nameof(settings));
+
+		var claimed = new List<NamedHotkey>();
+
+		foreach (var spec in CoreHotkeys.All)
+			claimed.Add(new(spec.SpokenName, spec.Getter(settings), spec.Registers));
+
+		var mappings = settings.HotKeyRouterSettings?.Mappings;
+		if (mappings is not null)
+		{
+			foreach (var mapping in mappings)
+				claimed.Add(new(RouteName, mapping.FromHotKey, ClaimsTheChord: true));
+		}
+
+		var prompts = settings.LlmSettings?.Prompts;
+		if (prompts is not null)
+		{
+			foreach (var prompt in prompts)
+			{
+				// By reference, not by name: two prompts may share a name, and the one being
+				// edited is the object the editor was handed.
+				if (ReferenceEquals(prompt, excludedPrompt))
+					continue;
+
+				claimed.Add(new(NameOf(prompt), prompt.Hotkey, ClaimsTheChord: true));
+			}
+		}
+
+		return claimed;
+	}
+
+	/// <summary>
+	/// How a prompt is referred to in a clash message. Quoted, because a prompt's name is the
+	/// user's own words and could be anything — an unquoted "Already used by the prompt do the
+	/// thing." reads as a sentence that lost its ending.
+	/// </summary>
+	public static string NameOf(LlmSettings.LlmPrompt prompt)
+	{
+		string name = prompt?.Name ?? string.Empty;
+		return string.IsNullOrWhiteSpace(name) ? "an unnamed LLM prompt" : $"the LLM prompt \"{name.Trim()}\"";
+	}
+}

--- a/Mutation.Ui/Core/CoreHotkeys.cs
+++ b/Mutation.Ui/Core/CoreHotkeys.cs
@@ -1,0 +1,91 @@
+using CognitiveSupport;
+using Mutation.Ui.Views.SettingsUi;
+
+namespace Mutation.Ui.Core;
+
+/// <summary>
+/// Every shortcut the app itself owns, in the order the Hotkeys page shows them.
+/// <para>
+/// It lives here rather than on the settings page because two screens need it now. The page
+/// builds a row per entry; the prompt editor reads the same list to tell the user that the
+/// shortcut they are typing is already taken (issue #340). A second, hand-kept copy of this
+/// list in the prompt editor would go stale the first time a shortcut was added here.
+/// </para>
+/// </summary>
+internal static class CoreHotkeys
+{
+	public static readonly HotkeySpec[] All = new[]
+	{
+		new HotkeySpec("Toggle microphone mute",
+			s => s.AudioSettings?.MicrophoneToggleMuteHotKey,
+			(s, v) => (s.AudioSettings ??= new AudioSettings()).MicrophoneToggleMuteHotKey = v,
+			false, SettingsDefaults.Audio.MicrophoneToggleMuteHotKey),
+
+		new HotkeySpec("Take screenshot",
+			s => s.AzureComputerVisionSettings?.ScreenshotHotKey,
+			(s, v) => (s.AzureComputerVisionSettings ??= new AzureComputerVisionSettings()).ScreenshotHotKey = v,
+			false, SettingsDefaults.Ocr.ScreenshotHotKey),
+		new HotkeySpec("Screenshot + OCR",
+			s => s.AzureComputerVisionSettings?.ScreenshotOcrHotKey,
+			(s, v) => (s.AzureComputerVisionSettings ??= new AzureComputerVisionSettings()).ScreenshotOcrHotKey = v,
+			false, SettingsDefaults.Ocr.ScreenshotOcrHotKey),
+		new HotkeySpec("Screenshot + OCR (left-to-right)",
+			s => s.AzureComputerVisionSettings?.ScreenshotLeftToRightTopToBottomOcrHotKey,
+			(s, v) => (s.AzureComputerVisionSettings ??= new AzureComputerVisionSettings()).ScreenshotLeftToRightTopToBottomOcrHotKey = v,
+			false, SettingsDefaults.Ocr.ScreenshotLeftToRightTopToBottomOcrHotKey),
+		new HotkeySpec("OCR clipboard",
+			s => s.AzureComputerVisionSettings?.OcrHotKey,
+			(s, v) => (s.AzureComputerVisionSettings ??= new AzureComputerVisionSettings()).OcrHotKey = v,
+			false, SettingsDefaults.Ocr.OcrHotKey),
+		new HotkeySpec("OCR clipboard (left-to-right)",
+			s => s.AzureComputerVisionSettings?.OcrLeftToRightTopToBottomHotKey,
+			(s, v) => (s.AzureComputerVisionSettings ??= new AzureComputerVisionSettings()).OcrLeftToRightTopToBottomHotKey = v,
+			false, SettingsDefaults.Ocr.OcrLeftToRightTopToBottomHotKey),
+		new HotkeySpec("Send key after OCR (optional)",
+			s => s.AzureComputerVisionSettings?.SendHotkeyAfterOcrOperation,
+			(s, v) => (s.AzureComputerVisionSettings ??= new AzureComputerVisionSettings()).SendHotkeyAfterOcrOperation = v,
+			true, null, Registers: false),
+
+		new HotkeySpec("Speech to text",
+			s => s.SpeechToTextSettings?.SpeechToTextHotKey,
+			(s, v) => (s.SpeechToTextSettings ??= new SpeechToTextSettings()).SpeechToTextHotKey = v,
+			false, SettingsDefaults.Speech.SpeechToTextHotKey),
+		new HotkeySpec("Speech to text + process with LLM",
+			s => s.SpeechToTextSettings?.SpeechToTextWithLlmProcessingHotKey,
+			(s, v) => (s.SpeechToTextSettings ??= new SpeechToTextSettings()).SpeechToTextWithLlmProcessingHotKey = v,
+			false, SettingsDefaults.Speech.SpeechToTextWithLlmProcessingHotKey),
+		new HotkeySpec("Send key after transcription (optional)",
+			s => s.SpeechToTextSettings?.SendHotkeyAfterTranscriptionOperation,
+			(s, v) => (s.SpeechToTextSettings ??= new SpeechToTextSettings()).SendHotkeyAfterTranscriptionOperation = v,
+			true, null, Registers: false),
+
+		new HotkeySpec("Speak clipboard",
+			s => s.TextToSpeechSettings?.SpeakClipboard,
+			(s, v) => (s.TextToSpeechSettings ??= new TextToSpeechSettings()).SpeakClipboard = v,
+			false, SettingsDefaults.Tts.SpeakClipboard),
+		new HotkeySpec("Speak selection",
+			s => s.TextToSpeechSettings?.SpeakSelectionHotKey,
+			(s, v) => (s.TextToSpeechSettings ??= new TextToSpeechSettings()).SpeakSelectionHotKey = v,
+			false, SettingsDefaults.Tts.SpeakSelectionHotKey),
+		new HotkeySpec("Restart speech from beginning",
+			s => s.TextToSpeechSettings?.RestartFromBeginningHotKey,
+			(s, v) => (s.TextToSpeechSettings ??= new TextToSpeechSettings()).RestartFromBeginningHotKey = v,
+			false, SettingsDefaults.Tts.RestartFromBeginningHotKey),
+		new HotkeySpec("Skip sentence backward",
+			s => s.TextToSpeechSettings?.SkipSentenceBackwardHotKey,
+			(s, v) => (s.TextToSpeechSettings ??= new TextToSpeechSettings()).SkipSentenceBackwardHotKey = v,
+			false, SettingsDefaults.Tts.SkipSentenceBackwardHotKey),
+		new HotkeySpec("Skip sentence forward",
+			s => s.TextToSpeechSettings?.SkipSentenceForwardHotKey,
+			(s, v) => (s.TextToSpeechSettings ??= new TextToSpeechSettings()).SkipSentenceForwardHotKey = v,
+			false, SettingsDefaults.Tts.SkipSentenceForwardHotKey),
+		new HotkeySpec("Speak reading position",
+			s => s.TextToSpeechSettings?.SpeakPositionHotKey,
+			(s, v) => (s.TextToSpeechSettings ??= new TextToSpeechSettings()).SpeakPositionHotKey = v,
+			false, SettingsDefaults.Tts.SpeakPositionHotKey),
+		new HotkeySpec("Pause or resume reading",
+			s => s.TextToSpeechSettings?.PauseResumeHotKey,
+			(s, v) => (s.TextToSpeechSettings ??= new TextToSpeechSettings()).PauseResumeHotKey = v,
+			false, SettingsDefaults.Tts.PauseResumeHotKey),
+	};
+}

--- a/Mutation.Ui/Core/HotkeyClashDescription.cs
+++ b/Mutation.Ui/Core/HotkeyClashDescription.cs
@@ -21,9 +21,12 @@ internal static class HotkeyClashDescription
 	/// is free. Blank and half-typed text is free by definition — it cannot be registered, so
 	/// it cannot be taken.
 	/// </summary>
-	public static string? For(string? hotkey, IReadOnlyList<NamedHotkey> claimedElsewhere)
+	public static string? For(
+		string? hotkey,
+		IReadOnlyList<NamedHotkey> claimedElsewhere,
+		bool claimsTheChord = true)
 	{
-		var names = NamesHolding(hotkey, claimedElsewhere);
+		var names = NamesHolding(hotkey, claimedElsewhere, claimsTheChord);
 		return names.Count == 0 ? null : $"Already used by {JoinNames(names)}.";
 	}
 
@@ -40,7 +43,17 @@ internal static class HotkeyClashDescription
 	/// key is not claimed, unparseable text is not a chord — still decide each answer.
 	/// </para>
 	/// </summary>
-	public static IReadOnlyList<string> NamesHolding(string? hotkey, IReadOnlyList<NamedHotkey> claimedElsewhere)
+	/// <param name="claimsTheChord">
+	/// Whether <paramref name="hotkey"/> is claimed from Windows. True for a prompt's shortcut,
+	/// which is what the prompt editor asks about. False for a "Send key after…" value, which
+	/// is read differently — it may be a comma-separated sequence, and it may be spelled in
+	/// SendKeys shorthand. Left at true, <c>^{F5}</c> in such a box parses as nothing at all
+	/// and the answer comes back empty rather than naming what holds it.
+	/// </param>
+	public static IReadOnlyList<string> NamesHolding(
+		string? hotkey,
+		IReadOnlyList<NamedHotkey> claimedElsewhere,
+		bool claimsTheChord = true)
 	{
 		if (claimedElsewhere is null) throw new ArgumentNullException(nameof(claimedElsewhere));
 
@@ -48,7 +61,7 @@ internal static class HotkeyClashDescription
 		if (string.IsNullOrWhiteSpace(hotkey))
 			return names;
 
-		var mine = new[] { new HotkeyConflictFinder.ConfiguredHotkey(hotkey, ClaimsTheChord: true) };
+		var mine = new[] { new HotkeyConflictFinder.ConfiguredHotkey(hotkey, claimsTheChord) };
 
 		foreach (var other in claimedElsewhere)
 		{

--- a/Mutation.Ui/Core/HotkeyClashDescription.cs
+++ b/Mutation.Ui/Core/HotkeyClashDescription.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Mutation.Ui.Core;
+
+/// <summary>
+/// What to tell someone whose shortcut is already taken, and by what.
+/// <para>
+/// The Hotkeys page can say "Duplicate hotkey" and leave it there, because both ends of the
+/// clash are rows on the same screen and the user only has to look up. Neither the prompt
+/// editor nor a prompt's clash partner has that: a prompt is edited in its own window, so a
+/// bare "duplicate" sends the user hunting for something that is not in front of them
+/// (issues #336, #340).
+/// </para>
+/// </summary>
+internal static class HotkeyClashDescription
+{
+	/// <summary>
+	/// A sentence naming everything already holding <paramref name="hotkey"/>, or null when it
+	/// is free. Blank and half-typed text is free by definition — it cannot be registered, so
+	/// it cannot be taken.
+	/// </summary>
+	public static string? For(string? hotkey, IReadOnlyList<NamedHotkey> claimedElsewhere)
+	{
+		var names = NamesHolding(hotkey, claimedElsewhere);
+		return names.Count == 0 ? null : $"Already used by {JoinNames(names)}.";
+	}
+
+	/// <summary>
+	/// The names in <paramref name="claimedElsewhere"/> whose shortcut is the same chord as
+	/// <paramref name="hotkey"/>, in the order they were given, without repeats.
+	/// <para>
+	/// Asked one at a time rather than all at once, and that is the point.
+	/// <see cref="HotkeyConflictFinder.DuplicateIndexesAcross"/> answers "which entries clash
+	/// with <em>something</em>", which is the right question for a page that flags every row —
+	/// but it would also hand back two other prompts clashing with each other, and neither of
+	/// them is an answer to "what is holding mine". A list of one against a list of one asks
+	/// only about this pair, and the exclusions the finder settled in #306 and #320 — a sent
+	/// key is not claimed, unparseable text is not a chord — still decide each answer.
+	/// </para>
+	/// </summary>
+	public static IReadOnlyList<string> NamesHolding(string? hotkey, IReadOnlyList<NamedHotkey> claimedElsewhere)
+	{
+		if (claimedElsewhere is null) throw new ArgumentNullException(nameof(claimedElsewhere));
+
+		var names = new List<string>();
+		if (string.IsNullOrWhiteSpace(hotkey))
+			return names;
+
+		var mine = new[] { new HotkeyConflictFinder.ConfiguredHotkey(hotkey, ClaimsTheChord: true) };
+
+		foreach (var other in claimedElsewhere)
+		{
+			var across = HotkeyConflictFinder.DuplicateIndexesAcross(
+				new IReadOnlyList<HotkeyConflictFinder.ConfiguredHotkey>[] { mine, new[] { other.Configured } });
+
+			// One name per thing that holds it. Several routes can share a name, and reading
+			// "a hotkey route and a hotkey route" says nothing the first half did not.
+			if (across[0].Contains(0) && !names.Contains(other.Name, StringComparer.Ordinal))
+				names.Add(other.Name);
+		}
+
+		return names;
+	}
+
+	/// <summary>
+	/// "A", "A and B", "A, B and C" — read aloud, so the last pair is joined with a word
+	/// rather than a comma the reader would run straight through.
+	/// </summary>
+	private static string JoinNames(IReadOnlyList<string> names)
+	{
+		if (names.Count == 1)
+			return names[0];
+
+		string last = names[names.Count - 1];
+		string rest = string.Join(", ", names.Take(names.Count - 1));
+		return $"{rest} and {last}";
+	}
+}

--- a/Mutation.Ui/Core/HotkeySpec.cs
+++ b/Mutation.Ui/Core/HotkeySpec.cs
@@ -1,0 +1,53 @@
+using System;
+using CognitiveSupport;
+
+namespace Mutation.Ui.Core;
+
+/// <summary>
+/// One of the app's built-in shortcuts: what it is called, where its value lives in
+/// <see cref="Settings"/>, and how it behaves.
+/// </summary>
+/// <param name="Registers">
+/// Whether this shortcut is claimed from Windows. The "Send key after…" entries are typed
+/// out to whichever app is in front rather than registered, so two of them holding the same
+/// key is an ordinary way to set the app up and not a conflict — it used to be reported as
+/// one (issue #306). They are still checked against the shortcuts Mutation does claim,
+/// because Windows routes a synthesized keystroke back to whoever registered it.
+/// </param>
+internal sealed record HotkeySpec(
+	string Label,
+	Func<Settings, string?> Getter,
+	Action<Settings, string?> Setter,
+	bool AllowEmpty,
+	string? Default = null,
+	bool Registers = true)
+{
+	/// <summary>
+	/// Whether this row's box also accepts SendKeys syntax, the way the same two values
+	/// already do on the OCR and Speech pages. The Hotkeys page used to leave the flag off, so
+	/// a working <c>^{F5}</c> was read out there as "Unsupported key" — on the page whose job
+	/// is telling the user which shortcuts are wrong (issue #322).
+	/// <para>
+	/// It follows from <see cref="Registers"/> because the reason is the same one: a value
+	/// that is typed out rather than claimed is a keystroke to send, and a keystroke to
+	/// send is what SendKeys syntax spells. Derived rather than a flag of its own so the
+	/// two cannot be set to disagree — a row that is not registered but must be a plain
+	/// chord would need its own flag, and there is no such row.
+	/// </para>
+	/// </summary>
+	public bool AllowsSendKeysSyntax => !Registers;
+
+	/// <summary>
+	/// The label with any parenthesised aside dropped, for sentences that name this shortcut
+	/// rather than heading a row. "Send key after OCR (optional)" is the right header for a box
+	/// the user may leave blank, and the wrong thing to read out inside "Already used by…".
+	/// </summary>
+	public string SpokenName
+	{
+		get
+		{
+			int aside = Label.IndexOf(" (", StringComparison.Ordinal);
+			return aside < 0 ? Label : Label[..aside];
+		}
+	}
+}

--- a/Mutation.Ui/Core/NamedHotkey.cs
+++ b/Mutation.Ui/Core/NamedHotkey.cs
@@ -1,0 +1,22 @@
+using Mutation.Ui.Services;
+
+namespace Mutation.Ui.Core;
+
+/// <summary>
+/// A configured shortcut together with the name the user would recognise it by.
+/// <para>
+/// <see cref="HotkeyConflictFinder"/> answers in positions, which is all a page of rows needs
+/// — it flags the row and the user reads the header beside it. The prompt editor has no such
+/// row: the thing it clashes with is on another screen entirely, so the warning has to say
+/// what it is (issue #336). The name travels with the shortcut so the wording is decided in
+/// one place instead of at each screen that reports a clash.
+/// </para>
+/// </summary>
+/// <param name="Name">
+/// Read out inside a sentence — "Already used by <em>Speak clipboard</em>." — so it is phrased
+/// as a thing rather than as a row header, and carries its own article where it needs one.
+/// </param>
+internal readonly record struct NamedHotkey(string Name, string? Text, bool ClaimsTheChord)
+{
+	public HotkeyConflictFinder.ConfiguredHotkey Configured => new(Text, ClaimsTheChord);
+}

--- a/Mutation.Ui/Core/OcrRunOutcome.cs
+++ b/Mutation.Ui/Core/OcrRunOutcome.cs
@@ -1,0 +1,22 @@
+namespace Mutation.Ui.Core;
+
+/// <summary>
+/// What became of an OCR run, for the one decision that cannot be made from success alone:
+/// whether there is anything for the configured post-run shortcut to act on.
+/// </summary>
+public enum OcrRunOutcome
+{
+	/// <summary>
+	/// The run reached an answer — recognised text, or a message saying why not. Either is
+	/// worth reading, which is why the shortcut is sent after a failure as well as a success.
+	/// </summary>
+	Answered,
+
+	/// <summary>
+	/// The run never started, because a capture was already on screen. Nothing changed, there
+	/// is no new answer in the OCR box, and the full-screen capture overlay still has the
+	/// keyboard — so a shortcut sent now would land in the overlay rather than anywhere it was
+	/// aimed (issue #342).
+	/// </summary>
+	Refused,
+}

--- a/Mutation.Ui/Core/PostOperationHotkey.cs
+++ b/Mutation.Ui/Core/PostOperationHotkey.cs
@@ -27,4 +27,16 @@ internal static class PostOperationHotkey
 	/// it is text.
 	/// </summary>
 	public static int OcrDelay(bool success) => success ? SuccessDelayMs : FailureDelayMs;
+
+	/// <summary>
+	/// Whether an OCR run left anything for the shortcut to act on.
+	/// <para>
+	/// Sending after a failure is deliberate, and stays: an error in the OCR box wants reading
+	/// as much as a result does. A refusal is not that kind of failure. Pressing an OCR
+	/// shortcut while a capture is already on screen changes nothing — the OCR box still holds
+	/// the last run's answer — and the thing in front of the user at that moment is the capture
+	/// overlay, so the keystroke would be typed into it (issue #342).
+	/// </para>
+	/// </summary>
+	public static bool ShouldSendAfterOcr(OcrRunOutcome outcome) => outcome != OcrRunOutcome.Refused;
 }

--- a/Mutation.Ui/MainWindow.xaml.cs
+++ b/Mutation.Ui/MainWindow.xaml.cs
@@ -505,8 +505,7 @@ public sealed partial class MainWindow : Window, IDisposable
 				{
 					if (!await EnsureOcrConfiguredAsync()) return;
 					var result = await _ocrManager.TakeScreenshotAndExtractTextAsync(OcrReadingOrder.TopToBottomColumnAware);
-					SetOcrText(result.Message);
-					HotkeyManager.SendHotkeyAfterDelay(_settings.AzureComputerVisionSettings?.SendHotkeyAfterOcrOperation, PostOperationHotkey.OcrDelay(result.Success));
+					PublishOcrResult(result);
 				}
 				catch (Exception ex) { await ShowErrorDialog("Screenshot + OCR Error", ex); }
 			});
@@ -518,8 +517,7 @@ public sealed partial class MainWindow : Window, IDisposable
 				{
 					if (!await EnsureOcrConfiguredAsync()) return;
 					var result = await _ocrManager.TakeScreenshotAndExtractTextAsync(OcrReadingOrder.LeftToRightTopToBottom);
-					SetOcrText(result.Message);
-					HotkeyManager.SendHotkeyAfterDelay(_settings.AzureComputerVisionSettings?.SendHotkeyAfterOcrOperation, PostOperationHotkey.OcrDelay(result.Success));
+					PublishOcrResult(result);
 				}
 				catch (Exception ex) { await ShowErrorDialog("Screenshot + OCR (LRTB) Error", ex); }
 			});
@@ -531,8 +529,7 @@ public sealed partial class MainWindow : Window, IDisposable
 				{
 					if (!await EnsureOcrConfiguredAsync()) return;
 					var result = await _ocrManager.ExtractTextFromClipboardImageAsync(OcrReadingOrder.TopToBottomColumnAware);
-					SetOcrText(result.Message);
-					HotkeyManager.SendHotkeyAfterDelay(_settings.AzureComputerVisionSettings?.SendHotkeyAfterOcrOperation, PostOperationHotkey.OcrDelay(result.Success));
+					PublishOcrResult(result);
 				}
 				catch (Exception ex) { await ShowErrorDialog("OCR Clipboard Error", ex); }
 			});
@@ -544,8 +541,7 @@ public sealed partial class MainWindow : Window, IDisposable
 				{
 					if (!await EnsureOcrConfiguredAsync()) return;
 					var result = await _ocrManager.ExtractTextFromClipboardImageAsync(OcrReadingOrder.LeftToRightTopToBottom);
-					SetOcrText(result.Message);
-					HotkeyManager.SendHotkeyAfterDelay(_settings.AzureComputerVisionSettings?.SendHotkeyAfterOcrOperation, PostOperationHotkey.OcrDelay(result.Success));
+					PublishOcrResult(result);
 				}
 				catch (Exception ex) { await ShowErrorDialog("OCR Clipboard (LRTB) Error", ex); }
 			});
@@ -1020,8 +1016,7 @@ public sealed partial class MainWindow : Window, IDisposable
 		{
 			if (!await EnsureOcrConfiguredAsync()) return;
 			var result = await _ocrManager.TakeScreenshotAndExtractTextAsync(OcrReadingOrder.TopToBottomColumnAware);
-			SetOcrText(result.Message);
-			HotkeyManager.SendHotkeyAfterDelay(_settings.AzureComputerVisionSettings?.SendHotkeyAfterOcrOperation, PostOperationHotkey.OcrDelay(result.Success));
+			PublishOcrResult(result);
 			if (result.Success)
 				ShowStatus("Screenshot & OCR", "Text captured from screenshot.", InfoBarSeverity.Success);
 			else
@@ -1040,8 +1035,7 @@ public sealed partial class MainWindow : Window, IDisposable
 		{
 			if (!await EnsureOcrConfiguredAsync()) return;
 			var result = await _ocrManager.TakeScreenshotAndExtractTextAsync(OcrReadingOrder.LeftToRightTopToBottom);
-			SetOcrText(result.Message);
-			HotkeyManager.SendHotkeyAfterDelay(_settings.AzureComputerVisionSettings?.SendHotkeyAfterOcrOperation, PostOperationHotkey.OcrDelay(result.Success));
+			PublishOcrResult(result);
 			if (result.Success)
 				ShowStatus("Screenshot & OCR (left-to-right)", "Text captured from screenshot using left-to-right reading order.", InfoBarSeverity.Success);
 			else
@@ -1060,8 +1054,7 @@ public sealed partial class MainWindow : Window, IDisposable
 		{
 			if (!await EnsureOcrConfiguredAsync()) return;
 			var result = await _ocrManager.ExtractTextFromClipboardImageAsync(OcrReadingOrder.TopToBottomColumnAware);
-			SetOcrText(result.Message);
-			HotkeyManager.SendHotkeyAfterDelay(_settings.AzureComputerVisionSettings?.SendHotkeyAfterOcrOperation, PostOperationHotkey.OcrDelay(result.Success));
+			PublishOcrResult(result);
 			if (result.Success)
 				ShowStatus("OCR", "Clipboard image converted to text.", InfoBarSeverity.Success);
 			else
@@ -1164,7 +1157,15 @@ public sealed partial class MainWindow : Window, IDisposable
 			}
 			else if (result.Success)
 			{
-				ShowStatus("OCR documents", $"Processed {result.SuccessCount} document(s). Results copied to the clipboard.", InfoBarSeverity.Success);
+				// The clipboard half of this sentence is not a foregone conclusion: something
+				// else can hold the clipboard open through every retry, and telling the user
+				// their forty pages are on it when they are not is worse than saying nothing
+				// (issue #341). The text is in the OCR box either way.
+				(string clipboard, InfoBarSeverity severity) = result.ClipboardCopyFailed
+					? ("but they could not be copied to the clipboard. They are in the OCR results box.", InfoBarSeverity.Warning)
+					: ("Results copied to the clipboard.", InfoBarSeverity.Success);
+
+				ShowStatus("OCR documents", $"Processed {result.SuccessCount} document(s){(result.ClipboardCopyFailed ? ", " : ". ")}{clipboard}", severity);
 			}
 			else
 			{
@@ -1430,8 +1431,7 @@ public sealed partial class MainWindow : Window, IDisposable
 		{
 			if (!await EnsureOcrConfiguredAsync()) return;
 			var result = await _ocrManager.ExtractTextFromClipboardImageAsync(OcrReadingOrder.LeftToRightTopToBottom);
-			SetOcrText(result.Message);
-			HotkeyManager.SendHotkeyAfterDelay(_settings.AzureComputerVisionSettings?.SendHotkeyAfterOcrOperation, PostOperationHotkey.OcrDelay(result.Success));
+			PublishOcrResult(result);
 			if (result.Success)
 				ShowStatus("OCR (left-to-right)", "Clipboard image converted using left-to-right reading order.", InfoBarSeverity.Success);
 			else
@@ -3531,6 +3531,44 @@ public sealed partial class MainWindow : Window, IDisposable
 			summary += "; ...";
 
 		return summary;
+	}
+
+	/// <summary>
+	/// Said when the text was read but the clipboard would not take it. Both halves matter: the
+	/// user has to know the copy did not happen, and — because the shortcut that runs next is
+	/// usually a screen-reader command aimed at the result — that the text itself is not lost.
+	/// </summary>
+	private const string OcrClipboardCopyFailedMessage =
+		"The text was recognised, but it could not be copied to the clipboard. It is in the OCR results box.";
+
+	/// <summary>
+	/// Puts an OCR run's answer in front of the user: the text, or the error, in the OCR box;
+	/// then the shortcut configured to run afterwards; then a word about the clipboard if it
+	/// would not take the text.
+	/// <para>
+	/// One method for all eight single-image paths rather than the same three lines eight times.
+	/// A ninth path added without the send is how batch OCR came to have none (issue #335), and
+	/// the two things this now decides — that a refused capture sends nothing (issue #342), and
+	/// that a failed copy is said out loud (issue #341) — are decided once instead of eight
+	/// times.
+	/// </para>
+	/// <para>
+	/// The send goes before the status, not after. A status builds an automation peer and starts
+	/// a timer, the operation issue #234 was filed about throwing, and a throw there used to take
+	/// the shortcut with it after the text had already landed.
+	/// </para>
+	/// </summary>
+	private void PublishOcrResult(OcrResult result)
+	{
+		SetOcrText(result.Message);
+
+		if (PostOperationHotkey.ShouldSendAfterOcr(result.Outcome))
+			HotkeyManager.SendHotkeyAfterDelay(
+				_settings.AzureComputerVisionSettings?.SendHotkeyAfterOcrOperation,
+				PostOperationHotkey.OcrDelay(result.Success));
+
+		if (result.ClipboardCopyFailed)
+			ShowStatus("OCR", OcrClipboardCopyFailedMessage, InfoBarSeverity.Warning);
 	}
 
 	internal void SetOcrText(string message)

--- a/Mutation.Ui/MainWindow.xaml.cs
+++ b/Mutation.Ui/MainWindow.xaml.cs
@@ -1016,11 +1016,7 @@ public sealed partial class MainWindow : Window, IDisposable
 		{
 			if (!await EnsureOcrConfiguredAsync()) return;
 			var result = await _ocrManager.TakeScreenshotAndExtractTextAsync(OcrReadingOrder.TopToBottomColumnAware);
-			PublishOcrResult(result);
-			if (result.Success)
-				ShowStatus("Screenshot & OCR", "Text captured from screenshot.", InfoBarSeverity.Success);
-			else
-				ShowStatus("Screenshot & OCR", result.Message, InfoBarSeverity.Error);
+			PublishOcrResult(result, "Screenshot & OCR", "Text captured from screenshot.");
 		}
 		catch (Exception ex)
 		{
@@ -1035,11 +1031,7 @@ public sealed partial class MainWindow : Window, IDisposable
 		{
 			if (!await EnsureOcrConfiguredAsync()) return;
 			var result = await _ocrManager.TakeScreenshotAndExtractTextAsync(OcrReadingOrder.LeftToRightTopToBottom);
-			PublishOcrResult(result);
-			if (result.Success)
-				ShowStatus("Screenshot & OCR (left-to-right)", "Text captured from screenshot using left-to-right reading order.", InfoBarSeverity.Success);
-			else
-				ShowStatus("Screenshot & OCR (left-to-right)", result.Message, InfoBarSeverity.Error);
+			PublishOcrResult(result, "Screenshot & OCR (left-to-right)", "Text captured from screenshot using left-to-right reading order.");
 		}
 		catch (Exception ex)
 		{
@@ -1054,11 +1046,7 @@ public sealed partial class MainWindow : Window, IDisposable
 		{
 			if (!await EnsureOcrConfiguredAsync()) return;
 			var result = await _ocrManager.ExtractTextFromClipboardImageAsync(OcrReadingOrder.TopToBottomColumnAware);
-			PublishOcrResult(result);
-			if (result.Success)
-				ShowStatus("OCR", "Clipboard image converted to text.", InfoBarSeverity.Success);
-			else
-				ShowStatus("OCR", result.Message, InfoBarSeverity.Warning);
+			PublishOcrResult(result, "OCR", "Clipboard image converted to text.", InfoBarSeverity.Warning);
 		}
 		catch (Exception ex)
 		{
@@ -1431,11 +1419,7 @@ public sealed partial class MainWindow : Window, IDisposable
 		{
 			if (!await EnsureOcrConfiguredAsync()) return;
 			var result = await _ocrManager.ExtractTextFromClipboardImageAsync(OcrReadingOrder.LeftToRightTopToBottom);
-			PublishOcrResult(result);
-			if (result.Success)
-				ShowStatus("OCR (left-to-right)", "Clipboard image converted using left-to-right reading order.", InfoBarSeverity.Success);
-			else
-				ShowStatus("OCR (left-to-right)", result.Message, InfoBarSeverity.Warning);
+			PublishOcrResult(result, "OCR (left-to-right)", "Clipboard image converted using left-to-right reading order.", InfoBarSeverity.Warning);
 		}
 		catch (Exception ex)
 		{
@@ -3558,7 +3542,17 @@ public sealed partial class MainWindow : Window, IDisposable
 	/// the shortcut with it after the text had already landed.
 	/// </para>
 	/// </summary>
-	private void PublishOcrResult(OcrResult result)
+	/// <param name="statusTitle">
+	/// The heading for this path's status line, or null for the four hotkey paths, which have
+	/// no status of their own: the shortcut runs, the reader reads the OCR box, and a status
+	/// would be one more thing between the user and the answer. A failed copy is said even
+	/// then, because it is the only way they would learn of it.
+	/// </param>
+	private void PublishOcrResult(
+		OcrResult result,
+		string? statusTitle = null,
+		string? successMessage = null,
+		InfoBarSeverity failureSeverity = InfoBarSeverity.Error)
 	{
 		SetOcrText(result.Message);
 
@@ -3567,8 +3561,22 @@ public sealed partial class MainWindow : Window, IDisposable
 				_settings.AzureComputerVisionSettings?.SendHotkeyAfterOcrOperation,
 				PostOperationHotkey.OcrDelay(result.Success));
 
-		if (result.ClipboardCopyFailed)
-			ShowStatus("OCR", OcrClipboardCopyFailedMessage, InfoBarSeverity.Warning);
+		// The clipboard warning outranks the success line, and says so here rather than being
+		// followed by it. The four button paths used to announce their own success afterwards,
+		// which would leave the user believing a copy that did not happen.
+		if (result.Success && result.ClipboardCopyFailed)
+		{
+			ShowStatus(statusTitle ?? "OCR", OcrClipboardCopyFailedMessage, InfoBarSeverity.Warning);
+			return;
+		}
+
+		if (statusTitle is null)
+			return;
+
+		if (result.Success)
+			ShowStatus(statusTitle, successMessage ?? string.Empty, InfoBarSeverity.Success);
+		else
+			ShowStatus(statusTitle, result.Message, failureSeverity);
 	}
 
 	internal void SetOcrText(string message)

--- a/Mutation.Ui/Services/OcrManager.cs
+++ b/Mutation.Ui/Services/OcrManager.cs
@@ -1,5 +1,6 @@
 ﻿using CognitiveSupport;
 using Microsoft.UI.Xaml;
+using Mutation.Ui.Core;
 using Mutation.Ui.Views;
 using PdfSharp.Pdf;
 using PdfSharp.Pdf.IO;
@@ -25,8 +26,34 @@ using System.Runtime.CompilerServices;
 
 namespace Mutation.Ui.Services;
 
-public record OcrResult(bool Success, string Message);
-public record OcrBatchResult(bool Success, string Text, int TotalCount, int SuccessCount, IReadOnlyList<string> Failures);
+/// <param name="Message">The recognised text when <paramref name="Success"/>, otherwise why not.</param>
+/// <param name="Outcome">
+/// Whether this run produced an answer at all. Read instead of comparing
+/// <paramref name="Message"/> against a known string, which is how a refused run used to be
+/// told apart from a failed one — a decision that broke the moment anybody reworded a message.
+/// </param>
+/// <param name="ClipboardCopyFailed">
+/// True when there is recognised text here that did not reach the clipboard. It says something
+/// only alongside <c>Success</c>: a run that recognised nothing had nothing to copy, and does
+/// not report a copy that never happened as having failed (issue #341).
+/// </param>
+public record OcrResult(
+	bool Success,
+	string Message,
+	OcrRunOutcome Outcome = OcrRunOutcome.Answered,
+	bool ClipboardCopyFailed = false);
+
+/// <param name="ClipboardCopyFailed">
+/// As on <see cref="OcrResult"/>: the combined text was recognised but could not be put on the
+/// clipboard, so the run must not announce that the results were copied.
+/// </param>
+public record OcrBatchResult(
+	bool Success,
+	string Text,
+	int TotalCount,
+	int SuccessCount,
+	IReadOnlyList<string> Failures,
+	bool ClipboardCopyFailed = false);
 public record OcrProcessingProgress(int ProcessedSegments, int TotalSegments, string FileName, int PageNumber, int TotalPagesForFile);
 
 public class OcrManager
@@ -95,12 +122,30 @@ public class OcrManager
         }
     }
 
+    /// <summary>
+    /// The answer to a capture press that arrives while one is already on screen.
+    /// <para>
+    /// Refused, not failed. Nothing happened, the OCR box still holds the last run's answer,
+    /// and the thing in front of the user is the capture overlay — so the shortcut configured
+    /// to run after an OCR must not be sent, or it is typed into that overlay (issue #342).
+    /// The outcome carries that; the message used to be the only way to tell, which meant
+    /// rewording it would have quietly broken the decision.
+    /// </para>
+    /// <para>
+    /// Its own method so the outcome can be pinned by a test. Reaching this branch through
+    /// <see cref="TakeScreenshotAndExtractTextAsync"/> would need a real capture already on a
+    /// real screen (issue #304 is the same missing seam).
+    /// </para>
+    /// </summary>
+    internal static OcrResult CaptureAlreadyInProgress() =>
+        new(false, "Screenshot already in progress", OcrRunOutcome.Refused);
+
     public async Task<OcrResult> TakeScreenshotAndExtractTextAsync(OcrReadingOrder order)
     {
         if (Interlocked.CompareExchange(ref _captureInFlight, 1, 0) != 0)
         {
             try { _activeOverlay?.BringToFront(); } catch { }
-            return new(false, "Screenshot already in progress");
+            return CaptureAlreadyInProgress();
         }
         try
         {
@@ -230,13 +275,14 @@ public class OcrManager
         }
 
         string resultText = combinedText.ToString();
+        bool copied = true;
         if (successCount > 0 && !string.IsNullOrWhiteSpace(resultText))
-            await SetClipboardTextAsync(resultText);
+            copied = await TrySetClipboardTextAsync(resultText);
 
         bool success = successCount > 0 && failures.Count == 0;
         await PlayBeepSafeAsync(success ? BeepType.Success : BeepType.Failure);
 
-        return new(success, resultText, paths.Count, successCount, failures.AsReadOnly());
+        return new(success, resultText, paths.Count, successCount, failures.AsReadOnly(), ClipboardCopyFailed: !copied);
     }
 
     // Self-contained processing for a single file. Returns a FileOcrOutcome and never mutates
@@ -425,8 +471,12 @@ public class OcrManager
         try
         {
             var text = await _ocrService.ExtractText(order, netStream, default);
-            await SetClipboardTextAsync(text);
-            return new(true, text);
+
+            // Outside the catch on purpose. The read has already succeeded by this point, and a
+            // clipboard that will not open is not a reason to call the read a failure and put a
+            // COM error where the recognised text belongs (issue #341).
+            bool copied = await TrySetClipboardTextAsync(text);
+            return new(true, text, ClipboardCopyFailed: !copied);
         }
         catch (Exception ex)
         {
@@ -516,18 +566,39 @@ public class OcrManager
         return string.Equals(uri.Host, "placeholder.com", StringComparison.OrdinalIgnoreCase);
     }
 
-    private async Task SetClipboardTextAsync(string text)
+    /// <summary>
+    /// Puts <paramref name="text"/> on the clipboard, retrying while something else has it
+    /// open. True when it landed, or when there was nothing worth copying.
+    /// <para>
+    /// It used to be a bare <c>SetContent</c> with no retry, which the speech-to-text path had
+    /// already stopped doing. The window for losing the race is at its widest on the screenshot
+    /// path, which puts the <em>image</em> on the clipboard a moment earlier — exactly when a
+    /// clipboard manager or a screen reader opens the clipboard to look at what arrived. The
+    /// <c>CLIPBRD_E_CANT_OPEN</c> that came back was caught as an OCR failure, so a perfectly
+    /// good read was reported as a failed one and the shortcut that ran afterwards acted on the
+    /// screenshot still sitting there (issue #341).
+    /// </para>
+    /// </summary>
+    private Task<bool> TrySetClipboardTextAsync(string text)
     {
         if (string.IsNullOrWhiteSpace(text))
-            return;
+            return Task.FromResult(true);
 
-        if (HasDispatcherThreadAccess())
+        // The retry wraps the dispatcher hop rather than the other way round, so every attempt
+        // is made from the UI thread. ClipboardRetry waits with ConfigureAwait(false), so a
+        // ladder started on the UI thread resumes its second attempt on the thread pool — where
+        // the clipboard refuses the call for a second reason that no number of further attempts
+        // ever gets past.
+        return ClipboardRetry.TryAsync(() =>
         {
-            _clipboard.SetText(text);
-            return;
-        }
+            if (HasDispatcherThreadAccess())
+            {
+                _clipboard.SetText(text);
+                return Task.CompletedTask;
+            }
 
-        await RunOnDispatcherAsync(() => _clipboard.SetText(text));
+            return RunOnDispatcherAsync(() => _clipboard.SetText(text));
+        });
     }
 
     private static IReadOnlyList<FileOcrBatch> ExpandFileBatches(IReadOnlyList<string> paths)
@@ -803,7 +874,22 @@ public class OcrManager
                 Rect? selectionRect = await selectTask;
                 await beepTask;
                 if (selectionRect == null || selectionRect.Value.Width < 1 || selectionRect.Value.Height < 1)
+                {
+                    // Nothing was captured, so what follows is an error message and the shortcut
+                    // the user configured to read it — both aimed at the window the overlay took
+                    // the keyboard from. Waiting for the overlay to hand it back keeps that
+                    // shortcut out of the overlay, which the 50 ms failure delay could otherwise
+                    // beat (issue #342). Only on this branch: a capture that produced an image
+                    // goes on to spend hundreds of milliseconds reading it.
+                    //
+                    // Released before the wait rather than in the finally below. The overlay is
+                    // already hidden by now, and a hotkey press arriving during the wait is
+                    // answered by bringing the active overlay to the front — which would put
+                    // this one back on screen after it had finished standing down.
+                    _activeOverlay = null;
+                    await overlay.ForegroundHandedBack;
                     return null;
+                }
                 return await CropBitmapAsync(bmp, selectionRect.Value);
             }
             finally

--- a/Mutation.Ui/Services/PromptLibraryController.cs
+++ b/Mutation.Ui/Services/PromptLibraryController.cs
@@ -1,5 +1,6 @@
 using CognitiveSupport;
 using Microsoft.UI.Xaml.Controls;
+using Mutation.Ui.Core;
 using Mutation.Ui.Views;
 using System;
 using System.Collections.Generic;
@@ -78,7 +79,9 @@ internal sealed class PromptLibraryController
 		if (_settings.LlmSettings == null)
 			return;
 
-		var dialog = new PromptEditorWindow(null, _transcriptFormatter, GetAvailableModelNames(), _shutdownToken);
+		var dialog = new PromptEditorWindow(
+			null, _transcriptFormatter, GetAvailableModelNames(), _shutdownToken,
+			ClaimedHotkeys.Excluding(_settings, excludedPrompt: null));
 		dialog.Activate();
 		dialog.Closed += (_, _) =>
 		{
@@ -104,7 +107,11 @@ internal sealed class PromptLibraryController
 		if (prompt == null || _settings.LlmSettings == null)
 			return;
 
-		var dialog = new PromptEditorWindow(prompt, _transcriptFormatter, GetAvailableModelNames(), _shutdownToken);
+		// This prompt is left out of its own check: its saved shortcut is the one in the box,
+		// and a prompt cannot be a duplicate of itself.
+		var dialog = new PromptEditorWindow(
+			prompt, _transcriptFormatter, GetAvailableModelNames(), _shutdownToken,
+			ClaimedHotkeys.Excluding(_settings, prompt));
 		dialog.Activate();
 		dialog.Closed += (_, _) =>
 		{

--- a/Mutation.Ui/Views/PromptEditorWindow.xaml
+++ b/Mutation.Ui/Views/PromptEditorWindow.xaml
@@ -36,12 +36,23 @@
                      AutomationProperties.Name="Name"
                      AutomationProperties.HelpText="Name shown for this prompt in the prompt list."
                      Grid.Column="0" />
-            <controls:HotkeyEditor x:Name="HkPromptHotkey"
-                                   Header="Hotkey"
-                                   HelpText="Optional global shortcut that runs this prompt."
-                                   AllowEmpty="True"
-                                   Grid.Column="1"
-                                   VerticalAlignment="Bottom" />
+            <!-- The box and its clash warning move together, so the warning appearing
+                 cannot push the Model row about. The warning is its own assertive live
+                 region: it says the shortcut is already spoken for, and a user who cannot
+                 see the badge has to hear it as it appears rather than on the way past. -->
+            <StackPanel Grid.Column="1" Spacing="2" VerticalAlignment="Bottom">
+                <controls:HotkeyEditor x:Name="HkPromptHotkey"
+                                       Header="Hotkey"
+                                       HelpText="Optional global shortcut that runs this prompt."
+                                       AllowEmpty="True" />
+                <TextBlock x:Name="TxtHotkeyClash"
+                           Text=""
+                           Visibility="Collapsed"
+                           TextWrapping="Wrap"
+                           Foreground="OrangeRed"
+                           Style="{StaticResource CaptionTextBlockStyle}"
+                           AutomationProperties.LiveSetting="Assertive" />
+            </StackPanel>
 
             <ComboBox x:Name="CmbModel"
                       Header="Model"

--- a/Mutation.Ui/Views/PromptEditorWindow.xaml.cs
+++ b/Mutation.Ui/Views/PromptEditorWindow.xaml.cs
@@ -46,16 +46,26 @@ public sealed partial class PromptEditorWindow : Window
     // this editor's Closed handler alone does not cover that.
     private readonly CancellationToken _shutdownToken;
 
-    public PromptEditorWindow(
+    // Every shortcut the rest of the app has already claimed, with the name each one goes by.
+    // Snapshotted when the editor opens, which is when it is true: this window is effectively
+    // modal, so nothing else can take a shortcut while it is up.
+    private readonly IReadOnlyList<NamedHotkey> _claimedElsewhere;
+
+    // Internal rather than public because of the last argument: the shortcuts already claimed
+    // are described with an internal type, and everything that opens this window is in here.
+    internal PromptEditorWindow(
         LlmSettings.LlmPrompt? prompt,
         TranscriptFormatter formatter,
         IReadOnlyList<string> availableModels,
-        CancellationToken shutdownToken = default)
+        CancellationToken shutdownToken = default,
+        IReadOnlyList<NamedHotkey>? claimedElsewhere = null)
     {
         this.InitializeComponent();
         _formatter = formatter;
         _shutdownToken = shutdownToken;
+        _claimedElsewhere = claimedElsewhere ?? Array.Empty<NamedHotkey>();
         this.Closed += PromptEditorWindow_Closed;
+        HkPromptHotkey.HotkeyCommitted += HkPromptHotkey_HotkeyCommitted;
 
         _statusDismissTimer = new DispatcherTimer { Interval = StatusDismissDelay };
         _statusDismissTimer.Tick += StatusDismissTimer_Tick;
@@ -115,7 +125,35 @@ public sealed partial class PromptEditorWindow : Window
             }
             CmbModel.SelectedItem = desiredModel;
         }
+
+        // Checked as the window opens, not only after an edit. A prompt saved before the other
+        // end existed is already clashing, and the user opening it is exactly who needs to know.
+        ShowHotkeyClash();
     }
+
+    private void HkPromptHotkey_HotkeyCommitted(object? sender, string value) => ShowHotkeyClash();
+
+    /// <summary>
+    /// Says whether this shortcut is already claimed — by another prompt, by one of the app's
+    /// own shortcuts, or by a hotkey route.
+    /// <para>
+    /// The Hotkeys page checks its own rows against each other and against the prompts, so a
+    /// prompt clashing with a core hotkey or a route is flagged there. Nothing checked a prompt
+    /// against another prompt: two of them on <c>CTRL+ALT+P</c> looked right in both editors,
+    /// and whichever registered second came back in the "Some hotkeys could not be registered"
+    /// dialog after saving — the wrong moment to find out, and the last list where finding out
+    /// late was still possible (issue #340).
+    /// </para>
+    /// <para>
+    /// A warning, not a refusal. Registration is what actually fails, one shortcut is still
+    /// perfectly usable while the other is not, and taking the Save button away from someone
+    /// mid-edit is a worse answer than telling them plainly.
+    /// </para>
+    /// </summary>
+    private void ShowHotkeyClash() =>
+        LiveMessage.Show(
+            TxtHotkeyClash,
+            HotkeyClashDescription.For(HkPromptHotkey.Hotkey, _claimedElsewhere));
 
     private void BtnSave_Click(object sender, RoutedEventArgs e)
     {
@@ -281,6 +319,7 @@ public sealed partial class PromptEditorWindow : Window
     private void PromptEditorWindow_Closed(object sender, WindowEventArgs args)
     {
         this.Closed -= PromptEditorWindow_Closed;
+        HkPromptHotkey.HotkeyCommitted -= HkPromptHotkey_HotkeyCommitted;
         _closed = true;
         _statusDismissTimer.Stop();
         _statusDismissTimer.Tick -= StatusDismissTimer_Tick;

--- a/Mutation.Ui/Views/RegionSelectionWindow.xaml.cs
+++ b/Mutation.Ui/Views/RegionSelectionWindow.xaml.cs
@@ -29,6 +29,13 @@ public sealed partial class RegionSelectionWindow : Window
 	private IntPtr _previousForeground;
 	private readonly DispatcherQueue? _dispatcherQueue;
 
+	/// <summary>
+	/// Completed when <see cref="HideAndRestore"/> has finished with the foreground — either the
+	/// window that was in front before the overlay opened has the keyboard back, or the retry
+	/// ladder has given up on it.
+	/// </summary>
+	private TaskCompletionSource? _foregroundHandback;
+
 	// Keyboard path for the overlay, so the four screenshot/OCR hotkeys are completable
 	// without sight of the crosshair (issue #215).
 	private readonly KeyboardRegionSelector _keyboard = new();
@@ -807,43 +814,84 @@ public sealed partial class RegionSelectionWindow : Window
 		return success;
 	}
 
+	/// <summary>
+	/// Waits for the window that was in front before this overlay opened to get the keyboard
+	/// back, or for the attempt to be given up on. Already complete when there is nothing to
+	/// wait for.
+	/// <para>
+	/// A cancelled capture is followed by an error message and, 50 ms later, by whatever
+	/// shortcut the user configured to read it — and that shortcut lands wherever the keyboard
+	/// is. The restore below runs a ladder of retries at that same 50 ms spacing, so the two
+	/// used to race, and the shortcut could be typed into a capture overlay that had not
+	/// finished standing down (issue #342). A successful OCR is never affected: it spends
+	/// hundreds of milliseconds on the network first.
+	/// </para>
+	/// </summary>
+	public Task ForegroundHandedBack => _foregroundHandback?.Task ?? Task.CompletedTask;
+
 	private void HideAndRestore()
 	{
 		UninstallKeyboardHook();
+		// Runs continuations asynchronously so a waiter cannot resume inline on this thread and
+		// carry on with the rest of the capture in the middle of the handback.
+		var handback = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+		_foregroundHandback = handback;
+
 		try { this.AppWindow?.Hide(); } catch { }
 		if (TryRestoreForegroundWindow() || _previousForeground == IntPtr.Zero)
 		{
+			handback.TrySetResult();
 			return;
 		}
 		if (_dispatcherQueue is null)
 		{
+			handback.TrySetResult();
 			return;
 		}
-		_dispatcherQueue.TryEnqueue(DispatcherQueuePriority.Low, () =>
+		if (!_dispatcherQueue.TryEnqueue(DispatcherQueuePriority.Low, () =>
 		{
 			if (TryRestoreForegroundWindow() || _previousForeground == IntPtr.Zero)
 			{
+				handback.TrySetResult();
 				return;
 			}
 			_ = Task.Run(async () =>
 			{
-				await Task.Delay(FocusRetryDelayMilliseconds);
-				if (this._dispatcherQueue is DispatcherQueue queue)
+				// True once the last rung owns the completion. Until then this method does,
+				// because a waiter that is never released would hold up the message saying the
+				// capture was cancelled — worse than releasing it a moment early.
+				bool lastRungOwnsIt = false;
+				try
 				{
-					if (this._previousForeground == IntPtr.Zero)
+					await Task.Delay(FocusRetryDelayMilliseconds);
+					if (this._dispatcherQueue is DispatcherQueue queue && this._previousForeground != IntPtr.Zero)
 					{
-						return;
-					}
-					queue.TryEnqueue(DispatcherQueuePriority.Low, () =>
-					{
-						if (!this.TryRestoreForegroundWindow())
+						lastRungOwnsIt = queue.TryEnqueue(DispatcherQueuePriority.Low, () =>
 						{
-							this._previousForeground = IntPtr.Zero;
-						}
-					});
+							try
+							{
+								if (!this.TryRestoreForegroundWindow())
+								{
+									this._previousForeground = IntPtr.Zero;
+								}
+							}
+							finally
+							{
+								handback.TrySetResult();
+							}
+						});
+					}
+				}
+				finally
+				{
+					if (!lastRungOwnsIt)
+						handback.TrySetResult();
 				}
 			});
-		});
+		}))
+		{
+			handback.TrySetResult();
+		}
 	}
 
 	private void InstallKeyboardHook()

--- a/Mutation.Ui/Views/Settings/Pages/HotkeysSettingsPage.xaml.cs
+++ b/Mutation.Ui/Views/Settings/Pages/HotkeysSettingsPage.xaml.cs
@@ -168,14 +168,22 @@ public sealed partial class HotkeysSettingsPage : UserControl
 	/// — the badge names the prompt instead, which is the difference between a warning the user
 	/// can act on and one that only says something is wrong somewhere (issue #336).
 	/// </summary>
-	private static string PromptClashBadge(HotkeyRow row, IReadOnlyList<NamedHotkey> prompts)
+	/// <remarks>
+	/// Asked with the same two things the cross-list check was given — the saved value, not
+	/// what is in the box, and the row's own <see cref="HotkeySpec.Registers"/> flag — so the
+	/// two cannot disagree about what this row holds. The flag matters on the two "Send key
+	/// after…" rows: their value may be a comma-separated sequence or SendKeys shorthand, and
+	/// asking about it as though it were a single claimed chord parses <c>^{F5}</c> as nothing
+	/// and comes back with no name to show.
+	/// </remarks>
+	private string PromptClashBadge(HotkeyRow row, IReadOnlyList<NamedHotkey> prompts)
 	{
-		var names = HotkeyClashDescription.NamesHolding(row.Editor.Hotkey, prompts);
+		var names = HotkeyClashDescription.NamesHolding(
+			row.Spec.Getter(_settings), prompts, row.Spec.Registers);
 
-		// The cross-list check already said this row clashes with a prompt, so an empty answer
-		// here means the two disagree — which they can, because that check reads the saved
-		// setting and this one reads the box. Falling back keeps the badge honest rather than
-		// blank.
+		// A guard rather than an expected branch: the caller only reaches here because the
+		// cross-list check found a prompt clash on this row, and this asks the same question of
+		// the same values. A badge that named nothing would still be better than a blank one.
 		return names.Count == 0
 			? "Also used by an LLM prompt"
 			: $"Also used by {string.Join(", ", names)}";

--- a/Mutation.Ui/Views/Settings/Pages/HotkeysSettingsPage.xaml.cs
+++ b/Mutation.Ui/Views/Settings/Pages/HotkeysSettingsPage.xaml.cs
@@ -18,14 +18,6 @@ public sealed partial class HotkeysSettingsPage : UserControl
 {
 	private const string DuplicateBadgeText = "Duplicate hotkey";
 
-	/// <summary>
-	/// For a row whose only clash is with a prompt's own shortcut. The prompt is edited in its
-	/// own window rather than in a list on this page, so there is no second row here to look
-	/// at — saying "Duplicate hotkey" and leaving every visible row unflagged would send the
-	/// user hunting down the page for a partner that is not on it.
-	/// </summary>
-	private const string PromptClashBadgeText = "Also used by an LLM prompt";
-
 	private readonly Settings _settings;
 	private readonly List<HotkeyRow> _rows = new();
 	private readonly HotkeyRouterController _routerController;
@@ -53,37 +45,6 @@ public sealed partial class HotkeysSettingsPage : UserControl
 		_routerController.Initialize();
 	}
 
-	/// <param name="Registers">
-	/// Whether this shortcut is claimed from Windows. The "Send key after…" entries are typed
-	/// out to whichever app is in front rather than registered, so two of them holding the same
-	/// key is an ordinary way to set the app up and not a conflict — it used to be reported as
-	/// one (issue #306). They are still checked against the shortcuts Mutation does claim,
-	/// because Windows routes a synthesized keystroke back to whoever registered it.
-	/// </param>
-	internal sealed record HotkeySpec(
-		string Label,
-		Func<Settings, string?> Getter,
-		Action<Settings, string?> Setter,
-		bool AllowEmpty,
-		string? Default = null,
-		bool Registers = true)
-	{
-		/// <summary>
-		/// Whether this row's box also accepts SendKeys syntax, the way the same two values
-		/// already do on the OCR and Speech pages. This page used to leave the flag off, so a
-		/// working <c>^{F5}</c> was read out here as "Unsupported key" — on the page whose job
-		/// is telling the user which shortcuts are wrong (issue #322).
-		/// <para>
-		/// It follows from <see cref="Registers"/> because the reason is the same one: a value
-		/// that is typed out rather than claimed is a keystroke to send, and a keystroke to
-		/// send is what SendKeys syntax spells. Derived rather than a flag of its own so the
-		/// two cannot be set to disagree — a row that is not registered but must be a plain
-		/// chord would need its own flag, and there is no such row.
-		/// </para>
-		/// </summary>
-		public bool AllowsSendKeysSyntax => !Registers;
-	}
-
 	private sealed class HotkeyRow
 	{
 		public required HotkeySpec Spec { get; init; }
@@ -92,92 +53,13 @@ public sealed partial class HotkeysSettingsPage : UserControl
 		public required TextBlock DuplicateBadge { get; init; }
 	}
 
-	/// <summary>
-	/// Every row on the page, in the order it appears. Reachable from tests because the flags
-	/// on it decide what each box accepts, and the page itself cannot be built without a WinUI
-	/// host (issue #304 tracks that seam).
-	/// </summary>
-	internal static readonly HotkeySpec[] Specs = new[]
-	{
-		new HotkeySpec("Toggle microphone mute",
-			s => s.AudioSettings?.MicrophoneToggleMuteHotKey,
-			(s, v) => (s.AudioSettings ??= new AudioSettings()).MicrophoneToggleMuteHotKey = v,
-			false, SettingsDefaults.Audio.MicrophoneToggleMuteHotKey),
-
-		new HotkeySpec("Take screenshot",
-			s => s.AzureComputerVisionSettings?.ScreenshotHotKey,
-			(s, v) => (s.AzureComputerVisionSettings ??= new AzureComputerVisionSettings()).ScreenshotHotKey = v,
-			false, SettingsDefaults.Ocr.ScreenshotHotKey),
-		new HotkeySpec("Screenshot + OCR",
-			s => s.AzureComputerVisionSettings?.ScreenshotOcrHotKey,
-			(s, v) => (s.AzureComputerVisionSettings ??= new AzureComputerVisionSettings()).ScreenshotOcrHotKey = v,
-			false, SettingsDefaults.Ocr.ScreenshotOcrHotKey),
-		new HotkeySpec("Screenshot + OCR (left-to-right)",
-			s => s.AzureComputerVisionSettings?.ScreenshotLeftToRightTopToBottomOcrHotKey,
-			(s, v) => (s.AzureComputerVisionSettings ??= new AzureComputerVisionSettings()).ScreenshotLeftToRightTopToBottomOcrHotKey = v,
-			false, SettingsDefaults.Ocr.ScreenshotLeftToRightTopToBottomOcrHotKey),
-		new HotkeySpec("OCR clipboard",
-			s => s.AzureComputerVisionSettings?.OcrHotKey,
-			(s, v) => (s.AzureComputerVisionSettings ??= new AzureComputerVisionSettings()).OcrHotKey = v,
-			false, SettingsDefaults.Ocr.OcrHotKey),
-		new HotkeySpec("OCR clipboard (left-to-right)",
-			s => s.AzureComputerVisionSettings?.OcrLeftToRightTopToBottomHotKey,
-			(s, v) => (s.AzureComputerVisionSettings ??= new AzureComputerVisionSettings()).OcrLeftToRightTopToBottomHotKey = v,
-			false, SettingsDefaults.Ocr.OcrLeftToRightTopToBottomHotKey),
-		new HotkeySpec("Send key after OCR (optional)",
-			s => s.AzureComputerVisionSettings?.SendHotkeyAfterOcrOperation,
-			(s, v) => (s.AzureComputerVisionSettings ??= new AzureComputerVisionSettings()).SendHotkeyAfterOcrOperation = v,
-			true, null, Registers: false),
-
-		new HotkeySpec("Speech to text",
-			s => s.SpeechToTextSettings?.SpeechToTextHotKey,
-			(s, v) => (s.SpeechToTextSettings ??= new SpeechToTextSettings()).SpeechToTextHotKey = v,
-			false, SettingsDefaults.Speech.SpeechToTextHotKey),
-		new HotkeySpec("Speech to text + process with LLM",
-			s => s.SpeechToTextSettings?.SpeechToTextWithLlmProcessingHotKey,
-			(s, v) => (s.SpeechToTextSettings ??= new SpeechToTextSettings()).SpeechToTextWithLlmProcessingHotKey = v,
-			false, SettingsDefaults.Speech.SpeechToTextWithLlmProcessingHotKey),
-		new HotkeySpec("Send key after transcription (optional)",
-			s => s.SpeechToTextSettings?.SendHotkeyAfterTranscriptionOperation,
-			(s, v) => (s.SpeechToTextSettings ??= new SpeechToTextSettings()).SendHotkeyAfterTranscriptionOperation = v,
-			true, null, Registers: false),
-
-		new HotkeySpec("Speak clipboard",
-			s => s.TextToSpeechSettings?.SpeakClipboard,
-			(s, v) => (s.TextToSpeechSettings ??= new TextToSpeechSettings()).SpeakClipboard = v,
-			false, SettingsDefaults.Tts.SpeakClipboard),
-		new HotkeySpec("Speak selection",
-			s => s.TextToSpeechSettings?.SpeakSelectionHotKey,
-			(s, v) => (s.TextToSpeechSettings ??= new TextToSpeechSettings()).SpeakSelectionHotKey = v,
-			false, SettingsDefaults.Tts.SpeakSelectionHotKey),
-		new HotkeySpec("Restart speech from beginning",
-			s => s.TextToSpeechSettings?.RestartFromBeginningHotKey,
-			(s, v) => (s.TextToSpeechSettings ??= new TextToSpeechSettings()).RestartFromBeginningHotKey = v,
-			false, SettingsDefaults.Tts.RestartFromBeginningHotKey),
-		new HotkeySpec("Skip sentence backward",
-			s => s.TextToSpeechSettings?.SkipSentenceBackwardHotKey,
-			(s, v) => (s.TextToSpeechSettings ??= new TextToSpeechSettings()).SkipSentenceBackwardHotKey = v,
-			false, SettingsDefaults.Tts.SkipSentenceBackwardHotKey),
-		new HotkeySpec("Skip sentence forward",
-			s => s.TextToSpeechSettings?.SkipSentenceForwardHotKey,
-			(s, v) => (s.TextToSpeechSettings ??= new TextToSpeechSettings()).SkipSentenceForwardHotKey = v,
-			false, SettingsDefaults.Tts.SkipSentenceForwardHotKey),
-		new HotkeySpec("Speak reading position",
-			s => s.TextToSpeechSettings?.SpeakPositionHotKey,
-			(s, v) => (s.TextToSpeechSettings ??= new TextToSpeechSettings()).SpeakPositionHotKey = v,
-			false, SettingsDefaults.Tts.SpeakPositionHotKey),
-		new HotkeySpec("Pause or resume reading",
-			s => s.TextToSpeechSettings?.PauseResumeHotKey,
-			(s, v) => (s.TextToSpeechSettings ??= new TextToSpeechSettings()).PauseResumeHotKey = v,
-			false, SettingsDefaults.Tts.PauseResumeHotKey),
-	};
 
 	private void BuildRows()
 	{
 		HotkeyList.Children.Clear();
 		_rows.Clear();
 
-		foreach (var spec in Specs)
+		foreach (var spec in CoreHotkeys.All)
 		{
 			var editor = new HotkeyEditor
 			{
@@ -256,20 +138,22 @@ public sealed partial class HotkeysSettingsPage : UserControl
 
 		var routerRows = _routerController.ConfiguredFromHotkeys();
 
+		var prompts = NamedPromptHotkeys();
+
 		// Two passes rather than one, so a row can say which kind of clash it has. The prompt
 		// shortcuts take part in the check but have no rows on this page to flag, and a badge
 		// reading "Duplicate hotkey" beside seventeen unflagged rows would be a hunt with no
 		// quarry.
 		var onThisPage = HotkeyConflictFinder.DuplicateIndexesAcross([coreRows, routerRows]);
 		var everywhere = HotkeyConflictFinder.DuplicateIndexesAcross(
-			[coreRows, routerRows, ConfiguredPromptHotkeys()]);
+			[coreRows, routerRows, ConfiguredHotkeysOf(prompts)]);
 
 		for (int i = 0; i < _rows.Count; i++)
 		{
 			LiveMessage.Show(
 				_rows[i].DuplicateBadge,
 				onThisPage[0].Contains(i) ? DuplicateBadgeText
-					: everywhere[0].Contains(i) ? PromptClashBadgeText
+					: everywhere[0].Contains(i) ? PromptClashBadge(_rows[i], prompts)
 					: null);
 		}
 
@@ -279,19 +163,48 @@ public sealed partial class HotkeysSettingsPage : UserControl
 	}
 
 	/// <summary>
-	/// The shortcut on each LLM prompt. They are registered from the same table as everything
-	/// on this page, so they clash with it, but they are edited in the prompt window rather
-	/// than here — they take part in the check without being flagged by it.
+	/// For a row whose only clash is with a prompt's own shortcut. The prompt is edited in its
+	/// own window rather than in a list on this page, so there is no second row here to look at
+	/// — the badge names the prompt instead, which is the difference between a warning the user
+	/// can act on and one that only says something is wrong somewhere (issue #336).
 	/// </summary>
-	private IReadOnlyList<HotkeyConflictFinder.ConfiguredHotkey> ConfiguredPromptHotkeys()
+	private static string PromptClashBadge(HotkeyRow row, IReadOnlyList<NamedHotkey> prompts)
+	{
+		var names = HotkeyClashDescription.NamesHolding(row.Editor.Hotkey, prompts);
+
+		// The cross-list check already said this row clashes with a prompt, so an empty answer
+		// here means the two disagree — which they can, because that check reads the saved
+		// setting and this one reads the box. Falling back keeps the badge honest rather than
+		// blank.
+		return names.Count == 0
+			? "Also used by an LLM prompt"
+			: $"Also used by {string.Join(", ", names)}";
+	}
+
+	/// <summary>
+	/// The shortcut on each LLM prompt, with the prompt's name. They are registered from the
+	/// same table as everything on this page, so they clash with it, but they are edited in the
+	/// prompt window rather than here — they take part in the check without being flagged by it.
+	/// </summary>
+	private IReadOnlyList<NamedHotkey> NamedPromptHotkeys()
 	{
 		var prompts = _settings.LlmSettings?.Prompts;
 		if (prompts is null)
-			return Array.Empty<HotkeyConflictFinder.ConfiguredHotkey>();
+			return Array.Empty<NamedHotkey>();
 
-		var configured = new List<HotkeyConflictFinder.ConfiguredHotkey>(prompts.Count);
+		var named = new List<NamedHotkey>(prompts.Count);
 		foreach (var prompt in prompts)
-			configured.Add(new(prompt.Hotkey, ClaimsTheChord: true));
+			named.Add(new(ClaimedHotkeys.NameOf(prompt), prompt.Hotkey, ClaimsTheChord: true));
+
+		return named;
+	}
+
+	private static IReadOnlyList<HotkeyConflictFinder.ConfiguredHotkey> ConfiguredHotkeysOf(
+		IReadOnlyList<NamedHotkey> named)
+	{
+		var configured = new List<HotkeyConflictFinder.ConfiguredHotkey>(named.Count);
+		foreach (var entry in named)
+			configured.Add(entry.Configured);
 
 		return configured;
 	}


### PR DESCRIPTION
Closes #336. Closes #340. Closes #341. Closes #342.

Three fixes, each one about a moment where the app knew something and the user found
out later, or somewhere else, or not at all.

## The one list where a clash was still found out after the fact (#340, #336)

[#338](https://github.com/Subverting-complexity/Mutation/pull/338) made the Hotkeys page
check its rows, its router "From" chords and the per-prompt shortcuts as one list. That
left one pair unchecked: two prompts against each other. Neither has a row on that page,
so neither screen had anything to flag. Two prompts on `CTRL+ALT+P` looked right in both
editors, the user saved, and whichever registered second came back in the "Some hotkeys
could not be registered" dialog — the after-the-fact discovery #306 and #321 set out to
remove, on the last list either of them reached.

The prompt editor now says so while the shortcut is being typed, in a live region under
the **Hotkey** box, and **names what has it**: `Already used by the LLM prompt
"Summarize".` That naming is the other half of #336. A bare "duplicate" is enough on the
Hotkeys page, where both rows are on screen; it is useless here, where the other end is
on a screen the user is not looking at. The Hotkeys page badge names the prompt now for
the same reason — **Also used by the LLM prompt "Summarize"** rather than **Also used by
an LLM prompt**.

- `HotkeyClashDescription` asks about one candidate at a time rather than handing the
  whole set to `DuplicateIndexesAcross` at once. The finder answers "which entries clash
  with *something*", which is the right question for a page that flags every row and the
  wrong one here — it would hand back two other prompts clashing with each other,
  neither of which is holding the shortcut in the box.
- Both #320 exclusions survive unchanged, because every answer still goes through the
  finder: half-typed text is not a chord and clashes with nothing, and two "send key
  after" values are not a conflict. A sent key against a *prompt* still is — Windows
  routes the synthesized keystroke back to whoever claimed it, so the prompt would run
  itself.
- The prompt being edited is excluded by reference, not by name, so two prompts sharing
  a name cannot hide a real clash behind a coincidence.
- A warning, not a refusal. Registration is what actually fails, one of the two
  shortcuts still works, and taking the Save button away mid-edit is a worse answer than
  saying so plainly.

`HotkeysSettingsPage.Specs` moved to `Core/CoreHotkeys.cs` on the way. Two screens read
that list now, and a second hand-kept copy in the prompt editor would have gone stale
the first time a shortcut was added to the other one.

## A busy clipboard was reported as a failed reading (#341)

`OcrManager` copied with a bare `Clipboard.SetContent` and no retry, while the
speech-to-text path had already stopped doing that. The window is at its widest on the
screenshot path, which puts the *image* on the clipboard a moment earlier — exactly when
a clipboard manager or a screen reader opens the clipboard to see what arrived. The
`CLIPBRD_E_CANT_OPEN` was caught by the broad handler around the OCR call, so a
perfectly good read came back as a COM error where the text should have been, and the
shortcut that ran afterwards acted on whatever was on the clipboard before — which, for
a screenshot OCR, is the screenshot.

`OcrResult` gained the third piece of information the issue asked for, so a run can say
"read this, but it is not on your clipboard". The text goes in the OCR box either way
and the run still counts as a success, because the reading succeeded; a warning names
the clipboard.

The retry wraps the dispatcher hop rather than the other way round. `ClipboardRetry`
waits with `ConfigureAwait(false)`, so a ladder started on the UI thread resumes its
second attempt on the thread pool — where the clipboard refuses the call for a second
reason that no number of further attempts ever gets past. Worth knowing: the other
`ClipboardRetry` call sites have the same shape, so their retries are thinner than they
look. Not touched here — it is a separate change on paths this PR is not about.

The batch path stops claiming "Results copied to the clipboard." when they were not.

## A keystroke aimed at a window that was not there yet (#342)

Pressing an OCR shortcut while a capture is already on screen returned
`new(false, "Screenshot already in progress")`, and the handlers treated it like any
other unsuccessful OCR — so the configured shortcut was injected 50 ms later, into the
full-screen capture overlay.

Sending on failure is deliberate and stays: an error in the OCR box wants reading as
much as a result does. This is not that kind of failure. `OcrRunOutcome.Refused` says so
structurally, rather than by comparing the message text, which would have broken the
moment anybody reworded it.

The cancel case is a race rather than a category error. `TryRestoreForegroundWindow`
retries at 50 ms intervals and the failure delay is 50 ms, so the two could cross.
`RegionSelectionWindow.ForegroundHandedBack` completes when the ladder is done — every
rung of it, including the queue refusing the work, because a waiter never released would
hold up the message saying the capture was cancelled. A cancelled capture waits for it
before reporting. A successful one does not: it spends hundreds of milliseconds on the
network first, which is why this was never visible there.

`_activeOverlay` is cleared before that wait. It is what a re-entrant press is answered
by bringing to the front, and the overlay is already hidden by then — leaving it set
would put a window that had finished standing down back on screen.

## MainWindow

The eight single-image OCR handlers each published and sent in three lines of their own.
That is how batch OCR came to have no send at all (#335): eight things to remember, and
one of them forgotten. They go through one `PublishOcrResult` now, which is where the
two new decisions live — a refused run sends nothing, a failed copy is said out loud —
decided once instead of eight times.

`PostOperationHotkeyCoverageTests` moved with it. It pinned nine publish sites each
followed by a send; it now pins that there are only **two** places an OCR result reaches
the user and that both send, plus that all eight handlers go through the one that does.
Checked falsifiable both ways.

## Tests

2118 passing, 0 warnings. New coverage: the clash wording including the cases that must
*not* warn, the inventory including the by-reference exclusion, the refusal outcome, and
the clipboard — retried and landing, never opening and reported as a failed copy with
the text intact, and a run with no text not claiming a copy failed.

Two gaps stated rather than papered over. `PromptEditorWindow` and
`RegionSelectionWindow` both need a WinUI host the test project cannot start (#304), so
what is pinned is the unit each calls, not the wiring. The `ForegroundHandedBack` ladder
has no test at all for that reason.

## Guide

The AI prompts and Keyboard shortcuts chapters on the new warning and the named badge,
the OCR chapter on the retry and on the two times the post-run shortcut holds back, and
two troubleshooting entries. Markdown and HTML committed together.

## What to test

1. Give two prompts the same shortcut. The second editor should say so, by name, as you
   tab out of the **Hotkey** box — and say it out loud.
2. Give a prompt the same shortcut as **Speak clipboard**, then open the Hotkeys page:
   the **Speak clipboard** row should name the prompt.
3. Press **Screenshot + OCR**, and while the overlay is up press it again. The overlay
   should come to the front and nothing should be typed into it.
4. Cancel a capture with **Esc**. The shortcut should still fire, in the window you
   started from.
5. With a clipboard-history tool running, OCR a screenshot a few times. The text should
   land; if a copy ever does fail you should hear that the copy failed, not that the OCR
   did, and the text should be in the **OCR result** box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
