### PR TITLE
Let a router row's error be heard, not just seen (#346)

### DIFF
--- a/Documentation/UserGuide/html/keyboard-shortcuts.html
+++ b/Documentation/UserGuide/html/keyboard-shortcuts.html
@@ -481,8 +481,9 @@ the &quot;From&quot; box and <strong>Ctrl+Shift+M</strong> in the &quot;To&quot;
 are in, and the call mutes.</p>
 <p>To set one up, go to <strong>Settings</strong> (<strong>Ctrl+Comma</strong>), pick <strong>Hotkeys</strong>, and scroll
 down to the <strong>Hotkey Router</strong> section. Press <strong>Add mapping</strong>, fill in the &quot;From&quot;
-and &quot;To&quot; boxes, and press <strong>Save</strong>. Each row shows a small status marker: a tick
-once the mapping is live, or an error marker with a message if something is wrong.
+and &quot;To&quot; boxes, and press <strong>Save</strong>. If something is wrong with a row, a marker
+appears beside the &quot;From&quot; box and the reason is written underneath, where a screen
+reader reads it out as soon as it turns up.
 A mapping whose &quot;From&quot; combination is already taken gets a &quot;Duplicate 'From'
 hotkey&quot; message — again comparing the keys rather than the spelling. That covers
 another mapping, any shortcut higher up the Hotkeys page, and any of your prompt

--- a/Documentation/UserGuide/markdown/keyboard-shortcuts.md
+++ b/Documentation/UserGuide/markdown/keyboard-shortcuts.md
@@ -226,8 +226,9 @@ are in, and the call mutes.
 
 To set one up, go to **Settings** (**Ctrl+Comma**), pick **Hotkeys**, and scroll
 down to the **Hotkey Router** section. Press **Add mapping**, fill in the "From"
-and "To" boxes, and press **Save**. Each row shows a small status marker: a tick
-once the mapping is live, or an error marker with a message if something is wrong.
+and "To" boxes, and press **Save**. If something is wrong with a row, a marker
+appears beside the "From" box and the reason is written underneath, where a screen
+reader reads it out as soon as it turns up.
 A mapping whose "From" combination is already taken gets a "Duplicate 'From'
 hotkey" message — again comparing the keys rather than the spelling. That covers
 another mapping, any shortcut higher up the Hotkeys page, and any of your prompt

--- a/Mutation.Ui/HotkeyRouterEntry.cs
+++ b/Mutation.Ui/HotkeyRouterEntry.cs
@@ -276,12 +276,6 @@ public sealed class HotkeyRouterEntry : INotifyPropertyChanged
                 {
                         ApplyFormattedValue(ref _fromHotkeyText, _formattedFrom, nameof(FromHotkey));
 
-                        if (announce)
-                        {
-                                SetFromCommitAnnouncement(HotkeyCommitAnnouncement.For(
-                                        FromBoxLabel, typedBeforeCommit, _fromHotkeyText, FromErrorMessage));
-                        }
-
                         // Only update underlying map if valid; do NOT clear an existing persisted value here
                         // to avoid wiping settings when a parse hiccup occurs (e.g., at startup before full init).
                         if (_isFromValid)
@@ -301,6 +295,23 @@ public sealed class HotkeyRouterEntry : INotifyPropertyChanged
                 OnPropertyChanged(nameof(IsValid));
                 OnPropertyChanged(nameof(FromBackgroundBrush));
                 UpdateCombinedError();
+
+                // Last, after UpdateCombinedError, for the same reason HotkeyEditor.Commit
+                // announces last: the row's error is an assertive live region and this is a
+                // polite one, and both are raised on the same dispatcher pass in the order they
+                // were set, so a polite notice set first would be cut off by the assertive one
+                // behind it.
+                //
+                // No reachable flow actually sets both in one call — the error settles while the
+                // user types, a commit cannot change validity that the setter has not already
+                // seen, and the one thing that can (a duplicate found through the controller)
+                // suppresses the notice anyway. Ordered this way so the two conventions on this
+                // page agree, not to fix an audible clash (issue #346).
+                if (commit && announce)
+                {
+                        SetFromCommitAnnouncement(HotkeyCommitAnnouncement.For(
+                                FromBoxLabel, typedBeforeCommit, _fromHotkeyText, FromErrorMessage));
+                }
         }
 
         /// <param name="announce">See <see cref="EvaluateFrom"/>.</param>
@@ -314,12 +325,6 @@ public sealed class HotkeyRouterEntry : INotifyPropertyChanged
                 if (commit)
                 {
                         ApplyFormattedValue(ref _toHotkeyText, _formattedTo, nameof(ToHotkey));
-
-                        if (announce)
-                        {
-                                SetToCommitAnnouncement(HotkeyCommitAnnouncement.For(
-                                        ToBoxLabel, typedBeforeCommit, _toHotkeyText, _toValidationMessage));
-                        }
 
                         // Only update underlying map if valid; avoid clearing persisted value on transient invalid state.
                         if (_isToValid)
@@ -335,6 +340,13 @@ public sealed class HotkeyRouterEntry : INotifyPropertyChanged
                 OnPropertyChanged(nameof(IsValid));
                 OnPropertyChanged(nameof(ToBackgroundBrush));
                 UpdateCombinedError();
+
+                // Last, after UpdateCombinedError — see EvaluateFrom.
+                if (commit && announce)
+                {
+                        SetToCommitAnnouncement(HotkeyCommitAnnouncement.For(
+                                ToBoxLabel, typedBeforeCommit, _toHotkeyText, _toValidationMessage));
+                }
         }
 
         /// <summary>

--- a/Mutation.Ui/Views/Settings/Pages/HotkeysSettingsPage.xaml
+++ b/Mutation.Ui/Views/Settings/Pages/HotkeysSettingsPage.xaml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <UserControl
 	x:Class="Mutation.Ui.Views.SettingsUi.Pages.HotkeysSettingsPage"
 	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
@@ -57,6 +57,7 @@
 									<Grid.RowDefinitions>
 										<RowDefinition Height="Auto" />
 										<RowDefinition Height="Auto" />
+										<RowDefinition Height="Auto" />
 									</Grid.RowDefinitions>
 
 									<Grid Grid.Row="0" Grid.Column="0">
@@ -103,6 +104,31 @@
 										Click="HotkeyRouterDelete_Click"
 										Tag="{x:Bind}" />
 
+									<!-- What is wrong with this row: the validation message or the duplicate
+									     notice, whichever UpdateCombinedError picked. The marker beside the
+									     "From" box carries the same words, but a marker announces nothing
+									     when it appears — an AutomationProperties.Name is read when you land
+									     on the element, and you have to know it is there to land on it. So
+									     this row's errors reached this app's reader only by hunting, while
+									     the same message on the hotkey rows above has been read out since
+									     issue #243 (issue #346).
+
+									     Assertive, where the notices below are polite, so an error is not
+									     left queued behind a message about spelling. The two never both have
+									     something to say about one box — the notice stands down while the
+									     box has an error — so this is which of them interrupts, not a race
+									     between them. -->
+									<TextBlock
+										Grid.Row="1"
+										Grid.Column="0"
+										Grid.ColumnSpan="3"
+										views:LiveText.Message="{x:Bind BindingErrorMessage, Mode=OneWay}"
+										Foreground="{ThemeResource SystemFillColorCriticalBrush}"
+										Visibility="Collapsed"
+										AutomationProperties.LiveSetting="Assertive"
+										Style="{StaticResource CaptionTextBlockStyle}"
+										TextWrapping="Wrap" />
+
 									<!-- Says what the box above it rewrote itself to when the user left it.
 									     One region per box, under that box: the two are tabbed through one
 									     after the other, so a shared one would be taken down by entering
@@ -114,7 +140,7 @@
 									     caption would normally take: this app's reader is low-vision, and a
 									     message worth showing at all is worth being able to read. -->
 									<TextBlock
-										Grid.Row="1"
+										Grid.Row="2"
 										Grid.Column="0"
 										views:LiveText.Message="{x:Bind FromCommitAnnouncement, Mode=OneWay}"
 										Foreground="{ThemeResource TextFillColorPrimaryBrush}"
@@ -124,7 +150,7 @@
 										TextWrapping="Wrap" />
 
 									<TextBlock
-										Grid.Row="1"
+										Grid.Row="2"
 										Grid.Column="1"
 										views:LiveText.Message="{x:Bind ToCommitAnnouncement, Mode=OneWay}"
 										Foreground="{ThemeResource TextFillColorPrimaryBrush}"


### PR DESCRIPTION
Closes #346.

Found by an independent review of #338, and still true after #349.

## What was wrong

A router row's validation message and its "Duplicate 'From' hotkey." notice both end up in `BindingErrorMessage`. The only thing rendering it was a `FontIcon`:

```xml
<FontIcon Glyph="&#xE783;"
          Visibility="{x:Bind BindingErrorVisibility, Mode=OneWay}"
          AutomationProperties.Name="{x:Bind BindingErrorMessage, Mode=OneWay}"
          ToolTipService.ToolTip="{x:Bind BindingErrorMessage, Mode=OneWay}" />
```

An `AutomationProperties.Name` is read when you land on the element. It announces nothing when it changes, and you have to know it is there to land on it. The hotkey rows above have had a live region for this since #243.

It matters more since #332 and #321 landed:

- **#332** stands the rewrite notice down while the row has an error, on the stated grounds that the error is the more important thing to hear. That only pays if the error is said. The user got neither.
- **#321** flags both ends of a clash across the page's lists. The core row's duplicate badge is assertive and is heard; the router row's is not. Set **Speak clipboard** and a mapping's "From" to the same chord and you are told there is a conflict and not told where.

## What changed

An assertive live region across the row, bound through the same `LiveText` the polite notices use. The row grid gains a third row so the error sits under the boxes and the two notices move below it.

Both `Evaluate` methods now decide what to announce *after* settling the error rather than before, matching `HotkeyEditor.Commit`.

**Worth being straight about that second change.** No reachable flow sets both in one call: the error settles while the user types, a commit cannot change validity the setter has not already seen, and the one thing that can — a duplicate found through the controller cascade — suppresses the notice anyway. I wrote a test to pin the ordering, then reverted the change to check the test would catch it. It passed anyway, so it proved nothing and is not in this PR. The reorder stays because the two conventions on this page should agree, not because it fixes an audible clash. The XAML comment says the same.

## Not fixed here

**#350** — a row built from settings can already carry `"Enter a hotkey."` before it reaches the screen, so opening the page with several stored-but-invalid mappings queues one assertive interruption per row. The rewrite notice has a gate for exactly this (`announce: false` from the constructor) and the error region does not. The obvious gate — arm on first user commit — would also silence a duplicate that appears because the user edited a different list on the page, and gating the visible text along with the announcement would take the written error off screen at load. It also applies to the hotkey rows above, which already behave this way. That is a decision about the page's manners, not a patch.

## Testing

`dotnet test --configuration Release` — 2107 passed, 0 failed. No new tests: what changed is XAML wiring plus an ordering that, as above, nothing can observe. The seam that would cover the wiring is the one #304 tracks.

## User guide

The shortcut-router section promised "a tick once the mapping is live". `BindingStatusGlyph`, `BindingStatusBrush` and `BindingStatusTooltip` compute that marker and nothing has ever bound them, so the sentence now describes the error marker that does exist, and says it is read out. Filed as #343 rather than fixed: the Settings page's controller is never given a `HotkeyManager`, so binding the glyph as it stands would report "not currently bound" against every working route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)