### PR TITLE
Make claiming a story the first thing a session does, not the last

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,30 @@ continue to implementation. Never stop to ask "Ready to implement?"
 Work on **one story at a time** in a **fresh session per story**.
 Complete it (PR created) or mark it blocked before starting the next.
 
+### Claim the story first
+
+**Before reading any code**, for every story you pick up:
+
+1. `gh issue edit <n> --add-assignee @me --add-label status-in-progress --remove-label status-ready`
+2. Move its card to **In Progress** on the board.
+
+Then start. Not after planning, not at PR time — first.
+
+**An assigned issue is taken.** Pick a different one, whatever the board
+column says. The Ready column is not a claim, and neither is a lifecycle
+label on its own.
+
+More than one session runs against this repo at once, and the board is the
+only thing they share. On 2026-08-08 three sessions each picked #332, #321
+and #316 out of Ready, built the same fixes, and raced to merge: two
+sessions' work was thrown away, and the issues went from `status-ready`
+straight to closed with no session ever having claimed them. Claiming costs
+one command. Not claiming cost most of a session, twice.
+
+This applies whether or not you invoke a workflow skill. Going straight from
+the board to the code is exactly the path that skips the claim — which is
+how it happened.
+
 ### Build Principles
 
 - One responsibility per file.

--- a/ClaudeProject.md
+++ b/ClaudeProject.md
@@ -118,6 +118,11 @@ Stories signal eligibility for pickup via the **Ready** column on the
 project board. (A board with a "Ready" option is required and configured
 below.)
 
+**Ready means available, not unclaimed.** Sessions run concurrently here, so
+picking a story means assigning it to yourself and moving its card to **In
+Progress** before reading any code, and skipping any issue that already has
+an assignee. See "Claim the story first" in `CLAUDE.md`.
+
 ## Agent Gating
 
 | Setting       | Value      |


### PR DESCRIPTION
Process fix, no code. Prompted by three sessions colliding on the Ready column today.

## What happened

#332, #321 and #316 were each picked up by three concurrent sessions. All three built the same fixes. One merged; the other two were thrown away.

The label history says why plainly:

| | |
|---|---|
| `status-in-progress` ever applied | **never**, to any of the three, by anyone |
| #316 lifecycle transitions | `status-ready` → closed. Nothing in between. |
| #332 / #321 | one transition, `status-ready` → `status-in-review`, at **16:30** — when the PR opened, three and a half hours after work started |

By the time anything was recorded, the race was already lost.

## Why nobody did it

Claiming is a **separate opt-in step**. `start-story` exists and its whole job is "assign a story, update the board, and create a working branch" — but implementing a story does not require it, and the shortest path from "pick up stories from the Ready column" to working code goes straight past it.

Two things made it worse:

- **There was no claim signal to miss.** All three issues had no assignee, and `agent-gating: disabled` means any unassigned issue in Ready is fair game. A session that carefully checked for a claim would have found nothing distinguishing "available" from "someone is three hours into this."
- **Moving to In Review at PR time records history; it does not reserve anything.**

## The change

The rule goes in **`CLAUDE.md`**, not only in `ClaudeProject.md`. That is the load-bearing detail: the failure mode is a session that never invokes a workflow command at all, and `ClaudeProject.md` is only auto-loaded when one does. Putting it only there would leave it invisible on exactly the path that caused this.

- `CLAUDE.md` — "Claim the story first" under Story Execution: assign and move the card **before reading any code**, and treat an assignee as a hard stop whatever column the card sits in. One `gh issue edit` line, so there is no excuse about ceremony.
- `ClaudeProject.md` — one line under Ready Gate: Ready means available, not unclaimed, pointing at the above.

The `gh issue edit --add-assignee @me --add-label ... --remove-label ...` form in the rule is checked against `gh issue edit --help`; all three flags exist and compose.

## Testing

`dotnet test --configuration Release` — 2142 passed, 0 failed. Documentation only; the run is just the standard gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)