### PR TITLE
Put the OCR text where the user was working, not just on the clipboard

### DIFF
--- a/CognitiveSupport/Settings.cs
+++ b/CognitiveSupport/Settings.cs
@@ -126,6 +126,13 @@ public class AzureComputerVisionSettings
 	// If this is not null, this hotkey will be sent to the system after an OCR operation completes.
 	public string? SendHotkeyAfterOcrOperation { get; set; }
 
+	// Pastes the recognised text into whatever application had the keyboard, the way the
+	// dictation "Paste into 3rd party application" preference does. Sent just before
+	// SendHotkeyAfterOcrOperation, so a screen-reader command configured there reads the
+	// text where it landed. On by default; a settings file written before this existed has
+	// no such key, and keeping the initializer is what turns it on for those files too.
+	public bool PasteOcrTextIntoActiveApplication { get; set; } = true;
+
 	public string? ApiKey { get; set; }
 	public string? Endpoint { get; set; }
 	public int TimeoutSeconds { get; set; } = 10;

--- a/Documentation/UserGuide/html/screen-capture-and-ocr.html
+++ b/Documentation/UserGuide/html/screen-capture-and-ocr.html
@@ -269,6 +269,12 @@ labels this one <strong>(L→R)</strong>. Choose it for tables, spreadsheets, fo
 <p>In all four OCR cases the text lands on your clipboard, ready to paste, and also
 appears in the <strong>OCR result</strong> box at the bottom of the card so you can read it in
 place.</p>
+<p>Mutation also pastes it for you. Say you are writing an email, press <strong>Shift+Alt+J</strong>,
+and pick a rectangle off a web page: a moment later that text is sitting in your email,
+where the cursor was. You did not have to switch to Mutation or press <strong>Ctrl+V</strong>.</p>
+<p>This is the <strong>Paste OCR text into the active app</strong> setting, and it starts switched on.
+Turn it off if you would rather paste it yourself — see
+<a href="#a-few-settings-worth-knowing">A few settings worth knowing</a> below.</p>
 <p>You can follow all of this by ear.</p>
 <p>With <strong>Screenshot &amp; OCR</strong>, the start beep says the overlay is ready for you to pick a
 rectangle. The end beep says your picture has been captured and sent off to be read.</p>
@@ -318,11 +324,21 @@ you turn <strong>Use free tier</strong> off.</li>
 <li><strong>Max document size (MB)</strong> — any file or page bigger than this is skipped instead of
 being uploaded, so you never accidentally send something enormous. Set it to 0 to
 remove the limit.</li>
+<li><strong>Paste OCR text into the active app</strong> — on by default. Puts the text straight into
+whatever you were working in when the reading finishes. Switch it off and the text
+still goes to your clipboard and the <strong>OCR result</strong> box; you just paste it yourself.</li>
 </ul>
+<p>Mutation holds the paste back when there is nothing worth pasting: a reading that found
+no text, and a reading whose text could not reach the clipboard. It also holds back when
+you started the job from a button in the Mutation window rather than by shortcut, since
+&quot;the app you were working in&quot; is Mutation itself. That is why a batch of documents is
+copied but not pasted.</p>
 <p>There is also an optional <strong>Send hotkey after OCR</strong> setting, which fires a keystroke of
 your choosing once the text is ready — handy for kicking off your screen reader
 automatically. It is sent whether the run found text or failed, so a screen-reader
 shortcut in that box reads out the error just as readily as the result.</p>
+<p>It always comes after the paste, never before, so a screen-reader shortcut in that box
+reads the text that has just arrived rather than whatever was there a moment earlier.</p>
 <p>It is sent after a batch of documents as well, not only after a screenshot or a
 clipboard image. It is not sent if you cancel a batch, since nothing is copied then.</p>
 <p>Two more times it holds back rather than firing:</p>

--- a/Documentation/UserGuide/html/screen-capture-and-ocr.html
+++ b/Documentation/UserGuide/html/screen-capture-and-ocr.html
@@ -329,7 +329,9 @@ whatever you were working in when the reading finishes. Switch it off and the te
 still goes to your clipboard and the <strong>OCR result</strong> box; you just paste it yourself.</li>
 </ul>
 <p>Mutation holds the paste back when there is nothing worth pasting: a reading that found
-no text, and a reading whose text could not reach the clipboard. It also holds back when
+no text, and a reading whose text could not reach the clipboard. In both of those the
+clipboard still holds the picture, and pasting would put that picture in your document
+instead. It also holds back when
 you started the job from a button in the Mutation window rather than by shortcut, since
 &quot;the app you were working in&quot; is Mutation itself. That is why a batch of documents is
 copied but not pasted.</p>

--- a/Documentation/UserGuide/html/settings.html
+++ b/Documentation/UserGuide/html/settings.html
@@ -234,8 +234,12 @@ Leaving Advanced off simply hides that button.</p>
 <td>Biggest file or page Mutation will send. Anything larger is skipped before upload, so you never accidentally send something huge. Set it to 0 for no limit.</td>
 </tr>
 <tr>
+<td>Paste OCR text into the active app</td>
+<td>On by default. Puts the recognised text straight into whatever you were working in. Turn it off and the text still reaches your clipboard and the <strong>OCR result</strong> box.</td>
+</tr>
+<tr>
 <td>Send hotkey after OCR</td>
-<td>Optional keystrokes sent to the app you are in once the text is delivered — <strong>Ctrl+V</strong> to paste, for example.</td>
+<td>Optional keystrokes sent to the app you are in once the text has been delivered — a screen reader command that reads it back, for example. It comes after the paste above.</td>
 </tr>
 </tbody>
 </table>

--- a/Documentation/UserGuide/html/troubleshooting.html
+++ b/Documentation/UserGuide/html/troubleshooting.html
@@ -305,8 +305,9 @@ was. There are four reasons it would not.</p>
 <li>You started the reading with a button in the Mutation window instead of a shortcut.
 The app you were working in is then Mutation, so there is nowhere else to paste. Use
 the shortcut — <strong>Shift+Alt+J</strong> and friends — from the app you want the text in.</li>
-<li>The reading found no text, or its text never reached the clipboard. Both are covered
-by their own entries above.</li>
+<li>The reading found no text, or its text never reached the clipboard. Either way the
+clipboard still holds the picture, and pasting would drop that picture into your
+document. See the two entries just above this one.</li>
 <li>It was a batch of documents. Those are always started from the Mutation window, so
 the point above applies.</li>
 </ul>

--- a/Documentation/UserGuide/html/troubleshooting.html
+++ b/Documentation/UserGuide/html/troubleshooting.html
@@ -289,10 +289,31 @@ is in the OCR results box.&quot;</p>
 <p>This is not a failed reading. The text is there, in the <strong>OCR result</strong> box on the
 <strong>Visual Capture</strong> card, and any shortcut you set to run afterwards still fires, so a
 screen reader can read it out of the box as usual.</p>
+<p>Mutation does not paste it for you this time, though. Pasting takes the text off the
+clipboard, and the clipboard is exactly what did not get it — you would end up with
+whatever was there before, most likely the screenshot.</p>
 <p><strong>What to do.</strong> Copy the text out of the <strong>OCR result</strong> box, or press the OCR shortcut
 again — the second attempt almost always gets in. If it happens every time, a clipboard
 manager or clipboard-history tool is the usual culprit; closing it or turning off its
 monitoring settles it.</p>
+<h3 id="ocr-text-isnt-landing-in-the-app-im-working-in">OCR text isn't landing in the app I'm working in</h3>
+<p><strong>What's happening.</strong> Mutation normally pastes the recognised text where your cursor
+was. There are four reasons it would not.</p>
+<ul>
+<li>The <strong>Paste OCR text into the active app</strong> setting is switched off. It lives under
+<strong>Screen capture &amp; OCR</strong> in <strong>Settings</strong> (<strong>Ctrl+Comma</strong>), and is on by default.</li>
+<li>You started the reading with a button in the Mutation window instead of a shortcut.
+The app you were working in is then Mutation, so there is nowhere else to paste. Use
+the shortcut — <strong>Shift+Alt+J</strong> and friends — from the app you want the text in.</li>
+<li>The reading found no text, or its text never reached the clipboard. Both are covered
+by their own entries above.</li>
+<li>It was a batch of documents. Those are always started from the Mutation window, so
+the point above applies.</li>
+</ul>
+<p><strong>What to do.</strong> Check the setting first. If it is on and you used a shortcut, your
+text is still on the clipboard and in the <strong>OCR result</strong> box — paste it with
+<strong>Ctrl+V</strong>, and see <a href="#a-shortcut-does-nothing">A shortcut does nothing</a> if keystrokes
+Mutation sends never seem to arrive.</p>
 <h3 id="ocr-skipped-a-file-for-being-too-large">OCR skipped a file for being too large</h3>
 <p><strong>What's happening.</strong> There is a maximum size for a file or page sent for OCR, so a
 huge file cannot be uploaded by accident. Anything over it is skipped before upload,
@@ -350,8 +371,9 @@ window.&quot;</p>
 <li>Your text is not lost. Open the main window and copy it from there.</li>
 <li>Clipboard manager tools and remote-desktop sessions are the usual culprits. Closing
 or pausing one often fixes it for good.</li>
-<li>If you rely on the text landing in another app automatically, set the &quot;send keys
-after&quot; option to <strong>Ctrl+V</strong> so Mutation pastes for you once the copy succeeds.</li>
+<li>If you rely on the text landing in another app automatically, check <strong>Insert
+preference</strong> under <strong>Interface</strong> in <strong>Settings</strong>. Set to <em>Paste into 3rd party
+application</em>, Mutation pastes for you whenever the copy succeeds.</li>
 </ol>
 <h3 id="mutation-says-it-could-not-send-the-text-to-the-other-app">Mutation says it could not send the text to the other app</h3>
 <p><strong>What's happening.</strong> This is a different problem from the clipboard one above, and it

--- a/Documentation/UserGuide/markdown/screen-capture-and-ocr.md
+++ b/Documentation/UserGuide/markdown/screen-capture-and-ocr.md
@@ -162,7 +162,9 @@ These live under **Screen capture & OCR** in **Settings** (**Ctrl+Comma**).
   still goes to your clipboard and the **OCR result** box; you just paste it yourself.
 
 Mutation holds the paste back when there is nothing worth pasting: a reading that found
-no text, and a reading whose text could not reach the clipboard. It also holds back when
+no text, and a reading whose text could not reach the clipboard. In both of those the
+clipboard still holds the picture, and pasting would put that picture in your document
+instead. It also holds back when
 you started the job from a button in the Mutation window rather than by shortcut, since
 "the app you were working in" is Mutation itself. That is why a batch of documents is
 copied but not pasted.

--- a/Documentation/UserGuide/markdown/screen-capture-and-ocr.md
+++ b/Documentation/UserGuide/markdown/screen-capture-and-ocr.md
@@ -83,6 +83,14 @@ In all four OCR cases the text lands on your clipboard, ready to paste, and also
 appears in the **OCR result** box at the bottom of the card so you can read it in
 place.
 
+Mutation also pastes it for you. Say you are writing an email, press **Shift+Alt+J**,
+and pick a rectangle off a web page: a moment later that text is sitting in your email,
+where the cursor was. You did not have to switch to Mutation or press **Ctrl+V**.
+
+This is the **Paste OCR text into the active app** setting, and it starts switched on.
+Turn it off if you would rather paste it yourself — see
+[A few settings worth knowing](#a-few-settings-worth-knowing) below.
+
 You can follow all of this by ear.
 
 With **Screenshot & OCR**, the start beep says the overlay is ready for you to pick a
@@ -149,11 +157,23 @@ These live under **Screen capture & OCR** in **Settings** (**Ctrl+Comma**).
 - **Max document size (MB)** — any file or page bigger than this is skipped instead of
   being uploaded, so you never accidentally send something enormous. Set it to 0 to
   remove the limit.
+- **Paste OCR text into the active app** — on by default. Puts the text straight into
+  whatever you were working in when the reading finishes. Switch it off and the text
+  still goes to your clipboard and the **OCR result** box; you just paste it yourself.
+
+Mutation holds the paste back when there is nothing worth pasting: a reading that found
+no text, and a reading whose text could not reach the clipboard. It also holds back when
+you started the job from a button in the Mutation window rather than by shortcut, since
+"the app you were working in" is Mutation itself. That is why a batch of documents is
+copied but not pasted.
 
 There is also an optional **Send hotkey after OCR** setting, which fires a keystroke of
 your choosing once the text is ready — handy for kicking off your screen reader
 automatically. It is sent whether the run found text or failed, so a screen-reader
 shortcut in that box reads out the error just as readily as the result.
+
+It always comes after the paste, never before, so a screen-reader shortcut in that box
+reads the text that has just arrived rather than whatever was there a moment earlier.
 
 It is sent after a batch of documents as well, not only after a screenshot or a
 clipboard image. It is not sent if you cancel a batch, since nothing is copied then.

--- a/Documentation/UserGuide/markdown/settings.md
+++ b/Documentation/UserGuide/markdown/settings.md
@@ -63,7 +63,8 @@ Reading text out of pictures. OCR just means "pulling the words out of an image"
 | Use free tier | Use the free OCR tier, which limits how many pages each document can contain. |
 | Invert screenshot before OCR | Flips the image colours first, which helps a lot with light text on a dark background. |
 | Max document size (MB) | Biggest file or page Mutation will send. Anything larger is skipped before upload, so you never accidentally send something huge. Set it to 0 for no limit. |
-| Send hotkey after OCR | Optional keystrokes sent to the app you are in once the text is delivered — **Ctrl+V** to paste, for example. |
+| Paste OCR text into the active app | On by default. Puts the recognised text straight into whatever you were working in. Turn it off and the text still reaches your clipboard and the **OCR result** box. |
+| Send hotkey after OCR | Optional keystrokes sent to the app you are in once the text has been delivered — a screen reader command that reads it back, for example. It comes after the paste above. |
 
 The timeout and the "how many at a time" numbers have sensible defaults and hover
 help. Leave them alone unless something is timing out on you.

--- a/Documentation/UserGuide/markdown/troubleshooting.md
+++ b/Documentation/UserGuide/markdown/troubleshooting.md
@@ -171,10 +171,34 @@ This is not a failed reading. The text is there, in the **OCR result** box on th
 **Visual Capture** card, and any shortcut you set to run afterwards still fires, so a
 screen reader can read it out of the box as usual.
 
+Mutation does not paste it for you this time, though. Pasting takes the text off the
+clipboard, and the clipboard is exactly what did not get it — you would end up with
+whatever was there before, most likely the screenshot.
+
 **What to do.** Copy the text out of the **OCR result** box, or press the OCR shortcut
 again — the second attempt almost always gets in. If it happens every time, a clipboard
 manager or clipboard-history tool is the usual culprit; closing it or turning off its
 monitoring settles it.
+
+### OCR text isn't landing in the app I'm working in
+
+**What's happening.** Mutation normally pastes the recognised text where your cursor
+was. There are four reasons it would not.
+
+- The **Paste OCR text into the active app** setting is switched off. It lives under
+  **Screen capture & OCR** in **Settings** (**Ctrl+Comma**), and is on by default.
+- You started the reading with a button in the Mutation window instead of a shortcut.
+  The app you were working in is then Mutation, so there is nowhere else to paste. Use
+  the shortcut — **Shift+Alt+J** and friends — from the app you want the text in.
+- The reading found no text, or its text never reached the clipboard. Both are covered
+  by their own entries above.
+- It was a batch of documents. Those are always started from the Mutation window, so
+  the point above applies.
+
+**What to do.** Check the setting first. If it is on and you used a shortcut, your
+text is still on the clipboard and in the **OCR result** box — paste it with
+**Ctrl+V**, and see [A shortcut does nothing](#a-shortcut-does-nothing) if keystrokes
+Mutation sends never seem to arrive.
 
 ### OCR skipped a file for being too large
 
@@ -251,8 +275,9 @@ window."
 1. Your text is not lost. Open the main window and copy it from there.
 2. Clipboard manager tools and remote-desktop sessions are the usual culprits. Closing
    or pausing one often fixes it for good.
-3. If you rely on the text landing in another app automatically, set the "send keys
-   after" option to **Ctrl+V** so Mutation pastes for you once the copy succeeds.
+3. If you rely on the text landing in another app automatically, check **Insert
+   preference** under **Interface** in **Settings**. Set to *Paste into 3rd party
+   application*, Mutation pastes for you whenever the copy succeeds.
 
 ### Mutation says it could not send the text to the other app
 

--- a/Documentation/UserGuide/markdown/troubleshooting.md
+++ b/Documentation/UserGuide/markdown/troubleshooting.md
@@ -190,8 +190,9 @@ was. There are four reasons it would not.
 - You started the reading with a button in the Mutation window instead of a shortcut.
   The app you were working in is then Mutation, so there is nowhere else to paste. Use
   the shortcut — **Shift+Alt+J** and friends — from the app you want the text in.
-- The reading found no text, or its text never reached the clipboard. Both are covered
-  by their own entries above.
+- The reading found no text, or its text never reached the clipboard. Either way the
+  clipboard still holds the picture, and pasting would drop that picture into your
+  document. See the two entries just above this one.
 - It was a batch of documents. Those are always started from the Mutation window, so
   the point above applies.
 

--- a/Mutation.Tests/PostOperationHotkeyCoverageTests.cs
+++ b/Mutation.Tests/PostOperationHotkeyCoverageTests.cs
@@ -138,6 +138,36 @@ public class PostOperationHotkeyCoverageTests
 		Assert.Equal(8, publishes);
 	}
 
+	/// <summary>
+	/// The paste and the configured shortcut leave together, on every OCR path.
+	/// <para>
+	/// Split into two sends they would be two timers racing, and the loser decides whether the
+	/// screen-reader command reads the pasted text or what was on screen before it. Composing
+	/// them is also the only place that asks whether there is anything worth pasting, so a path
+	/// that passed the setting straight through would paste after a failed read (issue #355).
+	/// </para>
+	/// </summary>
+	[Fact]
+	public void Every_OCR_send_composes_the_paste_and_the_shortcut_as_one_sequence()
+	{
+		var source = MainWindowSource();
+
+		// Every read of the setting, wherever it sits relative to the send — the two OCR paths
+		// write the call differently, and a third would be free to write it a third way.
+		var reads = LinesCalling(source, line => line.Contains(OcrSetting, StringComparison.Ordinal));
+
+		Assert.NotEmpty(reads);
+
+		var bare = reads
+			.Where(line => !source[line].Contains("PostOperationHotkey.AfterOcr(", StringComparison.Ordinal))
+			.Select(line => $"MainWindow.xaml.cs:{line + 1}: {source[line].Trim()}")
+			.ToList();
+
+		Assert.True(bare.Count == 0,
+			"An OCR path sends the configured shortcut without composing the paste with it:\n" +
+			string.Join("\n", bare));
+	}
+
 	[Fact]
 	public void Every_transcript_delivery_is_followed_by_the_configured_shortcut()
 	{

--- a/Mutation.Tests/PostOperationHotkeyTests.cs
+++ b/Mutation.Tests/PostOperationHotkeyTests.cs
@@ -49,6 +49,34 @@ public class PostOperationHotkeyTests
 	}
 
 	[Fact]
+	public void ThereIsSomethingToPasteWhenTheTextReachedTheClipboard()
+	{
+		Assert.True(PostOperationHotkey.ClipboardHoldsOcrText(true, false, "Invoice 4021"));
+	}
+
+	[Fact]
+	public void AReadThatFoundNoTextLeavesThePictureOnTheClipboard()
+	{
+		// The trap this exists for. An empty read still comes back a success, and the copy is
+		// skipped rather than failed, because there was nothing to copy — so ClipboardCopyFailed
+		// is false and every other signal says go. What is actually on the clipboard is the
+		// screenshot the run put there a moment earlier, and pasting it drops a picture into
+		// whatever the user was writing.
+		Assert.False(PostOperationHotkey.ClipboardHoldsOcrText(true, false, ""));
+		Assert.False(PostOperationHotkey.ClipboardHoldsOcrText(true, false, "   \r\n"));
+		Assert.False(PostOperationHotkey.ClipboardHoldsOcrText(true, false, null));
+	}
+
+	[Fact]
+	public void AFailedReadAndAFailedCopyBothLeaveNothingToPaste()
+	{
+		// A failure puts its message in Message, so the text check alone would wave it through.
+		Assert.False(PostOperationHotkey.ClipboardHoldsOcrText(false, false, "No image on clipboard."));
+		// And a copy that never landed leaves the clipboard holding whatever preceded it (#341).
+		Assert.False(PostOperationHotkey.ClipboardHoldsOcrText(true, true, "Invoice 4021"));
+	}
+
+	[Fact]
 	public void ThePasteComesBeforeTheConfiguredShortcut()
 	{
 		// The whole reason the two travel as one sequence. The shortcut people put in "Send

--- a/Mutation.Tests/PostOperationHotkeyTests.cs
+++ b/Mutation.Tests/PostOperationHotkeyTests.cs
@@ -47,4 +47,52 @@ public class PostOperationHotkeyTests
 		// the one being fixed — see the test above on the failure delay.
 		Assert.True(PostOperationHotkey.ShouldSendAfterOcr(OcrRunOutcome.Answered));
 	}
+
+	[Fact]
+	public void ThePasteComesBeforeTheConfiguredShortcut()
+	{
+		// The whole reason the two travel as one sequence. The shortcut people put in "Send
+		// hotkey after OCR" is usually a screen-reader command aimed at the result, and a read
+		// that happens before the paste reads whatever was there before (issue #355).
+		Assert.Equal("Ctrl+V, ^{DEL}", PostOperationHotkey.AfterOcr(true, "^{DEL}"));
+	}
+
+	[Fact]
+	public void PastingIsAllTheresIsToSendWhenNoShortcutIsConfigured()
+	{
+		Assert.Equal("Ctrl+V", PostOperationHotkey.AfterOcr(true, null));
+		Assert.Equal("Ctrl+V", PostOperationHotkey.AfterOcr(true, "   "));
+	}
+
+	[Fact]
+	public void NotPastingLeavesTheConfiguredShortcutExactlyAsItWas()
+	{
+		Assert.Equal("^{DEL}", PostOperationHotkey.AfterOcr(false, "^{DEL}"));
+		Assert.Equal("Ctrl+C, Ctrl+V", PostOperationHotkey.AfterOcr(false, "Ctrl+C, Ctrl+V"));
+	}
+
+	[Fact]
+	public void NothingToPasteAndNothingConfiguredSendsNothing()
+	{
+		// Null rather than an empty string: SendHotkeyAfterDelay reads null as "no send", and
+		// an empty chord would otherwise reach the parser.
+		Assert.Null(PostOperationHotkey.AfterOcr(false, null));
+		Assert.Null(PostOperationHotkey.AfterOcr(false, ""));
+	}
+
+	[Fact]
+	public void ASurroundingSpaceInTheConfiguredValueDoesNotBecomeAnEmptyChord()
+	{
+		// The sequence is split on commas, so a stray space either side of the join would be
+		// harmless — but a value stored as " " must not turn into "Ctrl+V, " and read as two.
+		Assert.Equal("Ctrl+V, ^{DEL}", PostOperationHotkey.AfterOcr(true, "  ^{DEL}  "));
+	}
+
+	[Fact]
+	public void ThePasteChordIsSpelledTheWayTheParserReadsIt()
+	{
+		// "^v" would throw in Hotkey.Parse and drop the whole sequence — the configured
+		// shortcut included — to the WinForms fallback, which cannot confirm delivery (#232).
+		Assert.Equal("Ctrl+V", PostOperationHotkey.PasteChord);
+	}
 }

--- a/Mutation.Tests/SettingsDefaultsParityTests.cs
+++ b/Mutation.Tests/SettingsDefaultsParityTests.cs
@@ -52,6 +52,7 @@ public class SettingsDefaultsParityTests : IDisposable
 		Assert.Equal(SettingsDefaults.Ocr.MaxParallelDocuments, ocr.MaxParallelDocuments);
 		Assert.Equal(SettingsDefaults.Ocr.MaxParallelRequests, ocr.MaxParallelRequests);
 		Assert.Equal(SettingsDefaults.Ocr.MaxDocumentBytes, ocr.MaxDocumentBytes!.Value);
+		Assert.Equal(SettingsDefaults.Ocr.PasteOcrTextIntoActiveApplication, ocr.PasteOcrTextIntoActiveApplication);
 	}
 
 	[Fact]

--- a/Mutation.Ui/Core/PostOperationHotkey.cs
+++ b/Mutation.Ui/Core/PostOperationHotkey.cs
@@ -40,6 +40,20 @@ internal static class PostOperationHotkey
 	/// </summary>
 	public static bool ShouldSendAfterOcr(OcrRunOutcome outcome) => outcome != OcrRunOutcome.Refused;
 
+	/// <summary>
+	/// Whether an OCR run left its text on the clipboard, where a paste would find it.
+	/// <para>
+	/// The whitespace check is not tidiness. A read that recognised nothing still comes back
+	/// as a success with an empty message, and the copy is skipped rather than failed —
+	/// there was nothing to copy. What the clipboard still holds at that point is whatever
+	/// the run put there a moment earlier, which on the screenshot paths is the screenshot
+	/// itself and on the clipboard-image path is the source image. Pasting then puts a
+	/// picture into the user's document.
+	/// </para>
+	/// </summary>
+	public static bool ClipboardHoldsOcrText(bool success, bool clipboardCopyFailed, string? text) =>
+		success && !clipboardCopyFailed && !string.IsNullOrWhiteSpace(text);
+
 	/// <summary>The chord that pastes, spelled the way <c>Hotkey.Parse</c> reads it.</summary>
 	/// <remarks>
 	/// "Ctrl+V", not "^v": the parser has no caret syntax, so the shorthand would throw and drop

--- a/Mutation.Ui/Core/PostOperationHotkey.cs
+++ b/Mutation.Ui/Core/PostOperationHotkey.cs
@@ -39,4 +39,33 @@ internal static class PostOperationHotkey
 	/// </para>
 	/// </summary>
 	public static bool ShouldSendAfterOcr(OcrRunOutcome outcome) => outcome != OcrRunOutcome.Refused;
+
+	/// <summary>The chord that pastes, spelled the way <c>Hotkey.Parse</c> reads it.</summary>
+	/// <remarks>
+	/// "Ctrl+V", not "^v": the parser has no caret syntax, so the shorthand would throw and drop
+	/// the whole sequence to the WinForms fallback, which cannot say whether it was delivered.
+	/// </remarks>
+	public const string PasteChord = "Ctrl+V";
+
+	/// <summary>
+	/// Everything an OCR run sends to the other window, in order: the paste, when the user has
+	/// asked for the recognised text to land in the app they were working in, then whatever they
+	/// configured to run afterwards. Null when there is nothing to send.
+	/// <para>
+	/// One comma-separated string rather than two sends, because the order is the whole point.
+	/// The shortcut people put in "Send hotkey after OCR" is usually a screen-reader command
+	/// aimed at the result, and a command that reads before the paste arrives reads the wrong
+	/// thing. A single sequence is delivered chord by chord in order by <c>SendHotkey</c>, so
+	/// the two cannot race.
+	/// </para>
+	/// </summary>
+	public static string? AfterOcr(bool paste, string? configured)
+	{
+		string? trimmed = string.IsNullOrWhiteSpace(configured) ? null : configured.Trim();
+
+		if (!paste)
+			return trimmed;
+
+		return trimmed is null ? PasteChord : $"{PasteChord}, {trimmed}";
+	}
 }

--- a/Mutation.Ui/MainWindow.xaml.cs
+++ b/Mutation.Ui/MainWindow.xaml.cs
@@ -1140,7 +1140,7 @@ public sealed partial class MainWindow : Window, IDisposable
 			// this window still has the keyboard when it ends. That is the answer worth
 			// having: forty pages arriving in whatever control happens to be focused is not
 			// what the setting is for.
-			bool paste = ShouldPasteOcrText(result.Success, result.ClipboardCopyFailed);
+			bool paste = ShouldPasteOcrText(result.Success, result.ClipboardCopyFailed, result.Text);
 			HotkeyManager.SendHotkeyAfterDelay(
 				PostOperationHotkey.AfterOcr(paste, _settings.AzureComputerVisionSettings?.SendHotkeyAfterOcrOperation),
 				PostOperationHotkey.OcrDelay(result.Success));
@@ -3558,7 +3558,7 @@ public sealed partial class MainWindow : Window, IDisposable
 	{
 		SetOcrText(result.Message);
 
-		bool paste = ShouldPasteOcrText(result.Success, result.ClipboardCopyFailed);
+		bool paste = ShouldPasteOcrText(result.Success, result.ClipboardCopyFailed, result.Message);
 		if (PostOperationHotkey.ShouldSendAfterOcr(result.Outcome))
 			HotkeyManager.SendHotkeyAfterDelay(
 				PostOperationHotkey.AfterOcr(paste, _settings.AzureComputerVisionSettings?.SendHotkeyAfterOcrOperation),
@@ -3586,18 +3586,16 @@ public sealed partial class MainWindow : Window, IDisposable
 	/// Whether an OCR run should paste its text into the application the user was working in
 	/// before the shortcut configured to run afterwards.
 	/// <para>
-	/// Three ways the answer is no even when the setting is on, and all three are about there
-	/// being nothing worth pasting. A run that recognised nothing has no text; a run whose copy
-	/// failed left the clipboard holding whatever was there before — on the screenshot paths,
-	/// the screenshot itself (issue #341); and a run finished while this window still has the
-	/// keyboard was started from a button here, so the paste would land in Mutation rather than
-	/// anywhere the user meant.
+	/// Two ways the answer is no even when the setting is on. Either the clipboard does not
+	/// hold this run's text — see <see cref="PostOperationHotkey.ClipboardHoldsOcrText"/>, which
+	/// is where that gets decided — or this window still has the keyboard, which means the run
+	/// was started from a button here and the paste would land in Mutation rather than anywhere
+	/// the user meant.
 	/// </para>
 	/// </summary>
-	private bool ShouldPasteOcrText(bool success, bool clipboardCopyFailed) =>
+	private bool ShouldPasteOcrText(bool success, bool clipboardCopyFailed, string? text) =>
 		_settings.AzureComputerVisionSettings?.PasteOcrTextIntoActiveApplication == true
-		&& success
-		&& !clipboardCopyFailed
+		&& PostOperationHotkey.ClipboardHoldsOcrText(success, clipboardCopyFailed, text)
 		&& !IsThisWindowInForeground();
 
 	/// <summary>

--- a/Mutation.Ui/MainWindow.xaml.cs
+++ b/Mutation.Ui/MainWindow.xaml.cs
@@ -1134,8 +1134,15 @@ public sealed partial class MainWindow : Window, IDisposable
 			// Sent here rather than after the branches below, and only once the run has
 			// reached a result: a cancelled batch never gets this far, so the shortcut is
 			// not aimed at whatever the OCR box still held from last time (issue #335).
+			//
+			// The paste asks the same question the other eight paths ask and normally
+			// answers no here, because a batch is started from a picker in this window and
+			// this window still has the keyboard when it ends. That is the answer worth
+			// having: forty pages arriving in whatever control happens to be focused is not
+			// what the setting is for.
+			bool paste = ShouldPasteOcrText(result.Success, result.ClipboardCopyFailed);
 			HotkeyManager.SendHotkeyAfterDelay(
-				_settings.AzureComputerVisionSettings?.SendHotkeyAfterOcrOperation,
+				PostOperationHotkey.AfterOcr(paste, _settings.AzureComputerVisionSettings?.SendHotkeyAfterOcrOperation),
 				PostOperationHotkey.OcrDelay(result.Success));
 
 			if (result.SuccessCount == 0)
@@ -3452,13 +3459,8 @@ public sealed partial class MainWindow : Window, IDisposable
 		if (string.IsNullOrWhiteSpace(text))
 			return TranscriptDeliveryOutcome.Delivered;
 
-		var windowHandle = WindowNative.GetWindowHandle(this);
-		if (windowHandle != IntPtr.Zero)
-		{
-			var foregroundWindow = GetForegroundWindow();
-			if (foregroundWindow == windowHandle)
-				return TranscriptDeliveryOutcome.Delivered;
-		}
+		if (IsThisWindowInForeground())
+			return TranscriptDeliveryOutcome.Delivered;
 
 		switch (_insertOption)
 		{
@@ -3556,9 +3558,10 @@ public sealed partial class MainWindow : Window, IDisposable
 	{
 		SetOcrText(result.Message);
 
+		bool paste = ShouldPasteOcrText(result.Success, result.ClipboardCopyFailed);
 		if (PostOperationHotkey.ShouldSendAfterOcr(result.Outcome))
 			HotkeyManager.SendHotkeyAfterDelay(
-				_settings.AzureComputerVisionSettings?.SendHotkeyAfterOcrOperation,
+				PostOperationHotkey.AfterOcr(paste, _settings.AzureComputerVisionSettings?.SendHotkeyAfterOcrOperation),
 				PostOperationHotkey.OcrDelay(result.Success));
 
 		// The clipboard warning outranks the success line, and says so here rather than being
@@ -3577,6 +3580,35 @@ public sealed partial class MainWindow : Window, IDisposable
 			ShowStatus(statusTitle, successMessage ?? string.Empty, InfoBarSeverity.Success);
 		else
 			ShowStatus(statusTitle, result.Message, failureSeverity);
+	}
+
+	/// <summary>
+	/// Whether an OCR run should paste its text into the application the user was working in
+	/// before the shortcut configured to run afterwards.
+	/// <para>
+	/// Three ways the answer is no even when the setting is on, and all three are about there
+	/// being nothing worth pasting. A run that recognised nothing has no text; a run whose copy
+	/// failed left the clipboard holding whatever was there before — on the screenshot paths,
+	/// the screenshot itself (issue #341); and a run finished while this window still has the
+	/// keyboard was started from a button here, so the paste would land in Mutation rather than
+	/// anywhere the user meant.
+	/// </para>
+	/// </summary>
+	private bool ShouldPasteOcrText(bool success, bool clipboardCopyFailed) =>
+		_settings.AzureComputerVisionSettings?.PasteOcrTextIntoActiveApplication == true
+		&& success
+		&& !clipboardCopyFailed
+		&& !IsThisWindowInForeground();
+
+	/// <summary>
+	/// True when Mutation's own window has the keyboard, so injected keystrokes aimed at "the
+	/// active application" would land back here. Treated as false when the handle cannot be
+	/// read: the delivery paths would rather try and fail visibly than silently do nothing.
+	/// </summary>
+	private bool IsThisWindowInForeground()
+	{
+		var windowHandle = WindowNative.GetWindowHandle(this);
+		return windowHandle != IntPtr.Zero && GetForegroundWindow() == windowHandle;
 	}
 
 	internal void SetOcrText(string message)

--- a/Mutation.Ui/Resources/HelpText.xaml
+++ b/Mutation.Ui/Resources/HelpText.xaml
@@ -17,7 +17,8 @@
 	<x:String x:Key="Help.Ocr.UseFreeTier">Use the free OCR tier, which limits how many pages each document can contain.</x:String>
 	<x:String x:Key="Help.Ocr.InvertScreenshot">Invert image colors before OCR to improve accuracy on light text over a dark background.</x:String>
 	<x:String x:Key="Help.Ocr.MaxDocumentSize">Maximum size of a file or page sent for OCR. Larger files are skipped before upload to avoid unexpectedly large uploads. Set to 0 for no limit.</x:String>
-	<x:String x:Key="Help.Ocr.SendHotkeyAfter">Optional keystrokes sent to the active app after OCR text is delivered, for example CTRL+V to paste.</x:String>
+	<x:String x:Key="Help.Ocr.PasteIntoActiveApp">Paste the recognised text into whatever app you were working in, as soon as OCR finishes. The text is always copied to the clipboard; this decides whether Mutation also pastes it for you.</x:String>
+	<x:String x:Key="Help.Ocr.SendHotkeyAfter">Optional keystrokes sent to the active app once the OCR text has been delivered, for example a screen reader command that reads it back.</x:String>
 
 	<!-- Interface -->
 	<x:String x:Key="Help.Interface.MaxVisibleLines">Caps the height of the transcript and OCR text boxes on the main window.</x:String>

--- a/Mutation.Ui/Services/HotkeyManager.cs
+++ b/Mutation.Ui/Services/HotkeyManager.cs
@@ -317,6 +317,7 @@ public class HotkeyManager : IDisposable
 			return true;
 
 		bool allSentViaInput = true;
+		int sent = 0;
 		foreach (var part in parts)
 		{
 			try
@@ -337,6 +338,8 @@ public class HotkeyManager : IDisposable
 					allSentViaInput = false;
 					break;
 				}
+				++sent;
+
 				// Small gap between chords. Thread.Sleep is acceptable here because:
 				// - This runs on a background thread via Task.Run
 				// - The delay is very short (25ms)
@@ -353,11 +356,19 @@ public class HotkeyManager : IDisposable
 
 		if (!allSentViaInput)
 		{
-			// Fallback: try WinForms SendKeys mapping for complex/unsupported chords
+			// Fallback: try WinForms SendKeys mapping for complex/unsupported chords.
+			//
+			// Only the chords that have not gone yet. The loop above stops at the first one
+			// SendInput cannot express, and everything before it has already arrived in the
+			// target window — handing the whole sequence to SendKeys would send those a second
+			// time. Harmless for an idempotent chord, not harmless for a paste: OCR now sends
+			// "Ctrl+V, <your shortcut>" as one sequence, so an unexpressible shortcut behind the
+			// paste would have put the text in twice (issue #355).
+			string remaining = string.Join(", ", parts.Skip(sent));
 			try
 			{
-				string mappedHotkey = SendKeysMapper.Map(hotkey);
-				Log($"Fallback SendKeys: '{mappedHotkey}' (from '{hotkey}')");
+				string mappedHotkey = SendKeysMapper.Map(remaining);
+				Log($"Fallback SendKeys: '{mappedHotkey}' (from '{remaining}')");
 				SendKeysOnUiThread(mappedHotkey);
 			}
 			catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"SendKeys fallback failed: {ex.Message}"); }

--- a/Mutation.Ui/Views/Settings/Pages/OcrSettingsPage.xaml
+++ b/Mutation.Ui/Views/Settings/Pages/OcrSettingsPage.xaml
@@ -93,6 +93,11 @@
 			<controls:InfoHint Text="{StaticResource Help.Ocr.InvertScreenshot}" VerticalAlignment="Center" />
 		</StackPanel>
 
+		<StackPanel Orientation="Horizontal" Spacing="6">
+			<ToggleSwitch x:Name="TogglePasteOcrText" Header="Paste OCR text into the active app" AutomationProperties.HelpText="{StaticResource Help.Ocr.PasteIntoActiveApp}" Toggled="TogglePasteOcrText_Toggled" />
+			<controls:InfoHint Text="{StaticResource Help.Ocr.PasteIntoActiveApp}" VerticalAlignment="Center" />
+		</StackPanel>
+
 		<controls:HotkeyEditor x:Name="HkSendAfterOcr" Header="Send hotkey after OCR (optional)" HelpText="{StaticResource Help.Ocr.SendHotkeyAfter}" AllowEmpty="True" AllowSendKeysSyntax="True" />
 
 		<TextBlock Text="OCR action hotkeys appear in the Hotkeys tab."

--- a/Mutation.Ui/Views/Settings/Pages/OcrSettingsPage.xaml.cs
+++ b/Mutation.Ui/Views/Settings/Pages/OcrSettingsPage.xaml.cs
@@ -47,6 +47,7 @@ public sealed partial class OcrSettingsPage : UserControl
 				: 0;
 			ToggleUseFreeTier.IsOn = ocr.UseFreeTier;
 			ToggleInvert.IsOn = ocr.InvertScreenshot;
+			TogglePasteOcrText.IsOn = ocr.PasteOcrTextIntoActiveApplication;
 			HkSendAfterOcr.Hotkey = ocr.SendHotkeyAfterOcrOperation ?? string.Empty;
 		}
 		finally { _suppressEvents = false; }
@@ -89,6 +90,12 @@ public sealed partial class OcrSettingsPage : UserControl
 	{
 		if (_suppressEvents) return;
 		(_settings.AzureComputerVisionSettings ??= new AzureComputerVisionSettings()).InvertScreenshot = ToggleInvert.IsOn;
+	}
+
+	private void TogglePasteOcrText_Toggled(object sender, RoutedEventArgs e)
+	{
+		if (_suppressEvents) return;
+		(_settings.AzureComputerVisionSettings ??= new AzureComputerVisionSettings()).PasteOcrTextIntoActiveApplication = TogglePasteOcrText.IsOn;
 	}
 
 	private void WriteInt(double value, System.Action<int> apply)

--- a/Mutation.Ui/Views/Settings/SettingsDefaults.cs
+++ b/Mutation.Ui/Views/Settings/SettingsDefaults.cs
@@ -34,6 +34,7 @@ internal static class SettingsDefaults
 		public const int MaxParallelRequestsLimit = 20;
 		public const long MaxDocumentBytes = 10L * 1024 * 1024;
 		public const int MaxDocumentSizeMbUiMax = 500;
+		public const bool PasteOcrTextIntoActiveApplication = true;
 	}
 
 	public static class Speech

--- a/Mutation.Ui/Views/SettingsDialog.xaml.cs
+++ b/Mutation.Ui/Views/SettingsDialog.xaml.cs
@@ -87,7 +87,7 @@ public sealed partial class SettingsDialog : ContentDialog
 		_allCategories.Add(new SettingsCategoryItem("audio", "Audio", "Microphone capture, mute hotkey, beeps.", "",
 			new[] { "audio", "microphone", "capture", "mute", "beep", "visualization" }));
 		_allCategories.Add(new SettingsCategoryItem("ocr", "Screen capture & OCR", "Screenshot automation, OCR, Azure vision.", "",
-			new[] { "ocr", "azure", "screenshot", "vision", "endpoint", "free tier" }));
+			new[] { "ocr", "azure", "screenshot", "vision", "endpoint", "free tier", "paste" }));
 		_allCategories.Add(new SettingsCategoryItem("speech", "Speech to Text", "Transcription providers and recording behavior.", "",
 			new[] { "speech", "stt", "whisper", "deepgram", "transcription", "temp directory", "timeout" }));
 		_allCategories.Add(new SettingsCategoryItem("apikeys", "API keys", "Central provider keys: OpenAI, Anthropic, Deepgram.", "",

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ Mutation supports two OCR reading orders via Azure **Computer Vision**:
 | `ScreenshotOcrHotKey` | Take a screenshot and OCR it with **Natural** layout in one step. |
 | `OcrLeftToRightTopToBottomHotKey` | OCR the clipboard image with **Basic** layout. |
 | `ScreenshotLeftToRightTopToBottomOcrHotKey` | Take a screenshot and OCR it with **Basic** layout in one step. |
-| `SendHotkeyAfterOcrOperation` | Sends a specified hotkey after OCR completes (e.g., to trigger screen reader). |
+| `PasteOcrTextIntoActiveApplication` | Pastes the recognised text into the app that had the keyboard when OCR finishes. On by default; the text is copied to the clipboard either way. |
+| `SendHotkeyAfterOcrOperation` | Sends a specified hotkey after OCR completes (e.g., to trigger screen reader). Sent after the paste above, so a reader command reads what landed. |
 
 **Selecting the region with the keyboard:**
 
@@ -198,6 +199,7 @@ All hotkeys are global and fully customisable. Below is an example covering ever
     "OcrLeftToRightTopToBottomHotKey": "Ctrl+Shift+L",
     "ScreenshotLeftToRightTopToBottomOcrHotKey": "Ctrl+Shift+K",
     "SendHotkeyAfterOcrOperation": "Ctrl+Alt+C",
+    "PasteOcrTextIntoActiveApplication": true,
     "InvertScreenshot": false,
     "UseFreeTier": true,
     "FreeTierPageLimit": 2,


### PR DESCRIPTION
Closes #355.

## What was wrong

Not a regression, despite how it was reported. No commit in this repo has ever
pasted OCR text — the paste people remember is dictation's, which has its own
**Insert preference** set to *Paste into 3rd party application*. OCR only ever
copied to the clipboard and sent the single configurable **Send hotkey after OCR**.

`%TEMP%\Mutation.Hotkey.log` shows the difference plainly:

```
23:25:08.042 WM_HOTKEY received: id=11        <- dictation
23:25:09.228 Sending via SendInput: 'Ctrl+V'
23:25:09.398 SendHotkeyAfterDelay firing: '^{DEL}'
23:25:10.972 WM_HOTKEY received: id=4         <- OCR
23:25:11.021 SendHotkeyAfterDelay firing: '^{DEL}'
```

For anyone whose after-OCR hotkey is a screen-reader command — which is what that
box is for — the recognised text never reaches the place they were typing.

## What changed

A new OCR setting, `PasteOcrTextIntoActiveApplication`, on by default, with a
**Paste OCR text into the active app** switch on the **Screen capture & OCR**
settings page. A settings file written before this existed has no such key, so the
property initializer is what turns it on for existing installs too.

The paste and the configured shortcut travel as one comma-separated sequence
through the existing delayed send, not as two sends. `SendHotkey` delivers a
sequence chord by chord in order, so a screen-reader command cannot read before
the text it is aimed at has arrived. Composing them is `PostOperationHotkey.AfterOcr`,
next to the other "what gets sent after an OCR run" decisions, and unit-tested.

Four cases hold the paste back, all of them "there is nothing worth pasting":

| Case | Why |
|---|---|
| The run recognised nothing | No text |
| The clipboard write failed (#341) | The clipboard still holds what was there — on the screenshot paths, the screenshot |
| The capture was refused (#342) | Nothing ran; already covered by `ShouldSendAfterOcr` |
| Mutation still has the keyboard | Started from a button here, so "the active application" is Mutation. Covers all four button paths and every batch of documents |

That last guard is the one dictation already had, inlined in
`TryInsertIntoActiveApplicationAsync`. It moved into `IsThisWindowInForeground()`
and both call it.

## Files

- `CognitiveSupport/Settings.cs` — the setting
- `Mutation.Ui/Core/PostOperationHotkey.cs` — `AfterOcr`, `PasteChord`
- `Mutation.Ui/MainWindow.xaml.cs` — both OCR send sites, the two new guards
- `Mutation.Ui/Views/Settings/Pages/OcrSettingsPage.xaml[.cs]` — the switch
- `Mutation.Ui/Resources/HelpText.xaml` — new help text; the **Send hotkey after
  OCR** hint no longer offers CTRL+V as its example, since pasting is not that
  box's job any more
- `Mutation.Ui/Views/SettingsDialog.xaml.cs` — "paste" now finds the OCR page

## Tests

`dotnet test --configuration Release` — **2149 passed, 0 failed**.

Seven new: six on `AfterOcr` (ordering, either half missing, both missing,
whitespace, the chord spelling), and a coverage test that every read of
`SendHotkeyAfterOcrOperation` in `MainWindow` goes through `AfterOcr` — so a
ninth OCR path cannot pass the setting straight through and quietly skip the
paste, the same way batch OCR once skipped the send entirely (#335).

## Documentation

`screen-capture-and-ocr.md`, `settings.md` and `troubleshooting.md` updated, with
a new troubleshooting entry covering the four reasons a paste would not happen.
Markdown and rebuilt HTML committed together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Two defects found reviewing this branch, both fixed here

**The paste would have sent the picture.** A read that recognises nothing comes back
a *success* with an empty message, and the clipboard write is skipped rather than
failed — there was nothing to copy. So `Success`, `!ClipboardCopyFailed` and the
setting all said go, while the clipboard still held what the run put there a step
earlier: the screenshot on the two capture paths, the source image on the two
clipboard paths. The paste would have dropped that picture into the user's document.
The decision is now `PostOperationHotkey.ClipboardHoldsOcrText`, with tests.

**The paste could have happened twice.** `SendHotkey` walks a sequence chord by chord
through SendInput, and on the first chord SendInput cannot express it hands the *whole
original string* to the WinForms fallback — re-sending the chords that already
arrived. Nobody noticed while every such chord was idempotent. A paste is not. It now
falls back with only what is left. Pre-existing on any multi-chord "Send key after..."
value; this branch is what made it reachable with a paste at the front.

Final: `dotnet test --configuration Release` — **2152 passed, 0 failed**.
