### PR TITLE
Say whether a router mapping is live, hold the Hotkeys page's tongue on arrival, and ask before typing

### DIFF
--- a/Documentation/UserGuide/html/accessibility.html
+++ b/Documentation/UserGuide/html/accessibility.html
@@ -206,6 +206,14 @@ typed says so as you leave it — &quot;Speak clipboard now reads CTRL+SHIFT+A.&
 its turn, so it never talks over a warning about the same box. A box that was already
 written Mutation's way stays quiet. See
 <a href="keyboard-shortcuts.html">Keyboard shortcuts</a> for what the tidying up does.</p>
+<p>The <strong>Hotkeys</strong> page stays quiet when you first open it. Any problems it has already
+spotted — an empty box, two shortcuts wanting the same keys — are written on the page
+straight away, so your screen reader reads them as you move down it. They are not read
+out at you on arrival, because a page with several of them would greet you with a run
+of interruptions about settings you have not touched. As soon as you change anything
+on the page, problems are announced the moment they appear again, wherever on the page
+they turn up. Pressing <strong>Add mapping</strong> counts as changing something, so the new empty
+row does tell you it wants a shortcut.</p>
 <h2 id="the-screenshot-overlay-talks-you-through-it">The screenshot overlay talks you through it</h2>
 <p>Grabbing part of a screen you cannot see sounds impossible. It is not.</p>
 <p>When the screen-capture overlay opens, it announces itself and tells you the keys:

--- a/Documentation/UserGuide/html/dictation.html
+++ b/Documentation/UserGuide/html/dictation.html
@@ -287,13 +287,16 @@ don't want stray text landing in another window.</p>
 <p>One thing worth knowing: if the Mutation window itself is the one in front, nothing
 is inserted anywhere. Mutation won't paste into itself.</p>
 <p>Whichever choice you make, Mutation waits for the typing or pasting to finish before
-it tells you the result, and checks that Windows accepted the keystrokes. If Windows
-turned them down, you get the failure beep and a message saying the text could not be
-sent, instead of a success beep for text that never landed. The transcript stays in
-the Mutation window either way, so nothing is lost.</p>
-<p>Windows does not always admit that it refused, so this catch is not a guarantee. If a
-success beep is ever followed by an empty window in the other app, the text is still
-in Mutation — paste it yourself with <strong>Ctrl+V</strong>.</p>
+it tells you the result. It checks twice that the text can land: once before sending,
+by asking Windows whether the app in front is one it is allowed to type into, and once
+after, that Windows accepted the keystrokes. Either check failing gets you the failure
+beep and a message saying the text could not be sent, instead of a success beep for
+text that never landed. The transcript stays in the Mutation window either way, so
+nothing is lost.</p>
+<p>The check before sending is the one that catches an app running as administrator.
+Windows throws keystrokes aimed at those away without telling the sender, so asking
+first is the only way to know — see
+<a href="troubleshooting.html">Troubleshooting</a> for what to do about it.</p>
 <h3 id="sending-a-shortcut-afterwards">Sending a shortcut afterwards</h3>
 <p>In <strong>Settings</strong>, on the <strong>Speech to Text</strong> page, there is an optional box called
 <strong>Send hotkey after transcription</strong>. Whatever shortcut you put there is sent to the

--- a/Documentation/UserGuide/html/dictation.html
+++ b/Documentation/UserGuide/html/dictation.html
@@ -288,15 +288,19 @@ don't want stray text landing in another window.</p>
 is inserted anywhere. Mutation won't paste into itself.</p>
 <p>Whichever choice you make, Mutation waits for the typing or pasting to finish before
 it tells you the result. It checks twice that the text can land: once before sending,
-by asking Windows whether the app in front is one it is allowed to type into, and once
-after, that Windows accepted the keystrokes. Either check failing gets you the failure
-beep and a message saying the text could not be sent, instead of a success beep for
-text that never landed. The transcript stays in the Mutation window either way, so
+by comparing how much privilege the app in front is running with against its own, and
+once after, that Windows accepted the keystrokes. Either check failing gets you the
+failure beep and a message saying the text could not be sent, instead of a success beep
+for text that never landed. The transcript stays in the Mutation window either way, so
 nothing is lost.</p>
 <p>The check before sending is the one that catches an app running as administrator.
 Windows throws keystrokes aimed at those away without telling the sender, so asking
 first is the only way to know — see
 <a href="troubleshooting.html">Troubleshooting</a> for what to do about it.</p>
+<p>Neither check is a cast-iron guarantee. If Windows will not tell Mutation anything
+about the app in front, Mutation sends the text rather than refusing to. So if a
+success beep is ever followed by an empty window in the other app, the text is still
+in Mutation — paste it yourself with <strong>Ctrl+V</strong>.</p>
 <h3 id="sending-a-shortcut-afterwards">Sending a shortcut afterwards</h3>
 <p>In <strong>Settings</strong>, on the <strong>Speech to Text</strong> page, there is an optional box called
 <strong>Send hotkey after transcription</strong>. Whatever shortcut you put there is sent to the

--- a/Documentation/UserGuide/html/index.html
+++ b/Documentation/UserGuide/html/index.html
@@ -283,7 +283,7 @@ authoritative version. To rebuild the web pages after an edit, run
 <code>Build-UserGuide.cmd</code> in the <code>Documentation</code> folder.</p>
 
 <footer>
-<p>Generated from the Markdown source on 8 August 2026. The Markdown files are the source of truth &ndash; do not edit these HTML pages by hand.</p>
+<p>Generated from the Markdown source on 11 August 2026. The Markdown files are the source of truth &ndash; do not edit these HTML pages by hand.</p>
 </footer>
 </main>
 </div>

--- a/Documentation/UserGuide/html/keyboard-shortcuts.html
+++ b/Documentation/UserGuide/html/keyboard-shortcuts.html
@@ -487,15 +487,21 @@ are in, and the call mutes.</p>
 <p>To set one up, go to <strong>Settings</strong> (<strong>Ctrl+Comma</strong>), pick <strong>Hotkeys</strong>, and scroll
 down to the <strong>Hotkey Router</strong> section. Press <strong>Add mapping</strong>, fill in the &quot;From&quot;
 and &quot;To&quot; boxes, and press <strong>Save</strong>. If something is wrong with a row, a marker
-appears beside the &quot;From&quot; box and the reason is written underneath, where a screen
-reader reads it out as soon as it turns up.</p>
+appears beside the &quot;From&quot; box and the reason is written underneath. Once you have
+changed anything on the page, a screen reader reads that reason out as soon as it
+turns up. Problems the page had already spotted when you opened it are written but
+not read out at you — see
+<a href="accessibility.html">Screen reader and accessibility notes</a> for why.</p>
 <p>Each row also says whether it is actually working. A mapping Mutation is listening
-for reads &quot;This mapping is live.&quot; A mapping you have just typed or changed reads
-&quot;Not active yet — press Save to apply.&quot; — because mappings only start working when
-you save. It is written in the row, not tucked into a tooltip, so your screen reader
-reads it along with the rest of the row and you do not have to press the shortcut to
-find out whether it took.
-A mapping whose &quot;From&quot; combination is already taken gets a &quot;Duplicate 'From'
+for reads &quot;CTRL+ALT+1 is live.&quot; A mapping you have changed and not yet saved reads
+&quot;CTRL+ALT+1 is not active yet — press Save to apply.&quot; — because mappings only start
+working when you save. The line names the shortcut, so you can tell which row it
+belongs to when you hear it. It is written in the row, not tucked into a tooltip, so
+your screen reader reads it along with the rest of the row and you do not have to
+press the shortcut to find out whether it took.</p>
+<p>While you are still typing in a box, the line goes away — Mutation cannot say
+anything useful about half a shortcut. It comes back when you leave the box.</p>
+<p>A mapping whose &quot;From&quot; combination is already taken gets a &quot;Duplicate 'From'
 hotkey&quot; message — again comparing the keys rather than the spelling. That covers
 another mapping, any shortcut higher up the Hotkeys page, and any of your prompt
 shortcuts. <strong>Delete</strong> removes a mapping.</p>

--- a/Documentation/UserGuide/html/keyboard-shortcuts.html
+++ b/Documentation/UserGuide/html/keyboard-shortcuts.html
@@ -488,7 +488,13 @@ are in, and the call mutes.</p>
 down to the <strong>Hotkey Router</strong> section. Press <strong>Add mapping</strong>, fill in the &quot;From&quot;
 and &quot;To&quot; boxes, and press <strong>Save</strong>. If something is wrong with a row, a marker
 appears beside the &quot;From&quot; box and the reason is written underneath, where a screen
-reader reads it out as soon as it turns up.
+reader reads it out as soon as it turns up.</p>
+<p>Each row also says whether it is actually working. A mapping Mutation is listening
+for reads &quot;This mapping is live.&quot; A mapping you have just typed or changed reads
+&quot;Not active yet — press Save to apply.&quot; — because mappings only start working when
+you save. It is written in the row, not tucked into a tooltip, so your screen reader
+reads it along with the rest of the row and you do not have to press the shortcut to
+find out whether it took.
 A mapping whose &quot;From&quot; combination is already taken gets a &quot;Duplicate 'From'
 hotkey&quot; message — again comparing the keys rather than the spelling. That covers
 another mapping, any shortcut higher up the Hotkeys page, and any of your prompt

--- a/Documentation/UserGuide/html/troubleshooting.html
+++ b/Documentation/UserGuide/html/troubleshooting.html
@@ -382,9 +382,11 @@ has its own message: &quot;The transcript could not be sent to the other applica
 be running with higher privileges than Mutation. It is available in the Mutation
 window.&quot; You get a failure beep with it, not the success beep.</p>
 <p>Windows will not let an ordinary program type into a window that is running with
-administrator privileges. It simply throws the keystrokes away. Mutation checks
-whether Windows accepted them and tells you when it did not, rather than announcing
-success for text that never arrived.</p>
+administrator privileges. It simply throws the keystrokes away, and it does not tell
+the program that sent them. So Mutation asks first: before typing or pasting, it checks
+whether the app in front is one it is allowed to send keys to, and stops with this
+message when it is not. That is why you hear about it instead of getting a success beep
+for text that never arrived.</p>
 <p><strong>What to do.</strong></p>
 <ol>
 <li>Your text is not lost. It is in the main window and, unless the clipboard also

--- a/Documentation/UserGuide/html/troubleshooting.html
+++ b/Documentation/UserGuide/html/troubleshooting.html
@@ -383,10 +383,14 @@ be running with higher privileges than Mutation. It is available in the Mutation
 window.&quot; You get a failure beep with it, not the success beep.</p>
 <p>Windows will not let an ordinary program type into a window that is running with
 administrator privileges. It simply throws the keystrokes away, and it does not tell
-the program that sent them. So Mutation asks first: before typing or pasting, it checks
-whether the app in front is one it is allowed to send keys to, and stops with this
-message when it is not. That is why you hear about it instead of getting a success beep
-for text that never arrived.</p>
+the program that sent them. So Mutation asks first: before typing or pasting, it
+compares how much privilege the app in front is running with against its own, and stops
+with this message when the other app is higher. That is why you hear about it instead of
+getting a success beep for text that never arrived.</p>
+<p>It is not a cast-iron guarantee. When Windows will not tell Mutation anything about the
+app in front, Mutation sends the text rather than refusing to — so a success beep
+followed by an empty window in the other app is still possible. Your text is in the
+Mutation window either way.</p>
 <p><strong>What to do.</strong></p>
 <ol>
 <li>Your text is not lost. It is in the main window and, unless the clipboard also

--- a/Documentation/UserGuide/markdown/accessibility.md
+++ b/Documentation/UserGuide/markdown/accessibility.md
@@ -77,6 +77,15 @@ its turn, so it never talks over a warning about the same box. A box that was al
 written Mutation's way stays quiet. See
 [Keyboard shortcuts](keyboard-shortcuts.md) for what the tidying up does.
 
+The **Hotkeys** page stays quiet when you first open it. Any problems it has already
+spotted — an empty box, two shortcuts wanting the same keys — are written on the page
+straight away, so your screen reader reads them as you move down it. They are not read
+out at you on arrival, because a page with several of them would greet you with a run
+of interruptions about settings you have not touched. As soon as you change anything
+on the page, problems are announced the moment they appear again, wherever on the page
+they turn up. Pressing **Add mapping** counts as changing something, so the new empty
+row does tell you it wants a shortcut.
+
 ## The screenshot overlay talks you through it
 
 Grabbing part of a screen you cannot see sounds impossible. It is not.

--- a/Documentation/UserGuide/markdown/dictation.md
+++ b/Documentation/UserGuide/markdown/dictation.md
@@ -158,16 +158,21 @@ is inserted anywhere. Mutation won't paste into itself.
 
 Whichever choice you make, Mutation waits for the typing or pasting to finish before
 it tells you the result. It checks twice that the text can land: once before sending,
-by asking Windows whether the app in front is one it is allowed to type into, and once
-after, that Windows accepted the keystrokes. Either check failing gets you the failure
-beep and a message saying the text could not be sent, instead of a success beep for
-text that never landed. The transcript stays in the Mutation window either way, so
+by comparing how much privilege the app in front is running with against its own, and
+once after, that Windows accepted the keystrokes. Either check failing gets you the
+failure beep and a message saying the text could not be sent, instead of a success beep
+for text that never landed. The transcript stays in the Mutation window either way, so
 nothing is lost.
 
 The check before sending is the one that catches an app running as administrator.
 Windows throws keystrokes aimed at those away without telling the sender, so asking
 first is the only way to know — see
 [Troubleshooting](troubleshooting.md) for what to do about it.
+
+Neither check is a cast-iron guarantee. If Windows will not tell Mutation anything
+about the app in front, Mutation sends the text rather than refusing to. So if a
+success beep is ever followed by an empty window in the other app, the text is still
+in Mutation — paste it yourself with **Ctrl+V**.
 
 ### Sending a shortcut afterwards
 

--- a/Documentation/UserGuide/markdown/dictation.md
+++ b/Documentation/UserGuide/markdown/dictation.md
@@ -157,14 +157,17 @@ One thing worth knowing: if the Mutation window itself is the one in front, noth
 is inserted anywhere. Mutation won't paste into itself.
 
 Whichever choice you make, Mutation waits for the typing or pasting to finish before
-it tells you the result, and checks that Windows accepted the keystrokes. If Windows
-turned them down, you get the failure beep and a message saying the text could not be
-sent, instead of a success beep for text that never landed. The transcript stays in
-the Mutation window either way, so nothing is lost.
+it tells you the result. It checks twice that the text can land: once before sending,
+by asking Windows whether the app in front is one it is allowed to type into, and once
+after, that Windows accepted the keystrokes. Either check failing gets you the failure
+beep and a message saying the text could not be sent, instead of a success beep for
+text that never landed. The transcript stays in the Mutation window either way, so
+nothing is lost.
 
-Windows does not always admit that it refused, so this catch is not a guarantee. If a
-success beep is ever followed by an empty window in the other app, the text is still
-in Mutation — paste it yourself with **Ctrl+V**.
+The check before sending is the one that catches an app running as administrator.
+Windows throws keystrokes aimed at those away without telling the sender, so asking
+first is the only way to know — see
+[Troubleshooting](troubleshooting.md) for what to do about it.
 
 ### Sending a shortcut afterwards
 

--- a/Documentation/UserGuide/markdown/keyboard-shortcuts.md
+++ b/Documentation/UserGuide/markdown/keyboard-shortcuts.md
@@ -233,15 +233,23 @@ are in, and the call mutes.
 To set one up, go to **Settings** (**Ctrl+Comma**), pick **Hotkeys**, and scroll
 down to the **Hotkey Router** section. Press **Add mapping**, fill in the "From"
 and "To" boxes, and press **Save**. If something is wrong with a row, a marker
-appears beside the "From" box and the reason is written underneath, where a screen
-reader reads it out as soon as it turns up.
+appears beside the "From" box and the reason is written underneath. Once you have
+changed anything on the page, a screen reader reads that reason out as soon as it
+turns up. Problems the page had already spotted when you opened it are written but
+not read out at you — see
+[Screen reader and accessibility notes](accessibility.md) for why.
 
 Each row also says whether it is actually working. A mapping Mutation is listening
-for reads "This mapping is live." A mapping you have just typed or changed reads
-"Not active yet — press Save to apply." — because mappings only start working when
-you save. It is written in the row, not tucked into a tooltip, so your screen reader
-reads it along with the rest of the row and you do not have to press the shortcut to
-find out whether it took.
+for reads "CTRL+ALT+1 is live." A mapping you have changed and not yet saved reads
+"CTRL+ALT+1 is not active yet — press Save to apply." — because mappings only start
+working when you save. The line names the shortcut, so you can tell which row it
+belongs to when you hear it. It is written in the row, not tucked into a tooltip, so
+your screen reader reads it along with the rest of the row and you do not have to
+press the shortcut to find out whether it took.
+
+While you are still typing in a box, the line goes away — Mutation cannot say
+anything useful about half a shortcut. It comes back when you leave the box.
+
 A mapping whose "From" combination is already taken gets a "Duplicate 'From'
 hotkey" message — again comparing the keys rather than the spelling. That covers
 another mapping, any shortcut higher up the Hotkeys page, and any of your prompt

--- a/Documentation/UserGuide/markdown/keyboard-shortcuts.md
+++ b/Documentation/UserGuide/markdown/keyboard-shortcuts.md
@@ -235,6 +235,13 @@ down to the **Hotkey Router** section. Press **Add mapping**, fill in the "From"
 and "To" boxes, and press **Save**. If something is wrong with a row, a marker
 appears beside the "From" box and the reason is written underneath, where a screen
 reader reads it out as soon as it turns up.
+
+Each row also says whether it is actually working. A mapping Mutation is listening
+for reads "This mapping is live." A mapping you have just typed or changed reads
+"Not active yet — press Save to apply." — because mappings only start working when
+you save. It is written in the row, not tucked into a tooltip, so your screen reader
+reads it along with the rest of the row and you do not have to press the shortcut to
+find out whether it took.
 A mapping whose "From" combination is already taken gets a "Duplicate 'From'
 hotkey" message — again comparing the keys rather than the spelling. That covers
 another mapping, any shortcut higher up the Hotkeys page, and any of your prompt

--- a/Documentation/UserGuide/markdown/troubleshooting.md
+++ b/Documentation/UserGuide/markdown/troubleshooting.md
@@ -288,9 +288,11 @@ be running with higher privileges than Mutation. It is available in the Mutation
 window." You get a failure beep with it, not the success beep.
 
 Windows will not let an ordinary program type into a window that is running with
-administrator privileges. It simply throws the keystrokes away. Mutation checks
-whether Windows accepted them and tells you when it did not, rather than announcing
-success for text that never arrived.
+administrator privileges. It simply throws the keystrokes away, and it does not tell
+the program that sent them. So Mutation asks first: before typing or pasting, it checks
+whether the app in front is one it is allowed to send keys to, and stops with this
+message when it is not. That is why you hear about it instead of getting a success beep
+for text that never arrived.
 
 **What to do.**
 

--- a/Documentation/UserGuide/markdown/troubleshooting.md
+++ b/Documentation/UserGuide/markdown/troubleshooting.md
@@ -289,10 +289,15 @@ window." You get a failure beep with it, not the success beep.
 
 Windows will not let an ordinary program type into a window that is running with
 administrator privileges. It simply throws the keystrokes away, and it does not tell
-the program that sent them. So Mutation asks first: before typing or pasting, it checks
-whether the app in front is one it is allowed to send keys to, and stops with this
-message when it is not. That is why you hear about it instead of getting a success beep
-for text that never arrived.
+the program that sent them. So Mutation asks first: before typing or pasting, it
+compares how much privilege the app in front is running with against its own, and stops
+with this message when the other app is higher. That is why you hear about it instead of
+getting a success beep for text that never arrived.
+
+It is not a cast-iron guarantee. When Windows will not tell Mutation anything about the
+app in front, Mutation sends the text rather than refusing to — so a success beep
+followed by an empty window in the other app is still possible. Your text is in the
+Mutation window either way.
 
 **What to do.**
 

--- a/Mutation.Tests/FirstTouchGateTests.cs
+++ b/Mutation.Tests/FirstTouchGateTests.cs
@@ -1,0 +1,66 @@
+using Mutation.Ui.Core;
+
+namespace Mutation.Tests;
+
+// The latch that decides whether a settings page may read its own errors out loud yet
+// (issue #350).
+public class FirstTouchGateTests
+{
+	[Fact]
+	public void APageStartsUntouched()
+	{
+		Assert.False(new FirstTouchGate().HasBeenTouched);
+	}
+
+	[Fact]
+	public void TouchingItOnce_OpensItAndSaysSo()
+	{
+		var gate = new FirstTouchGate();
+		int announced = 0;
+		gate.Touched += (_, _) => announced++;
+
+		gate.Touch();
+
+		Assert.True(gate.HasBeenTouched);
+		Assert.Equal(1, announced);
+	}
+
+	[Fact]
+	public void TouchingItAgain_ChangesNothingAndSaysNothing()
+	{
+		// Every handler on the page calls this without checking first, so the second call and
+		// every one after it has to be free.
+		var gate = new FirstTouchGate();
+		int announced = 0;
+		gate.Touched += (_, _) => announced++;
+
+		gate.Touch();
+		gate.Touch();
+		gate.Touch();
+
+		Assert.True(gate.HasBeenTouched);
+		Assert.Equal(1, announced);
+	}
+
+	[Fact]
+	public void AGateWithNobodyListening_StillOpens()
+	{
+		var gate = new FirstTouchGate();
+
+		gate.Touch();
+
+		Assert.True(gate.HasBeenTouched);
+	}
+
+	[Fact]
+	public void ItNeverCloses()
+	{
+		// One direction only, on purpose. A page cannot become unused, and a gate that could
+		// shut again would let a row that had spoken once fall silent later for no reason the
+		// user could see.
+		var gate = new FirstTouchGate();
+		gate.Touch();
+
+		Assert.True(gate.HasBeenTouched);
+	}
+}

--- a/Mutation.Tests/ForegroundInjectionGuardTests.cs
+++ b/Mutation.Tests/ForegroundInjectionGuardTests.cs
@@ -1,0 +1,89 @@
+using Mutation.Ui.Core;
+
+namespace Mutation.Tests;
+
+// The rule that decides whether an elevated window in front is going to swallow the
+// transcript, without needing an elevated window to point it at (issue #294). The P/Invoke
+// that feeds it lives in ForegroundIntegrityProbe and cannot be covered here.
+public class ForegroundInjectionGuardTests
+{
+	[Fact]
+	public void AnOutrightRefusal_MeansTheInputWillBeDiscarded()
+	{
+		// The whole point. Windows would not even let us identify the process, which it only
+		// does when the process is above us — and above us means UIPI drops our keystrokes.
+		var probe = ForegroundInjectionGuard.Classify(
+			hasForegroundWindow: true,
+			processId: 4321,
+			opened: false,
+			errorCode: ForegroundInjectionGuard.ErrorAccessDenied);
+
+		Assert.Equal(ForegroundInjectionGuard.ProbeResult.Refused, probe);
+		Assert.True(ForegroundInjectionGuard.InputWillBeDiscarded(probe));
+	}
+
+	[Fact]
+	public void AProcessWeCanOpen_IsFineToTypeInto()
+	{
+		var probe = ForegroundInjectionGuard.Classify(
+			hasForegroundWindow: true, processId: 4321, opened: true, errorCode: 0);
+
+		Assert.Equal(ForegroundInjectionGuard.ProbeResult.Opened, probe);
+		Assert.False(ForegroundInjectionGuard.InputWillBeDiscarded(probe));
+	}
+
+	[Fact]
+	public void NoWindowInFront_IsNotAnAnswerEitherWay()
+	{
+		// A locked screen or a moment between two apps. Nothing to decide, and refusing to
+		// deliver on the strength of it would invent a failure.
+		var probe = ForegroundInjectionGuard.Classify(
+			hasForegroundWindow: false, processId: 0, opened: false, errorCode: 0);
+
+		Assert.Equal(ForegroundInjectionGuard.ProbeResult.Unknown, probe);
+		Assert.False(ForegroundInjectionGuard.InputWillBeDiscarded(probe));
+	}
+
+	[Fact]
+	public void AWindowWhoseProcessCannotBeResolved_IsNotAnAnswerEither()
+	{
+		var probe = ForegroundInjectionGuard.Classify(
+			hasForegroundWindow: true, processId: 0, opened: false, errorCode: 0);
+
+		Assert.Equal(ForegroundInjectionGuard.ProbeResult.Unknown, probe);
+	}
+
+	[Theory]
+	// ERROR_INVALID_PARAMETER — the process exited between the two calls.
+	[InlineData(87)]
+	// ERROR_NOT_ENOUGH_MEMORY.
+	[InlineData(8)]
+	// No error reported at all, which should not happen after a failed OpenProcess.
+	[InlineData(0)]
+	public void AFailureThatIsNotARefusal_LetsDeliveryProceed(int errorCode)
+	{
+		// Deliberately one-sided. A false positive here would refuse to type into an ordinary
+		// window and tell the user their dictation failed when it would have worked — worse
+		// than the silent drop this check exists to catch.
+		var probe = ForegroundInjectionGuard.Classify(
+			hasForegroundWindow: true, processId: 4321, opened: false, errorCode: errorCode);
+
+		Assert.Equal(ForegroundInjectionGuard.ProbeResult.Unknown, probe);
+		Assert.False(ForegroundInjectionGuard.InputWillBeDiscarded(probe));
+	}
+
+	[Fact]
+	public void ASuccessfulOpenIgnoresWhateverErrorCodeWasLyingAround()
+	{
+		// GetLastError is not cleared by a successful call, so a stale code can arrive
+		// alongside a handle. The handle wins.
+		var probe = ForegroundInjectionGuard.Classify(
+			hasForegroundWindow: true,
+			processId: 4321,
+			opened: true,
+			errorCode: ForegroundInjectionGuard.ErrorAccessDenied);
+
+		Assert.Equal(ForegroundInjectionGuard.ProbeResult.Opened, probe);
+		Assert.False(ForegroundInjectionGuard.InputWillBeDiscarded(probe));
+	}
+}

--- a/Mutation.Tests/ForegroundInjectionGuardTests.cs
+++ b/Mutation.Tests/ForegroundInjectionGuardTests.cs
@@ -7,83 +7,174 @@ namespace Mutation.Tests;
 // that feeds it lives in ForegroundIntegrityProbe and cannot be covered here.
 public class ForegroundInjectionGuardTests
 {
-	[Fact]
-	public void AnOutrightRefusal_MeansTheInputWillBeDiscarded()
-	{
-		// The whole point. Windows would not even let us identify the process, which it only
-		// does when the process is above us — and above us means UIPI drops our keystrokes.
-		var probe = ForegroundInjectionGuard.Classify(
-			hasForegroundWindow: true,
-			processId: 4321,
-			opened: false,
-			errorCode: ForegroundInjectionGuard.ErrorAccessDenied);
+	private const ForegroundInjectionGuard.ProbeStep Ok = ForegroundInjectionGuard.ProbeStep.Succeeded;
+	private const ForegroundInjectionGuard.ProbeStep Refused = ForegroundInjectionGuard.ProbeStep.Refused;
+	private const ForegroundInjectionGuard.ProbeStep Failed = ForegroundInjectionGuard.ProbeStep.Failed;
 
-		Assert.Equal(ForegroundInjectionGuard.ProbeResult.Refused, probe);
-		Assert.True(ForegroundInjectionGuard.InputWillBeDiscarded(probe));
+	private static bool WillDiscard(
+		ForegroundInjectionGuard.ForegroundProbe probe, uint theirs = 0, uint ours = 0) =>
+		ForegroundInjectionGuard.InputWillBeDiscarded(probe, theirs, ours);
+
+	// ----- Reading one call's outcome -----
+
+	[Fact]
+	public void StepFrom_TellsARefusalApartFromAnyOtherFailure()
+	{
+		// The distinction the whole rule turns on, so it is worth its own test.
+		Assert.Equal(Ok, ForegroundInjectionGuard.StepFrom(true, 0));
+		Assert.Equal(Refused, ForegroundInjectionGuard.StepFrom(false, ForegroundInjectionGuard.ErrorAccessDenied));
+		// ERROR_INVALID_PARAMETER — the process exited between two calls.
+		Assert.Equal(Failed, ForegroundInjectionGuard.StepFrom(false, 87));
+		Assert.Equal(Failed, ForegroundInjectionGuard.StepFrom(false, 0));
 	}
 
 	[Fact]
-	public void AProcessWeCanOpen_IsFineToTypeInto()
+	public void StepFrom_ASuccessIgnoresWhateverErrorCodeWasLyingAround()
 	{
-		var probe = ForegroundInjectionGuard.Classify(
-			hasForegroundWindow: true, processId: 4321, opened: true, errorCode: 0);
-
-		Assert.Equal(ForegroundInjectionGuard.ProbeResult.Opened, probe);
-		Assert.False(ForegroundInjectionGuard.InputWillBeDiscarded(probe));
+		// GetLastError is not cleared by a successful call, so a stale code can arrive alongside
+		// a handle. The handle wins.
+		Assert.Equal(Ok, ForegroundInjectionGuard.StepFrom(true, ForegroundInjectionGuard.ErrorAccessDenied));
 	}
+
+	// ----- The signature of an integrity boundary -----
+
+	[Fact]
+	public void NamedButNotReadable_IsTheOneThingThatMeansAboveUs()
+	{
+		// PROCESS_QUERY_LIMITED_INFORMATION is granted across an integrity boundary on purpose —
+		// it is what lets an unelevated Task Manager list elevated processes by name — while
+		// PROCESS_QUERY_INFORMATION is not. Granted the first and refused the second is the pair
+		// nothing else produces.
+		var probe = ForegroundInjectionGuard.Classify(
+			hasForegroundWindow: true, processId: 4321, limitedOpen: Ok, fullOpen: Refused, tokenRead: Failed);
+
+		Assert.Equal(ForegroundInjectionGuard.ForegroundProbe.AboveUs, probe);
+		Assert.True(WillDiscard(probe));
+	}
+
+	[Fact]
+	public void ADaclRefusingEvenTheLimitedRight_TellsUsNothingWeCanActOn()
+	{
+		// Another user's process in the same session refuses this while running at our own
+		// integrity level, where UIPI would have let the input straight through. Reading it as
+		// "above us" would refuse to type into an ordinary window and report a failure that would
+		// not have happened — the one outcome worse than the silent drop this exists to catch.
+		var probe = ForegroundInjectionGuard.Classify(
+			hasForegroundWindow: true, processId: 4321, limitedOpen: Refused, fullOpen: Failed, tokenRead: Failed);
+
+		Assert.Equal(ForegroundInjectionGuard.ForegroundProbe.Unknown, probe);
+		Assert.False(WillDiscard(probe));
+	}
+
+	// ----- Comparing the two integrity levels -----
+
+	[Fact]
+	public void AHigherIntegrityForegroundProcess_WillDiscardOurInput()
+	{
+		var probe = ForegroundInjectionGuard.Classify(true, 4321, Ok, Ok, Ok);
+
+		Assert.Equal(ForegroundInjectionGuard.ForegroundProbe.IntegrityKnown, probe);
+		Assert.True(WillDiscard(
+			probe,
+			theirs: ForegroundInjectionGuard.HighIntegrity,
+			ours: ForegroundInjectionGuard.MediumIntegrity));
+	}
+
+	[Fact]
+	public void EqualIntegrity_IsFine()
+	{
+		// UIPI blocks sending up, not sending across. The ordinary case: two medium-integrity
+		// apps, which is nearly every window the user dictates into.
+		Assert.False(WillDiscard(
+			ForegroundInjectionGuard.ForegroundProbe.IntegrityKnown,
+			theirs: ForegroundInjectionGuard.MediumIntegrity,
+			ours: ForegroundInjectionGuard.MediumIntegrity));
+	}
+
+	[Fact]
+	public void ALowerIntegrityForegroundProcess_IsFine()
+	{
+		// A sandboxed browser tab process, say. Sending down is allowed.
+		Assert.False(WillDiscard(
+			ForegroundInjectionGuard.ForegroundProbe.IntegrityKnown,
+			theirs: ForegroundInjectionGuard.LowIntegrity,
+			ours: ForegroundInjectionGuard.MediumIntegrity));
+	}
+
+	[Fact]
+	public void AnElevatedMutationTypingIntoAnElevatedApp_IsFine()
+	{
+		// Both above medium, and equal, so nothing is blocked.
+		Assert.False(WillDiscard(
+			ForegroundInjectionGuard.ForegroundProbe.IntegrityKnown,
+			theirs: ForegroundInjectionGuard.HighIntegrity,
+			ours: ForegroundInjectionGuard.HighIntegrity));
+	}
+
+	[Fact]
+	public void ASystemIntegrityWindow_WillDiscardOurInput()
+	{
+		Assert.True(WillDiscard(
+			ForegroundInjectionGuard.ForegroundProbe.IntegrityKnown,
+			theirs: ForegroundInjectionGuard.SystemIntegrity,
+			ours: ForegroundInjectionGuard.HighIntegrity));
+	}
+
+	// ----- Everything that is not an answer -----
 
 	[Fact]
 	public void NoWindowInFront_IsNotAnAnswerEitherWay()
 	{
 		// A locked screen or a moment between two apps. Nothing to decide, and refusing to
 		// deliver on the strength of it would invent a failure.
-		var probe = ForegroundInjectionGuard.Classify(
-			hasForegroundWindow: false, processId: 0, opened: false, errorCode: 0);
+		var probe = ForegroundInjectionGuard.Classify(false, 0, Failed, Failed, Failed);
 
-		Assert.Equal(ForegroundInjectionGuard.ProbeResult.Unknown, probe);
-		Assert.False(ForegroundInjectionGuard.InputWillBeDiscarded(probe));
+		Assert.Equal(ForegroundInjectionGuard.ForegroundProbe.Unknown, probe);
+		Assert.False(WillDiscard(probe));
 	}
 
 	[Fact]
 	public void AWindowWhoseProcessCannotBeResolved_IsNotAnAnswerEither()
 	{
-		var probe = ForegroundInjectionGuard.Classify(
-			hasForegroundWindow: true, processId: 0, opened: false, errorCode: 0);
-
-		Assert.Equal(ForegroundInjectionGuard.ProbeResult.Unknown, probe);
-	}
-
-	[Theory]
-	// ERROR_INVALID_PARAMETER — the process exited between the two calls.
-	[InlineData(87)]
-	// ERROR_NOT_ENOUGH_MEMORY.
-	[InlineData(8)]
-	// No error reported at all, which should not happen after a failed OpenProcess.
-	[InlineData(0)]
-	public void AFailureThatIsNotARefusal_LetsDeliveryProceed(int errorCode)
-	{
-		// Deliberately one-sided. A false positive here would refuse to type into an ordinary
-		// window and tell the user their dictation failed when it would have worked — worse
-		// than the silent drop this check exists to catch.
-		var probe = ForegroundInjectionGuard.Classify(
-			hasForegroundWindow: true, processId: 4321, opened: false, errorCode: errorCode);
-
-		Assert.Equal(ForegroundInjectionGuard.ProbeResult.Unknown, probe);
-		Assert.False(ForegroundInjectionGuard.InputWillBeDiscarded(probe));
+		Assert.Equal(
+			ForegroundInjectionGuard.ForegroundProbe.Unknown,
+			ForegroundInjectionGuard.Classify(true, 0, Ok, Ok, Ok));
 	}
 
 	[Fact]
-	public void ASuccessfulOpenIgnoresWhateverErrorCodeWasLyingAround()
+	public void TheFullOpenFailingForSomeOtherReason_LetsDeliveryProceed()
 	{
-		// GetLastError is not cleared by a successful call, so a stale code can arrive
-		// alongside a handle. The handle wins.
-		var probe = ForegroundInjectionGuard.Classify(
-			hasForegroundWindow: true,
-			processId: 4321,
-			opened: true,
-			errorCode: ForegroundInjectionGuard.ErrorAccessDenied);
+		// The process exited between the two calls, say. Says nothing about privilege.
+		var probe = ForegroundInjectionGuard.Classify(true, 4321, Ok, Failed, Failed);
 
-		Assert.Equal(ForegroundInjectionGuard.ProbeResult.Opened, probe);
-		Assert.False(ForegroundInjectionGuard.InputWillBeDiscarded(probe));
+		Assert.Equal(ForegroundInjectionGuard.ForegroundProbe.Unknown, probe);
+		Assert.False(WillDiscard(probe));
+	}
+
+	[Fact]
+	public void TheTokenFailingForSomeOtherReason_LetsDeliveryProceed()
+	{
+		var probe = ForegroundInjectionGuard.Classify(true, 4321, Ok, Ok, Failed);
+
+		Assert.Equal(ForegroundInjectionGuard.ForegroundProbe.Unknown, probe);
+		Assert.False(WillDiscard(probe));
+	}
+
+	[Fact]
+	public void ARefusedTokenAfterAGrantedFullOpen_IsStillAboveUs()
+	{
+		// Not expected — the full right is what OpenProcessToken needs — but if Windows refuses
+		// the token anyway, a refusal is a refusal.
+		var probe = ForegroundInjectionGuard.Classify(true, 4321, Ok, Ok, Refused);
+
+		Assert.Equal(ForegroundInjectionGuard.ForegroundProbe.Unknown, probe);
+	}
+
+	[Fact]
+	public void AboveUs_NeedsNoIntegrityLevelsToActOn()
+	{
+		// The refusal is conclusive by itself, so the zeros the probe hands over in that case
+		// must not be read as "equal integrity, carry on".
+		Assert.True(WillDiscard(ForegroundInjectionGuard.ForegroundProbe.AboveUs, theirs: 0, ours: 0));
 	}
 }

--- a/Mutation.Tests/HotkeyRouterControllerTests.cs
+++ b/Mutation.Tests/HotkeyRouterControllerTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using CognitiveSupport;
@@ -515,6 +516,55 @@ public class HotkeyRouterControllerTests
 		Assert.False(gate.HasBeenTouched);
 		Assert.True(entry.AnnouncementsMuted);
 	}
+
+	[Fact]
+	public void CeasingToBeADuplicate_GetsTheRowItsStatusBack()
+	{
+		// ApplyDuplicates is reached without a refresh when a *core* hotkey commits: the Hotkeys
+		// page recomputes across all its lists and stops there. A live route flagged because a
+		// core hotkey took its chord goes to Unknown, and nothing about unflagging it restored
+		// what it was — so it stayed silent about being live until a router box lost focus or the
+		// page was rebuilt (issue #343).
+		var (controller, _, _, entries, _) = BuildController(autoPersist: false, injectSettingsManager: false);
+		var entry = new HotkeyRouterEntry(new HotKeyRouterSettings.HotKeyRouterMap("Ctrl+Alt+1", "Ctrl+Shift+M"));
+		entries.Add(entry);
+		SetField(controller, "_liveRoutes", (Func<IReadOnlyList<RegisteredRouterRoute>?>)(() =>
+			new[] { new RegisteredRouterRoute("CTRL+ALT+1", "CTRL+SHIFT+M", true, null) }));
+		CallRefreshRegistrations(controller);
+		Assert.Equal(HotkeyBindingState.Bound, entry.BindingState);
+
+		controller.ApplyDuplicates(new HashSet<int> { 0 });
+		Assert.Equal(HotkeyBindingState.Unknown, entry.BindingState);
+
+		controller.ApplyDuplicates(new HashSet<int>());
+
+		Assert.Equal(HotkeyBindingState.Bound, entry.BindingState);
+	}
+
+	[Fact]
+	public void ARowsTextChangingIsOnlyTheUserWhenItIsNotBookkeeping()
+	{
+		// A row's text does not change only when the user types: a commit that rewrites a chord
+		// into the app's canonical spelling raises the same notification, and SyncSettings commits
+		// every row on every refresh. Today those passes happen to find nothing to rewrite, but
+		// relying on that would mean a reordering could open the gate at page load with nothing
+		// failing. This pins the guard rather than the accident (issue #350).
+		var (controller, _, _, _, _) = BuildController(autoPersist: false, injectSettingsManager: false);
+		var gate = InjectAnnouncementGate(controller);
+
+		SetField(controller, "_inBookkeepingCommit", true);
+		CallEntryPropertyChanged(controller, nameof(HotkeyRouterEntry.FromHotkey));
+		Assert.False(gate.HasBeenTouched);
+
+		SetField(controller, "_inBookkeepingCommit", false);
+		CallEntryPropertyChanged(controller, nameof(HotkeyRouterEntry.ToHotkey));
+		Assert.True(gate.HasBeenTouched);
+	}
+
+	private static void CallEntryPropertyChanged(HotkeyRouterController controller, string propertyName)
+		=> typeof(HotkeyRouterController)
+			.GetMethod("Entry_PropertyChanged", BindingFlags.NonPublic | BindingFlags.Instance)!
+			.Invoke(controller, new object?[] { null, new PropertyChangedEventArgs(propertyName) });
 
 	[Fact]
 	public void WithNoGateAtAll_NoRowIsEverMuted()

--- a/Mutation.Tests/HotkeyRouterControllerTests.cs
+++ b/Mutation.Tests/HotkeyRouterControllerTests.cs
@@ -3,6 +3,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using CognitiveSupport;
 using Mutation.Ui;
+using Mutation.Ui.Core;
 using Mutation.Ui.Services;
 
 namespace Mutation.Tests;
@@ -66,6 +67,24 @@ public class HotkeyRouterControllerTests
 		=> typeof(HotkeyRouterController)
 			.GetMethod("RecalculateDuplicates", BindingFlags.NonPublic | BindingFlags.Instance)!
 			.Invoke(controller, null);
+
+	private static void CallAttachEntry(HotkeyRouterController controller, HotkeyRouterEntry entry)
+		=> typeof(HotkeyRouterController)
+			.GetMethod("AttachEntry", BindingFlags.NonPublic | BindingFlags.Instance)!
+			.Invoke(controller, new object[] { entry });
+
+	// The gate has to be wired the way the constructor wires it, or an unmute never reaches the
+	// rows. Injected by hand here because the constructor needs a ListView and a DispatcherQueue.
+	private static FirstTouchGate InjectAnnouncementGate(HotkeyRouterController controller)
+	{
+		var gate = new FirstTouchGate();
+		SetField(controller, "_announcementGate", gate);
+		var unmute = (EventHandler)typeof(HotkeyRouterController)
+			.GetMethod("UnmuteAnnouncements", BindingFlags.NonPublic | BindingFlags.Instance)!
+			.CreateDelegate(typeof(EventHandler), controller);
+		gate.Touched += unmute;
+		return gate;
+	}
 
 	// ----- SyncSettings -----
 
@@ -370,6 +389,144 @@ public class HotkeyRouterControllerTests
 		CallRefreshRegistrations(controller);
 
 		Assert.Equal(1, settingsManager.SaveCount);
+	}
+
+	// ----- What each row says about being live (issue #343) -----
+
+	[Fact]
+	public void RefreshRegistrations_WithARouteTheAppHolds_TellsThatRowItIsLive()
+	{
+		// The page used to report every row as "not currently bound", working ones included,
+		// because nothing ever handed the controller a way to find out.
+		var (controller, _, _, entries, _) = BuildController(autoPersist: false, injectSettingsManager: false);
+		var live = new HotkeyRouterEntry(new HotKeyRouterSettings.HotKeyRouterMap("Ctrl+Alt+1", "Ctrl+Shift+M"));
+		var pending = new HotkeyRouterEntry(new HotKeyRouterSettings.HotKeyRouterMap("Ctrl+Alt+2", "Ctrl+Shift+N"));
+		entries.Add(live);
+		entries.Add(pending);
+		SetField(controller, "_liveRoutes", (Func<IReadOnlyList<RegisteredRouterRoute>?>)(() =>
+			new[] { new RegisteredRouterRoute("CTRL+ALT+1", "CTRL+SHIFT+M", true, null) }));
+
+		CallRefreshRegistrations(controller);
+
+		Assert.Equal(HotkeyBindingState.Bound, live.BindingState);
+		Assert.Equal(HotkeyBindingState.NotYetApplied, pending.BindingState);
+	}
+
+	[Fact]
+	public void RefreshRegistrations_WithNoWayToAsk_LeavesEveryRowSayingNothing()
+	{
+		// The shape every other caller has. Nothing is known, so no row claims anything.
+		var (controller, _, _, entries, _) = BuildController(autoPersist: false, injectSettingsManager: false);
+		var entry = new HotkeyRouterEntry(new HotKeyRouterSettings.HotKeyRouterMap("Ctrl+Alt+1", "Ctrl+Shift+M"));
+		entries.Add(entry);
+
+		CallRefreshRegistrations(controller);
+
+		Assert.Equal(HotkeyBindingState.Unknown, entry.BindingState);
+		Assert.Null(entry.RouteStatusText);
+	}
+
+	[Fact]
+	public void RefreshRegistrations_AHalfTypedRow_IsNotAskedAboutAtAll()
+	{
+		// It cannot be a route, and its own "Enter a hotkey." already says what is wrong.
+		var (controller, _, _, entries, _) = BuildController(autoPersist: false, injectSettingsManager: false);
+		var entry = new HotkeyRouterEntry(new HotKeyRouterSettings.HotKeyRouterMap("Ctrl+", string.Empty));
+		entries.Add(entry);
+		SetField(controller, "_liveRoutes", (Func<IReadOnlyList<RegisteredRouterRoute>?>)(() =>
+			Array.Empty<RegisteredRouterRoute>()));
+
+		CallRefreshRegistrations(controller);
+
+		Assert.Equal(HotkeyBindingState.Unknown, entry.BindingState);
+	}
+
+	[Fact]
+	public void RefreshRegistrations_ARouteThatFailedToRegister_CarriesTheReasonOntoTheRow()
+	{
+		var (controller, _, _, entries, _) = BuildController(autoPersist: false, injectSettingsManager: false);
+		var entry = new HotkeyRouterEntry(new HotKeyRouterSettings.HotKeyRouterMap("Ctrl+Alt+1", "Ctrl+Shift+M"));
+		entries.Add(entry);
+		SetField(controller, "_liveRoutes", (Func<IReadOnlyList<RegisteredRouterRoute>?>)(() =>
+			new[] { new RegisteredRouterRoute("CTRL+ALT+1", "CTRL+SHIFT+M", false, "The shortcut is already registered by another application.") }));
+
+		CallRefreshRegistrations(controller);
+
+		Assert.Equal(HotkeyBindingState.Failed, entry.BindingState);
+		Assert.Equal("The shortcut is already registered by another application.", entry.BindingErrorMessage);
+	}
+
+	// ----- Showing an error without reading it out (issue #350) -----
+
+	[Fact]
+	public void ARowBuiltWhileThePageIsUntouched_IsMutedBeforeItReachesTheScreen()
+	{
+		// The row already carries "Enter a hotkey." from its own constructor, so the mute has to
+		// be on before the binding runs or the page announces on the way in.
+		var (controller, _, _, entries, _) = BuildController(autoPersist: false, injectSettingsManager: false);
+		InjectAnnouncementGate(controller);
+		var entry = new HotkeyRouterEntry(new HotKeyRouterSettings.HotKeyRouterMap(string.Empty, string.Empty));
+
+		CallAttachEntry(controller, entry);
+		entries.Add(entry);
+
+		Assert.True(entry.AnnouncementsMuted);
+		// And the written half is untouched, which is the whole point of gating only the sound.
+		Assert.Equal("Enter a hotkey.", entry.BindingErrorMessage);
+	}
+
+	[Fact]
+	public void OnceThePageHasBeenUsed_EveryRowIsFreeToSpeakIncludingUntouchedOnes()
+	{
+		// A duplicate can appear on a row because the user edited a different row, or a core
+		// hotkey higher up the page. That row was never touched and it is exactly the news worth
+		// interrupting for, which is why the gate is one answer for the page.
+		var (controller, _, _, entries, _) = BuildController(autoPersist: false, injectSettingsManager: false);
+		var gate = InjectAnnouncementGate(controller);
+		var edited = new HotkeyRouterEntry(new HotKeyRouterSettings.HotKeyRouterMap("Ctrl+Alt+1", "Ctrl+Shift+M"));
+		var untouched = new HotkeyRouterEntry(new HotKeyRouterSettings.HotKeyRouterMap("Ctrl+Alt+2", "Ctrl+Shift+N"));
+		foreach (var entry in new[] { edited, untouched })
+		{
+			CallAttachEntry(controller, entry);
+			entries.Add(entry);
+		}
+		Assert.True(untouched.AnnouncementsMuted);
+
+		edited.FromHotkey = "Ctrl+Alt+3";
+
+		Assert.True(gate.HasBeenTouched);
+		Assert.False(edited.AnnouncementsMuted);
+		Assert.False(untouched.AnnouncementsMuted);
+	}
+
+	[Fact]
+	public void ABookkeepingCommit_DoesNotCountAsTheUserUsingThePage()
+	{
+		// The refresh re-commits every row. If that opened the gate, loading a settings file
+		// that needed tidying would announce the page's errors without anyone touching it.
+		var (controller, _, _, entries, _) = BuildController(autoPersist: false, injectSettingsManager: false);
+		var gate = InjectAnnouncementGate(controller);
+		var entry = new HotkeyRouterEntry(new HotKeyRouterSettings.HotKeyRouterMap("Ctrl+Alt+1", "Ctrl+Shift+M"));
+		CallAttachEntry(controller, entry);
+		entries.Add(entry);
+
+		CallRefreshRegistrations(controller);
+
+		Assert.False(gate.HasBeenTouched);
+		Assert.True(entry.AnnouncementsMuted);
+	}
+
+	[Fact]
+	public void WithNoGateAtAll_NoRowIsEverMuted()
+	{
+		// Every other user of this controller behaves exactly as it did before.
+		var (controller, _, _, entries, _) = BuildController(autoPersist: false, injectSettingsManager: false);
+		var entry = new HotkeyRouterEntry(new HotKeyRouterSettings.HotKeyRouterMap(string.Empty, string.Empty));
+
+		CallAttachEntry(controller, entry);
+		entries.Add(entry);
+
+		Assert.False(entry.AnnouncementsMuted);
 	}
 
 	private sealed class FakeSettingsManager : ISettingsManager

--- a/Mutation.Tests/HotkeyRouterEntryTests.cs
+++ b/Mutation.Tests/HotkeyRouterEntryTests.cs
@@ -416,7 +416,7 @@ public class HotkeyRouterEntryTests
 
 		entry.SetBindingResult(HotkeyBindingState.Bound, null);
 
-		Assert.Equal("This mapping is live.", entry.RouteStatusText);
+		Assert.Equal("CTRL+C is live.", entry.RouteStatusText);
 	}
 
 	[Fact]
@@ -426,7 +426,7 @@ public class HotkeyRouterEntryTests
 
 		entry.SetBindingResult(HotkeyBindingState.NotYetApplied, null);
 
-		Assert.Equal("Not active yet — press Save to apply.", entry.RouteStatusText);
+		Assert.Equal("CTRL+C is not active yet — press Save to apply.", entry.RouteStatusText);
 	}
 
 	[Fact]
@@ -480,7 +480,7 @@ public class HotkeyRouterEntryTests
 		entry.SetBindingResult(HotkeyBindingState.Bound, null);
 		entry.SetBindingResult(HotkeyBindingState.NotYetApplied, null);
 
-		Assert.Equal(["This mapping is live.", "Not active yet — press Save to apply."], raised);
+		Assert.Equal(["CTRL+C is live.", "CTRL+C is not active yet — press Save to apply."], raised);
 	}
 
 	// ----- Showing an error without reading it out (issue #350) -----

--- a/Mutation.Tests/HotkeyRouterEntryTests.cs
+++ b/Mutation.Tests/HotkeyRouterEntryTests.cs
@@ -1,5 +1,6 @@
 using CognitiveSupport;
 using Mutation.Ui;
+using Mutation.Ui.Core;
 
 namespace Mutation.Tests;
 
@@ -59,7 +60,7 @@ public class HotkeyRouterEntryTests
 		Assert.True(entry.IsDuplicate);
 		Assert.False(entry.IsFromInputValid);
 		Assert.False(entry.IsValid);
-		Assert.Equal(HotkeyBindingState.Inactive, entry.BindingState);
+		Assert.Equal(HotkeyBindingState.Unknown, entry.BindingState);
 	}
 
 	[Fact]
@@ -402,5 +403,127 @@ public class HotkeyRouterEntryTests
 		entry.ClearFromCommitAnnouncement();
 
 		Assert.Equal(["Shortcut to listen for now reads CTRL+SHIFT+A.", null], raised);
+	}
+
+	// ----- What the row says about being live (issue #343) -----
+
+	[Fact]
+	public void ARouteTheAppHolds_SaysSoInWords()
+	{
+		// The old design computed a tick, a colour and a tooltip for this and bound none of
+		// them, so a working route looked and read exactly like one that was never registered.
+		var entry = new HotkeyRouterEntry(Map("Ctrl+C", "Ctrl+V"));
+
+		entry.SetBindingResult(HotkeyBindingState.Bound, null);
+
+		Assert.Equal("This mapping is live.", entry.RouteStatusText);
+	}
+
+	[Fact]
+	public void ARouteTheAppHasNotBeenGivenYet_SaysWhatToDoAboutIt()
+	{
+		var entry = new HotkeyRouterEntry(Map("Ctrl+C", "Ctrl+V"));
+
+		entry.SetBindingResult(HotkeyBindingState.NotYetApplied, null);
+
+		Assert.Equal("Not active yet — press Save to apply.", entry.RouteStatusText);
+	}
+
+	[Fact]
+	public void ARouteNothingIsKnownAbout_SaysNothingRatherThanGuessing()
+	{
+		// The state every row used to sit in, reported as "Hotkey is not currently bound." even
+		// for routes that worked. Saying nothing is the honest version.
+		var entry = new HotkeyRouterEntry(Map("Ctrl+C", "Ctrl+V"));
+
+		Assert.Equal(HotkeyBindingState.Unknown, entry.BindingState);
+		Assert.Null(entry.RouteStatusText);
+	}
+
+	[Fact]
+	public void AFailedRoute_LeavesTheTellingToTheErrorRegion()
+	{
+		// The error is assertive and carries the reason. A second line saying the mapping is
+		// not live would be the same news, politely, straight afterwards.
+		var entry = new HotkeyRouterEntry(Map("Ctrl+C", "Ctrl+V"));
+
+		entry.SetBindingResult(HotkeyBindingState.Failed, "The shortcut is already registered by another application.");
+
+		Assert.Null(entry.RouteStatusText);
+		Assert.Equal("The shortcut is already registered by another application.", entry.BindingErrorMessage);
+	}
+
+	[Fact]
+	public void TypingInABox_TakesTheStatusDownUntilItIsWorkedOutAgain()
+	{
+		// Half-edited text is not the route that is registered, so the row must stop claiming to
+		// be live the moment the user changes it.
+		var entry = new HotkeyRouterEntry(Map("Ctrl+C", "Ctrl+V"));
+		entry.SetBindingResult(HotkeyBindingState.Bound, null);
+
+		entry.ToHotkey = "Ctrl+B";
+
+		Assert.Null(entry.RouteStatusText);
+	}
+
+	[Fact]
+	public void TheStatusIsPublishedSoTheRowCanBind()
+	{
+		var entry = new HotkeyRouterEntry(Map("Ctrl+C", "Ctrl+V"));
+		var raised = new List<string?>();
+		entry.PropertyChanged += (_, e) =>
+		{
+			if (e.PropertyName == nameof(HotkeyRouterEntry.RouteStatusText))
+				raised.Add(entry.RouteStatusText);
+		};
+
+		entry.SetBindingResult(HotkeyBindingState.Bound, null);
+		entry.SetBindingResult(HotkeyBindingState.NotYetApplied, null);
+
+		Assert.Equal(["This mapping is live.", "Not active yet — press Save to apply."], raised);
+	}
+
+	// ----- Showing an error without reading it out (issue #350) -----
+
+	[Fact]
+	public void ANewRow_StartsFreeToSpeak()
+	{
+		// Nothing is muted unless a page says so, which keeps every other user of this row
+		// behaving as it did.
+		var entry = new HotkeyRouterEntry(Map("Ctrl+C", "Ctrl+V"));
+
+		Assert.False(entry.AnnouncementsMuted);
+	}
+
+	[Fact]
+	public void MutingIsPublishedSoTheRowCanBindIt()
+	{
+		var entry = new HotkeyRouterEntry(Map(string.Empty, string.Empty));
+		int raised = 0;
+		entry.PropertyChanged += (_, e) =>
+		{
+			if (e.PropertyName == nameof(HotkeyRouterEntry.AnnouncementsMuted))
+				raised++;
+		};
+
+		entry.SetAnnouncementsMuted(true);
+		entry.SetAnnouncementsMuted(true);
+		entry.SetAnnouncementsMuted(false);
+
+		Assert.Equal(2, raised);
+		Assert.False(entry.AnnouncementsMuted);
+	}
+
+	[Fact]
+	public void MutingLeavesTheWrittenErrorExactlyWhereItWas()
+	{
+		// Only the announcement is gated. Taking the text off screen at load would be a plain
+		// regression for a sighted reader, who was never the problem.
+		var entry = new HotkeyRouterEntry(Map(string.Empty, string.Empty));
+
+		entry.SetAnnouncementsMuted(true);
+
+		Assert.True(entry.HasBindingError);
+		Assert.Equal("Enter a hotkey.", entry.BindingErrorMessage);
 	}
 }

--- a/Mutation.Tests/PromptLibraryMutationsTests.cs
+++ b/Mutation.Tests/PromptLibraryMutationsTests.cs
@@ -1,0 +1,186 @@
+using CognitiveSupport;
+using Mutation.Ui.Services;
+
+namespace Mutation.Tests;
+
+// The list work behind the prompt library, exercised without a PromptEditorWindow. Every
+// path here used to run inside that window's Closed handler, which is why none of it had
+// coverage (issue #304).
+public class PromptLibraryMutationsTests
+{
+	private static LlmSettings.LlmPrompt Prompt(
+		string name, int id = 0, bool autoRun = false, string? hotkey = null) =>
+		new() { Name = name, Id = id, AutoRun = autoRun, Hotkey = hotkey };
+
+	// ----- Add -----
+
+	[Fact]
+	public void Add_GivesTheNewPromptAnId()
+	{
+		var prompts = new List<LlmSettings.LlmPrompt> { Prompt("First", id: 1) };
+		var added = Prompt("Second");
+
+		PromptLibraryMutations.Add(prompts, added);
+
+		Assert.Equal(2, prompts.Count);
+		Assert.True(added.Id > 0);
+		Assert.NotEqual(prompts[0].Id, added.Id);
+	}
+
+	[Fact]
+	public void Add_AfterADelete_ReusesTheFreedIdRatherThanRepeatingALiveOne()
+	{
+		// The case the issue calls out. Ids are handed out from the lowest free number, so
+		// the gap a deleted prompt leaves is filled. Highest-plus-one would be fine here and
+		// wrong against a hand-written Id near int.MaxValue, which is why the rule is the way
+		// it is — this test pins the behaviour that follows from it.
+		var first = Prompt("First", id: 1);
+		var second = Prompt("Second", id: 2);
+		var third = Prompt("Third", id: 3);
+		var prompts = new List<LlmSettings.LlmPrompt> { first, second, third };
+
+		Assert.True(PromptLibraryMutations.Delete(prompts, second));
+		var added = Prompt("Fourth");
+		PromptLibraryMutations.Add(prompts, added);
+
+		Assert.Equal(2, added.Id);
+		Assert.Equal(3, prompts.Select(p => p.Id).Distinct().Count());
+	}
+
+	[Fact]
+	public void Add_RepairsHandWrittenPromptsThatShareAnId()
+	{
+		// A prompt typed straight into Mutation.json carries Id 0, and several of them look
+		// like one prompt to anything that identifies a prompt by Id.
+		var prompts = new List<LlmSettings.LlmPrompt> { Prompt("Hand written A"), Prompt("Hand written B") };
+
+		PromptLibraryMutations.Add(prompts, Prompt("Added"));
+
+		Assert.Equal(3, prompts.Select(p => p.Id).Distinct().Count());
+		Assert.All(prompts, p => Assert.True(p.Id > 0));
+	}
+
+	[Fact]
+	public void Add_AnAutoRunPrompt_TakesTheFlagOffTheOneThatHadIt()
+	{
+		var incumbent = Prompt("Incumbent", id: 1, autoRun: true);
+		var prompts = new List<LlmSettings.LlmPrompt> { incumbent };
+		var added = Prompt("Newcomer", autoRun: true);
+
+		PromptLibraryMutations.Add(prompts, added);
+
+		Assert.False(incumbent.AutoRun);
+		Assert.True(added.AutoRun);
+	}
+
+	[Fact]
+	public void Add_APromptThatDoesNotWantAutoRun_LeavesTheIncumbentHoldingIt()
+	{
+		// Adding an ordinary prompt is not a reason to switch auto-run off.
+		var incumbent = Prompt("Incumbent", id: 1, autoRun: true);
+		var prompts = new List<LlmSettings.LlmPrompt> { incumbent };
+		var added = Prompt("Newcomer");
+
+		PromptLibraryMutations.Add(prompts, added);
+
+		Assert.True(incumbent.AutoRun);
+		Assert.False(added.AutoRun);
+	}
+
+	[Fact]
+	public void Add_RejectsNulls()
+	{
+		var prompts = new List<LlmSettings.LlmPrompt>();
+
+		Assert.Throws<ArgumentNullException>(() => PromptLibraryMutations.Add(prompts, null!));
+		Assert.Throws<ArgumentNullException>(() => PromptLibraryMutations.Add(null!, Prompt("x")));
+	}
+
+	// ----- CommitEdit -----
+
+	[Fact]
+	public void CommitEdit_APromptThatJustClaimedAutoRun_TakesItOffEveryOther()
+	{
+		var first = Prompt("First", id: 1, autoRun: true);
+		var second = Prompt("Second", id: 2, autoRun: true);
+		var third = Prompt("Third", id: 3, autoRun: true);
+		var prompts = new List<LlmSettings.LlmPrompt> { first, second, third };
+
+		PromptLibraryMutations.CommitEdit(prompts, second);
+
+		Assert.False(first.AutoRun);
+		Assert.True(second.AutoRun);
+		Assert.False(third.AutoRun);
+	}
+
+	[Fact]
+	public void CommitEdit_APromptWithoutAutoRun_ChangesNobodyElse()
+	{
+		var incumbent = Prompt("Incumbent", id: 1, autoRun: true);
+		var edited = Prompt("Edited", id: 2);
+		var prompts = new List<LlmSettings.LlmPrompt> { incumbent, edited };
+
+		PromptLibraryMutations.CommitEdit(prompts, edited);
+
+		Assert.True(incumbent.AutoRun);
+		Assert.False(edited.AutoRun);
+	}
+
+	[Fact]
+	public void CommitEdit_LeavesIdsAlone()
+	{
+		// Renumbering a prompt the user was only renaming would move an identity they did not
+		// ask to change, so an edit hands out no Ids — not even to repair a clash.
+		var first = Prompt("First", id: 7);
+		var second = Prompt("Second", id: 7);
+		var prompts = new List<LlmSettings.LlmPrompt> { first, second };
+
+		PromptLibraryMutations.CommitEdit(prompts, second);
+
+		Assert.Equal(7, first.Id);
+		Assert.Equal(7, second.Id);
+	}
+
+	// ----- Delete -----
+
+	[Fact]
+	public void Delete_RemovesThePromptAndSaysSo()
+	{
+		var doomed = Prompt("Doomed", id: 2);
+		var prompts = new List<LlmSettings.LlmPrompt> { Prompt("Kept", id: 1), doomed };
+
+		Assert.True(PromptLibraryMutations.Delete(prompts, doomed));
+		Assert.Single(prompts);
+		Assert.Equal("Kept", prompts[0].Name);
+	}
+
+	[Fact]
+	public void Delete_APromptThatIsNotThere_SaysNothingWasRemoved()
+	{
+		// The caller announces the outcome, so a false has to mean "nothing happened" rather
+		// than "probably fine".
+		var prompts = new List<LlmSettings.LlmPrompt> { Prompt("Kept", id: 1) };
+
+		Assert.False(PromptLibraryMutations.Delete(prompts, Prompt("Stranger", id: 9)));
+		Assert.False(PromptLibraryMutations.Delete(prompts, null));
+		Assert.Single(prompts);
+	}
+
+	// ----- AutoRunPrompt -----
+
+	[Fact]
+	public void AutoRunPrompt_FindsTheFlaggedOne()
+	{
+		var wanted = Prompt("Wanted", id: 2, autoRun: true);
+		var prompts = new List<LlmSettings.LlmPrompt> { Prompt("First", id: 1), wanted };
+
+		Assert.Same(wanted, PromptLibraryMutations.AutoRunPrompt(prompts));
+	}
+
+	[Fact]
+	public void AutoRunPrompt_WithNoneFlaggedOrNoList_IsNull()
+	{
+		Assert.Null(PromptLibraryMutations.AutoRunPrompt(new List<LlmSettings.LlmPrompt> { Prompt("First", id: 1) }));
+		Assert.Null(PromptLibraryMutations.AutoRunPrompt(null));
+	}
+}

--- a/Mutation.Tests/RouterBindingStatusTests.cs
+++ b/Mutation.Tests/RouterBindingStatusTests.cs
@@ -92,12 +92,54 @@ public class RouterBindingStatusTests
 	[Fact]
 	public void SpellingIsForgivenSoAHandEditedFileStillMatches()
 	{
-		// Both sides are written canonically by the app, so this only matters for a settings
-		// file someone typed by hand.
 		var (state, _) = RouterBindingStatus.For(
 			"CTRL+ALT+1", "CTRL+SHIFT+M", [Route(" ctrl+alt+1 ", "ctrl+shift+m")]);
 
 		Assert.Equal(HotkeyBindingState.Bound, state);
+	}
+
+	[Fact]
+	public void TheShippedDefaultMappingIsRecognisedAsLive()
+	{
+		// The bug this test exists for. SettingsManager seeds a brand-new settings file with a
+		// router mapping written CONTROL+SHIFT+ALT+8, and the row's side of the comparison has
+		// been through Canonicalize, which spells it CTRL+SHIFT+ALT+8. Comparing the two as text
+		// meant that on a fresh install the only router row on the page reported a working
+		// mapping as "not active yet" — the same class of false statement issue #343 was filed
+		// about.
+		var (state, _) = RouterBindingStatus.For(
+			"CTRL+SHIFT+ALT+8",
+			"CTRL+SHIFT+ALT+9",
+			[Route("CONTROL+SHIFT+ALT+8", "CONTROL+SHIFT+ALT+9")]);
+
+		Assert.Equal(HotkeyBindingState.Bound, state);
+	}
+
+	[Theory]
+	// The order the modifiers were typed in, which files written before the canonicalisation
+	// work still carry.
+	[InlineData("SHIFT+CTRL+A")]
+	// The long spelling of the same modifier.
+	[InlineData("CONTROL+SHIFT+A")]
+	[InlineData("control+shift+a")]
+	public void AChordSpelledAnotherWayIsStillTheSameChord(string onDisk)
+	{
+		// A shortcut has one identity and many spellings. HotkeyConflictFinder learned this for
+		// duplicate detection in issue #306; comparing spellings gets it wrong here too.
+		var (state, _) = RouterBindingStatus.For(
+			"CTRL+SHIFT+A", "CTRL+V", [Route(onDisk, "CTRL+V")]);
+
+		Assert.Equal(HotkeyBindingState.Bound, state);
+	}
+
+	[Fact]
+	public void ADifferentChordIsStillADifferentChord()
+	{
+		// Forgiving the spelling must not go so far as forgiving the shortcut.
+		var (state, _) = RouterBindingStatus.For(
+			"CTRL+SHIFT+A", "CTRL+V", [Route("CTRL+SHIFT+B", "CTRL+V")]);
+
+		Assert.Equal(HotkeyBindingState.NotYetApplied, state);
 	}
 
 	[Fact]

--- a/Mutation.Tests/RouterBindingStatusTests.cs
+++ b/Mutation.Tests/RouterBindingStatusTests.cs
@@ -1,0 +1,118 @@
+using Mutation.Ui.Core;
+
+namespace Mutation.Tests;
+
+// Telling a router row that is live from one the user has only typed. Settings pages edit a
+// copy and hand it over on save, so those are two different things and the row had no way to
+// say which it was (issue #343).
+public class RouterBindingStatusTests
+{
+	private static RegisteredRouterRoute Route(string from, string to, bool success = true, string? error = null)
+		=> new(from, to, success, error);
+
+	[Fact]
+	public void ARowMatchingARegisteredRoute_IsLive()
+	{
+		var (state, message) = RouterBindingStatus.For(
+			"CTRL+ALT+1", "CTRL+SHIFT+M", [Route("CTRL+ALT+1", "CTRL+SHIFT+M")]);
+
+		Assert.Equal(HotkeyBindingState.Bound, state);
+		Assert.Null(message);
+	}
+
+	[Fact]
+	public void ARowMatchingARouteThatFailedToRegister_CarriesTheReason()
+	{
+		var (state, message) = RouterBindingStatus.For(
+			"CTRL+ALT+1",
+			"CTRL+SHIFT+M",
+			[Route("CTRL+ALT+1", "CTRL+SHIFT+M", success: false, error: "The shortcut is already registered by another application.")]);
+
+		Assert.Equal(HotkeyBindingState.Failed, state);
+		Assert.Equal("The shortcut is already registered by another application.", message);
+	}
+
+	[Fact]
+	public void ARowTheAppHasNeverSeen_IsWaitingForASave()
+	{
+		var (state, message) = RouterBindingStatus.For(
+			"CTRL+ALT+2", "CTRL+SHIFT+M", [Route("CTRL+ALT+1", "CTRL+SHIFT+M")]);
+
+		Assert.Equal(HotkeyBindingState.NotYetApplied, state);
+		Assert.Null(message);
+	}
+
+	[Fact]
+	public void ChangingOnlyWhatIsSent_StopsTheRowCallingItselfLive()
+	{
+		// The chord being listened for is still registered, but what it sends is now out of
+		// date. A row that matched on the "From" side alone would tell the user their edit had
+		// taken effect when it had not.
+		var (state, _) = RouterBindingStatus.For(
+			"CTRL+ALT+1", "CTRL+SHIFT+N", [Route("CTRL+ALT+1", "CTRL+SHIFT+M")]);
+
+		Assert.Equal(HotkeyBindingState.NotYetApplied, state);
+	}
+
+	[Fact]
+	public void NoWayToAsk_MeansNothingIsClaimedEitherWay()
+	{
+		// A null list is "we cannot find out" — which is the state the Settings page was
+		// permanently in, while reporting every row as not bound.
+		var (state, message) = RouterBindingStatus.For("CTRL+ALT+1", "CTRL+SHIFT+M", null);
+
+		Assert.Equal(HotkeyBindingState.Unknown, state);
+		Assert.Null(message);
+	}
+
+	[Fact]
+	public void AnEmptyListIsARealAnswer_NotAnAbsentOne()
+	{
+		// The app holds no routes at all, so a valid row is genuinely waiting for a save.
+		var (state, _) = RouterBindingStatus.For("CTRL+ALT+1", "CTRL+SHIFT+M", []);
+
+		Assert.Equal(HotkeyBindingState.NotYetApplied, state);
+	}
+
+	[Theory]
+	[InlineData(null, "CTRL+SHIFT+M")]
+	[InlineData("CTRL+ALT+1", null)]
+	[InlineData("", "CTRL+SHIFT+M")]
+	[InlineData("   ", "   ")]
+	public void HalfAMapping_SaysNothing(string? from, string? to)
+	{
+		// Not a route and cannot be one. The row's own "Enter a hotkey." already says so, and a
+		// second line about not being active would repeat it.
+		var (state, message) = RouterBindingStatus.For(from, to, [Route("CTRL+ALT+1", "CTRL+SHIFT+M")]);
+
+		Assert.Equal(HotkeyBindingState.Unknown, state);
+		Assert.Null(message);
+	}
+
+	[Fact]
+	public void SpellingIsForgivenSoAHandEditedFileStillMatches()
+	{
+		// Both sides are written canonically by the app, so this only matters for a settings
+		// file someone typed by hand.
+		var (state, _) = RouterBindingStatus.For(
+			"CTRL+ALT+1", "CTRL+SHIFT+M", [Route(" ctrl+alt+1 ", "ctrl+shift+m")]);
+
+		Assert.Equal(HotkeyBindingState.Bound, state);
+	}
+
+	[Fact]
+	public void TheFirstMatchingRouteAnswers()
+	{
+		// Two identical routes cannot both be registered — the second is refused as a duplicate
+		// — so the row reports the one that took.
+		var (state, _) = RouterBindingStatus.For(
+			"CTRL+ALT+1",
+			"CTRL+SHIFT+M",
+			[
+				Route("CTRL+ALT+1", "CTRL+SHIFT+M"),
+				Route("CTRL+ALT+1", "CTRL+SHIFT+M", success: false, error: "The shortcut is already registered."),
+			]);
+
+		Assert.Equal(HotkeyBindingState.Bound, state);
+	}
+}

--- a/Mutation.Tests/SettingsSectionMatcherTests.cs
+++ b/Mutation.Tests/SettingsSectionMatcherTests.cs
@@ -1,0 +1,82 @@
+using Mutation.Ui.Core;
+
+namespace Mutation.Tests;
+
+// The settings search rule on its own, without a Panel to walk. SettingsSearchStatusTests
+// covers the sentence the search box reports afterwards; this covers which sections it is
+// counting (issue #304).
+public class SettingsSectionMatcherTests
+{
+	[Theory]
+	[InlineData(null)]
+	[InlineData("")]
+	[InlineData("   ")]
+	[InlineData("\t")]
+	public void IsEmptyQuery_TreatsNothingTypedAndOnlySpacesTheSame(string? query)
+	{
+		Assert.True(SettingsSectionMatcher.IsEmptyQuery(query));
+	}
+
+	[Fact]
+	public void IsEmptyQuery_IsFalseForRealText()
+	{
+		Assert.False(SettingsSectionMatcher.IsEmptyQuery("beep"));
+		Assert.False(SettingsSectionMatcher.IsEmptyQuery("  beep  "));
+	}
+
+	[Fact]
+	public void Matches_EmptyQuery_MatchesEverySection()
+	{
+		// An empty search box shows the whole page, including a section with no text in it.
+		Assert.True(SettingsSectionMatcher.Matches("Audio device", string.Empty));
+		Assert.True(SettingsSectionMatcher.Matches(string.Empty, "   "));
+		Assert.True(SettingsSectionMatcher.Matches(null, null));
+	}
+
+	[Fact]
+	public void Matches_FindsTheQueryAnywhereInTheSection()
+	{
+		const string section = "Speech to Text  Deepgram API key  Retry count ";
+
+		Assert.True(SettingsSectionMatcher.Matches(section, "Deepgram"));
+		Assert.True(SettingsSectionMatcher.Matches(section, "retry"));
+		Assert.True(SettingsSectionMatcher.Matches(section, "Speech"));
+	}
+
+	[Fact]
+	public void Matches_IgnoresCaseInBothDirections()
+	{
+		Assert.True(SettingsSectionMatcher.Matches("Microphone Level", "MICROPHONE"));
+		Assert.True(SettingsSectionMatcher.Matches("MICROPHONE LEVEL", "microphone"));
+	}
+
+	[Fact]
+	public void Matches_IgnoresSpacesAroundTheQuery()
+	{
+		// The user typed with a trailing space, or pasted a label with one.
+		Assert.True(SettingsSectionMatcher.Matches("Hotkey Router", "  router  "));
+	}
+
+	[Fact]
+	public void Matches_DoesNotIgnoreSpacesInsideTheQuery()
+	{
+		// "hotkey router" is a phrase; a section that has both words apart does not answer it.
+		Assert.True(SettingsSectionMatcher.Matches("Hotkey Router", "hotkey router"));
+		Assert.False(SettingsSectionMatcher.Matches("Hotkey  Router", "hotkey router"));
+	}
+
+	[Fact]
+	public void Matches_SectionWithoutTheQuery_DoesNotMatch()
+	{
+		Assert.False(SettingsSectionMatcher.Matches("Audio device", "Deepgram"));
+	}
+
+	[Fact]
+	public void Matches_SectionWithNoTextAtAll_AnswersOnlyAnEmptyQuery()
+	{
+		// A section made only of icons and spacing gathers no text. It has to fall out of the
+		// results rather than match everything.
+		Assert.False(SettingsSectionMatcher.Matches(string.Empty, "beep"));
+		Assert.False(SettingsSectionMatcher.Matches(null, "beep"));
+	}
+}

--- a/Mutation.Ui/Core/FirstTouchGate.cs
+++ b/Mutation.Ui/Core/FirstTouchGate.cs
@@ -1,0 +1,57 @@
+using System;
+
+namespace Mutation.Ui.Core;
+
+/// <summary>
+/// Whether a page has been touched yet, and therefore whether it is allowed to read its own
+/// errors out loud.
+/// <para>
+/// The Hotkeys page builds every row from settings before the user sees it, and a stored row
+/// that is empty or unparseable already carries "Enter a hotkey." by the time it reaches the
+/// screen. Each of those errors sits in an assertive live region, so opening the page queued
+/// one interruption per bad row, about settings nobody had touched. Two of the app's own
+/// conventions were already fighting over this: the router row's rewrite notice is committed
+/// with <c>announce: false</c> at load precisely so seventeen rows are not read aloud on the
+/// way in, while the error beside it had no such gate (issue #350).
+/// </para>
+/// <para>
+/// The gate is per page rather than per row, and that is the point. A row-by-row rule — a row
+/// speaks once it has been left once — would silence the case where the user edits a *core*
+/// hotkey and a *router* row two sections down becomes a duplicate because of it. That row was
+/// never touched, and it is exactly the news the user needs. Once anything on the page has
+/// been used, every row on it may speak.
+/// </para>
+/// <para>
+/// It gates the announcement only, never the written text. An error is on screen from the
+/// moment it exists, because taking it off screen at load would be a plain regression for a
+/// sighted reader — the visible half of this was never broken.
+/// </para>
+/// </summary>
+internal sealed class FirstTouchGate
+{
+	/// <summary>
+	/// True once the user has done something on the page. Errors announce normally from then
+	/// on; before it, they are shown in silence.
+	/// </summary>
+	internal bool HasBeenTouched { get; private set; }
+
+	/// <summary>
+	/// Raised the once, when the page goes from untouched to touched, so anything holding a
+	/// message it was told not to say can stop holding back. It does not repeat.
+	/// </summary>
+	internal event EventHandler? Touched;
+
+	/// <summary>
+	/// Records that the user has used the page. Idempotent — the second call and every one
+	/// after it does nothing at all, which is what lets every handler on the page call it
+	/// freely without checking first.
+	/// </summary>
+	internal void Touch()
+	{
+		if (HasBeenTouched)
+			return;
+
+		HasBeenTouched = true;
+		Touched?.Invoke(this, EventArgs.Empty);
+	}
+}

--- a/Mutation.Ui/Core/ForegroundInjectionGuard.cs
+++ b/Mutation.Ui/Core/ForegroundInjectionGuard.cs
@@ -4,11 +4,11 @@ namespace Mutation.Ui.Core;
 /// Whether Windows is going to throw away a keystroke aimed at the window in front, worked
 /// out from what a probe of that window's process managed to find out and nothing else.
 /// <para>
-/// User Interface Privilege Isolation stops an ordinary process sending input to a window
-/// owned by one running at a higher integrity level. Microsoft's documentation for
-/// <c>SendInput</c> is explicit that this failure is invisible from the calling side: the
-/// events are accepted into the input stream, the return count is the full number submitted,
-/// and <c>GetLastError</c> reports nothing. They are discarded further down.
+/// User Interface Privilege Isolation stops a process sending input to a window owned by one
+/// running at a higher integrity level. Microsoft's documentation for <c>SendInput</c> is
+/// explicit that this failure is invisible from the calling side: the events are accepted into
+/// the input stream, the return count is the full number submitted, and <c>GetLastError</c>
+/// reports nothing. They are discarded further down.
 /// </para>
 /// <para>
 /// So the count check that <see cref="Mutation.Ui.Services.HotkeyManager"/> does after the
@@ -17,69 +17,156 @@ namespace Mutation.Ui.Core;
 /// does catch input genuinely refused, which is a different set of causes (issue #294).
 /// </para>
 /// <para>
-/// The question has to be asked before sending, and the only reliable way to ask is to try
-/// to open the foreground window's process for a query and see whether Windows says no. Kept
-/// apart from the P/Invoke that does the asking so the rule can be exercised without an
-/// elevated process to point it at.
+/// The question has to be asked before sending, and the answer is a comparison of two
+/// integrity levels: ours and the foreground process's. Kept apart from the P/Invoke that
+/// fetches them so the rule can be exercised without an elevated process to point it at.
+/// </para>
+/// <para>
+/// Two access rights are asked for, and the difference between them is the signal.
+/// <c>PROCESS_QUERY_LIMITED_INFORMATION</c> exists precisely so that an ordinary process
+/// <em>can</em> identify a more privileged one — it is what lets an unelevated Task Manager
+/// list elevated processes by name — so it is granted across an integrity boundary and a
+/// refusal of it says nothing about privilege. <c>PROCESS_QUERY_INFORMATION</c> is not granted
+/// across one, and it is the right <c>OpenProcessToken</c> needs. So:
+/// </para>
+/// <list type="bullet">
+/// <item>Both granted — read the two integrity levels and compare them.</item>
+/// <item>Limited granted, full refused — we can name the process but not read its token. That
+/// is the integrity boundary's signature.</item>
+/// <item>Limited refused — a DACL said no, which is a different question. Another user's
+/// process in the same session refuses this while running at our own integrity level, where
+/// UIPI would have let the input through. Treated as "cannot tell".</item>
+/// </list>
+/// <para>
+/// That last case is why the refusal of the limited right is not read as a positive. Getting it
+/// wrong would refuse to type into an ordinary window and report a failure that would not have
+/// happened, which is worse than the silent drop this exists to catch.
 /// </para>
 /// </summary>
 internal static class ForegroundInjectionGuard
 {
 	/// <summary>
-	/// <c>ERROR_ACCESS_DENIED</c>. The one error code that means the foreground process sits
-	/// above us, rather than that the question could not be asked.
+	/// <c>ERROR_ACCESS_DENIED</c>. Windows saying no to a look at a process or its token,
+	/// which it only does when that process sits above us.
 	/// </summary>
 	internal const int ErrorAccessDenied = 5;
 
-	/// <summary>What trying to open the foreground window's process told us.</summary>
-	internal enum ProbeResult
+	// The well-known integrity level RIDs, named so a test can talk about them. They are the
+	// low twelve bits of the S-1-16-x SID that every token carries, and they are ordered — a
+	// plain greater-than is the whole comparison.
+	internal const uint UntrustedIntegrity = 0x0000;
+	internal const uint LowIntegrity = 0x1000;
+	internal const uint MediumIntegrity = 0x2000;
+	internal const uint HighIntegrity = 0x3000;
+	internal const uint SystemIntegrity = 0x4000;
+
+	/// <summary>How one call in the probe went.</summary>
+	internal enum ProbeStep
+	{
+		/// <summary>It worked.</summary>
+		Succeeded,
+
+		/// <summary>Windows refused it with <see cref="ErrorAccessDenied"/>.</summary>
+		Refused,
+
+		/// <summary>
+		/// It failed for some other reason — the process exited between two calls, memory ran
+		/// short. Says nothing about privilege either way.
+		/// </summary>
+		Failed,
+	}
+
+	/// <summary>What the probe as a whole established.</summary>
+	internal enum ForegroundProbe
 	{
 		/// <summary>
-		/// Nothing could be established: no window in front, no process id for it, or a
-		/// failure that was not a refusal. Injection goes ahead.
+		/// Nothing. No window in front, no process id for it, a call that failed for a reason
+		/// unrelated to privilege, or a DACL refusing us a process we could otherwise have typed
+		/// into. Injection goes ahead.
 		/// </summary>
 		Unknown,
 
 		/// <summary>
-		/// The process opened, so it does not sit above us and our input will reach it.
+		/// The process could be named but not read: limited query granted, full query refused.
+		/// Nothing but an integrity boundary produces that pair, so it is conclusive on its own
+		/// and no integrity level is needed to act on it.
 		/// </summary>
-		Opened,
+		AboveUs,
 
 		/// <summary>
-		/// Windows refused the handle outright. The process is at a higher integrity level and
-		/// anything we inject will be discarded without a word.
+		/// Both integrity levels were read, so the answer is a straight comparison.
 		/// </summary>
-		Refused,
+		IntegrityKnown,
+	}
+
+	/// <summary>Reads one call's outcome. <paramref name="errorCode"/> matters only on failure.</summary>
+	internal static ProbeStep StepFrom(bool succeeded, int errorCode)
+	{
+		if (succeeded)
+			return ProbeStep.Succeeded;
+
+		return errorCode == ErrorAccessDenied ? ProbeStep.Refused : ProbeStep.Failed;
 	}
 
 	/// <summary>
-	/// Reads the outcome of one probe. <paramref name="errorCode"/> is only consulted when
-	/// <paramref name="opened"/> is false.
-	/// <para>
-	/// <c>PROCESS_QUERY_LIMITED_INFORMATION</c> is deliberately the weakest right that
-	/// identifies a process — it is granted for a process at our own integrity level or below,
-	/// and for processes belonging to other users. A flat refusal of it is therefore a strong
-	/// signal rather than a routine one.
-	/// </para>
+	/// What the probe's three calls together established.
 	/// </summary>
-	internal static ProbeResult Classify(bool hasForegroundWindow, uint processId, bool opened, int errorCode)
+	/// <param name="limitedOpen">
+	/// Opening the process for <c>PROCESS_QUERY_LIMITED_INFORMATION</c>. Granted across an
+	/// integrity boundary, so a refusal here is a DACL and tells us nothing we can act on.
+	/// </param>
+	/// <param name="fullOpen">
+	/// Opening the same process for <c>PROCESS_QUERY_INFORMATION</c>. Not granted across an
+	/// integrity boundary, so refused-here-but-granted-above is the signature we are looking for.
+	/// </param>
+	/// <param name="tokenRead">
+	/// Opening the process's token, which needs the full right. Reached only when
+	/// <paramref name="fullOpen"/> succeeded, so a failure is something unexpected rather than a
+	/// privilege answer.
+	/// </param>
+	internal static ForegroundProbe Classify(
+		bool hasForegroundWindow,
+		uint processId,
+		ProbeStep limitedOpen,
+		ProbeStep fullOpen,
+		ProbeStep tokenRead)
 	{
 		// No window in front — a locked screen, a moment between two apps — and nothing to
 		// decide. Likewise a window whose thread we cannot resolve to a process.
 		if (!hasForegroundWindow || processId == 0)
-			return ProbeResult.Unknown;
+			return ForegroundProbe.Unknown;
 
-		if (opened)
-			return ProbeResult.Opened;
+		// Includes Refused. Another user's process in this session refuses even the limited
+		// right while sitting at our own integrity level, where our input would have landed.
+		if (limitedOpen != ProbeStep.Succeeded)
+			return ForegroundProbe.Unknown;
 
-		return errorCode == ErrorAccessDenied ? ProbeResult.Refused : ProbeResult.Unknown;
+		if (fullOpen == ProbeStep.Refused)
+			return ForegroundProbe.AboveUs;
+
+		if (fullOpen != ProbeStep.Succeeded || tokenRead != ProbeStep.Succeeded)
+			return ForegroundProbe.Unknown;
+
+		return ForegroundProbe.IntegrityKnown;
 	}
 
 	/// <summary>
-	/// True only for an outright refusal. Every other answer lets the injection proceed,
-	/// deliberately: a false positive here would refuse to type into a perfectly ordinary
+	/// Whether our input is going to be discarded. Equal integrity is fine — UIPI blocks
+	/// sending up, not sending across — so the comparison is strictly greater than.
+	/// <para>
+	/// Deliberately one-sided everywhere else: anything that could not be established lets the
+	/// injection proceed. A false positive here would refuse to type into a perfectly ordinary
 	/// window and tell the user their dictation failed when it would have worked, which is a
-	/// worse outcome than the silent drop this exists to catch.
+	/// worse outcome than the silent drop this exists to catch. It is also why the user guide
+	/// still says this catch is not a guarantee.
+	/// </para>
 	/// </summary>
-	internal static bool InputWillBeDiscarded(ProbeResult probe) => probe == ProbeResult.Refused;
+	internal static bool InputWillBeDiscarded(
+		ForegroundProbe probe, uint foregroundIntegrity, uint ownIntegrity) =>
+		probe switch
+		{
+			ForegroundProbe.AboveUs => true,
+			ForegroundProbe.IntegrityKnown => foregroundIntegrity > ownIntegrity,
+			_ => false,
+		};
 }

--- a/Mutation.Ui/Core/ForegroundInjectionGuard.cs
+++ b/Mutation.Ui/Core/ForegroundInjectionGuard.cs
@@ -1,0 +1,85 @@
+namespace Mutation.Ui.Core;
+
+/// <summary>
+/// Whether Windows is going to throw away a keystroke aimed at the window in front, worked
+/// out from what a probe of that window's process managed to find out and nothing else.
+/// <para>
+/// User Interface Privilege Isolation stops an ordinary process sending input to a window
+/// owned by one running at a higher integrity level. Microsoft's documentation for
+/// <c>SendInput</c> is explicit that this failure is invisible from the calling side: the
+/// events are accepted into the input stream, the return count is the full number submitted,
+/// and <c>GetLastError</c> reports nothing. They are discarded further down.
+/// </para>
+/// <para>
+/// So the count check that <see cref="Mutation.Ui.Services.HotkeyManager"/> does after the
+/// fact cannot see the case this app was actually failing at — a transcript dictated with
+/// Task Manager or an elevated console in front, announced as delivered, typed nowhere. It
+/// does catch input genuinely refused, which is a different set of causes (issue #294).
+/// </para>
+/// <para>
+/// The question has to be asked before sending, and the only reliable way to ask is to try
+/// to open the foreground window's process for a query and see whether Windows says no. Kept
+/// apart from the P/Invoke that does the asking so the rule can be exercised without an
+/// elevated process to point it at.
+/// </para>
+/// </summary>
+internal static class ForegroundInjectionGuard
+{
+	/// <summary>
+	/// <c>ERROR_ACCESS_DENIED</c>. The one error code that means the foreground process sits
+	/// above us, rather than that the question could not be asked.
+	/// </summary>
+	internal const int ErrorAccessDenied = 5;
+
+	/// <summary>What trying to open the foreground window's process told us.</summary>
+	internal enum ProbeResult
+	{
+		/// <summary>
+		/// Nothing could be established: no window in front, no process id for it, or a
+		/// failure that was not a refusal. Injection goes ahead.
+		/// </summary>
+		Unknown,
+
+		/// <summary>
+		/// The process opened, so it does not sit above us and our input will reach it.
+		/// </summary>
+		Opened,
+
+		/// <summary>
+		/// Windows refused the handle outright. The process is at a higher integrity level and
+		/// anything we inject will be discarded without a word.
+		/// </summary>
+		Refused,
+	}
+
+	/// <summary>
+	/// Reads the outcome of one probe. <paramref name="errorCode"/> is only consulted when
+	/// <paramref name="opened"/> is false.
+	/// <para>
+	/// <c>PROCESS_QUERY_LIMITED_INFORMATION</c> is deliberately the weakest right that
+	/// identifies a process — it is granted for a process at our own integrity level or below,
+	/// and for processes belonging to other users. A flat refusal of it is therefore a strong
+	/// signal rather than a routine one.
+	/// </para>
+	/// </summary>
+	internal static ProbeResult Classify(bool hasForegroundWindow, uint processId, bool opened, int errorCode)
+	{
+		// No window in front — a locked screen, a moment between two apps — and nothing to
+		// decide. Likewise a window whose thread we cannot resolve to a process.
+		if (!hasForegroundWindow || processId == 0)
+			return ProbeResult.Unknown;
+
+		if (opened)
+			return ProbeResult.Opened;
+
+		return errorCode == ErrorAccessDenied ? ProbeResult.Refused : ProbeResult.Unknown;
+	}
+
+	/// <summary>
+	/// True only for an outright refusal. Every other answer lets the injection proceed,
+	/// deliberately: a false positive here would refuse to type into a perfectly ordinary
+	/// window and tell the user their dictation failed when it would have worked, which is a
+	/// worse outcome than the silent drop this exists to catch.
+	/// </summary>
+	internal static bool InputWillBeDiscarded(ProbeResult probe) => probe == ProbeResult.Refused;
+}

--- a/Mutation.Ui/Core/HotkeyBindingState.cs
+++ b/Mutation.Ui/Core/HotkeyBindingState.cs
@@ -1,0 +1,34 @@
+namespace Mutation.Ui.Core;
+
+/// <summary>
+/// What the app knows about one hotkey-router route: whether the running app is listening for
+/// it, whether it tried and could not, or whether there is nothing to say yet.
+/// <para>
+/// The old shape had three states and called the third one <c>Inactive</c>, which the row
+/// reported as "Hotkey is not currently bound." That was the lie behind issue #343 — the
+/// Settings page never learned any registration outcome at all, so every row, working ones
+/// included, sat in that state. The states below separate not knowing from knowing the answer
+/// is no, and add the one the Settings page is usually in: a perfectly good mapping the running
+/// app has not been handed yet, because it is handed them on save.
+/// </para>
+/// </summary>
+public enum HotkeyBindingState
+{
+	/// <summary>
+	/// Nothing is known. No registration outcome is available, or the row is not a usable
+	/// mapping yet, so the row says nothing about being live rather than guessing.
+	/// </summary>
+	Unknown,
+
+	/// <summary>The running app is listening for this route, and it works.</summary>
+	Bound,
+
+	/// <summary>Registration was attempted and refused. The reason travels with it.</summary>
+	Failed,
+
+	/// <summary>
+	/// A valid mapping that the running app has not been given. Editing an existing row or
+	/// adding a new one puts it here until the settings are saved.
+	/// </summary>
+	NotYetApplied,
+}

--- a/Mutation.Ui/Core/RegisteredRouterRoute.cs
+++ b/Mutation.Ui/Core/RegisteredRouterRoute.cs
@@ -1,0 +1,18 @@
+namespace Mutation.Ui.Core;
+
+/// <summary>
+/// One hotkey-router route the running app was asked to register, and how that went.
+/// <para>
+/// This is what the Hotkeys page compares its rows against. Registration happens once, on save,
+/// and the page is editing a copy of the settings — so without something like this, a row has no
+/// way to tell being live from merely being typed, which is the whole of issue #343.
+/// </para>
+/// <para>
+/// <see cref="ErrorMessage"/> is set only when <see cref="Success"/> is false.
+/// </para>
+/// </summary>
+public readonly record struct RegisteredRouterRoute(
+	string? From,
+	string? To,
+	bool Success,
+	string? ErrorMessage);

--- a/Mutation.Ui/Core/RouterBindingStatus.cs
+++ b/Mutation.Ui/Core/RouterBindingStatus.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+
+namespace Mutation.Ui.Core;
+
+/// <summary>
+/// Works out what one row of the Hotkey Router table should say about itself, given the routes
+/// the running app actually holds.
+/// <para>
+/// The Settings pages edit a copy of the settings and hand it over on save, so a row on screen
+/// is not necessarily a route the app has. That is why a plain "bound or not" answer was never
+/// going to be honest here: most rows on that page are neither, they are waiting. Comparing the
+/// row against the app's live routes tells the three apart (issue #343).
+/// </para>
+/// </summary>
+internal static class RouterBindingStatus
+{
+	/// <summary>
+	/// The state of a row whose canonical "From" and "To" chords are
+	/// <paramref name="normalizedFrom"/> and <paramref name="normalizedTo"/>.
+	/// <para>
+	/// A null <paramref name="liveRoutes"/> means the caller has no way to ask — nothing is
+	/// registered yet, or this page has no connection to the running app — and the answer is
+	/// <see cref="HotkeyBindingState.Unknown"/> rather than a guess. An empty list is a real
+	/// answer: the app holds no routes, so a valid row is waiting for a save.
+	/// </para>
+	/// <para>
+	/// Both halves of the mapping have to match, not just the shortcut being listened for.
+	/// Changing only the "To" side leaves the same chord registered while what it sends is now
+	/// out of date, and a row calling itself live on the strength of the "From" match alone
+	/// would be telling the user their edit had taken effect when it had not.
+	/// </para>
+	/// </summary>
+	internal static (HotkeyBindingState State, string? Message) For(
+		string? normalizedFrom,
+		string? normalizedTo,
+		IReadOnlyList<RegisteredRouterRoute>? liveRoutes)
+	{
+		if (liveRoutes is null)
+			return (HotkeyBindingState.Unknown, null);
+
+		// Half a mapping is not a route. The row's own validation message already says what is
+		// wrong with it, and a second line about not being live would be noise on top of it.
+		if (string.IsNullOrWhiteSpace(normalizedFrom) || string.IsNullOrWhiteSpace(normalizedTo))
+			return (HotkeyBindingState.Unknown, null);
+
+		foreach (var route in liveRoutes)
+		{
+			if (!SameChord(route.From, normalizedFrom) || !SameChord(route.To, normalizedTo))
+				continue;
+
+			return route.Success
+				? (HotkeyBindingState.Bound, null)
+				: (HotkeyBindingState.Failed, route.ErrorMessage);
+		}
+
+		return (HotkeyBindingState.NotYetApplied, null);
+	}
+
+	/// <summary>
+	/// Both sides are written in the app's one canonical spelling already — the rows canonicalise
+	/// on commit, and what is on disk was written by a commit — so this is a comparison of two
+	/// spellings that should agree, with the case and stray spaces forgiven in case one of them
+	/// came from a hand-edited settings file.
+	/// </summary>
+	private static bool SameChord(string? left, string? right) =>
+		string.Equals(left?.Trim(), right?.Trim(), StringComparison.OrdinalIgnoreCase);
+}

--- a/Mutation.Ui/Core/RouterBindingStatus.cs
+++ b/Mutation.Ui/Core/RouterBindingStatus.cs
@@ -1,3 +1,4 @@
+using Mutation.Ui.Services;
 using System;
 using System.Collections.Generic;
 
@@ -58,11 +59,28 @@ internal static class RouterBindingStatus
 	}
 
 	/// <summary>
-	/// Both sides are written in the app's one canonical spelling already — the rows canonicalise
-	/// on commit, and what is on disk was written by a commit — so this is a comparison of two
-	/// spellings that should agree, with the case and stray spaces forgiven in case one of them
-	/// came from a hand-edited settings file.
+	/// Whether two spellings name the same chord. Both sides go through
+	/// <see cref="Hotkey.Canonicalize"/> first, which is the app's single authority on how a
+	/// chord is spelled, so <c>CONTROL+SHIFT+ALT+8</c> and <c>CTRL+SHIFT+ALT+8</c> are one
+	/// shortcut and <c>SHIFT+CTRL+A</c> and <c>CTRL+SHIFT+A</c> are one shortcut.
+	/// <para>
+	/// Comparing the raw text instead was a real bug, not a theoretical one. The row's side has
+	/// been through <c>Canonicalize</c>; the live route's side is whatever is in the settings
+	/// file. A brand-new settings file is seeded with a router mapping written
+	/// <c>CONTROL+SHIFT+ALT+8</c>, so on a fresh install the one router row on the page reported
+	/// a working mapping as "not active yet" — the same class of false statement issue #343 was
+	/// filed about. Any file written before the canonicalisation work, or edited by hand, does
+	/// the same.
+	/// </para>
+	/// <para>
+	/// This is the lesson <see cref="HotkeyConflictFinder"/> already learned for duplicate
+	/// detection (issue #306): a shortcut has one identity and many spellings, and comparing
+	/// spellings gets it wrong.
+	/// </para>
 	/// </summary>
 	private static bool SameChord(string? left, string? right) =>
-		string.Equals(left?.Trim(), right?.Trim(), StringComparison.OrdinalIgnoreCase);
+		string.Equals(
+			Hotkey.Canonicalize(left)?.Trim(),
+			Hotkey.Canonicalize(right)?.Trim(),
+			StringComparison.OrdinalIgnoreCase);
 }

--- a/Mutation.Ui/Core/SettingsSectionMatcher.cs
+++ b/Mutation.Ui/Core/SettingsSectionMatcher.cs
@@ -1,0 +1,44 @@
+using System;
+
+namespace Mutation.Ui.Core;
+
+/// <summary>
+/// Whether one section of a settings page answers what the user typed into the search box.
+/// <para>
+/// Split out of the tree walk in <c>SettingsSearchHelper</c>, which gathers a section's text
+/// out of the live visual tree and then reports its answer by collapsing the section. The
+/// gathering and the collapsing both need a real WinUI tree; deciding matched or not does
+/// not, and it is the part with a rule in it (issue #304).
+/// </para>
+/// </summary>
+internal static class SettingsSectionMatcher
+{
+	/// <summary>
+	/// True when the search box is effectively empty — nothing typed, or only spaces. Every
+	/// section matches an empty query, so the caller shows the whole page rather than gathering
+	/// any text at all.
+	/// </summary>
+	internal static bool IsEmptyQuery(string? query) => Normalize(query).Length == 0;
+
+	/// <summary>
+	/// True when <paramref name="sectionText"/> contains <paramref name="query"/>, ignoring
+	/// case and surrounding spaces. A section with no text at all matches only an empty query.
+	/// <para>
+	/// Case is folded with the invariant culture, matching what the tree walk did before this
+	/// was split out. It means the match does not follow the user's locale, which for a query
+	/// against English setting labels is the behaviour that stays predictable — Turkish
+	/// lower-casing an "I" would stop "Interface" answering a typed "i".
+	/// </para>
+	/// </summary>
+	internal static bool Matches(string? sectionText, string? query)
+	{
+		string needle = Normalize(query);
+		if (needle.Length == 0)
+			return true;
+
+		return (sectionText ?? string.Empty).ToLowerInvariant().Contains(needle, StringComparison.Ordinal);
+	}
+
+	private static string Normalize(string? query) =>
+		(query ?? string.Empty).Trim().ToLowerInvariant();
+}

--- a/Mutation.Ui/HotkeyRouterEntry.cs
+++ b/Mutation.Ui/HotkeyRouterEntry.cs
@@ -139,15 +139,36 @@ public sealed class HotkeyRouterEntry : INotifyPropertyChanged
         /// well so acting on the row is answered rather than leaving the user to press the
         /// shortcut and find out (issue #343).
         /// </para>
+        /// <para>
+        /// It names the shortcut, for the same reason the rewrite notices name their box: it can
+        /// be announced out of a row the user is not in. Pressing <b>Delete</b> re-evaluates every
+        /// remaining row, so deleting one of two rows that were flagged as duplicates of each
+        /// other leaves the survivor announcing its new state while focus sits on a button in a
+        /// row that no longer exists. "Not active yet" on its own would give the user no way to
+        /// tell which mapping was meant, and a chord that three rows shared would say it three
+        /// times.
+        /// </para>
         /// </summary>
-        public string? RouteStatusText => _bindingState switch
+        public string? RouteStatusText
         {
-                HotkeyBindingState.Bound => "This mapping is live.",
-                HotkeyBindingState.NotYetApplied => "Not active yet \u2014 press Save to apply.",
-                // Failed says why in the error region below, which is assertive and reaches the
-                // user without being hunted for. Two lines saying the same thing is one too many.
-                _ => null,
-        };
+                get
+                {
+                        // The chord is always present in these two states: the controller only asks
+                        // about a row that is valid, and a valid row has a normalized "From".
+                        string chord = NormalizedFromHotkey ?? string.Empty;
+
+                        return _bindingState switch
+                        {
+                                HotkeyBindingState.Bound => $"{chord} is live.",
+                                HotkeyBindingState.NotYetApplied =>
+                                        $"{chord} is not active yet \u2014 press Save to apply.",
+                                // Failed says why in the error region below, which is assertive and
+                                // reaches the user without being hunted for. Two lines saying the
+                                // same thing is one too many.
+                                _ => null,
+                        };
+                }
+        }
 
         /// <summary>
         /// While true, this row's error and status still appear on screen but are not read out.

--- a/Mutation.Ui/HotkeyRouterEntry.cs
+++ b/Mutation.Ui/HotkeyRouterEntry.cs
@@ -9,22 +9,16 @@ using Microsoft.UI.Xaml.Media;
 using Windows.UI;
 using Microsoft.UI;
 
-namespace Mutation.Ui;
+// HotkeyBindingState moved to Mutation.Ui.Core so the rule that decides it —
+// RouterBindingStatus — can live next to the app's other pure units instead of depending on a
+// file that pulls in WinUI (issue #343).
 
-public enum HotkeyBindingState
-{
-        Inactive,
-        Bound,
-        Failed
-}
+namespace Mutation.Ui;
 
 public sealed class HotkeyRouterEntry : INotifyPropertyChanged
 {
         private static readonly Brush TransparentBrush = new SolidColorBrush(Colors.Transparent);
         private static readonly Brush InvalidBackgroundBrush = new SolidColorBrush(Color.FromArgb(0x33, 0xB2, 0x1E, 0x1E));
-        private static readonly Brush NeutralStatusBrush = ResolveThemeBrush("SystemFillColorNeutralBrush") ?? new SolidColorBrush(Color.FromArgb(0xFF, 0x6B, 0x6B, 0x6B));
-        private static readonly Brush SuccessStatusBrush = ResolveThemeBrush("SystemFillColorSuccessBrush") ?? new SolidColorBrush(Color.FromArgb(0xFF, 0x0B, 0x8A, 0x00));
-        private static readonly Brush FailureStatusBrush = ResolveThemeBrush("SystemFillColorCriticalBrush") ?? new SolidColorBrush(Color.FromArgb(0xFF, 0xD1, 0x42, 0x42));
 
         private string _fromHotkeyText = string.Empty;
         private string _toHotkeyText = string.Empty;
@@ -35,11 +29,12 @@ public sealed class HotkeyRouterEntry : INotifyPropertyChanged
         private bool _isDuplicate;
         private string? _fromValidationMessage;
         private string? _toValidationMessage;
-        private HotkeyBindingState _bindingState = HotkeyBindingState.Inactive;
+        private HotkeyBindingState _bindingState = HotkeyBindingState.Unknown;
         private string? _bindingError;
         private string? _combinedError;
         private string? _fromCommitAnnouncement;
         private string? _toCommitAnnouncement;
+        private bool _announcementsMuted;
 
         /// <summary>
         /// What the two boxes are called to a screen reader, matching the
@@ -94,7 +89,7 @@ public sealed class HotkeyRouterEntry : INotifyPropertyChanged
                         if (SetField(ref _fromHotkeyText, value ?? string.Empty, nameof(FromHotkey)))
                         {
                                 EvaluateFrom(commit: false, announce: false);
-                                SetBindingResult(HotkeyBindingState.Inactive, null);
+                                SetBindingResult(HotkeyBindingState.Unknown, null);
                         }
                 }
         }
@@ -107,7 +102,7 @@ public sealed class HotkeyRouterEntry : INotifyPropertyChanged
                         if (SetField(ref _toHotkeyText, value ?? string.Empty, nameof(ToHotkey)))
                         {
                                 EvaluateTo(commit: false, announce: false);
-                                SetBindingResult(HotkeyBindingState.Inactive, null);
+                                SetBindingResult(HotkeyBindingState.Unknown, null);
                         }
                 }
         }
@@ -132,32 +127,49 @@ public sealed class HotkeyRouterEntry : INotifyPropertyChanged
 
         public HotkeyBindingState BindingState => _bindingState;
 
-        public string BindingStatusGlyph => _bindingState switch
+        /// <summary>
+        /// Whether the running app is listening for this route, in words, or null when there is
+        /// nothing worth saying \u2014 the row is half filled in, it has an error of its own that says
+        /// more than this would, or nobody has told us what the app holds.
+        /// <para>
+        /// A written line rather than a tick beside the box. The tick was the whole of the old
+        /// design and none of it worked: a glyph carries no text, and the tooltip that explained
+        /// it announced nothing until you knew it was there and went looking. This sits in the
+        /// row's reading order, so going down the page reads it out, and it is a live region as
+        /// well so acting on the row is answered rather than leaving the user to press the
+        /// shortcut and find out (issue #343).
+        /// </para>
+        /// </summary>
+        public string? RouteStatusText => _bindingState switch
         {
-                HotkeyBindingState.Bound => "\uE73E", // CheckMark
-                HotkeyBindingState.Failed => "\uEA39", // StatusErrorFull
-                _ => "\uF142" // Record
+                HotkeyBindingState.Bound => "This mapping is live.",
+                HotkeyBindingState.NotYetApplied => "Not active yet \u2014 press Save to apply.",
+                // Failed says why in the error region below, which is assertive and reaches the
+                // user without being hunted for. Two lines saying the same thing is one too many.
+                _ => null,
         };
 
-        public Brush BindingStatusBrush => _bindingState switch
-        {
-                HotkeyBindingState.Bound => SuccessStatusBrush,
-                HotkeyBindingState.Failed => FailureStatusBrush,
-                _ => NeutralStatusBrush
-        };
+        /// <summary>
+        /// While true, this row's error and status still appear on screen but are not read out.
+        /// The page sets it for rows built straight from settings, which can arrive already
+        /// carrying "Enter a hotkey." \u2014 one assertive interruption per stored bad row, about
+        /// settings the user has not touched (issue #350).
+        /// </summary>
+        public bool AnnouncementsMuted => _announcementsMuted;
 
-        public string BindingStatusTooltip
+        /// <summary>
+        /// Lets this row speak, or stops it. Called for every row at once, because the page is
+        /// what has or has not been used \u2014 a row-by-row rule would silence a duplicate that
+        /// appears in this list because the user edited a core hotkey higher up the page, which
+        /// is exactly the news worth interrupting for.
+        /// </summary>
+        public void SetAnnouncementsMuted(bool muted)
         {
-                get
-                {
-                        if (_bindingState == HotkeyBindingState.Bound)
-                                return "Hotkey is bound.";
-                        if (HasBindingError && !string.IsNullOrEmpty(_combinedError))
-                                return _combinedError!;
-                        if (_bindingState == HotkeyBindingState.Failed)
-                                return "Hotkey binding failed.";
-                        return "Hotkey is not currently bound.";
-                }
+                if (_announcementsMuted == muted)
+                        return;
+
+                _announcementsMuted = muted;
+                OnPropertyChanged(nameof(AnnouncementsMuted));
         }
 
         public bool HasBindingError => !string.IsNullOrEmpty(_combinedError);
@@ -235,8 +247,10 @@ public sealed class HotkeyRouterEntry : INotifyPropertyChanged
                 OnPropertyChanged(nameof(IsFromInputValid));
                 OnPropertyChanged(nameof(IsValid));
                 OnPropertyChanged(nameof(FromBackgroundBrush));
+                // A row whose chord is already taken is not a route and cannot be one, so it has
+                // nothing to say about being live. The duplicate message says what is wrong.
                 if (isDuplicate)
-                        SetBindingResult(HotkeyBindingState.Inactive, null);
+                        SetBindingResult(HotkeyBindingState.Unknown, null);
                 else
                         UpdateCombinedError();
         }
@@ -252,9 +266,7 @@ public sealed class HotkeyRouterEntry : INotifyPropertyChanged
                 _bindingState = state;
                 _bindingError = message;
                 OnPropertyChanged(nameof(BindingState));
-                OnPropertyChanged(nameof(BindingStatusGlyph));
-                OnPropertyChanged(nameof(BindingStatusBrush));
-                OnPropertyChanged(nameof(BindingStatusTooltip));
+                OnPropertyChanged(nameof(RouteStatusText));
                 UpdateCombinedError();
         }
 
@@ -428,7 +440,6 @@ public sealed class HotkeyRouterEntry : INotifyPropertyChanged
                         OnPropertyChanged(nameof(BindingErrorMessage));
                         OnPropertyChanged(nameof(HasBindingError));
                         OnPropertyChanged(nameof(BindingErrorVisibility));
-                        OnPropertyChanged(nameof(BindingStatusTooltip));
                 }
         }
 
@@ -440,13 +451,6 @@ public sealed class HotkeyRouterEntry : INotifyPropertyChanged
                 storage = value;
                 OnPropertyChanged(propertyName);
                 return true;
-        }
-
-        private static Brush? ResolveThemeBrush(string key)
-        {
-                if (Application.Current?.Resources.TryGetValue(key, out object? value) == true && value is Brush brush)
-                        return brush;
-                return null;
         }
 
         private void OnPropertyChanged(string propertyName) =>

--- a/Mutation.Ui/MainWindow.Onboarding.cs
+++ b/Mutation.Ui/MainWindow.Onboarding.cs
@@ -56,7 +56,12 @@ public sealed partial class MainWindow
 			_settingsManager,
 			_settingsManager.SettingsFilePath,
 			ApplyLiveSettings,
-			initialCategoryKey)
+			initialCategoryKey,
+			// So a Hotkey Router row on the Hotkeys page can say whether the app is actually
+			// listening for it. Null while there is no hotkey manager yet — before startup has
+			// finished wiring one up — and the rows then say nothing rather than guess
+			// (issue #343).
+			liveRouterRoutes: () => _hotkeyManager?.LiveRouterRoutes())
 		{
 			XamlRoot = rootElement.XamlRoot,
 			RequestedTheme = rootElement.ActualTheme

--- a/Mutation.Ui/MainWindow.xaml.cs
+++ b/Mutation.Ui/MainWindow.xaml.cs
@@ -3445,15 +3445,19 @@ public sealed partial class MainWindow : Window, IDisposable
 	// Reports how far the text actually got. Every path that needs no insert — an empty
 	// transcript, Mutation itself in front, the "do not insert" option — is Delivered.
 	//
-	// The injection is awaited rather than fired and forgotten (#232). Windows drops
-	// injected input silently when the foreground application runs with higher
-	// privileges, so the only moment the failure can be seen is when SendInput returns
-	// a short count; a caller that had already announced success by then would have
-	// told a blind user their dictation landed in a window that never received it. The
-	// await keeps the work off the UI thread — it runs on the thread pool and the UI
-	// thread returns to its message pump — and it is bounded: SendInput is synchronous,
-	// and the hotkey path waits at most ModifierReleaseTimeoutMs for the user to let go
-	// of the chord they triggered this with.
+	// The injection is awaited rather than fired and forgotten (#232), so a short count
+	// from SendInput is seen before anything announces success; a caller that had already
+	// announced by then would have told a blind user their dictation landed in a window
+	// that never received it. The await keeps the work off the UI thread — it runs on the
+	// thread pool and the UI thread returns to its message pump — and it is bounded:
+	// SendInput is synchronous, and the hotkey path waits at most
+	// ModifierReleaseTimeoutMs for the user to let go of the chord they triggered this
+	// with.
+	//
+	// The short count is not the whole story, which is why each branch below asks a
+	// question first. When the window in front runs at a higher integrity level, Windows
+	// takes the events and discards them with no failure reported anywhere, so the
+	// elevated-app case has to be detected before sending rather than after (issue #294).
 	private async Task<TranscriptDeliveryOutcome> TryInsertIntoActiveApplicationAsync(string text, bool clipboardAvailable = true)
 	{
 		if (string.IsNullOrWhiteSpace(text))
@@ -3465,6 +3469,14 @@ public sealed partial class MainWindow : Window, IDisposable
 		switch (_insertOption)
 		{
 			case DictationInsertOption.SendKeys:
+				// Asked before sending, because afterwards there is nothing to see. Windows
+				// discards input aimed at a window above us without saying so — SendInput
+				// accepts the events, returns the full count, and they are dropped further
+				// down. The count check inside SendText catches input genuinely refused, but
+				// not this, which is the elevated-app case the failure was filed about
+				// (issue #294).
+				if (ForegroundIntegrityProbe.ForegroundWindowWillDiscardInput())
+					return TranscriptDeliveryOutcome.InjectionFailed;
 				BeepPlayer.Play(BeepType.Start);
 				bool typed = await Task.Run(() => HotkeyManager.SendText(text));
 				return typed ? TranscriptDeliveryOutcome.Delivered : TranscriptDeliveryOutcome.InjectionFailed;
@@ -3473,6 +3485,11 @@ public sealed partial class MainWindow : Window, IDisposable
 				// clipboard; retry the write here if the earlier copy failed.
 				if (!clipboardAvailable && !await _clipboard.TrySetTextAsync(text))
 					return TranscriptDeliveryOutcome.ClipboardBlocked;
+				// After the clipboard write, not before it. The failure message tells the
+				// user to paste the transcript themselves, so the text has to be somewhere
+				// they can paste it from even when we already know Ctrl+V will not land.
+				if (ForegroundIntegrityProbe.ForegroundWindowWillDiscardInput())
+					return TranscriptDeliveryOutcome.InjectionFailed;
 				// "Ctrl+V" (not "^v"): Hotkey.Parse has no caret syntax, so the
 				// literal would throw and drop to the SendKeys.SendWait fallback.
 				bool pasted = await Task.Run(() => HotkeyManager.SendHotkey("Ctrl+V"));

--- a/Mutation.Ui/Services/ForegroundIntegrityProbe.cs
+++ b/Mutation.Ui/Services/ForegroundIntegrityProbe.cs
@@ -1,0 +1,76 @@
+using Mutation.Ui.Core;
+using System;
+using System.Runtime.InteropServices;
+
+namespace Mutation.Ui.Services;
+
+/// <summary>
+/// Asks Windows whether the window in front belongs to a process we are allowed to touch.
+/// Three syscalls and no rules — the rule lives in <see cref="ForegroundInjectionGuard"/>,
+/// which can be tested without an elevated process to aim at (issue #294).
+/// </summary>
+internal static class ForegroundIntegrityProbe
+{
+	/// <summary>
+	/// The weakest access right that still identifies a process. Windows grants it for a
+	/// process at our own integrity level or below; a refusal means the target sits above us.
+	/// </summary>
+	private const uint ProcessQueryLimitedInformation = 0x1000;
+
+	[DllImport("user32.dll")]
+	private static extern IntPtr GetForegroundWindow();
+
+	[DllImport("user32.dll")]
+	private static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint lpdwProcessId);
+
+	[DllImport("kernel32.dll", SetLastError = true)]
+	private static extern IntPtr OpenProcess(uint dwDesiredAccess, bool bInheritHandle, uint dwProcessId);
+
+	[DllImport("kernel32.dll", SetLastError = true)]
+	[return: MarshalAs(UnmanagedType.Bool)]
+	private static extern bool CloseHandle(IntPtr hObject);
+
+	/// <summary>
+	/// True when anything we inject into the foreground window will be silently discarded.
+	/// False whenever that cannot be established, so a probe that fails for any other reason
+	/// leaves delivery to proceed exactly as it did before.
+	/// </summary>
+	internal static bool ForegroundWindowWillDiscardInput() =>
+		ForegroundInjectionGuard.InputWillBeDiscarded(Probe());
+
+	/// <summary>
+	/// One probe of the current foreground window. Swallows a failure to call Windows at all
+	/// — a missing entry point on an unexpected platform — as "cannot tell", for the same
+	/// reason the guard is conservative: this check exists to add a failure the app was
+	/// missing, not to take away a delivery that would have worked.
+	/// </summary>
+	internal static ForegroundInjectionGuard.ProbeResult Probe()
+	{
+		try
+		{
+			IntPtr foreground = GetForegroundWindow();
+			if (foreground == IntPtr.Zero)
+				return ForegroundInjectionGuard.Classify(false, 0, false, 0);
+
+			GetWindowThreadProcessId(foreground, out uint processId);
+			if (processId == 0)
+				return ForegroundInjectionGuard.Classify(true, 0, false, 0);
+
+			IntPtr handle = OpenProcess(ProcessQueryLimitedInformation, false, processId);
+
+			// Read straight after the call. Anything in between — a log line, a comparison
+			// that itself sets an error — replaces the code we came for.
+			int errorCode = handle == IntPtr.Zero ? Marshal.GetLastWin32Error() : 0;
+
+			if (handle != IntPtr.Zero)
+				CloseHandle(handle);
+
+			return ForegroundInjectionGuard.Classify(true, processId, handle != IntPtr.Zero, errorCode);
+		}
+		catch (Exception ex)
+		{
+			System.Diagnostics.Debug.WriteLine($"Foreground integrity probe failed: {ex.Message}");
+			return ForegroundInjectionGuard.ProbeResult.Unknown;
+		}
+	}
+}

--- a/Mutation.Ui/Services/ForegroundIntegrityProbe.cs
+++ b/Mutation.Ui/Services/ForegroundIntegrityProbe.cs
@@ -5,17 +5,32 @@ using System.Runtime.InteropServices;
 namespace Mutation.Ui.Services;
 
 /// <summary>
-/// Asks Windows whether the window in front belongs to a process we are allowed to touch.
-/// Three syscalls and no rules — the rule lives in <see cref="ForegroundInjectionGuard"/>,
-/// which can be tested without an elevated process to aim at (issue #294).
+/// Finds out how much privilege the window in front is running with, compared to us. All
+/// P/Invoke and no rules — the rule lives in <see cref="ForegroundInjectionGuard"/>, which can
+/// be tested without an elevated process to aim at (issue #294).
 /// </summary>
 internal static class ForegroundIntegrityProbe
 {
 	/// <summary>
-	/// The weakest access right that still identifies a process. Windows grants it for a
-	/// process at our own integrity level or below; a refusal means the target sits above us.
+	/// The weakest access right that still identifies a process. Windows grants it across an
+	/// integrity boundary on purpose, so that an ordinary process can name a more privileged one
+	/// — which is why being granted this is not the test. A refusal of it means a DACL said no,
+	/// which is a different question entirely.
 	/// </summary>
 	private const uint ProcessQueryLimitedInformation = 0x1000;
+
+	/// <summary>
+	/// The right <c>OpenProcessToken</c> needs, and the one an integrity boundary refuses. Asked
+	/// for separately from the limited right so the two answers can be told apart.
+	/// </summary>
+	private const uint ProcessQueryInformation = 0x0400;
+
+	private const uint TokenQuery = 0x0008;
+
+	/// <summary><c>TOKEN_INFORMATION_CLASS.TokenIntegrityLevel</c>.</summary>
+	private const uint TokenIntegrityLevel = 25;
+
+	private const int ErrorInsufficientBuffer = 122;
 
 	[DllImport("user32.dll")]
 	private static extern IntPtr GetForegroundWindow();
@@ -26,51 +41,195 @@ internal static class ForegroundIntegrityProbe
 	[DllImport("kernel32.dll", SetLastError = true)]
 	private static extern IntPtr OpenProcess(uint dwDesiredAccess, bool bInheritHandle, uint dwProcessId);
 
+	[DllImport("kernel32.dll")]
+	private static extern IntPtr GetCurrentProcess();
+
 	[DllImport("kernel32.dll", SetLastError = true)]
 	[return: MarshalAs(UnmanagedType.Bool)]
 	private static extern bool CloseHandle(IntPtr hObject);
+
+	[DllImport("advapi32.dll", SetLastError = true)]
+	[return: MarshalAs(UnmanagedType.Bool)]
+	private static extern bool OpenProcessToken(IntPtr processHandle, uint desiredAccess, out IntPtr tokenHandle);
+
+	[DllImport("advapi32.dll", SetLastError = true)]
+	[return: MarshalAs(UnmanagedType.Bool)]
+	private static extern bool GetTokenInformation(
+		IntPtr tokenHandle,
+		uint tokenInformationClass,
+		IntPtr tokenInformation,
+		uint tokenInformationLength,
+		out uint returnLength);
+
+	[DllImport("advapi32.dll")]
+	private static extern IntPtr GetSidSubAuthority(IntPtr sid, uint subAuthorityIndex);
+
+	[DllImport("advapi32.dll")]
+	private static extern IntPtr GetSidSubAuthorityCount(IntPtr sid);
 
 	/// <summary>
 	/// True when anything we inject into the foreground window will be silently discarded.
 	/// False whenever that cannot be established, so a probe that fails for any other reason
 	/// leaves delivery to proceed exactly as it did before.
 	/// </summary>
-	internal static bool ForegroundWindowWillDiscardInput() =>
-		ForegroundInjectionGuard.InputWillBeDiscarded(Probe());
+	internal static bool ForegroundWindowWillDiscardInput()
+	{
+		var (probe, foregroundIntegrity, ownIntegrity) = Probe();
+		return ForegroundInjectionGuard.InputWillBeDiscarded(probe, foregroundIntegrity, ownIntegrity);
+	}
 
 	/// <summary>
-	/// One probe of the current foreground window. Swallows a failure to call Windows at all
-	/// — a missing entry point on an unexpected platform — as "cannot tell", for the same
-	/// reason the guard is conservative: this check exists to add a failure the app was
-	/// missing, not to take away a delivery that would have worked.
+	/// One probe of the current foreground window: what could be established, and the two
+	/// integrity levels when both were read.
+	/// <para>
+	/// Swallows a failure to call Windows at all — a missing entry point on an unexpected
+	/// platform — as "cannot tell", for the same reason the guard is conservative: this check
+	/// exists to add a failure the app was missing, not to take away a delivery that would have
+	/// worked.
+	/// </para>
 	/// </summary>
-	internal static ForegroundInjectionGuard.ProbeResult Probe()
+	internal static (ForegroundInjectionGuard.ForegroundProbe Probe, uint ForegroundIntegrity, uint OwnIntegrity) Probe()
 	{
+		var unknown = (ForegroundInjectionGuard.ForegroundProbe.Unknown, 0u, 0u);
+		var failed = ForegroundInjectionGuard.ProbeStep.Failed;
+
 		try
 		{
 			IntPtr foreground = GetForegroundWindow();
 			if (foreground == IntPtr.Zero)
-				return ForegroundInjectionGuard.Classify(false, 0, false, 0);
+				return unknown;
 
 			GetWindowThreadProcessId(foreground, out uint processId);
 			if (processId == 0)
-				return ForegroundInjectionGuard.Classify(true, 0, false, 0);
+				return unknown;
 
-			IntPtr handle = OpenProcess(ProcessQueryLimitedInformation, false, processId);
+			var limitedOpen = TryOpen(processId, ProcessQueryLimitedInformation, out IntPtr limited);
+			if (limited != IntPtr.Zero)
+				CloseHandle(limited);
 
-			// Read straight after the call. Anything in between — a log line, a comparison
-			// that itself sets an error — replaces the code we came for.
-			int errorCode = handle == IntPtr.Zero ? Marshal.GetLastWin32Error() : 0;
+			if (limitedOpen != ForegroundInjectionGuard.ProbeStep.Succeeded)
+				return (ForegroundInjectionGuard.Classify(true, processId, limitedOpen, failed, failed), 0u, 0u);
 
-			if (handle != IntPtr.Zero)
-				CloseHandle(handle);
+			var fullOpen = TryOpen(processId, ProcessQueryInformation, out IntPtr process);
+			if (process == IntPtr.Zero)
+				return (ForegroundInjectionGuard.Classify(true, processId, limitedOpen, fullOpen, failed), 0u, 0u);
 
-			return ForegroundInjectionGuard.Classify(true, processId, handle != IntPtr.Zero, errorCode);
+			try
+			{
+				bool tokenOpened = OpenProcessToken(process, TokenQuery, out IntPtr token);
+				int tokenError = tokenOpened ? 0 : Marshal.GetLastWin32Error();
+				var tokenRead = ForegroundInjectionGuard.StepFrom(tokenOpened, tokenError);
+
+				if (!tokenOpened)
+					return (ForegroundInjectionGuard.Classify(true, processId, limitedOpen, fullOpen, tokenRead), 0u, 0u);
+
+				try
+				{
+					uint? theirs = IntegrityLevelOf(token);
+					uint? ours = OwnIntegrityLevel();
+
+					if (theirs is null || ours is null)
+						return unknown;
+
+					return (
+						ForegroundInjectionGuard.Classify(true, processId, limitedOpen, fullOpen, tokenRead),
+						theirs.Value,
+						ours.Value);
+				}
+				finally
+				{
+					CloseHandle(token);
+				}
+			}
+			finally
+			{
+				CloseHandle(process);
+			}
 		}
 		catch (Exception ex)
 		{
 			System.Diagnostics.Debug.WriteLine($"Foreground integrity probe failed: {ex.Message}");
-			return ForegroundInjectionGuard.ProbeResult.Unknown;
+			return unknown;
+		}
+	}
+
+	/// <summary>
+	/// Opens <paramref name="processId"/> for <paramref name="access"/> and reports how it went.
+	/// The error code is read on the line after the call: anything in between — a log line, a
+	/// comparison that itself sets an error — replaces the code we came for.
+	/// </summary>
+	private static ForegroundInjectionGuard.ProbeStep TryOpen(uint processId, uint access, out IntPtr handle)
+	{
+		handle = OpenProcess(access, false, processId);
+		int errorCode = handle == IntPtr.Zero ? Marshal.GetLastWin32Error() : 0;
+		return ForegroundInjectionGuard.StepFrom(handle != IntPtr.Zero, errorCode);
+	}
+
+	/// <summary>
+	/// Our own integrity level. The pseudo-handle from <c>GetCurrentProcess</c> needs no
+	/// closing and can always be opened, so this only fails if the token cannot be read at all.
+	/// </summary>
+	private static uint? OwnIntegrityLevel()
+	{
+		if (!OpenProcessToken(GetCurrentProcess(), TokenQuery, out IntPtr token))
+			return null;
+
+		try
+		{
+			return IntegrityLevelOf(token);
+		}
+		finally
+		{
+			CloseHandle(token);
+		}
+	}
+
+	/// <summary>
+	/// The integrity level in <paramref name="token"/>, or null when it could not be read.
+	/// <para>
+	/// Asked for twice, as Windows requires: once with no buffer, to be told how big one has to
+	/// be, and once with a buffer that size. What comes back is a <c>TOKEN_MANDATORY_LABEL</c>,
+	/// whose only field is a pointer to the S-1-16-x SID; the level is that SID's last
+	/// sub-authority.
+	/// </para>
+	/// </summary>
+	private static uint? IntegrityLevelOf(IntPtr token)
+	{
+		if (GetTokenInformation(token, TokenIntegrityLevel, IntPtr.Zero, 0, out uint size))
+			return null; // Cannot happen with a zero-length buffer, and a success here tells us nothing.
+
+		if (Marshal.GetLastWin32Error() != ErrorInsufficientBuffer || size == 0)
+			return null;
+
+		IntPtr buffer = Marshal.AllocHGlobal((int)size);
+		try
+		{
+			if (!GetTokenInformation(token, TokenIntegrityLevel, buffer, size, out _))
+				return null;
+
+			// TOKEN_MANDATORY_LABEL is a single SID_AND_ATTRIBUTES, so the SID pointer is the
+			// first field.
+			IntPtr sid = Marshal.ReadIntPtr(buffer);
+			if (sid == IntPtr.Zero)
+				return null;
+
+			IntPtr countPtr = GetSidSubAuthorityCount(sid);
+			if (countPtr == IntPtr.Zero)
+				return null;
+
+			int count = Marshal.ReadByte(countPtr);
+			if (count <= 0)
+				return null;
+
+			IntPtr levelPtr = GetSidSubAuthority(sid, (uint)(count - 1));
+			if (levelPtr == IntPtr.Zero)
+				return null;
+
+			return unchecked((uint)Marshal.ReadInt32(levelPtr));
+		}
+		finally
+		{
+			Marshal.FreeHGlobal(buffer);
 		}
 	}
 }

--- a/Mutation.Ui/Services/HotkeyManager.cs
+++ b/Mutation.Ui/Services/HotkeyManager.cs
@@ -22,6 +22,14 @@ public class HotkeyManager : IDisposable
 	private readonly HotkeyRegistrationTable _registrations;
 
 	private readonly Settings _settings;
+
+	// What the last router registration pass made of each mapping, kept so the Settings page
+	// can tell a route that is live from one the user has typed but not saved. It is the only
+	// thing that knows: registration happens here, on save, and the page that shows the rows
+	// is editing a copy of the settings that has not been handed over yet (issue #343).
+	private IReadOnlyList<RegisteredRouterRoute> _routerRoutes =
+		Array.Empty<RegisteredRouterRoute>();
+
 	private static SynchronizationContext? s_uiCtx;
 	private IntPtr _prevWndProc;
 	private WndProcDelegate? _newWndProc;
@@ -179,7 +187,25 @@ public class HotkeyManager : IDisposable
                         }
                 }
 
+                _routerRoutes = ToRegisteredRoutes(results);
                 return results;
+        }
+
+        /// <summary>
+        /// Every router route the app currently holds, and how registering it went. The Settings
+        /// page reads this so a row can say whether it is live; it registers nothing and changes
+        /// nothing (issue #343).
+        /// </summary>
+        public IReadOnlyList<RegisteredRouterRoute> LiveRouterRoutes() => _routerRoutes;
+
+        private static IReadOnlyList<RegisteredRouterRoute> ToRegisteredRoutes(
+                IReadOnlyList<HotkeyRegistrationResult> results)
+        {
+                var routes = new List<RegisteredRouterRoute>(results.Count);
+                foreach (var result in results)
+                        routes.Add(new(result.Map.FromHotKey, result.Map.ToHotKey, result.Success, result.ErrorMessage));
+
+                return routes;
         }
 
         public IReadOnlyList<HotkeyRegistrationResult> RefreshRouterHotkeys()
@@ -202,6 +228,10 @@ public class HotkeyManager : IDisposable
         private void ClearRouterHotkeys()
         {
                 _registrations.ClearGroup(HotkeyRegistrationTable.HotkeyGroup.Router);
+
+                // Released, so nothing is live any more. Leaving the old list standing would have
+                // the Settings page calling a route live that this had just let go of.
+                _routerRoutes = Array.Empty<RegisteredRouterRoute>();
         }
 
         // Registers each prompt's optional hotkey and returns the ones that could not be bound,
@@ -247,6 +277,7 @@ public class HotkeyManager : IDisposable
         public void UnregisterAll()
         {
                 _registrations.ClearAll();
+                _routerRoutes = Array.Empty<RegisteredRouterRoute>();
         }
 
         // Clears ALL registrations (core + router + prompt) so the caller can

--- a/Mutation.Ui/Services/HotkeyManager.cs
+++ b/Mutation.Ui/Services/HotkeyManager.cs
@@ -148,7 +148,14 @@ public class HotkeyManager : IDisposable
         public IReadOnlyList<HotkeyRegistrationResult> RegisterRouterHotkeys()
         {
                 if (_settings.HotKeyRouterSettings is null)
+                {
+                        // Nothing to register means nothing is live. Both callers happen to clear
+                        // first, so leaving the old list standing would not show up today — but the
+                        // Settings page reads that list to decide whether a row is live, and a
+                        // third caller inheriting stale routes would make it lie silently.
+                        _routerRoutes = Array.Empty<RegisteredRouterRoute>();
                         return Array.Empty<HotkeyRegistrationResult>();
+                }
 
                 return RegisterRouterHotkeys(_settings.HotKeyRouterSettings.Mappings);
         }

--- a/Mutation.Ui/Services/HotkeyRouterController.cs
+++ b/Mutation.Ui/Services/HotkeyRouterController.cs
@@ -24,10 +24,28 @@ internal sealed class HotkeyRouterController
 	private readonly List<(string From, string To)> _persistedSnapshot = new();
 	private readonly bool _autoPersist;
 	private readonly Action? _crossListDuplicateCheck;
+	private readonly Func<IReadOnlyList<RegisteredRouterRoute>?>? _liveRoutes;
+	private readonly FirstTouchGate? _announcementGate;
 
 	private bool _initialized;
-	private HotkeyManager? _hotkeyManager;
 
+	/// <param name="announcementGate">
+	/// Whether the page holding these rows has been used yet. Until it has, a row's error is on
+	/// screen but not read out, because rows built from settings can arrive already carrying one
+	/// (issue #350). Null leaves every row free to speak, which is what it did before.
+	/// </param>
+	/// <param name="liveRoutes">
+	/// The routes the running app actually holds, asked freshly each time the rows are
+	/// refreshed. Read-only: it reports what registration did, it does not cause any. That
+	/// matters on the Settings page, which edits a copy of the settings — registering from the
+	/// copy would claim chords the user might still cancel out of.
+	/// <para>
+	/// Null means there is no way to ask, and every row then says nothing about being live
+	/// rather than guessing. The old shape took a <see cref="HotkeyManager"/> here, was never
+	/// given one by anybody, and so left every row reporting "not currently bound" including
+	/// the ones that worked (issue #343).
+	/// </para>
+	/// </param>
 	/// <param name="crossListDuplicateCheck">
 	/// Runs the duplicate check on an owner that has more lists to compare than this one — the
 	/// Hotkeys page, which holds the core hotkey rows as well. Null leaves the router checking
@@ -45,9 +63,15 @@ internal sealed class HotkeyRouterController
 		DispatcherQueue dispatcherQueue,
 		ListView routerListView,
 		bool autoPersist = true,
-		Action? crossListDuplicateCheck = null)
+		Action? crossListDuplicateCheck = null,
+		Func<IReadOnlyList<RegisteredRouterRoute>?>? liveRoutes = null,
+		FirstTouchGate? announcementGate = null)
 	{
 		_crossListDuplicateCheck = crossListDuplicateCheck;
+		_liveRoutes = liveRoutes;
+		_announcementGate = announcementGate;
+		if (_announcementGate is not null)
+			_announcementGate.Touched += UnmuteAnnouncements;
 		_entries = entries ?? throw new ArgumentNullException(nameof(entries));
 		_settings = settings ?? throw new ArgumentNullException(nameof(settings));
 		_dispatcherQueue = dispatcherQueue ?? throw new ArgumentNullException(nameof(dispatcherQueue));
@@ -83,17 +107,21 @@ internal sealed class HotkeyRouterController
 		UpdateSnapshot(initialPairs);
 
 		RecalculateDuplicates();
-		_initialized = true;
-	}
 
-	public void AttachHotkeyManager(HotkeyManager hotkeyManager)
-	{
-		_hotkeyManager = hotkeyManager ?? throw new ArgumentNullException(nameof(hotkeyManager));
-		RefreshRegistrations();
+		// Before the page is shown, so a stored route already says whether it is live rather
+		// than waiting for the user to touch something first.
+		ApplyBindingStates();
+
+		_initialized = true;
 	}
 
 	public void AddNewMapping()
 	{
+		// Before the row is built, so the row is free to speak from the moment it exists. Being
+		// told the empty row wants a shortcut is the answer to the button the user just pressed
+		// — this is the one case where announcing an untouched row's error is right (issue #350).
+		_announcementGate?.Touch();
+
 		_settings.HotKeyRouterSettings ??= new HotKeyRouterSettings();
 
 		var map = new HotKeyRouterSettings.HotKeyRouterMap(string.Empty, string.Empty);
@@ -111,6 +139,10 @@ internal sealed class HotkeyRouterController
 	{
 		if (sender is not FrameworkElement element || element.Tag is not HotkeyRouterEntry entry)
 			return;
+
+		// Deleting a mapping can leave a duplicate behind on another row, and that row is now
+		// worth hearing about even though the user never edited it.
+		_announcementGate?.Touch();
 
 		if (_settings.HotKeyRouterSettings is not null)
 			_settings.HotKeyRouterSettings.Mappings.Remove(entry.Map);
@@ -227,6 +259,17 @@ internal sealed class HotkeyRouterController
 		_persistedSnapshot.AddRange(normalizedPairs);
 	}
 
+	/// <summary>
+	/// Settles every row after something on the page changed: which rows clash, what is written
+	/// back into settings, and what each row now says about being live.
+	/// <para>
+	/// It registers nothing. It used to look as though it might — there was a branch that called
+	/// <c>RefreshRouterHotkeys</c> — but nothing ever handed this controller a
+	/// <see cref="HotkeyManager"/>, so that branch never ran, and had it run on the Settings page
+	/// it would have claimed chords out of a settings copy the user could still cancel. The rows
+	/// now read the outcome of the registration the app already did (issue #343).
+	/// </para>
+	/// </summary>
 	private void RefreshRegistrations()
 	{
 		_settings.HotKeyRouterSettings ??= new HotKeyRouterSettings();
@@ -234,36 +277,48 @@ internal sealed class HotkeyRouterController
 		RecalculateDuplicates();
 		var normalizedPairs = SyncSettings();
 
-		if (_hotkeyManager is null)
-		{
-			foreach (var entry in _entries)
-				entry.SetBindingResult(HotkeyBindingState.Inactive, null);
-
-			if (_autoPersist && ShouldPersist(normalizedPairs))
-			{
-				_settingsManager!.SaveSettingsToFile(_settings);
-				UpdateSnapshot(normalizedPairs);
-			}
-			return;
-		}
-
-		var mappings = _settings.HotKeyRouterSettings.Mappings;
-		var results = _hotkeyManager.RefreshRouterHotkeys(mappings);
-		var resultLookup = results.ToDictionary(r => r.Map);
-
-		foreach (var entry in _entries)
-		{
-			if (resultLookup.TryGetValue(entry.Map, out var result))
-				entry.SetBindingResult(result.Success ? HotkeyBindingState.Bound : HotkeyBindingState.Failed, result.ErrorMessage);
-			else
-				entry.SetBindingResult(HotkeyBindingState.Inactive, null);
-		}
+		ApplyBindingStates();
 
 		if (_autoPersist && ShouldPersist(normalizedPairs))
 		{
 			_settingsManager!.SaveSettingsToFile(_settings);
 			UpdateSnapshot(normalizedPairs);
 		}
+	}
+
+	/// <summary>
+	/// Tells each row where it stands against the routes the app actually holds. Asked once per
+	/// refresh rather than once per row, because the answer is the same list for all of them.
+	/// </summary>
+	private void ApplyBindingStates()
+	{
+		var live = _liveRoutes?.Invoke();
+
+		foreach (var entry in _entries)
+		{
+			// Offered as nothing unless the row is a usable mapping. A half-typed row cannot be
+			// a route, and saying "not active yet" underneath its own "Enter a hotkey." would be
+			// a second line telling the user what the first already told them.
+			var (state, message) = RouterBindingStatus.For(
+				entry.IsValid ? entry.NormalizedFromHotkey : null,
+				entry.IsValid ? entry.NormalizedToHotkey : null,
+				live);
+
+			entry.SetBindingResult(state, message);
+		}
+	}
+
+	/// <summary>
+	/// True while the page has not been used yet, so a row shows its error without reading it
+	/// out. One answer for the whole list rather than one per row — see
+	/// <see cref="FirstTouchGate"/> (issue #350). With no gate, nothing is ever muted.
+	/// </summary>
+	private bool AnnouncementsMuted => _announcementGate is not null && !_announcementGate.HasBeenTouched;
+
+	private void UnmuteAnnouncements(object? sender, EventArgs e)
+	{
+		foreach (var entry in _entries)
+			entry.SetAnnouncementsMuted(false);
 	}
 
 	private bool ShouldPersist(List<(string From, string To)> normalizedPairs)
@@ -337,14 +392,28 @@ internal sealed class HotkeyRouterController
 		ApplyDuplicates(HotkeyConflictFinder.DuplicateIndexes(ConfiguredFromHotkeys()));
 	}
 
-	private void AttachEntry(HotkeyRouterEntry entry) =>
+	private void AttachEntry(HotkeyRouterEntry entry)
+	{
+		// Set before the row reaches the screen. A row that arrives already carrying an error
+		// has to be muted by then or it announces on the way in, which is the whole complaint.
+		entry.SetAnnouncementsMuted(AnnouncementsMuted);
 		entry.PropertyChanged += Entry_PropertyChanged;
+	}
 
 	private void DetachEntry(HotkeyRouterEntry entry) =>
 		entry.PropertyChanged -= Entry_PropertyChanged;
 
 	private void Entry_PropertyChanged(object? sender, PropertyChangedEventArgs e)
 	{
+		// Typing in either box. The text of a row only changes through the two-way binding —
+		// loading and the bookkeeping commits write the backing fields directly — so this is the
+		// user, and it is what opens the page's mouth (issue #350).
+		if (e.PropertyName == nameof(HotkeyRouterEntry.FromHotkey) ||
+			e.PropertyName == nameof(HotkeyRouterEntry.ToHotkey))
+		{
+			_announcementGate?.Touch();
+		}
+
 		if (e.PropertyName == nameof(HotkeyRouterEntry.FromHotkey) ||
 			e.PropertyName == nameof(HotkeyRouterEntry.IsFromValid))
 		{

--- a/Mutation.Ui/Services/HotkeyRouterController.cs
+++ b/Mutation.Ui/Services/HotkeyRouterController.cs
@@ -29,6 +29,9 @@ internal sealed class HotkeyRouterController
 
 	private bool _initialized;
 
+	// Set only while SyncSettings is re-committing every row. See Entry_PropertyChanged.
+	private bool _inBookkeepingCommit;
+
 	/// <param name="announcementGate">
 	/// Whether the page holding these rows has been used yet. Until it has, a row's error is on
 	/// screen but not read out, because rows built from settings can arrive already carrying one
@@ -198,8 +201,19 @@ internal sealed class HotkeyRouterController
 		// just edited — which has already committed and announced. An announcing pass here
 		// finds nothing left to change and would take that notice straight back down again
 		// (issue #332).
-		foreach (var entry in _entries)
-			entry.CommitSilently();
+		//
+		// Flagged as bookkeeping while it runs, so a row this pass rewrites is not mistaken for a
+		// row the user typed in and does not open the announcement gate (issue #350).
+		_inBookkeepingCommit = true;
+		try
+		{
+			foreach (var entry in _entries)
+				entry.CommitSilently();
+		}
+		finally
+		{
+			_inBookkeepingCommit = false;
+		}
 
 		var validEntries = _entries
 			.Where(e => e.IsValid && e.NormalizedFromHotkey is not null && e.NormalizedToHotkey is not null)
@@ -361,6 +375,16 @@ internal sealed class HotkeyRouterController
 	/// <summary>
 	/// Flags the rows at <paramref name="duplicateRows"/> and clears the rest. The positions
 	/// are those of <see cref="ConfiguredFromHotkeys"/>, whoever worked them out.
+	/// <para>
+	/// Settling the binding states afterwards is not tidiness. A row that becomes a duplicate is
+	/// put back to <see cref="HotkeyBindingState.Unknown"/>, because a chord that is already
+	/// taken is not a route; nothing about ceasing to be a duplicate restores what it was. On the
+	/// paths that come through <see cref="RefreshRegistrations"/> that is covered, because the
+	/// binding states are settled last there. This is also called straight from the Hotkeys page
+	/// when a <em>core</em> hotkey commits, and that path stops here — so a live route that was
+	/// flagged because a core hotkey took its chord, and then unflagged when the user moved that
+	/// core hotkey elsewhere, stayed permanently silent about being live (issue #343).
+	/// </para>
 	/// </summary>
 	public void ApplyDuplicates(IReadOnlySet<int> duplicateRows)
 	{
@@ -368,6 +392,8 @@ internal sealed class HotkeyRouterController
 
 		for (int i = 0; i < _entries.Count; i++)
 			_entries[i].SetDuplicate(duplicateRows.Contains(i));
+
+		ApplyBindingStates();
 	}
 
 	/// <summary>
@@ -405,11 +431,17 @@ internal sealed class HotkeyRouterController
 
 	private void Entry_PropertyChanged(object? sender, PropertyChangedEventArgs e)
 	{
-		// Typing in either box. The text of a row only changes through the two-way binding —
-		// loading and the bookkeeping commits write the backing fields directly — so this is the
-		// user, and it is what opens the page's mouth (issue #350).
-		if (e.PropertyName == nameof(HotkeyRouterEntry.FromHotkey) ||
-			e.PropertyName == nameof(HotkeyRouterEntry.ToHotkey))
+		// Typing in either box, which is what opens the page's mouth (issue #350).
+		//
+		// A row's text does not only change through the two-way binding: a commit that rewrites a
+		// chord into the app's canonical spelling raises this too, and the bookkeeping pass in
+		// SyncSettings commits every row. Today those passes find nothing to rewrite, because the
+		// entry's constructor already canonicalised before this handler was subscribed — but that
+		// is an accident of ordering, not a rule, and relying on it means a future change could
+		// open the gate at page load with no test failing. Hence the explicit guard.
+		if (!_inBookkeepingCommit &&
+			(e.PropertyName == nameof(HotkeyRouterEntry.FromHotkey) ||
+			e.PropertyName == nameof(HotkeyRouterEntry.ToHotkey)))
 		{
 			_announcementGate?.Touch();
 		}

--- a/Mutation.Ui/Services/PromptLibraryController.cs
+++ b/Mutation.Ui/Services/PromptLibraryController.cs
@@ -71,7 +71,7 @@ internal sealed class PromptLibraryController
 
 	public LlmSettings.LlmPrompt? GetAutoRunPrompt()
 	{
-		return _settings.LlmSettings?.Prompts.FirstOrDefault(p => p.AutoRun);
+		return PromptLibraryMutations.AutoRunPrompt(_settings.LlmSettings?.Prompts);
 	}
 
 	public void OpenAddDialog()
@@ -87,15 +87,13 @@ internal sealed class PromptLibraryController
 		{
 			if (dialog.IsSaved && dialog.Prompt != null && !string.IsNullOrWhiteSpace(dialog.Prompt.Name))
 			{
-				if (dialog.Prompt.AutoRun)
-					foreach (var p in _settings.LlmSettings.Prompts) p.AutoRun = false;
-
-				_settings.LlmSettings.Prompts.Add(dialog.Prompt);
-
-				// One rule for handing out prompt Ids, shared with settings loading.
-				// Highest-plus-one would overflow to int.MinValue against a hand-written
-				// Id of int.MaxValue, and then hand every later prompt that same value.
-				PromptIdBackfill.Apply(_settings.LlmSettings.Prompts);
+				// Appending, taking AutoRun off whichever prompt held it, and handing out
+				// the new prompt's Id are all one unit now, shared with the edit path below
+				// and exercisable without opening a window (issue #304). The Id rule is the
+				// same one settings loading uses: lowest free number, because
+				// highest-plus-one would overflow to int.MinValue against a hand-written Id
+				// of int.MaxValue and then hand every later prompt that same value.
+				PromptLibraryMutations.Add(_settings.LlmSettings.Prompts, dialog.Prompt);
 
 				SaveAndRefresh();
 			}
@@ -118,13 +116,10 @@ internal sealed class PromptLibraryController
 			if (!dialog.IsSaved)
 				return;
 
-			if (prompt.AutoRun)
-			{
-				foreach (var p in _settings.LlmSettings.Prompts)
-				{
-					if (p != prompt) p.AutoRun = false;
-				}
-			}
+			// The editor writes straight into the prompt object, so there is nothing to copy
+			// back — the only thing left to settle is whether it has just taken AutoRun off
+			// another prompt.
+			PromptLibraryMutations.CommitEdit(_settings.LlmSettings.Prompts, prompt);
 
 			SaveAndRefresh();
 		};
@@ -138,10 +133,10 @@ internal sealed class PromptLibraryController
 	/// </summary>
 	public bool DeletePrompt(LlmSettings.LlmPrompt prompt)
 	{
-		if (prompt == null || _settings.LlmSettings == null)
+		if (_settings.LlmSettings == null)
 			return false;
 
-		if (!_settings.LlmSettings.Prompts.Remove(prompt))
+		if (!PromptLibraryMutations.Delete(_settings.LlmSettings.Prompts, prompt))
 			return false;
 
 		SaveAndRefresh();

--- a/Mutation.Ui/Services/PromptLibraryMutations.cs
+++ b/Mutation.Ui/Services/PromptLibraryMutations.cs
@@ -1,0 +1,122 @@
+using CognitiveSupport;
+using System;
+using System.Collections.Generic;
+
+namespace Mutation.Ui.Services;
+
+/// <summary>
+/// Every change the prompt library makes to the list of prompts, with none of the window
+/// that asks for it.
+/// <para>
+/// <see cref="PromptLibraryController"/> opens a <c>PromptEditorWindow</c> for each of add
+/// and edit and does the list work inside the window's <c>Closed</c> handler, so there was
+/// no add or delete to call without a UI and nothing to test but the whole screen. The rules
+/// worth testing are all in here: which prompt ends up carrying <c>AutoRun</c>, and whether
+/// every prompt still has a distinct Id afterwards (issue #304).
+/// </para>
+/// <para>
+/// The <c>AutoRun</c> sweep in particular was written out twice, once in the add path and
+/// once in the edit path, with the two spelling the "every prompt but this one" test
+/// differently — the add path cleared the flag on the whole list before appending the new
+/// prompt, the edit path skipped the prompt by reference. One rule now serves both.
+/// </para>
+/// </summary>
+internal static class PromptLibraryMutations
+{
+	/// <summary>
+	/// Appends <paramref name="prompt"/>. If it wants to be the auto-run prompt it takes the
+	/// flag off every other prompt, and if it does not, whichever prompt already had it keeps
+	/// it. Ids are handed out afterwards, so the new prompt gets one and any hand-written
+	/// clash in the file is repaired at the same time.
+	/// <para>
+	/// Ids are assigned from the lowest free number rather than above the highest in use
+	/// (see <see cref="PromptIdBackfill"/>), which is what makes add-after-delete safe: the
+	/// number the deleted prompt gave up is free, so the new prompt takes it instead of
+	/// repeating one that is still in use.
+	/// </para>
+	/// </summary>
+	internal static void Add(IList<LlmSettings.LlmPrompt> prompts, LlmSettings.LlmPrompt prompt)
+	{
+		if (prompts is null) throw new ArgumentNullException(nameof(prompts));
+		if (prompt is null) throw new ArgumentNullException(nameof(prompt));
+
+		prompts.Add(prompt);
+		ApplyAutoRunExclusivity(prompts, prompt);
+		PromptIdBackfill.Apply(AsReadOnlyList(prompts));
+	}
+
+	/// <summary>
+	/// Settles the list after <paramref name="prompt"/> was edited in place. The editor window
+	/// writes straight into the prompt object, so there is nothing to copy back — the only
+	/// thing left to decide is whether it has just claimed <c>AutoRun</c> from someone else.
+	/// <para>
+	/// No Id is handed out here on purpose. An edit adds no prompt, so it cannot leave one
+	/// without an Id, and renumbering a prompt the user was only renaming would move an
+	/// identity they did not ask to change.
+	/// </para>
+	/// </summary>
+	internal static void CommitEdit(IList<LlmSettings.LlmPrompt> prompts, LlmSettings.LlmPrompt prompt)
+	{
+		if (prompts is null) throw new ArgumentNullException(nameof(prompts));
+		if (prompt is null) throw new ArgumentNullException(nameof(prompt));
+
+		ApplyAutoRunExclusivity(prompts, prompt);
+	}
+
+	/// <summary>
+	/// Removes <paramref name="prompt"/>. Returns false when there was nothing to remove — a
+	/// null prompt, or one already gone — so the caller can say what actually happened rather
+	/// than announcing a deletion that did not occur.
+	/// </summary>
+	internal static bool Delete(IList<LlmSettings.LlmPrompt> prompts, LlmSettings.LlmPrompt? prompt)
+	{
+		if (prompts is null) throw new ArgumentNullException(nameof(prompts));
+
+		return prompt is not null && prompts.Remove(prompt);
+	}
+
+	/// <summary>The prompt that runs by itself when a transcript arrives, or null when none does.</summary>
+	internal static LlmSettings.LlmPrompt? AutoRunPrompt(IEnumerable<LlmSettings.LlmPrompt>? prompts)
+	{
+		if (prompts is null)
+			return null;
+
+		foreach (var prompt in prompts)
+		{
+			if (prompt.AutoRun)
+				return prompt;
+		}
+
+		return null;
+	}
+
+	/// <summary>
+	/// Leaves <paramref name="claimant"/> as the only prompt with <c>AutoRun</c> set, but only
+	/// if it has it. A prompt saved without asking for auto-run does not take the flag away
+	/// from the prompt that already holds it.
+	/// <para>
+	/// Compared by reference rather than by Id, because this also runs for a prompt that has
+	/// not been given an Id yet.
+	/// </para>
+	/// </summary>
+	private static void ApplyAutoRunExclusivity(
+		IList<LlmSettings.LlmPrompt> prompts, LlmSettings.LlmPrompt claimant)
+	{
+		if (!claimant.AutoRun)
+			return;
+
+		foreach (var other in prompts)
+		{
+			if (!ReferenceEquals(other, claimant))
+				other.AutoRun = false;
+		}
+	}
+
+	/// <summary>
+	/// The list as something <see cref="PromptIdBackfill"/> can read. A <c>List&lt;T&gt;</c> —
+	/// which is what every caller passes — is already one; anything else is copied, and the
+	/// copy is fine because the backfill mutates the prompts rather than the list holding them.
+	/// </summary>
+	private static IReadOnlyList<LlmSettings.LlmPrompt> AsReadOnlyList(IList<LlmSettings.LlmPrompt> prompts) =>
+		prompts as IReadOnlyList<LlmSettings.LlmPrompt> ?? new List<LlmSettings.LlmPrompt>(prompts);
+}

--- a/Mutation.Ui/Views/LiveMessage.cs
+++ b/Mutation.Ui/Views/LiveMessage.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Automation.Peers;
@@ -24,7 +25,24 @@ internal static class LiveMessage
 	/// same warning, and only when there is something to say — an emptied live region has
 	/// nothing to read out.
 	/// </summary>
-	public static void Show(TextBlock target, string? message)
+	/// <param name="shouldAnnounce">
+	/// Asked at the moment of raising rather than now, and null means always. It is how a page
+	/// shows a message without reading it out: the Hotkeys page builds rows from settings that
+	/// already carry "Enter a hotkey.", and announcing each of them would greet the user with
+	/// one interruption per stored row about settings nobody had touched (issue #350).
+	/// <para>
+	/// Asked late for a reason. The bindings in a list row all apply in one pass, and whichever
+	/// order they happen to run in, the raise is enqueued behind the whole pass — so a question
+	/// asked then gets the row's settled answer rather than a half-applied one.
+	/// </para>
+	/// <para>
+	/// Note what a silent show still does: it writes the text. So the same message becoming
+	/// allowed to speak later says nothing, because by then it is no longer a change. That is
+	/// the wanted behaviour — a stored error the user has since started editing around should
+	/// not suddenly be shouted at them — and it means nothing has to remember what it swallowed.
+	/// </para>
+	/// </summary>
+	public static void Show(TextBlock target, string? message, Func<bool>? shouldAnnounce = null)
 	{
 		string text = message ?? string.Empty;
 		if (target.Text == text)
@@ -41,12 +59,16 @@ internal static class LiveMessage
 		// the moment they have something to say, and a collapsed element is not in the
 		// automation tree yet — raising against it before layout has run would announce into
 		// nothing.
-		target.DispatcherQueue?.TryEnqueue(DispatcherQueuePriority.Low, () => Announce(target));
+		target.DispatcherQueue?.TryEnqueue(
+			DispatcherQueuePriority.Low, () => Announce(target, shouldAnnounce));
 	}
 
-	private static void Announce(TextBlock target)
+	private static void Announce(TextBlock target, Func<bool>? shouldAnnounce)
 	{
 		if (target.Visibility != Visibility.Visible || target.Text.Length == 0)
+			return;
+
+		if (shouldAnnounce is not null && !shouldAnnounce())
 			return;
 
 		AutomationPeer? peer = FrameworkElementAutomationPeer.FromElement(target)

--- a/Mutation.Ui/Views/LiveText.cs
+++ b/Mutation.Ui/Views/LiveText.cs
@@ -20,7 +20,17 @@ namespace Mutation.Ui.Views;
 public static class LiveText
 {
 	public static readonly DependencyProperty MessageProperty = DependencyProperty.RegisterAttached(
-		"Message", typeof(string), typeof(LiveText), new PropertyMetadata(null, OnMessageChanged));
+		"Message", typeof(string), typeof(LiveText), new PropertyMetadata(null, OnLiveValueChanged));
+
+	/// <summary>
+	/// Bind this true to put the message on screen without reading it out. The Hotkeys page
+	/// uses it for rows built straight from settings, which can already be carrying an error
+	/// before the user has seen the page at all — one assertive interruption per stored bad row
+	/// on the way in (issue #350). The written half is unaffected either way, because a sighted
+	/// reader was never the problem.
+	/// </summary>
+	public static readonly DependencyProperty MutedProperty = DependencyProperty.RegisterAttached(
+		"Muted", typeof(bool), typeof(LiveText), new PropertyMetadata(false, OnLiveValueChanged));
 
 	public static string? GetMessage(DependencyObject element) =>
 		(string?)element.GetValue(MessageProperty);
@@ -28,9 +38,21 @@ public static class LiveText
 	public static void SetMessage(DependencyObject element, string? value) =>
 		element.SetValue(MessageProperty, value);
 
-	private static void OnMessageChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+	public static bool GetMuted(DependencyObject element) =>
+		(bool)element.GetValue(MutedProperty);
+
+	public static void SetMuted(DependencyObject element, bool value) =>
+		element.SetValue(MutedProperty, value);
+
+	/// <summary>
+	/// One handler for both properties, so the order the row's bindings happen to apply in does
+	/// not decide whether the message is heard. Whichever of the two lands second re-runs this
+	/// with both settled values, and <see cref="LiveMessage"/> asks about muting later still —
+	/// at the moment it would raise, once the whole binding pass is behind it.
+	/// </summary>
+	private static void OnLiveValueChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
 	{
 		if (d is TextBlock block)
-			LiveMessage.Show(block, e.NewValue as string);
+			LiveMessage.Show(block, GetMessage(block), () => !GetMuted(block));
 	}
 }

--- a/Mutation.Ui/Views/Settings/Controls/HotkeyEditor.xaml.cs
+++ b/Mutation.Ui/Views/Settings/Controls/HotkeyEditor.xaml.cs
@@ -273,6 +273,12 @@ public sealed partial class HotkeyEditor : UserControl
 		bool rewritten = !string.Equals(committed, typed, StringComparison.Ordinal);
 		if (rewritten)
 		{
+			// A rewrite changes what this row holds, which can make it collide with another row,
+			// and it happens without the user typing a character — tabbing out of a box holding a
+			// hand-edited spelling is enough. Without this the resulting "Duplicate hotkey" badge
+			// was written and never spoken (issue #350).
+			AnnouncementGate?.Touch();
+
 			_suppressTextChanged = true;
 			try { HotkeyTextBox.Text = committed; }
 			finally { _suppressTextChanged = false; }
@@ -286,8 +292,12 @@ public sealed partial class HotkeyEditor : UserControl
 		// Only a rewrite can have left that message stale, and only a rewrite refreshes it.
 		// Doing it on every commit would newly complain at a required row that is empty and
 		// untouched — of which there are plenty — every single time the user tabbed past it.
+		// Through the gate like every other validation message, so one page has one set of
+		// manners. In practice the gate is already open by now — a rewrite opened it above — but
+		// leaving this path ungated meant a whitespace-only box, tabbed into and straight out of,
+		// announced "Enter a hotkey." on a page nobody had touched.
 		if (rewritten)
-			LiveMessage.Show(ValidationText, validation);
+			LiveMessage.Show(ValidationText, validation, AnnouncementAllowed);
 
 		if (!string.Equals(Hotkey, committed, StringComparison.Ordinal))
 			Hotkey = committed;

--- a/Mutation.Ui/Views/Settings/Controls/HotkeyEditor.xaml.cs
+++ b/Mutation.Ui/Views/Settings/Controls/HotkeyEditor.xaml.cs
@@ -40,6 +40,19 @@ public sealed partial class HotkeyEditor : UserControl
 		UpdateHelpVisibility();
 	}
 
+	/// <summary>
+	/// Whether the page holding this editor has been used yet. Until it has, this row's
+	/// validation message is written on screen but not read out — a settings page full of
+	/// required-but-empty rows would otherwise greet the user with one "Enter a hotkey."
+	/// interruption per row, about settings nobody had touched (issue #350).
+	/// <para>
+	/// Left null by any page that does not care, and then the message announces as it always
+	/// did. Editors on pages whose rows practically always have values were quiet in practice
+	/// anyway; the Hotkeys page is the one where it showed.
+	/// </para>
+	/// </summary>
+	internal FirstTouchGate? AnnouncementGate { get; set; }
+
 	public string Hotkey
 	{
 		get => (string)GetValue(HotkeyProperty);
@@ -121,6 +134,11 @@ public sealed partial class HotkeyEditor : UserControl
 	private void HotkeyTextBox_TextChanged(object sender, TextChangedEventArgs e)
 	{
 		if (_suppressTextChanged) return;
+
+		// Every programmatic write to this box suppresses this handler, so reaching here means
+		// the user typed. That is what opens the page's mouth — merely tabbing through a row
+		// does not (issue #350).
+		AnnouncementGate?.Touch();
 		Validate(HotkeyTextBox.Text);
 	}
 
@@ -175,6 +193,8 @@ public sealed partial class HotkeyEditor : UserControl
 
 	private void RecordButton_Click(object sender, RoutedEventArgs e)
 	{
+		AnnouncementGate?.Touch();
+
 		if (_isRecording)
 			StopRecording();
 		else
@@ -183,6 +203,8 @@ public sealed partial class HotkeyEditor : UserControl
 
 	private void ClearButton_Click(object sender, RoutedEventArgs e)
 	{
+		AnnouncementGate?.Touch();
+
 		_suppressTextChanged = true;
 		try { HotkeyTextBox.Text = string.Empty; }
 		finally { _suppressTextChanged = false; }
@@ -214,7 +236,19 @@ public sealed partial class HotkeyEditor : UserControl
 	/// #243).
 	/// </para>
 	/// </summary>
-	private void Validate(string text) => LiveMessage.Show(ValidationText, ValidationMessageFor(text));
+	/// <remarks>
+	/// Shown either way, announced only once the page has been used. Setting a row's
+	/// <c>Hotkey</c> while the page is being built runs straight through here, so without the
+	/// gate a page of required-but-empty rows reads them all out on the way in (issue #350).
+	/// </remarks>
+	private void Validate(string text) =>
+		LiveMessage.Show(ValidationText, ValidationMessageFor(text), AnnouncementAllowed);
+
+	/// <summary>
+	/// Asked at the moment the message would be raised rather than when it is set, so a page
+	/// used during the same dispatcher pass is heard rather than swallowed.
+	/// </summary>
+	private bool AnnouncementAllowed() => AnnouncementGate is null || AnnouncementGate.HasBeenTouched;
 
 	/// <summary>What is wrong with <paramref name="text"/>, or null when nothing is.</summary>
 	private string? ValidationMessageFor(string? text)

--- a/Mutation.Ui/Views/Settings/Pages/HotkeysSettingsPage.xaml
+++ b/Mutation.Ui/Views/Settings/Pages/HotkeysSettingsPage.xaml
@@ -37,6 +37,15 @@
 						<TextBlock Grid.Column="2" Text="Actions" FontWeight="SemiBold" />
 					</Grid>
 
+					<!-- Do not give this list a Height or MaxHeight without reading on. It sits
+					     inside a StackPanel inside the dialog's ScrollViewer, so it is measured
+					     with unbounded height and realises every row up front — no container is
+					     ever recycled. Two live regions in the row template rely on that. Bound
+					     the height and recycling resumes, at which point a row scrolling into
+					     view rebinds a reused TextBlock, LiveMessage sees the text change, and
+					     the row announces its error and its status again just for being looked
+					     at. If a long mapping list ever needs a scrolling list of its own, the
+					     live regions have to learn to stay quiet through container reuse first. -->
 					<ListView
 						x:Name="HotkeyRouterList"
 						AutomationProperties.Name="Hotkey router mappings"

--- a/Mutation.Ui/Views/Settings/Pages/HotkeysSettingsPage.xaml
+++ b/Mutation.Ui/Views/Settings/Pages/HotkeysSettingsPage.xaml
@@ -58,6 +58,7 @@
 										<RowDefinition Height="Auto" />
 										<RowDefinition Height="Auto" />
 										<RowDefinition Height="Auto" />
+										<RowDefinition Height="Auto" />
 									</Grid.RowDefinitions>
 
 									<Grid Grid.Row="0" Grid.Column="0">
@@ -117,15 +118,53 @@
 									     left queued behind a message about spelling. The two never both have
 									     something to say about one box — the notice stands down while the
 									     box has an error — so this is which of them interrupts, not a race
-									     between them. -->
+									     between them.
+
+									     Muted until the user has used the page. A row built from settings
+									     can already be carrying "Enter a hotkey." before it reaches the
+									     screen, so without the mute, opening this page on a settings file
+									     with several bad mappings queued one assertive interruption per row
+									     about settings nobody had touched. The written half is never muted
+									     — a sighted reader was not the problem (issue #350). -->
 									<TextBlock
 										Grid.Row="1"
 										Grid.Column="0"
 										Grid.ColumnSpan="3"
+										views:LiveText.Muted="{x:Bind AnnouncementsMuted, Mode=OneWay}"
 										views:LiveText.Message="{x:Bind BindingErrorMessage, Mode=OneWay}"
 										Foreground="{ThemeResource SystemFillColorCriticalBrush}"
 										Visibility="Collapsed"
 										AutomationProperties.LiveSetting="Assertive"
+										Style="{StaticResource CaptionTextBlockStyle}"
+										TextWrapping="Wrap" />
+
+									<!-- Whether the running app is actually listening for this mapping:
+									     "This mapping is live." once it is, or "Not active yet — press Save
+									     to apply." while it is only on screen. Settings pages edit a copy
+									     and hand it over on save, so a row and a live route are two
+									     different things, and this is the only confirmation a user gets
+									     that a mapping they just added took effect.
+
+									     Written text in the row's reading order, not a tick beside the box.
+									     The tick was the old design and none of it reached this app's
+									     reader: three properties computed a glyph, a colour and a tooltip,
+									     nothing bound any of them, and a glyph announces nothing even when
+									     bound (issue #343).
+
+									     Polite, so it waits its turn behind the error above rather than
+									     cutting across it, and muted on the way in for the same reason as
+									     the error: a page of stored routes would otherwise read "This
+									     mapping is live." out once per row. Failures say nothing here — the
+									     assertive error above carries the reason. -->
+									<TextBlock
+										Grid.Row="2"
+										Grid.Column="0"
+										Grid.ColumnSpan="3"
+										views:LiveText.Muted="{x:Bind AnnouncementsMuted, Mode=OneWay}"
+										views:LiveText.Message="{x:Bind RouteStatusText, Mode=OneWay}"
+										Foreground="{ThemeResource TextFillColorPrimaryBrush}"
+										Visibility="Collapsed"
+										AutomationProperties.LiveSetting="Polite"
 										Style="{StaticResource CaptionTextBlockStyle}"
 										TextWrapping="Wrap" />
 
@@ -140,7 +179,7 @@
 									     caption would normally take: this app's reader is low-vision, and a
 									     message worth showing at all is worth being able to read. -->
 									<TextBlock
-										Grid.Row="2"
+										Grid.Row="3"
 										Grid.Column="0"
 										views:LiveText.Message="{x:Bind FromCommitAnnouncement, Mode=OneWay}"
 										Foreground="{ThemeResource TextFillColorPrimaryBrush}"
@@ -150,7 +189,7 @@
 										TextWrapping="Wrap" />
 
 									<TextBlock
-										Grid.Row="2"
+										Grid.Row="3"
 										Grid.Column="1"
 										views:LiveText.Message="{x:Bind ToCommitAnnouncement, Mode=OneWay}"
 										Foreground="{ThemeResource TextFillColorPrimaryBrush}"

--- a/Mutation.Ui/Views/Settings/Pages/HotkeysSettingsPage.xaml.cs
+++ b/Mutation.Ui/Views/Settings/Pages/HotkeysSettingsPage.xaml.cs
@@ -22,9 +22,35 @@ public sealed partial class HotkeysSettingsPage : UserControl
 	private readonly List<HotkeyRow> _rows = new();
 	private readonly HotkeyRouterController _routerController;
 
+	/// <summary>
+	/// Whether the user has used this page yet. Every error on it is written the moment it
+	/// exists and read out only after this has been touched, so opening the page on a settings
+	/// file full of empty required rows is quiet instead of a queue of interruptions about rows
+	/// nobody has been near (issue #350).
+	/// <para>
+	/// One gate for the page rather than one per row, and shared with the router list below, so
+	/// the two halves of this screen have the same manners. It also means a clash that appears
+	/// in one list because the user edited the other is still announced — the row it lands on
+	/// was never touched, and it is precisely the news worth interrupting for.
+	/// </para>
+	/// </summary>
+	private readonly FirstTouchGate _announcementGate = new();
+
 	public ObservableCollection<Mutation.Ui.HotkeyRouterEntry> HotkeyRouterEntries { get; } = new();
 
 	public HotkeysSettingsPage(Settings settings)
+		: this(settings, null)
+	{
+	}
+
+	/// <param name="liveRouterRoutes">
+	/// The router routes the running app currently holds, so each row can say whether it is live
+	/// or still waiting for a save. Read-only — see <see cref="HotkeyRouterController"/>. Null
+	/// when there is nothing to ask, and then the rows say nothing about it (issue #343).
+	/// </param>
+	public HotkeysSettingsPage(
+		Settings settings,
+		Func<IReadOnlyList<RegisteredRouterRoute>?>? liveRouterRoutes)
 	{
 		_settings = settings;
 		InitializeComponent();
@@ -39,7 +65,9 @@ public sealed partial class HotkeysSettingsPage : UserControl
 			autoPersist: false,
 			// This page holds both lists, so it is the only place that can see a core hotkey
 			// and a route claiming the same chord (issue #321).
-			crossListDuplicateCheck: RecomputeDuplicates);
+			crossListDuplicateCheck: RecomputeDuplicates,
+			liveRoutes: liveRouterRoutes,
+			announcementGate: _announcementGate);
 
 		// Also runs the first duplicate check, once the router rows exist to take part in it.
 		_routerController.Initialize();
@@ -66,6 +94,10 @@ public sealed partial class HotkeysSettingsPage : UserControl
 				Header = spec.Label,
 				AllowEmpty = spec.AllowEmpty,
 				AllowSendKeysSyntax = spec.AllowsSendKeysSyntax,
+				// Before Hotkey is assigned, because assigning it validates straight away and a
+				// required row that is empty would announce "Enter a hotkey." as the page is
+				// still being built (issue #350).
+				AnnouncementGate = _announcementGate,
 				Hotkey = spec.Getter(_settings) ?? string.Empty,
 			};
 			var dupBadge = new TextBlock
@@ -91,6 +123,7 @@ public sealed partial class HotkeysSettingsPage : UserControl
 			{
 				var resetBtn = SettingsResetButton.Create($"Reset to default ({spec.Default})", () =>
 				{
+					_announcementGate.Touch();
 					editor.Hotkey = spec.Default!;
 					spec.Setter(_settings, spec.Default);
 					RecomputeDuplicates();
@@ -150,11 +183,16 @@ public sealed partial class HotkeysSettingsPage : UserControl
 
 		for (int i = 0; i < _rows.Count; i++)
 		{
+			// Shown always, announced once the page has been used. The first check of all runs
+			// while the page is still being built, and a settings file with two rows already
+			// sharing a chord would otherwise read the badge out before the user saw the page
+			// (issue #350).
 			LiveMessage.Show(
 				_rows[i].DuplicateBadge,
 				onThisPage[0].Contains(i) ? DuplicateBadgeText
 					: everywhere[0].Contains(i) ? PromptClashBadge(_rows[i], prompts)
-					: null);
+					: null,
+				AnnouncementAllowed);
 		}
 
 		// A route says "Duplicate 'From' hotkey." either way. The wording is true of a prompt
@@ -216,6 +254,13 @@ public sealed partial class HotkeysSettingsPage : UserControl
 
 		return configured;
 	}
+
+	/// <summary>
+	/// Whether this page may read its errors out yet. Asked at the moment a message would be
+	/// raised rather than when it is set, so a check that runs while the page is being built is
+	/// silent while the very next one, after the user has typed, is not.
+	/// </summary>
+	private bool AnnouncementAllowed() => _announcementGate.HasBeenTouched;
 
 	private void BtnAddHotkeyRoute_Click(object sender, RoutedEventArgs e) =>
 		_routerController.AddNewMapping();

--- a/Mutation.Ui/Views/Settings/Pages/HotkeysSettingsPage.xaml.cs
+++ b/Mutation.Ui/Views/Settings/Pages/HotkeysSettingsPage.xaml.cs
@@ -38,11 +38,6 @@ public sealed partial class HotkeysSettingsPage : UserControl
 
 	public ObservableCollection<Mutation.Ui.HotkeyRouterEntry> HotkeyRouterEntries { get; } = new();
 
-	public HotkeysSettingsPage(Settings settings)
-		: this(settings, null)
-	{
-	}
-
 	/// <param name="liveRouterRoutes">
 	/// The router routes the running app currently holds, so each row can say whether it is live
 	/// or still waiting for a save. Read-only — see <see cref="HotkeyRouterController"/>. Null

--- a/Mutation.Ui/Views/Settings/SettingsSearchHelper.cs
+++ b/Mutation.Ui/Views/Settings/SettingsSearchHelper.cs
@@ -3,6 +3,7 @@ using System.Text;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
+using Mutation.Ui.Core;
 
 namespace Mutation.Ui.Views.SettingsUi;
 
@@ -12,12 +13,15 @@ namespace Mutation.Ui.Views.SettingsUi;
 // sections from the tab order and the screen-reader tree, so search results are
 // perceivable without sight. Empty query restores all sections.
 // Returns the number of sections that match (all sections for an empty query).
+//
+// Only the two halves that need a live tree are here: gathering a section's text out
+// of it, and reporting the answer by collapsing the section. Deciding matched or not
+// is SettingsSectionMatcher, which can be exercised without a Panel (issue #304).
 internal static class SettingsSearchHelper
 {
 	public static int ApplyFilter(Panel root, string query)
 	{
-		string q = (query ?? string.Empty).Trim().ToLowerInvariant();
-		bool noQuery = q.Length == 0;
+		bool noQuery = SettingsSectionMatcher.IsEmptyQuery(query);
 		int matches = 0;
 
 		foreach (UIElement child in root.Children)
@@ -32,7 +36,7 @@ internal static class SettingsSearchHelper
 				continue;
 			}
 
-			bool isMatch = CollectText(fe).ToLowerInvariant().Contains(q);
+			bool isMatch = SettingsSectionMatcher.Matches(CollectText(fe), query);
 			fe.Visibility = isMatch ? Visibility.Visible : Visibility.Collapsed;
 			if (isMatch)
 				matches++;

--- a/Mutation.Ui/Views/SettingsDialog.xaml.cs
+++ b/Mutation.Ui/Views/SettingsDialog.xaml.cs
@@ -23,6 +23,7 @@ public sealed partial class SettingsDialog : ContentDialog
 	private readonly ISettingsManager? _settingsManager;
 	private readonly string? _settingsFilePath;
 	private readonly Action? _onLiveApply;
+	private readonly Func<IReadOnlyList<RegisteredRouterRoute>?>? _liveRouterRoutes;
 	private readonly List<SettingsCategoryItem> _allCategories = new();
 
 	private SettingsCategoryItem? _selectedCategory;
@@ -35,18 +36,26 @@ public sealed partial class SettingsDialog : ContentDialog
 	{
 	}
 
+	/// <param name="liveRouterRoutes">
+	/// The hotkey-router routes the running app currently holds, so the Hotkeys page can tell a
+	/// live mapping from one the user has typed but not saved. Asked freshly whenever the rows
+	/// refresh, and read-only — this dialog edits a copy of the settings, and registering out of
+	/// that copy would claim chords the user could still cancel (issue #343).
+	/// </param>
 	public SettingsDialog(
 		Settings settings,
 		ISettingsManager? settingsManager,
 		string? settingsFilePath,
 		Action? onLiveApply,
-		string? initialCategoryKey = null)
+		string? initialCategoryKey = null,
+		Func<IReadOnlyList<RegisteredRouterRoute>?>? liveRouterRoutes = null)
 	{
 		_live = settings ?? throw new ArgumentNullException(nameof(settings));
 		_workingCopy = SettingsWorkingCopy.Clone(_live);
 		_settingsManager = settingsManager;
 		_settingsFilePath = settingsFilePath;
 		_onLiveApply = onLiveApply;
+		_liveRouterRoutes = liveRouterRoutes;
 
 		PopulateCategories();
 		InitializeComponent();
@@ -165,7 +174,7 @@ public sealed partial class SettingsDialog : ContentDialog
 			"tts" => new TtsSettingsPage(_workingCopy),
 			"transcript" => new TranscriptFormattingSettingsPage(_workingCopy),
 			"ui" => new InterfaceSettingsPage(_workingCopy),
-			"hotkeys" => new HotkeysSettingsPage(_workingCopy),
+			"hotkeys" => new HotkeysSettingsPage(_workingCopy, _liveRouterRoutes),
 			_ => null,
 		};
 


### PR DESCRIPTION
Closes #343
Closes #350
Closes #294
Closes #304

Four small stories. Three of them land on the Hotkeys settings page and interlock there, so they are one branch; the fourth is in the dictation delivery path.

Two independent reviews ran over the first commit and found two real defects — a feature that would have lied and a feature that would have done nothing. Both are fixed in the second commit and described below.

## A router mapping now says whether it is live (#343)

`HotkeyRouterEntry` computed a tick glyph, a status colour and a status tooltip, and the row template in `HotkeysSettingsPage.xaml` bound none of them. A route that was working looked and read exactly like one that had never been registered — and it was the only confirmation available that a mapping just added had taken effect.

Binding the three properties as they stood would have made it worse. Nothing ever handed the Settings page's `HotkeyRouterController` a `HotkeyManager`, so `RefreshRegistrations` always took the early branch and set every row to `Inactive`, which the tooltip reported as "Hotkey is not currently bound." — for working routes included.

The three properties are deleted. In their place:

- `HotkeyManager` remembers what its last router registration pass made of each mapping, and exposes it as `LiveRouterRoutes()`.
- `MainWindow` passes a read-only getter for that list through `SettingsDialog` into the Hotkeys page. Read-only matters: the page edits a **copy** of the settings, and registering out of the copy would claim chords the user could still cancel out of. The dead branch that would have done exactly that is gone.
- A pure unit, `RouterBindingStatus`, compares a row against the list and returns one of four honest states. The state enum moved to `Mutation.Ui/Core` with it, and `Inactive` became `Unknown` plus a new `NotYetApplied`.
- The row shows the answer as **written text in its reading order**, not a tooltip on an icon: "CTRL+ALT+1 is live." or "CTRL+ALT+1 is not active yet — press Save to apply." It is also a polite live region, so acting on a row is answered.

Both halves of the mapping must match before a row calls itself live. Changing only the "To" side leaves the same chord registered while what it sends is out of date, and a row matching on "From" alone would tell the user their edit had taken effect when it had not.

Failures still go through the assertive error region, which already carried the reason; the status line says nothing for them rather than repeating it politely.

### Review fix: compare chords, not spellings

The first commit compared the row's canonical chord against the **raw text** in the settings file, forgiving only case and surrounding spaces. `Hotkey.Canonicalize` does more than fold case — it re-spells `CONTROL` as `CTRL` and re-orders modifiers — so any stored spelling that was not already canonical failed to match and the row reported a working mapping as pending.

The trigger is the shipped default. `SettingsManager` seeds a brand-new settings file with a router mapping written `CONTROL+SHIFT+ALT+8`, which canonicalises to `CTRL+SHIFT+ALT+8`. On a fresh install the only router row on the page would have said "not active yet" about a route that was live — the same class of false statement #343 was filed about. Files written before the canonicalisation work, or edited by hand, do the same.

Both sides now go through `Canonicalize`. This is the lesson `HotkeyConflictFinder` already learned for duplicate detection in #306: a shortcut has one identity and many spellings. Every test had handed the fake live route an already-canonical spelling, which is why the suite was green over it; there are now tests for the seeded default and for three other spellings of one chord.

### Review fix: the status names its shortcut

The status is announced out of rows the user is not in. **Delete mapping** re-evaluates every remaining row, so deleting one of two rows that were mutual duplicates leaves the survivor announcing its new state while focus sits on a button in a row that no longer exists — and a chord three rows shared would say it three times. Naming the shortcut is the convention the rewrite notices already follow, and for the same reason.

### Review fix: a live route going permanently quiet

`ApplyDuplicates` is reached without a refresh when a **core** hotkey commits: the page recomputes across all its lists and stops there. A live route flagged because a core hotkey took its chord went to `Unknown`, and nothing about ceasing to be a duplicate restored what it was — so it stayed silent about being live until a router box lost focus or the page was rebuilt. `ApplyDuplicates` now settles the binding states itself.

## The Hotkeys page is quiet until you touch it (#350)

The decision the issue asked for, and the reasoning behind each half of it.

**An error announces only once the page has been used.** A row built from settings can arrive already carrying `"Enter a hotkey."`, in an assertive live region, so opening the page on a settings file with several bad mappings queued one interruption per row about settings nobody had touched.

**The gate is per page, not per row.** A row-by-row rule — a row speaks once it has been left once — would silence a duplicate that appears in the router list because the user edited a *core* hotkey two sections up the page. That row was never touched and it is exactly the news worth interrupting for. `FirstTouchGate` is one latch, shared by the core hotkey rows, their duplicate badges, and the router rows, so one screen has one set of manners.

**It gates the announcement only, never the written text.** Taking the error off screen at load would be a plain regression for a sighted reader, who was never the problem. That needed `LiveMessage` to be able to show without raising, so it now takes a "should this be announced" predicate — asked at the moment it would raise, not when the message is set. `LiveText` gained a `Muted` attached property that feeds it, and both attached properties run through one handler, so the order a row's bindings happen to apply in cannot decide whether a message is heard.

**Add mapping stays loud**, as the issue suggested: the click opens the gate before the row is built, so being told the new empty row wants a shortcut is the answer to the button just pressed.

### Review fixes

- **Leaving a core hotkey box** whose stored spelling needed canonicalising changes what the row holds without the user typing a character, and can make it collide with another row. That commit now opens the gate, so the resulting "Duplicate hotkey" badge is spoken instead of appearing in silence. The one validation path inside `Commit` that bypassed the gate goes through it too.
- **The bookkeeping pass was quiet by accident.** A commit that rewrites a chord raises the same property change the user's typing does, and `SyncSettings` commits every row on every refresh. It happens to find nothing to rewrite today only because the entry's constructor canonicalises before the handler is subscribed. That is now an explicit flag with a test, so a reordering cannot silently reopen #350.

## Detecting the elevated app before typing, not after (#294)

Microsoft documents that `SendInput` fails silently under UIPI: the events are accepted into the input stream, the return count is the full number submitted, and `GetLastError` reports nothing. They are discarded further down. So the count check added by the earlier fix catches input genuinely refused — `BlockInput`, a low-level hook, a full queue — but not the elevated-app case the issue was filed about.

`TryInsertIntoActiveApplicationAsync` now asks first, and the existing `TranscriptDeliveryOutcome.InjectionFailed` path and message are reused. In Paste mode the check runs *after* the clipboard write, because the failure message tells the user to paste the text themselves and it has to be somewhere they can paste it from.

### Review fix: the first attempt would probably never have fired

The first commit opened the foreground process for `PROCESS_QUERY_LIMITED_INFORMATION` and read a refusal as "that process is above us". Both reviewers independently pointed out that this is backwards: that right exists so that an ordinary process *can* identify a more privileged one — it is what lets an unelevated Task Manager list elevated processes by name — so it is granted across an integrity boundary and every elevated app would have sailed through. And the one case it *did* fire on was a false positive: another user's process in the same session refuses even the limited right while running at our own integrity level, where the input would have landed.

It now asks for both rights and reads the difference, with the actual integrity comparison doing the work:

| Limited query | Full query | Verdict |
| --- | --- | --- |
| Granted | Granted | Read both tokens' integrity levels and compare. Strictly greater means discarded; equal is fine, since UIPI blocks sending up, not across. |
| Granted | Refused | Above us. `PROCESS_QUERY_INFORMATION` is what `OpenProcessToken` needs and is not granted across an integrity boundary, so named-but-not-readable is a signature nothing else produces. |
| Refused | — | Cannot tell. A DACL said no, which is a different question. Delivery proceeds. |

Everything that cannot be established lets delivery proceed, deliberately: a false positive would refuse an ordinary window and report a failure that would not have happened.

**What was not done:** the issue asks first for a by-hand confirmation — dictate with Task Manager focused, in both modes, and record whether the failure beep appears. That cannot be done in an agent session, and it is the one thing that would settle whether the integrity comparison fires in practice. The guide keeps its caveat and its paste-it-yourself recovery step for that reason.

## Two seams for the WinUI-bound units (#304)

- **`PromptLibraryMutations`** — add, commit-an-edit, delete over the prompt list, with no `PromptEditorWindow`. This puts the AutoRun exclusivity sweep in one place instead of two that spelled "every prompt but this one" differently (the add path cleared the flag on the whole list before appending; the edit path skipped by reference), and puts the Id backfill where add-after-delete can be tested. Reorder is **not** extracted — there is no reorder in the controller to extract, and inventing one would be a feature this issue did not ask for.
- **`SettingsSectionMatcher`** — "does this section's text answer the query", split from the `VisualTreeHelper` walk that gathers the text and the `Visibility` writes that report the answer. Both of those still need a live tree; the rule does not.

Both reviewers checked these two for behavioural equivalence against the code they replaced and found none.

## What a user notices

- A Hotkey Router row tells you whether it is live, by name, in text a screen reader reads.
- Opening the Hotkeys page no longer reads out errors about rows you have not touched. Once you change anything there, errors announce as before.
- Dictating with an elevated app in front should now get the failure beep and the "could not be sent" message instead of a success beep for text that went nowhere. Should, not will — see below.
- Nothing changes for the two extracted seams.

## Verification

`dotnet test --configuration Release` — 2233 passed, 0 failed. The user guide markdown and regenerated HTML are committed together.

**Not verified.** None of this was exercised in the running app, and two things cannot be verified from a test project at all:

1. **The UIPI detection.** Whether `OpenProcess(PROCESS_QUERY_INFORMATION)` is actually refused for a UAC-elevated foreground process, and whether the integrity levels read back the way the rule expects, needs an elevated window on a real desktop. The rule and the classification are covered directly; the P/Invoke that feeds them is not. This is the manual step #294 asked for first, and it is still outstanding. The failure mode if the premise is wrong is that the check stays silent — the same as before this PR — not that delivery breaks.
2. **What a screen reader actually reads out.** WinUI live regions, the attached-property binding order, and the automation tree cannot be driven from `Mutation.Tests`. The pure pieces — the status decision, the gate, the UIPI rule, both new seams — are covered. The wiring between them and WinUI is not: that `LiveText.Muted` and `LiveText.Message` settle the way the single-handler design intends, and that a collapsed `TextBlock` in a new grid row is in the automation tree by the time the raise happens.

One known limitation, left as-is deliberately: the router `ListView` realises every row up front because it sits in an unbounded `StackPanel`, and the two live regions in the row template depend on that. Giving it a bounded height would resume container recycling and make a row re-announce itself just for scrolling into view. There is a comment in the XAML saying so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
