### PR TITLE
Give the clipboard retry a thread it can actually retry on

### DIFF
--- a/Mutation.Tests/ClipboardManagerUiThreadTests.cs
+++ b/Mutation.Tests/ClipboardManagerUiThreadTests.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Mutation.Ui.Services;
+using Xunit;
+
+namespace Mutation.Tests;
+
+/// <summary>
+/// The clipboard only answers calls made from the UI thread. These pin that every attempt in
+/// the retry ladder is made there, not just the first one — which is what issue #352 was: the
+/// waits inside <see cref="ClipboardRetry"/> handed attempts two to five to the thread pool,
+/// where the clipboard refuses them for a reason no further attempt gets past, so these were
+/// one-attempt operations wearing a retry ladder.
+/// </summary>
+public class ClipboardManagerUiThreadTests
+{
+	[Fact]
+	public async Task TrySetTextAsync_MakesEveryRetryAttemptOnTheSameThreadAsTheFirst()
+	{
+		using var uiThread = new SingleThreadUiDispatcher();
+		var clipboard = new RecordingClipboard(uiThread) { FailWrites = 2 };
+
+		bool copied = await clipboard.TrySetTextAsync("transcript");
+
+		Assert.True(copied);
+		Assert.Equal(3, clipboard.WriteThreadIds.Count);
+		Assert.All(clipboard.WriteThreadIds, id => Assert.Equal(uiThread.ThreadId, id));
+	}
+
+	/// <summary>
+	/// The full ladder is still walked when the clipboard never lets go, and every rung of it is
+	/// walked in the one place the clipboard will answer from.
+	/// </summary>
+	[Fact]
+	public async Task TrySetTextAsync_WalksTheWholeLadderOnTheUiThread_WhenTheClipboardNeverLetsGo()
+	{
+		using var uiThread = new SingleThreadUiDispatcher();
+		var clipboard = new RecordingClipboard(uiThread) { FailWrites = int.MaxValue };
+
+		bool copied = await clipboard.TrySetTextAsync("transcript");
+
+		Assert.False(copied);
+		Assert.Equal(ClipboardRetry.DefaultAttempts, clipboard.WriteThreadIds.Count);
+		Assert.All(clipboard.WriteThreadIds, id => Assert.Equal(uiThread.ThreadId, id));
+	}
+
+	/// <summary>
+	/// Each attempt asks for the UI thread again rather than assuming the last wait left it
+	/// there. Counting the hops is what separates this from a ladder that merely started in the
+	/// right place.
+	/// </summary>
+	[Fact]
+	public async Task TrySetTextAsync_AsksForTheUiThreadOncePerAttempt()
+	{
+		using var uiThread = new SingleThreadUiDispatcher();
+		var clipboard = new RecordingClipboard(uiThread) { FailWrites = 2 };
+
+		await clipboard.TrySetTextAsync("transcript");
+
+		Assert.Equal(3, uiThread.DispatchCount);
+	}
+
+	[Fact]
+	public async Task TrySetTextAsync_DoesNotTouchTheClipboard_ForBlankText()
+	{
+		using var uiThread = new SingleThreadUiDispatcher();
+		var clipboard = new RecordingClipboard(uiThread);
+
+		bool copied = await clipboard.TrySetTextAsync("   ");
+
+		Assert.False(copied);
+		Assert.Empty(clipboard.WriteThreadIds);
+	}
+
+	/// <summary>
+	/// Without a dispatcher the call is made where the caller stands. Tests that care about what
+	/// reached the clipboard rather than which thread put it there rely on this.
+	/// </summary>
+	[Fact]
+	public async Task TrySetTextAsync_RunsInPlace_WhenThereIsNoDispatcher()
+	{
+		var clipboard = new RecordingClipboard(uiThread: null);
+
+		bool copied = await clipboard.TrySetTextAsync("transcript");
+
+		Assert.True(copied);
+		Assert.Equal(new[] { Environment.CurrentManagedThreadId }, clipboard.WriteThreadIds);
+	}
+
+	/// <summary>
+	/// A failure on the UI thread has to come back to the caller, or the retry above it has
+	/// nothing to react to and a busy clipboard would read as a successful write.
+	/// </summary>
+	[Fact]
+	public async Task RunAsync_FaultsTheCaller_WhenTheOperationThrowsOnTheUiThread()
+	{
+		using var uiThread = new SingleThreadUiDispatcher();
+
+		await Assert.ThrowsAsync<InvalidOperationException>(
+			() => uiThread.RunAsync<object?>(() => throw new InvalidOperationException("clipboard busy")));
+	}
+
+	/// <summary>
+	/// A <see cref="ClipboardManager"/> whose one clipboard call records the thread it was made
+	/// on, and which can be told to fail the way a clipboard held open by another process does.
+	/// </summary>
+	private sealed class RecordingClipboard : ClipboardManager
+	{
+		private readonly List<int> _writeThreadIds = new();
+
+		public RecordingClipboard(IUiThreadDispatcher? uiThread)
+			: base(uiThread)
+		{
+		}
+
+		public IReadOnlyList<int> WriteThreadIds => _writeThreadIds;
+
+		/// <summary>
+		/// How many of the next writes throw. <see cref="int.MaxValue"/> for a clipboard that
+		/// never lets go.
+		/// </summary>
+		public int FailWrites { get; set; }
+
+		public override void SetText(string text)
+		{
+			_writeThreadIds.Add(Environment.CurrentManagedThreadId);
+
+			if (FailWrites <= 0)
+				return;
+
+			if (FailWrites != int.MaxValue)
+				FailWrites--;
+
+			// The real one is a COMException carrying CLIPBRD_E_CANT_OPEN when something else
+			// has the clipboard, or RPC_E_WRONG_THREAD when the call was made from the wrong
+			// place. All the retry above looks at is that the write threw.
+			throw new InvalidOperationException("OpenClipboard Failed (0x800401D0)");
+		}
+	}
+}

--- a/Mutation.Tests/ClipboardManagerUiThreadTests.cs
+++ b/Mutation.Tests/ClipboardManagerUiThreadTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Mutation.Ui.Services;
 using Xunit;
@@ -19,7 +18,7 @@ public class ClipboardManagerUiThreadTests
 	public async Task TrySetTextAsync_MakesEveryRetryAttemptOnTheSameThreadAsTheFirst()
 	{
 		using var uiThread = new SingleThreadUiDispatcher();
-		var clipboard = new RecordingClipboard(uiThread) { FailWrites = 2 };
+		var clipboard = new TestClipboard(uiThread) { FailWrites = 2 };
 
 		bool copied = await clipboard.TrySetTextAsync("transcript");
 
@@ -36,7 +35,7 @@ public class ClipboardManagerUiThreadTests
 	public async Task TrySetTextAsync_WalksTheWholeLadderOnTheUiThread_WhenTheClipboardNeverLetsGo()
 	{
 		using var uiThread = new SingleThreadUiDispatcher();
-		var clipboard = new RecordingClipboard(uiThread) { FailWrites = int.MaxValue };
+		var clipboard = new TestClipboard(uiThread) { FailWrites = int.MaxValue };
 
 		bool copied = await clipboard.TrySetTextAsync("transcript");
 
@@ -48,29 +47,88 @@ public class ClipboardManagerUiThreadTests
 	/// <summary>
 	/// Each attempt asks for the UI thread again rather than assuming the last wait left it
 	/// there. Counting the hops is what separates this from a ladder that merely started in the
-	/// right place.
+	/// right place — one hop and four attempts would satisfy the thread-id checks above.
 	/// </summary>
 	[Fact]
 	public async Task TrySetTextAsync_AsksForTheUiThreadOncePerAttempt()
 	{
 		using var uiThread = new SingleThreadUiDispatcher();
-		var clipboard = new RecordingClipboard(uiThread) { FailWrites = 2 };
+		var clipboard = new TestClipboard(uiThread) { FailWrites = 2 };
 
 		await clipboard.TrySetTextAsync("transcript");
 
 		Assert.Equal(3, uiThread.DispatchCount);
 	}
 
+	/// <summary>
+	/// The snapshot taken and put back either side of a paste retries too. This is the half of
+	/// the story's acceptance list that is not about dictation: a clipboard manager that holds
+	/// on through the first attempt used to mean the user's own clipboard contents were not put
+	/// back.
+	/// </summary>
+	[Fact]
+	public async Task TryRestoreSnapshotAsync_RetriesOnTheUiThread_WhenTheClipboardIsBrieflyBusy()
+	{
+		using var uiThread = new SingleThreadUiDispatcher();
+		var clipboard = new TestClipboard(uiThread) { FailWrites = 2 };
+		var snapshot = new ClipboardSnapshot { Text = "what the user had before" };
+
+		bool restored = await clipboard.TryRestoreSnapshotAsync(snapshot);
+
+		Assert.True(restored);
+		Assert.Same(snapshot, clipboard.LastRestoredSnapshot);
+		Assert.Equal(3, clipboard.WriteThreadIds.Count);
+		Assert.All(clipboard.WriteThreadIds, id => Assert.Equal(uiThread.ThreadId, id));
+	}
+
+	[Fact]
+	public async Task TryRestoreSnapshotAsync_ReportsFailure_WhenTheClipboardNeverLetsGo()
+	{
+		using var uiThread = new SingleThreadUiDispatcher();
+		var clipboard = new TestClipboard(uiThread) { FailWrites = int.MaxValue };
+
+		bool restored = await clipboard.TryRestoreSnapshotAsync(
+			new ClipboardSnapshot { Text = "what the user had before" });
+
+		Assert.False(restored);
+		Assert.Null(clipboard.LastRestoredSnapshot);
+		Assert.Equal(ClipboardRetry.DefaultAttempts, clipboard.WriteThreadIds.Count);
+	}
+
 	[Fact]
 	public async Task TrySetTextAsync_DoesNotTouchTheClipboard_ForBlankText()
 	{
 		using var uiThread = new SingleThreadUiDispatcher();
-		var clipboard = new RecordingClipboard(uiThread);
+		var clipboard = new TestClipboard(uiThread);
 
 		bool copied = await clipboard.TrySetTextAsync("   ");
 
 		Assert.False(copied);
 		Assert.Empty(clipboard.WriteThreadIds);
+	}
+
+	/// <summary>
+	/// A caller already on the UI thread is left there rather than queued behind itself. The
+	/// hop count is what says so; the thread ids alone cannot tell the two apart.
+	/// </summary>
+	[Fact]
+	public async Task TrySetTextAsync_RunsInPlace_WhenTheCallerIsAlreadyOnTheUiThread()
+	{
+		using var uiThread = new SingleThreadUiDispatcher();
+		var clipboard = new TestClipboard(uiThread) { FailWrites = 2 };
+
+		// Start the whole ladder on the dispatcher's own thread, which is what a real clipboard
+		// call from a UI event handler looks like.
+		bool copied = await uiThread.RunAsync(() => clipboard.TrySetTextAsync("transcript"));
+
+		Assert.True(copied);
+		Assert.Equal(3, clipboard.WriteThreadIds.Count);
+		Assert.All(clipboard.WriteThreadIds, id => Assert.Equal(uiThread.ThreadId, id));
+
+		// One hop to get the ladder started, and none for the attempts themselves: the first
+		// runs in place, and the two after it are queued back because ClipboardRetry's wait
+		// leaves them on the thread pool.
+		Assert.Equal(3, uiThread.DispatchCount);
 	}
 
 	/// <summary>
@@ -80,20 +138,27 @@ public class ClipboardManagerUiThreadTests
 	[Fact]
 	public async Task TrySetTextAsync_RunsInPlace_WhenThereIsNoDispatcher()
 	{
-		var clipboard = new RecordingClipboard(uiThread: null);
+		var clipboard = new TestClipboard(uiThread: null);
+		int callerThreadId = Environment.CurrentManagedThreadId;
 
 		bool copied = await clipboard.TrySetTextAsync("transcript");
 
 		Assert.True(copied);
-		Assert.Equal(new[] { Environment.CurrentManagedThreadId }, clipboard.WriteThreadIds);
+		Assert.Equal(new[] { callerThreadId }, clipboard.WriteThreadIds);
 	}
 
 	/// <summary>
 	/// A failure on the UI thread has to come back to the caller, or the retry above it has
 	/// nothing to react to and a busy clipboard would read as a successful write.
+	/// <para>
+	/// This pins the contract every <see cref="IUiThreadDispatcher"/> owes its caller, using the
+	/// test double. It is not a test of <c>DispatcherQueueUiThread</c>, the one that ships:
+	/// that needs a real WinUI dispatcher queue and a real UI thread, neither of which exists in
+	/// this test assembly.
+	/// </para>
 	/// </summary>
 	[Fact]
-	public async Task RunAsync_FaultsTheCaller_WhenTheOperationThrowsOnTheUiThread()
+	public async Task ADispatcher_FaultsTheCaller_WhenTheOperationThrowsOnTheUiThread()
 	{
 		using var uiThread = new SingleThreadUiDispatcher();
 
@@ -101,41 +166,11 @@ public class ClipboardManagerUiThreadTests
 			() => uiThread.RunAsync<object?>(() => throw new InvalidOperationException("clipboard busy")));
 	}
 
-	/// <summary>
-	/// A <see cref="ClipboardManager"/> whose one clipboard call records the thread it was made
-	/// on, and which can be told to fail the way a clipboard held open by another process does.
-	/// </summary>
-	private sealed class RecordingClipboard : ClipboardManager
+	private sealed class TestClipboard : RecordingClipboardManager
 	{
-		private readonly List<int> _writeThreadIds = new();
-
-		public RecordingClipboard(IUiThreadDispatcher? uiThread)
+		public TestClipboard(IUiThreadDispatcher? uiThread)
 			: base(uiThread)
 		{
-		}
-
-		public IReadOnlyList<int> WriteThreadIds => _writeThreadIds;
-
-		/// <summary>
-		/// How many of the next writes throw. <see cref="int.MaxValue"/> for a clipboard that
-		/// never lets go.
-		/// </summary>
-		public int FailWrites { get; set; }
-
-		public override void SetText(string text)
-		{
-			_writeThreadIds.Add(Environment.CurrentManagedThreadId);
-
-			if (FailWrites <= 0)
-				return;
-
-			if (FailWrites != int.MaxValue)
-				FailWrites--;
-
-			// The real one is a COMException carrying CLIPBRD_E_CANT_OPEN when something else
-			// has the clipboard, or RPC_E_WRONG_THREAD when the call was made from the wrong
-			// place. All the retry above looks at is that the write threw.
-			throw new InvalidOperationException("OpenClipboard Failed (0x800401D0)");
 		}
 	}
 }

--- a/Mutation.Tests/OcrManagerTests.cs
+++ b/Mutation.Tests/OcrManagerTests.cs
@@ -76,11 +76,7 @@ public class OcrManagerTests
 		var clipboard = new TestClipboard();
 		var service = new StubOcrService("recognized text");
 		using var file = new TempFile(".png");
-		var manager = new TestableOcrManager(settings, service, clipboard, () => true, action =>
-		{
-			action();
-			return Task.CompletedTask;
-		});
+		var manager = new TestableOcrManager(settings, service, clipboard);
 
 		var result = await manager.ExtractTextFromFilesAsync(new[] { file.Path }, DefaultOrder, CancellationToken.None);
 
@@ -91,7 +87,6 @@ public class OcrManagerTests
 		Assert.Equal(expectedText, result.Text);
 		Assert.Equal(expectedText, clipboard.LastText);
 		Assert.Equal(1, clipboard.SetTextCalls);
-		Assert.Equal(0, manager.RunOnDispatcherCalls);
 		WaitForBeep(manager, 1);
 		Assert.Contains(BeepType.Success, manager.Beeps);
 	}
@@ -211,29 +206,31 @@ public class OcrManagerTests
 		Assert.True(PostOperationHotkey.ShouldSendAfterOcr(result.Outcome));
 	}
 
+	/// <summary>
+	/// Batch OCR reads its files on the thread pool and finishes there, so the copy at the end
+	/// of the run is made from the wrong thread unless something moves it. That something is now
+	/// the clipboard itself rather than a second copy of the rule kept here, so what this checks
+	/// is that the OCR path goes through it and the text still lands on the UI thread (issue
+	/// #352).
+	/// </summary>
 	[Fact]
-	public async Task ExtractTextFromFilesAsync_DispatchesClipboardUpdate_WhenOffUiThread()
+	public async Task ExtractTextFromFilesAsync_PutsTheTextOnTheClipboardFromTheUiThread()
 	{
 		var settings = CreateValidSettings();
-		var clipboard = new TestClipboard();
+		using var uiThread = new SingleThreadUiDispatcher();
+		var clipboard = new TestClipboard(uiThread);
 		var service = new StubOcrService("batched result");
 		using var file = new TempFile(".png");
-		var dispatched = false;
-		var manager = new TestableOcrManager(settings, service, clipboard, () => false, action =>
-		{
-			dispatched = true;
-			action();
-			return Task.CompletedTask;
-		});
+		var manager = new TestableOcrManager(settings, service, clipboard);
 
-		var result = await manager.ExtractTextFromFilesAsync(new[] { file.Path }, DefaultOrder, CancellationToken.None);
+		var result = await Task.Run(() =>
+			manager.ExtractTextFromFilesAsync(new[] { file.Path }, DefaultOrder, CancellationToken.None));
 
 		string expectedText = $"[{Path.GetFileName(file.Path)}]{Environment.NewLine}batched result{Environment.NewLine}";
 		Assert.True(result.Success);
-		Assert.True(dispatched);
-		Assert.Equal(1, manager.RunOnDispatcherCalls);
 		Assert.Equal(expectedText, clipboard.LastText);
 		Assert.Equal(1, clipboard.SetTextCalls);
+		Assert.Equal(new[] { uiThread.ThreadId }, clipboard.WriteThreadIds);
 		WaitForBeep(manager, 1);
 		Assert.Contains(BeepType.Success, manager.Beeps);
 	}
@@ -1065,34 +1062,17 @@ public class OcrManagerTests
 
 	private sealed class TestableOcrManager : OcrManager
 	{
-		private readonly Func<bool> _hasThreadAccess;
-		private readonly Func<Action, Task> _dispatcher;
 		private readonly ConcurrentQueue<BeepType> _beeps = new();
 
-		public TestableOcrManager(Settings settings, IOcrService ocrService, TestClipboard clipboard, Func<bool>? hasThreadAccess = null, Func<Action, Task>? dispatcher = null)
+		public TestableOcrManager(Settings settings, IOcrService ocrService, TestClipboard clipboard)
 			: base(settings, ocrService, clipboard)
 		{
 			Clipboard = clipboard;
-			_hasThreadAccess = hasThreadAccess ?? (() => true);
-			_dispatcher = dispatcher ?? (action =>
-			{
-				action();
-				return Task.CompletedTask;
-			});
 		}
 
 		public TestClipboard Clipboard { get; }
-		public int RunOnDispatcherCalls { get; private set; }
 		public int BeepCount => _beeps.Count;
 		public IReadOnlyCollection<BeepType> Beeps => _beeps.ToArray();
-
-		protected override bool HasDispatcherThreadAccess() => _hasThreadAccess();
-
-		protected override Task RunOnDispatcherAsync(Action action)
-		{
-			RunOnDispatcherCalls++;
-			return _dispatcher(action);
-		}
 
 		protected override void PlayBeep(BeepType type)
 		{
@@ -1102,8 +1082,22 @@ public class OcrManagerTests
 
 	private sealed class TestClipboard : ClipboardManager
 	{
+		private readonly List<int> _writeThreadIds = new();
+
+		/// <param name="uiThread">
+		/// Null for the tests that only care what reached the clipboard, so the write happens
+		/// where the test stands. Supply one to check which thread the write was made on.
+		/// </param>
+		public TestClipboard(IUiThreadDispatcher? uiThread = null)
+			: base(uiThread)
+		{
+		}
+
 		public string? LastText { get; private set; }
 		public int SetTextCalls { get; private set; }
+
+		/// <summary>The thread each write was made on, in order.</summary>
+		public IReadOnlyList<int> WriteThreadIds => _writeThreadIds;
 
 		/// <summary>
 		/// How many of the next writes throw the way a clipboard held open by another process
@@ -1118,6 +1112,7 @@ public class OcrManagerTests
 		public override void SetText(string text)
 		{
 			SetTextCalls++;
+			_writeThreadIds.Add(Environment.CurrentManagedThreadId);
 			if (FailWrites > 0)
 			{
 				if (FailWrites != int.MaxValue)

--- a/Mutation.Tests/OcrManagerTests.cs
+++ b/Mutation.Tests/OcrManagerTests.cs
@@ -1080,10 +1080,8 @@ public class OcrManagerTests
 		}
 	}
 
-	private sealed class TestClipboard : ClipboardManager
+	private sealed class TestClipboard : RecordingClipboardManager
 	{
-		private readonly List<int> _writeThreadIds = new();
-
 		/// <param name="uiThread">
 		/// Null for the tests that only care what reached the clipboard, so the write happens
 		/// where the test stands. Supply one to check which thread the write was made on.
@@ -1093,38 +1091,9 @@ public class OcrManagerTests
 		{
 		}
 
-		public string? LastText { get; private set; }
-		public int SetTextCalls { get; private set; }
-
-		/// <summary>The thread each write was made on, in order.</summary>
-		public IReadOnlyList<int> WriteThreadIds => _writeThreadIds;
-
-		/// <summary>
-		/// How many of the next writes throw the way a clipboard held open by another process
-		/// does. <see cref="int.MaxValue"/> for one that never lets go.
-		/// </summary>
-		public int FailWrites { get; set; }
-
 		// The image ExtractTextFromClipboardImageAsync will find. Null means "no image
 		// on the clipboard", which is the path that beeps failure.
 		public SoftwareBitmap? Image { get; set; }
-
-		public override void SetText(string text)
-		{
-			SetTextCalls++;
-			_writeThreadIds.Add(Environment.CurrentManagedThreadId);
-			if (FailWrites > 0)
-			{
-				if (FailWrites != int.MaxValue)
-					FailWrites--;
-
-				// The real one is a COMException carrying CLIPBRD_E_CANT_OPEN. What matters
-				// here is only that the write throws, which is all the retry looks at.
-				throw new InvalidOperationException("OpenClipboard Failed (0x800401D0)");
-			}
-
-			LastText = text;
-		}
 
 		public override Task<SoftwareBitmap?> TryGetImageAsync(int attempts = 5, int delayMs = 150)
 			=> Task.FromResult(Image);

--- a/Mutation.Tests/RecordingClipboardManager.cs
+++ b/Mutation.Tests/RecordingClipboardManager.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Mutation.Ui.Services;
+
+namespace Mutation.Tests;
+
+/// <summary>
+/// A <see cref="ClipboardManager"/> whose writes are recorded rather than made, and which can be
+/// told to fail the way a clipboard held open by another process does.
+/// <para>
+/// Shared, because the threading tests and the OCR tests both need exactly this and had grown
+/// their own copies of it. The OCR ones subclass it to add the image the clipboard is pretending
+/// to hold.
+/// </para>
+/// </summary>
+internal class RecordingClipboardManager : ClipboardManager
+{
+	private readonly List<int> _writeThreadIds = new();
+
+	/// <param name="uiThread">
+	/// Null for tests that only care what reached the clipboard, so the write happens where the
+	/// test stands. Supply one to check which thread the write was made on.
+	/// </param>
+	protected RecordingClipboardManager(IUiThreadDispatcher? uiThread)
+		: base(uiThread)
+	{
+	}
+
+	/// <summary>The last text written, or null when nothing was written.</summary>
+	public string? LastText { get; private set; }
+
+	/// <summary>The last snapshot restored, or null when none was.</summary>
+	public ClipboardSnapshot? LastRestoredSnapshot { get; private set; }
+
+	public int SetTextCalls { get; private set; }
+
+	/// <summary>
+	/// The thread each write was made on, in order. A plain list is enough: every path that
+	/// reaches these doubles makes its writes one at a time, and the task completion between a
+	/// write and the assertion that reads it supplies the memory barrier.
+	/// </summary>
+	public IReadOnlyList<int> WriteThreadIds => _writeThreadIds;
+
+	/// <summary>
+	/// How many of the next writes throw. <see cref="int.MaxValue"/> for a clipboard that never
+	/// lets go.
+	/// </summary>
+	public int FailWrites { get; set; }
+
+	public override void SetText(string text)
+	{
+		SetTextCalls++;
+		if (RecordWriteAndDecideToFail())
+			return;
+
+		LastText = text;
+	}
+
+	protected override Task RestoreSnapshotAsync(ClipboardSnapshot snapshot)
+	{
+		if (RecordWriteAndDecideToFail())
+			return Task.CompletedTask;
+
+		LastRestoredSnapshot = snapshot;
+		return Task.CompletedTask;
+	}
+
+	/// <summary>
+	/// Records the thread this write was made on and throws when the double is still in its
+	/// failing streak. Never returns true — the throw is the "failed" answer — but it is written
+	/// as a guard so each caller reads as "record, maybe fail, then do the work".
+	/// </summary>
+	private bool RecordWriteAndDecideToFail()
+	{
+		_writeThreadIds.Add(Environment.CurrentManagedThreadId);
+
+		if (FailWrites <= 0)
+			return false;
+
+		if (FailWrites != int.MaxValue)
+			FailWrites--;
+
+		// The real one is a COMException carrying CLIPBRD_E_CANT_OPEN when something else has
+		// the clipboard, or RPC_E_WRONG_THREAD when the call was made from the wrong place. All
+		// the retry above looks at is that the write threw.
+		throw new InvalidOperationException("OpenClipboard Failed (0x800401D0)");
+	}
+}

--- a/Mutation.Tests/SingleThreadUiDispatcher.cs
+++ b/Mutation.Tests/SingleThreadUiDispatcher.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+using Mutation.Ui.Services;
+
+namespace Mutation.Tests;
+
+/// <summary>
+/// A stand-in for the WinUI dispatcher: one dedicated thread that work is queued onto, so a
+/// test can name the thread a call was supposed to be made on and then check that it was.
+/// <para>
+/// Unlike the real UI thread this one has no synchronization context, so an operation that
+/// genuinely suspends would resume on the thread pool rather than back here. Hand it operations
+/// that complete synchronously — that is what keeps a thread assertion honest.
+/// </para>
+/// </summary>
+internal sealed class SingleThreadUiDispatcher : IUiThreadDispatcher, IDisposable
+{
+	private readonly BlockingCollection<Action> _work = new();
+	private readonly Thread _thread;
+	private int _dispatchCount;
+
+	public SingleThreadUiDispatcher()
+	{
+		_thread = new Thread(() =>
+		{
+			foreach (var item in _work.GetConsumingEnumerable())
+				item();
+		})
+		{ IsBackground = true, Name = nameof(SingleThreadUiDispatcher) };
+
+		_thread.Start();
+	}
+
+	/// <summary>The thread every dispatched call is made on.</summary>
+	public int ThreadId => _thread.ManagedThreadId;
+
+	/// <summary>
+	/// How many calls were handed across from another thread. Calls already on this thread are
+	/// run in place and are not counted, the same way the real dispatcher skips the queue when
+	/// it is already where it needs to be.
+	/// </summary>
+	public int DispatchCount => Volatile.Read(ref _dispatchCount);
+
+	public Task<T> RunAsync<T>(Func<Task<T>> operation)
+	{
+		if (operation is null)
+			throw new ArgumentNullException(nameof(operation));
+
+		if (Environment.CurrentManagedThreadId == _thread.ManagedThreadId)
+			return operation();
+
+		Interlocked.Increment(ref _dispatchCount);
+
+		var completion = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+		_work.Add(() =>
+		{
+			try
+			{
+				operation().ContinueWith(
+					finished =>
+					{
+						if (finished.IsFaulted)
+							completion.SetException(finished.Exception!.InnerExceptions);
+						else if (finished.IsCanceled)
+							completion.SetCanceled();
+						else
+							completion.SetResult(finished.Result);
+					},
+					TaskContinuationOptions.ExecuteSynchronously);
+			}
+			catch (Exception ex)
+			{
+				completion.SetException(ex);
+			}
+		});
+
+		return completion.Task;
+	}
+
+	public void Dispose() => _work.CompleteAdding();
+}

--- a/Mutation.Tests/SingleThreadUiDispatcher.cs
+++ b/Mutation.Tests/SingleThreadUiDispatcher.cs
@@ -80,5 +80,15 @@ internal sealed class SingleThreadUiDispatcher : IUiThreadDispatcher, IDisposabl
 		return completion.Task;
 	}
 
-	public void Dispose() => _work.CompleteAdding();
+	/// <summary>
+	/// Stops the worker thread and waits for it, so a test that asserts on what ran has nothing
+	/// still running behind it. Work handed over after this throws out of <c>RunAsync</c> rather
+	/// than faulting a task nobody is waiting on any more.
+	/// </summary>
+	public void Dispose()
+	{
+		_work.CompleteAdding();
+		_thread.Join(TimeSpan.FromSeconds(5));
+		_work.Dispose();
+	}
 }

--- a/Mutation.Ui/App.xaml.cs
+++ b/Mutation.Ui/App.xaml.cs
@@ -195,6 +195,14 @@ public partial class App : Application
 			// where OnLaunched puts us on the UI thread, rather than inside a factory lambda
 			// that would run wherever the first resolve happens to be.
 			var uiDispatcherQueue = Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread();
+			if (uiDispatcherQueue is null)
+				// Cannot happen while this line runs before the first await in OnLaunched, and
+				// nothing enforces that it stays that way. Without a queue the clipboard falls
+				// back to calling from wherever the caller stands, which is the behaviour this
+				// whole change exists to remove, so it must not go unrecorded.
+				ErrorLogger.LogInfo("Startup",
+					"No UI dispatcher queue was available; clipboard calls will not be marshalled to the UI thread.");
+
 			builder.Services.AddSingleton(new ClipboardManager(
 				uiDispatcherQueue is null ? null : new DispatcherQueueUiThread(uiDispatcherQueue)));
 			builder.Services.AddSingleton<UiStateManager>();

--- a/Mutation.Ui/App.xaml.cs
+++ b/Mutation.Ui/App.xaml.cs
@@ -190,7 +190,13 @@ public partial class App : Application
 
 			builder.Services.AddSingleton<ISettingsManager>(settingsManager);
 			builder.Services.AddSingleton(settings);
-			builder.Services.AddSingleton<ClipboardManager>();
+			// The clipboard only answers calls made from this thread, and it needs one for every
+			// attempt its retry makes rather than only the first (issue #352). Captured here,
+			// where OnLaunched puts us on the UI thread, rather than inside a factory lambda
+			// that would run wherever the first resolve happens to be.
+			var uiDispatcherQueue = Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread();
+			builder.Services.AddSingleton(new ClipboardManager(
+				uiDispatcherQueue is null ? null : new DispatcherQueueUiThread(uiDispatcherQueue)));
 			builder.Services.AddSingleton<UiStateManager>();
 			builder.Services.AddSingleton<MMDeviceEnumerator>(_ => new MMDeviceEnumerator(Guid.NewGuid()));
 			builder.Services.AddSingleton<Mutation.Ui.Core.ICaptureDeviceChangeNotifier, Mutation.Ui.Core.MMDeviceCaptureDeviceChangeNotifier>();

--- a/Mutation.Ui/Services/ClipboardManager.cs
+++ b/Mutation.Ui/Services/ClipboardManager.cs
@@ -18,9 +18,20 @@ public enum ClipboardKind
 
 public class ClipboardManager
 {
+	private readonly IUiThreadDispatcher? _uiThread;
+
+	/// <param name="uiThread">
+	/// Where every clipboard call is made. Null means "make them wherever the caller is",
+	/// which is what the tests that do not care about threading get.
+	/// </param>
+	public ClipboardManager(IUiThreadDispatcher? uiThread = null)
+	{
+		_uiThread = uiThread;
+	}
+
 	public virtual async Task<(ClipboardKind Kind, string Text)> InspectAsync()
 	{
-		var (success, result) = await ClipboardRetry.TryAsync(async () =>
+		var (success, result) = await RetryOnUiThreadAsync(async () =>
 		{
 			var content = Clipboard.GetContent();
 
@@ -52,17 +63,27 @@ public class ClipboardManager
 		{
 			try
 			{
-				var content = Clipboard.GetContent();
-				if (content.Contains(StandardDataFormats.Bitmap))
+				// The hop is inside the loop, so every attempt is made on the UI thread rather
+				// than only the ones that happen to start there. This loop used to depend on
+				// the caller being on the UI thread and on the delay's continuation returning
+				// to it — true today, and nothing enforced it.
+				var bitmap = await OnUiThreadAsync<SoftwareBitmap?>(async () =>
 				{
+					var content = Clipboard.GetContent();
+					if (!content.Contains(StandardDataFormats.Bitmap))
+						return null;
+
 					IRandomAccessStreamReference? streamRef = await content.GetBitmapAsync();
-					if (streamRef != null)
-					{
-						using var stream = await streamRef.OpenReadAsync();
-						var decoder = await BitmapDecoder.CreateAsync(stream);
-						return await decoder.GetSoftwareBitmapAsync();
-					}
-				}
+					if (streamRef is null)
+						return null;
+
+					using var stream = await streamRef.OpenReadAsync();
+					var decoder = await BitmapDecoder.CreateAsync(stream);
+					return await decoder.GetSoftwareBitmapAsync();
+				});
+
+				if (bitmap is not null)
+					return bitmap;
 			}
 			catch
 			{
@@ -94,18 +115,18 @@ public class ClipboardManager
 		if (string.IsNullOrWhiteSpace(text))
 			return Task.FromResult(false);
 
-		return ClipboardRetry.TryAsync(() =>
+		// Through the virtual SetText rather than a second copy of the DataPackage code, so a
+		// test double substituting one substitutes both.
+		return RetryOnUiThreadAsync(() =>
 		{
-			var data = new DataPackage();
-			data.SetText(text);
-			Clipboard.SetContent(data);
+			SetText(text);
 			return Task.CompletedTask;
 		});
 	}
 
 	public virtual async Task<string> GetTextAsync()
 	{
-		var (success, text) = await ClipboardRetry.TryAsync(async () =>
+		var (success, text) = await RetryOnUiThreadAsync(async () =>
 		{
 			var content = Clipboard.GetContent();
 			return content.Contains(StandardDataFormats.Text) ? await content.GetTextAsync() : string.Empty;
@@ -124,7 +145,7 @@ public class ClipboardManager
 		string? text = null;
 		byte[]? pngBytes = null;
 
-		bool read = await ClipboardRetry.TryAsync(async () =>
+		bool read = await RetryOnUiThreadAsync(async () =>
 		{
 			var content = Clipboard.GetContent();
 
@@ -160,7 +181,7 @@ public class ClipboardManager
 		if (snapshot is null || !snapshot.HasContent)
 			return Task.FromResult(false);
 
-		return ClipboardRetry.TryAsync(async () =>
+		return RetryOnUiThreadAsync(async () =>
 		{
 			var data = new DataPackage();
 
@@ -178,6 +199,40 @@ public class ClipboardManager
 			Clipboard.SetContent(data);
 		});
 	}
+
+	/// <summary>
+	/// Retries <paramref name="operation"/> while another process holds the clipboard open,
+	/// making every attempt on the UI thread.
+	/// <para>
+	/// The retry wraps the thread hop, not the other way round, and that ordering is the whole
+	/// point. <see cref="ClipboardRetry"/> waits with <c>ConfigureAwait(false)</c>, so a ladder
+	/// that starts on the UI thread resumes its second attempt on the thread pool. The
+	/// clipboard refuses a call from there outright, with an error no further attempt gets
+	/// past, so attempts two to five were guaranteed to fail and these were one-attempt
+	/// operations wearing a retry ladder (issue #352).
+	/// </para>
+	/// </summary>
+	private async Task<bool> RetryOnUiThreadAsync(Func<Task> operation)
+	{
+		var (success, _) = await RetryOnUiThreadAsync<object?>(async () =>
+		{
+			await operation();
+			return null;
+		});
+
+		return success;
+	}
+
+	/// <inheritdoc cref="RetryOnUiThreadAsync(Func{Task})"/>
+	private Task<(bool Success, T? Value)> RetryOnUiThreadAsync<T>(Func<Task<T>> operation) =>
+		ClipboardRetry.TryAsync(() => OnUiThreadAsync(operation));
+
+	/// <summary>
+	/// Runs one clipboard call on the UI thread. Runs it where it stands when there is no
+	/// dispatcher, which is how the tests that do not care about threading see it.
+	/// </summary>
+	private Task<T> OnUiThreadAsync<T>(Func<Task<T>> operation) =>
+		_uiThread is null ? operation() : _uiThread.RunAsync(operation);
 
 	private static async Task<byte[]> EncodeToPngAsync(SoftwareBitmap bitmap)
 	{

--- a/Mutation.Ui/Services/ClipboardManager.cs
+++ b/Mutation.Ui/Services/ClipboardManager.cs
@@ -21,8 +21,13 @@ public class ClipboardManager
 	private readonly IUiThreadDispatcher? _uiThread;
 
 	/// <param name="uiThread">
-	/// Where every clipboard call is made. Null means "make them wherever the caller is",
-	/// which is what the tests that do not care about threading get.
+	/// Where the retrying calls on this class are made. Null means "make them wherever the
+	/// caller is", which is what the tests that do not care about threading get.
+	/// <para>
+	/// It covers the methods that retry, not every method here. <see cref="SetText"/> is
+	/// synchronous and cannot hop, and <see cref="SetImageAsync"/> has neither a retry nor a
+	/// hop — see issue #360. Both predate this and both are called from the UI thread today.
+	/// </para>
 	/// </param>
 	public ClipboardManager(IUiThreadDispatcher? uiThread = null)
 	{
@@ -181,23 +186,30 @@ public class ClipboardManager
 		if (snapshot is null || !snapshot.HasContent)
 			return Task.FromResult(false);
 
-		return RetryOnUiThreadAsync(async () =>
+		return RetryOnUiThreadAsync(() => RestoreSnapshotAsync(snapshot));
+	}
+
+	/// <summary>
+	/// One attempt at putting a snapshot back. Split out and virtual for the same reason
+	/// <see cref="SetText"/> is: this is the write either side of a paste, and a test cannot
+	/// reach the real clipboard to check that a busy one is retried rather than reported.
+	/// </summary>
+	protected virtual async Task RestoreSnapshotAsync(ClipboardSnapshot snapshot)
+	{
+		var data = new DataPackage();
+
+		if (!string.IsNullOrEmpty(snapshot.Text))
+			data.SetText(snapshot.Text);
+
+		if (snapshot.PngImageBytes is { Length: > 0 })
 		{
-			var data = new DataPackage();
+			var stream = new InMemoryRandomAccessStream();
+			await stream.WriteAsync(snapshot.PngImageBytes.AsBuffer());
+			stream.Seek(0);
+			data.SetBitmap(RandomAccessStreamReference.CreateFromStream(stream));
+		}
 
-			if (!string.IsNullOrEmpty(snapshot.Text))
-				data.SetText(snapshot.Text);
-
-			if (snapshot.PngImageBytes is { Length: > 0 })
-			{
-				var stream = new InMemoryRandomAccessStream();
-				await stream.WriteAsync(snapshot.PngImageBytes.AsBuffer());
-				stream.Seek(0);
-				data.SetBitmap(RandomAccessStreamReference.CreateFromStream(stream));
-			}
-
-			Clipboard.SetContent(data);
-		});
+		Clipboard.SetContent(data);
 	}
 
 	/// <summary>

--- a/Mutation.Ui/Services/ClipboardRetry.cs
+++ b/Mutation.Ui/Services/ClipboardRetry.cs
@@ -7,6 +7,14 @@ namespace Mutation.Ui.Services;
 /// Retry policy for clipboard operations. Another process can hold the
 /// clipboard open at any moment, making reads and writes fail transiently,
 /// so callers wrap them in a short retry loop instead of failing outright.
+/// <para>
+/// It waits with <c>ConfigureAwait(false)</c>, which means the second and every later attempt
+/// is made from the thread pool no matter where the first one was made. The clipboard only
+/// works from the UI thread, so an operation handed to this must put <em>itself</em> on the
+/// UI thread every time it is called rather than trusting where the last wait left it.
+/// <see cref="ClipboardManager"/> does that for its own callers, and it is why the retry
+/// there wraps the thread hop instead of the hop wrapping the retry (issue #352).
+/// </para>
 /// </summary>
 public static class ClipboardRetry
 {

--- a/Mutation.Ui/Services/DispatcherQueueUiThread.cs
+++ b/Mutation.Ui/Services/DispatcherQueueUiThread.cs
@@ -7,7 +7,7 @@ namespace Mutation.Ui.Services;
 /// <summary>
 /// Runs work on the UI thread through the WinUI dispatcher queue.
 /// </summary>
-public sealed class DispatcherQueueUiThread : IUiThreadDispatcher
+internal sealed class DispatcherQueueUiThread : IUiThreadDispatcher
 {
 	private readonly DispatcherQueue _queue;
 
@@ -25,14 +25,17 @@ public sealed class DispatcherQueueUiThread : IUiThreadDispatcher
 			return operation();
 
 		// RunContinuationsAsynchronously keeps whatever awaits this task off the UI thread.
-		// Without it the awaiter's continuation runs inline on the UI thread, inside the
-		// dispatched callback, which is how a retry ladder ends up re-entering the dispatcher
-		// from within itself.
+		// Without it the awaiter's continuation runs inline on the UI thread inside the
+		// dispatched callback, which would put the retry loop's own bookkeeping — its counter,
+		// its catch, its delay — on the UI thread between attempts. Only the clipboard call
+		// itself needs to be there.
 		var completion = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-		// Deliberately an async void callback: DispatcherQueueHandler returns void, and this is
-		// the one shape where that is safe, because every exception the operation can raise is
-		// caught here and handed to the caller through the task instead of escaping.
+		// Deliberately an async void callback: DispatcherQueueHandler returns void. It is safe
+		// because every exception the operation can raise is caught here and handed to the
+		// caller through the task instead of escaping. The completion calls themselves are not
+		// inside that guarantee, but they cannot throw: this source is completed either by the
+		// callback or by the not-queued branch below, never by both.
 		bool queued = _queue.TryEnqueue(async () =>
 		{
 			try

--- a/Mutation.Ui/Services/DispatcherQueueUiThread.cs
+++ b/Mutation.Ui/Services/DispatcherQueueUiThread.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.UI.Dispatching;
+
+namespace Mutation.Ui.Services;
+
+/// <summary>
+/// Runs work on the UI thread through the WinUI dispatcher queue.
+/// </summary>
+public sealed class DispatcherQueueUiThread : IUiThreadDispatcher
+{
+	private readonly DispatcherQueue _queue;
+
+	public DispatcherQueueUiThread(DispatcherQueue queue)
+	{
+		_queue = queue ?? throw new ArgumentNullException(nameof(queue));
+	}
+
+	public Task<T> RunAsync<T>(Func<Task<T>> operation)
+	{
+		if (operation is null)
+			throw new ArgumentNullException(nameof(operation));
+
+		if (_queue.HasThreadAccess)
+			return operation();
+
+		// RunContinuationsAsynchronously keeps whatever awaits this task off the UI thread.
+		// Without it the awaiter's continuation runs inline on the UI thread, inside the
+		// dispatched callback, which is how a retry ladder ends up re-entering the dispatcher
+		// from within itself.
+		var completion = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+		// Deliberately an async void callback: DispatcherQueueHandler returns void, and this is
+		// the one shape where that is safe, because every exception the operation can raise is
+		// caught here and handed to the caller through the task instead of escaping.
+		bool queued = _queue.TryEnqueue(async () =>
+		{
+			try
+			{
+				completion.SetResult(await operation());
+			}
+			catch (Exception ex)
+			{
+				completion.SetException(ex);
+			}
+		});
+
+		if (!queued)
+			completion.SetException(new InvalidOperationException(
+				"The UI thread is shutting down and is no longer accepting work."));
+
+		return completion.Task;
+	}
+}

--- a/Mutation.Ui/Services/IUiThreadDispatcher.cs
+++ b/Mutation.Ui/Services/IUiThreadDispatcher.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Mutation.Ui.Services;
+
+/// <summary>
+/// A way to run a piece of work on the UI thread and await its result.
+/// <para>
+/// This exists for APIs that only work when called from the thread that owns the window.
+/// The Windows clipboard is one: <c>Clipboard.GetContent</c> and <c>Clipboard.SetContent</c>
+/// fail with <c>RPC_E_WRONG_THREAD</c> anywhere else, and no amount of retrying gets past
+/// that. A caller that must touch such an API repeatedly cannot rely on where the previous
+/// <c>await</c> happened to leave it, so it asks for the thread it needs each time.
+/// </para>
+/// </summary>
+public interface IUiThreadDispatcher
+{
+	/// <summary>
+	/// Runs <paramref name="operation"/> on the UI thread and completes with its result, or
+	/// faults with whatever it threw.
+	/// <para>
+	/// Implementations run the operation in place when the caller is already on the UI
+	/// thread, so a caller never needs to ask first.
+	/// </para>
+	/// </summary>
+	Task<T> RunAsync<T>(Func<Task<T>> operation);
+}

--- a/Mutation.Ui/Services/OcrManager.cs
+++ b/Mutation.Ui/Services/OcrManager.cs
@@ -578,28 +578,18 @@ public class OcrManager
     /// good read was reported as a failed one and the shortcut that ran afterwards acted on the
     /// screenshot still sitting there (issue #341).
     /// </para>
+    /// <para>
+    /// The retry and the UI-thread hop it used to own both live in <see cref="ClipboardManager"/>
+    /// now. Every clipboard caller in the app had the same problem, not just this one, and two
+    /// copies of the rule was one too many (issue #352). What stays here is the difference that
+    /// is genuinely this path's own: blank text is a success, because there was nothing worth
+    /// copying and nothing failed.
+    /// </para>
     /// </summary>
-    private Task<bool> TrySetClipboardTextAsync(string text)
-    {
-        if (string.IsNullOrWhiteSpace(text))
-            return Task.FromResult(true);
-
-        // The retry wraps the dispatcher hop rather than the other way round, so every attempt
-        // is made from the UI thread. ClipboardRetry waits with ConfigureAwait(false), so a
-        // ladder started on the UI thread resumes its second attempt on the thread pool — where
-        // the clipboard refuses the call for a second reason that no number of further attempts
-        // ever gets past.
-        return ClipboardRetry.TryAsync(() =>
-        {
-            if (HasDispatcherThreadAccess())
-            {
-                _clipboard.SetText(text);
-                return Task.CompletedTask;
-            }
-
-            return RunOnDispatcherAsync(() => _clipboard.SetText(text));
-        });
-    }
+    private Task<bool> TrySetClipboardTextAsync(string text) =>
+        string.IsNullOrWhiteSpace(text)
+            ? Task.FromResult(true)
+            : _clipboard.TrySetTextAsync(text);
 
     private static IReadOnlyList<FileOcrBatch> ExpandFileBatches(IReadOnlyList<string> paths)
     {
@@ -747,41 +737,6 @@ public class OcrManager
 
             return await _streamFactory();
         }
-    }
-
-    protected virtual bool HasDispatcherThreadAccess()
-    {
-        var dispatcher = _window?.DispatcherQueue;
-        return dispatcher?.HasThreadAccess ?? true;
-    }
-
-    protected virtual Task RunOnDispatcherAsync(Action action)
-    {
-        var dispatcher = _window?.DispatcherQueue;
-        if (dispatcher is null || dispatcher.HasThreadAccess)
-        {
-            action();
-            return Task.CompletedTask;
-        }
-
-        var tcs = new TaskCompletionSource<object?>();
-        if (!dispatcher.TryEnqueue(() =>
-        {
-            try
-            {
-                action();
-                tcs.SetResult(null);
-            }
-            catch (Exception ex)
-            {
-                tcs.SetException(ex);
-            }
-        }))
-        {
-            tcs.SetException(new InvalidOperationException("Failed to enqueue work on the dispatcher."));
-        }
-
-        return tcs.Task;
     }
 
     protected virtual void PlayBeep(BeepType type)


### PR DESCRIPTION
Closes #352

## What was wrong

Every clipboard read and write in the app goes through `ClipboardRetry.TryAsync`, which tries five times with 100 ms between attempts. Only the first attempt was ever made on the UI thread.

`ClipboardRetry` waits with `ConfigureAwait(false)` on both the operation and the delay. WinUI installs a `DispatcherQueueSynchronizationContext` on the UI thread, so without that call a continuation posts back to the UI thread; with it, the continuation resumes on the thread pool — and every later `operation()` was invoked from there. `Windows.ApplicationModel.DataTransfer.Clipboard` is UI-thread-affine, so those calls came back with `RPC_E_WRONG_THREAD` rather than the transient "someone has it open" error the ladder exists for. No number of further attempts gets past that.

So every one of these was a one-attempt operation wearing a retry ladder: clipboard inspection, the speech-to-text delivery write, the text read, and the snapshot capture and restore either side of a paste.

`ConfigureAwait(false)` is the right default for a library that must not deadlock on a blocking caller, which is presumably why it was there. It is the wrong default for an operation whose whole point is to touch a UI-thread-affine API repeatedly.

## The fix

`ClipboardManager` now owns an `IUiThreadDispatcher` and asks for the UI thread **once per attempt**, so the retry wraps the thread hop rather than the hop wrapping the retry. That ordering is the whole fix, and it is why the change is not simply dropping `ConfigureAwait(false)`: doing that would make every caller's threading a caller-side obligation with nothing enforcing it, and it would still depend on a synchronization context being captured at a point nobody checks.

- `IUiThreadDispatcher` is one method — run this and give me back its result. Implementations run the work in place when the caller is already on the UI thread, so no caller has to ask first.
- `DispatcherQueueUiThread` implements it over the WinUI dispatcher queue. The callback it enqueues is deliberately `async void`, which is safe only because every exception the operation can raise is caught and handed back through the task instead of escaping. It completes with `RunContinuationsAsynchronously`, so whatever awaits it does not run inline on the UI thread inside the dispatched callback — that is how a retry ladder would otherwise re-enter the dispatcher from within itself.
- `App` builds one at startup, where `OnLaunched` is already on the UI thread, and hands it to the `ClipboardManager` singleton. Capturing the queue there rather than inside a factory lambda matters: the lambda runs at first resolve, which is not necessarily the UI thread.
- A null dispatcher means "run it where the caller stands". That is what the tests which only care what reached the clipboard get, and it keeps `new ClipboardManager()` legal.

Two smaller things came with it:

`TrySetTextAsync` now writes through the virtual `SetText` instead of keeping a second copy of the `DataPackage` code, so a test double that substitutes one substitutes both.

`TryGetImageAsync` keeps its own loop — its semantics differ, since a clipboard holding no image is not an error — but each pass now goes through the hop. The issue notes this method was not affected, and that is true today only because its delay has no `ConfigureAwait(false)` and so resumes on whatever context the caller had. Nothing enforced that the caller was on the UI thread. Now nothing needs to.

## The OCR path's private copy is gone

The fix for the OCR clipboard copy (#341, landed in #351) had already worked this out and solved it inside `OcrManager`. That was the right call for one path but the problem was never one path's. `OcrManager.TrySetClipboardTextAsync` is now a call to `_clipboard.TrySetTextAsync`, and `HasDispatcherThreadAccess` and `RunOnDispatcherAsync` are deleted.

What stays behind is the one difference that is genuinely that path's own: blank text counts as a **success** there, because there was nothing worth copying and nothing failed, whereas `ClipboardManager.TrySetTextAsync` reports false for a blank write. Collapsing that difference away would have turned an empty OCR result into a reported clipboard failure.

## What a user notices

A transcript, an OCR result, or a clipboard snapshot that runs into a clipboard held open for a moment by a clipboard manager or a screen reader now actually gets the four further tries it was supposed to get, instead of one try and a failure message.

The user guide needed no change. Its troubleshooting entry for text that did not paste already says "Mutation retries a few times before giving up". That sentence describes what the code was meant to do; it is now what the code does.

## Verification

`dotnet test --configuration Release` — 2239 passed, 0 failed, run after rebasing onto the router-status and page-manners work (#358) that merged while this was being built.

Three new tests in `ClipboardManagerUiThreadTests` pin the behaviour: that attempts two onward are made on the same thread as the first, that the whole ladder is walked there when the clipboard never lets go, and that the UI thread is asked for once per attempt rather than once per operation. All three were run against the pre-fix ordering — the hop wrapping the retry instead of the other way round — and all three fail, so they are not passing vacuously.

The OCR test that used to assert `OcrManager` dispatched its own clipboard write is rewritten rather than deleted: it now runs the batch OCR from the thread pool and checks the write still lands on the dispatcher's thread, which is the same guarantee asserted one layer down.

**Not verified:** none of this was exercised in the running app, and the acceptance criteria's by-hand checks — hold the clipboard open through the first attempt and confirm a dictation transcript still arrives — cannot be done in an agent session. The test double is a dedicated thread rather than a real WinUI dispatcher queue, so what is pinned is that each attempt is marshalled to the one named thread, not that `DispatcherQueue.TryEnqueue` behaves as documented. `TryGetImageAsync`'s new hop is not covered by a test, because the test double for it replaces the whole method.

🤖 Generated with [Claude Code](https://claude.com/claude-code)