### PR TITLE
Retry the screenshot clipboard write, and fail calls the UI thread drops

### DIFF
--- a/Documentation/UserGuide/html/screen-capture-and-ocr.html
+++ b/Documentation/UserGuide/html/screen-capture-and-ocr.html
@@ -286,9 +286,15 @@ beep says something went wrong, and the status area tells you what.</p>
 <p>Now and then another program has the clipboard open at the moment Mutation wants to
 copy to it — a clipboard manager, or your screen reader taking a look at the
 screenshot that went there a second earlier. Mutation waits a moment and tries again a
-few times. If it still cannot get in, the reading itself is not lost: the text is in
-the <strong>OCR result</strong> box as usual, and a message says it could not be copied to the
-clipboard. That way you know to copy it out of the box yourself.</p>
+few times, for the picture and for the text alike. That is usually enough and you never
+notice it.</p>
+<p>When it is not enough, nothing is thrown away. A plain <strong>Screenshot to clipboard</strong> tells
+you the clipboard was busy and asks you to press the shortcut again. A <strong>Screenshot &amp;
+OCR</strong> still reads the text, because the reading works from the picture Mutation is
+holding and never needed the clipboard for it — you get the text on your clipboard and
+in the <strong>OCR result</strong> box, and a message telling you that only the picture did not make
+it. And if the text is the part that could not be copied, it is still in the <strong>OCR
+result</strong> box for you to copy out yourself.</p>
 <h2 id="reading-a-batch-of-files-at-once">Reading a batch of files at once</h2>
 <p>The <strong>OCR documents</strong> button handles whole files rather than screenshots. Click it,
 pick one or more files, and Mutation reads them all.</p>

--- a/Documentation/UserGuide/html/screen-capture-and-ocr.html
+++ b/Documentation/UserGuide/html/screen-capture-and-ocr.html
@@ -288,13 +288,16 @@ copy to it — a clipboard manager, or your screen reader taking a look at the
 screenshot that went there a second earlier. Mutation waits a moment and tries again a
 few times, for the picture and for the text alike. That is usually enough and you never
 notice it.</p>
-<p>When it is not enough, nothing is thrown away. A plain <strong>Screenshot to clipboard</strong> tells
-you the clipboard was busy and asks you to press the shortcut again. A <strong>Screenshot &amp;
-OCR</strong> still reads the text, because the reading works from the picture Mutation is
-holding and never needed the clipboard for it — you get the text on your clipboard and
-in the <strong>OCR result</strong> box, and a message telling you that only the picture did not make
-it. And if the text is the part that could not be copied, it is still in the <strong>OCR
-result</strong> box for you to copy out yourself.</p>
+<p>When it is not enough, what happens depends on which one you used.</p>
+<p>A plain <strong>Screenshot to clipboard</strong> tells you the clipboard was busy and asks you to try
+again. That picture is gone, so you do need to pick the region a second time. Your
+clipboard still holds whatever it held before.</p>
+<p>A <strong>Screenshot &amp; OCR</strong> still reads the text. The reading works from the picture Mutation
+is holding, and never needed the clipboard for it, so you get your text on the clipboard
+and in the <strong>OCR result</strong> box as usual, with a message telling you that only the picture
+did not make it. You still hear the success beep, because the reading itself worked. And
+if the text is the part that could not be copied, it is still in the <strong>OCR result</strong> box
+for you to copy out yourself.</p>
 <h2 id="reading-a-batch-of-files-at-once">Reading a batch of files at once</h2>
 <p>The <strong>OCR documents</strong> button handles whole files rather than screenshots. Click it,
 pick one or more files, and Mutation reads them all.</p>

--- a/Documentation/UserGuide/html/troubleshooting.html
+++ b/Documentation/UserGuide/html/troubleshooting.html
@@ -279,6 +279,21 @@ page, which is better for columns and tables. <strong>Basic</strong> layout read
 to right, top to bottom, which is better for a plain block of text that Natural has
 scrambled. Each has its own shortcut, so you can just try the other one.</li>
 </ol>
+<h3 id="the-screenshot-could-not-be-copied-to-the-clipboard">The screenshot could not be copied to the clipboard</h3>
+<p><strong>What's happening.</strong> Only one program can have the clipboard open at a time, and the
+moment a picture lands there is exactly when a clipboard manager or your screen reader
+opens it to see what arrived. Mutation waits and tries again a few times, which almost
+always gets in. When it does not, you hear the failure beep and see the message &quot;Another
+program is using the clipboard, so the screenshot was not copied. Press the shortcut
+again.&quot;</p>
+<p>Nothing was lost except the picture, and your clipboard still holds whatever it held
+before — Mutation does not wipe it on the way to failing.</p>
+<p>If you used <strong>Screenshot &amp; OCR</strong> rather than a plain screenshot, the reading still
+happens. Mutation reads from the picture it is holding, not from the clipboard, so you
+get your text as usual and only a note that the picture itself did not make it.</p>
+<p><strong>What to do.</strong> Press the shortcut again and pick the region again — the second attempt
+almost always gets in. If it happens every time, a clipboard manager or clipboard-history
+tool is the usual culprit; closing it or turning off its monitoring settles it.</p>
 <h3 id="ocr-read-the-text-but-could-not-copy-it-to-the-clipboard">OCR read the text but could not copy it to the clipboard</h3>
 <p><strong>What's happening.</strong> Only one program can have the clipboard open at a time. Just
 after a screenshot, a clipboard manager or your screen reader often opens it to look at
@@ -305,9 +320,12 @@ was. There are four reasons it would not.</p>
 <li>You started the reading with a button in the Mutation window instead of a shortcut.
 The app you were working in is then Mutation, so there is nowhere else to paste. Use
 the shortcut — <strong>Shift+Alt+J</strong> and friends — from the app you want the text in.</li>
-<li>The reading found no text, or its text never reached the clipboard. Either way the
-clipboard still holds the picture, and pasting would drop that picture into your
-document. See the two entries just above this one.</li>
+<li>The reading found no text, or its text never reached the clipboard. Either way there
+is no new text to paste, and pasting would put whatever the clipboard does hold — most
+likely the screenshot — into your document. See
+<a href="#ocr-returns-nothing-useful-or-the-wrong-reading-order">OCR returns nothing useful</a>
+and
+<a href="#ocr-read-the-text-but-could-not-copy-it-to-the-clipboard">OCR read the text but could not copy it</a>.</li>
 <li>It was a batch of documents. Those are always started from the Mutation window, so
 the point above applies.</li>
 </ul>

--- a/Documentation/UserGuide/html/troubleshooting.html
+++ b/Documentation/UserGuide/html/troubleshooting.html
@@ -283,17 +283,19 @@ scrambled. Each has its own shortcut, so you can just try the other one.</li>
 <p><strong>What's happening.</strong> Only one program can have the clipboard open at a time, and the
 moment a picture lands there is exactly when a clipboard manager or your screen reader
 opens it to see what arrived. Mutation waits and tries again a few times, which almost
-always gets in. When it does not, you hear the failure beep and see the message &quot;Another
-program is using the clipboard, so the screenshot was not copied. Press the shortcut
-again.&quot;</p>
-<p>Nothing was lost except the picture, and your clipboard still holds whatever it held
-before — Mutation does not wipe it on the way to failing.</p>
-<p>If you used <strong>Screenshot &amp; OCR</strong> rather than a plain screenshot, the reading still
-happens. Mutation reads from the picture it is holding, not from the clipboard, so you
-get your text as usual and only a note that the picture itself did not make it.</p>
-<p><strong>What to do.</strong> Press the shortcut again and pick the region again — the second attempt
-almost always gets in. If it happens every time, a clipboard manager or clipboard-history
-tool is the usual culprit; closing it or turning off its monitoring settles it.</p>
+always gets in.</p>
+<p>With a plain <strong>Screenshot to clipboard</strong>, when it does not get in you hear the failure
+beep and see the message &quot;Another program is using the clipboard, so the screenshot was
+not copied. Try again in a moment.&quot; That picture is gone and you will need to pick the
+region again. Your clipboard still holds whatever it held before — Mutation does not wipe
+it on the way to failing.</p>
+<p>With <strong>Screenshot &amp; OCR</strong> it is gentler, because the reading does not need the clipboard.
+Mutation reads from the picture it is holding, so you get your text as usual, you hear
+the ordinary success beep, and the message tells you only that the picture itself did not
+make it.</p>
+<p><strong>What to do.</strong> Take the screenshot again — the second attempt almost always gets in. If
+it happens every time, a clipboard manager or clipboard-history tool is the usual
+culprit; closing it or turning off its monitoring settles it.</p>
 <h3 id="ocr-read-the-text-but-could-not-copy-it-to-the-clipboard">OCR read the text but could not copy it to the clipboard</h3>
 <p><strong>What's happening.</strong> Only one program can have the clipboard open at a time. Just
 after a screenshot, a clipboard manager or your screen reader often opens it to look at

--- a/Documentation/UserGuide/markdown/screen-capture-and-ocr.md
+++ b/Documentation/UserGuide/markdown/screen-capture-and-ocr.md
@@ -109,13 +109,18 @@ screenshot that went there a second earlier. Mutation waits a moment and tries a
 few times, for the picture and for the text alike. That is usually enough and you never
 notice it.
 
-When it is not enough, nothing is thrown away. A plain **Screenshot to clipboard** tells
-you the clipboard was busy and asks you to press the shortcut again. A **Screenshot &
-OCR** still reads the text, because the reading works from the picture Mutation is
-holding and never needed the clipboard for it — you get the text on your clipboard and
-in the **OCR result** box, and a message telling you that only the picture did not make
-it. And if the text is the part that could not be copied, it is still in the **OCR
-result** box for you to copy out yourself.
+When it is not enough, what happens depends on which one you used.
+
+A plain **Screenshot to clipboard** tells you the clipboard was busy and asks you to try
+again. That picture is gone, so you do need to pick the region a second time. Your
+clipboard still holds whatever it held before.
+
+A **Screenshot & OCR** still reads the text. The reading works from the picture Mutation
+is holding, and never needed the clipboard for it, so you get your text on the clipboard
+and in the **OCR result** box as usual, with a message telling you that only the picture
+did not make it. You still hear the success beep, because the reading itself worked. And
+if the text is the part that could not be copied, it is still in the **OCR result** box
+for you to copy out yourself.
 
 ## Reading a batch of files at once
 

--- a/Documentation/UserGuide/markdown/screen-capture-and-ocr.md
+++ b/Documentation/UserGuide/markdown/screen-capture-and-ocr.md
@@ -106,9 +106,16 @@ beep says something went wrong, and the status area tells you what.
 Now and then another program has the clipboard open at the moment Mutation wants to
 copy to it — a clipboard manager, or your screen reader taking a look at the
 screenshot that went there a second earlier. Mutation waits a moment and tries again a
-few times. If it still cannot get in, the reading itself is not lost: the text is in
-the **OCR result** box as usual, and a message says it could not be copied to the
-clipboard. That way you know to copy it out of the box yourself.
+few times, for the picture and for the text alike. That is usually enough and you never
+notice it.
+
+When it is not enough, nothing is thrown away. A plain **Screenshot to clipboard** tells
+you the clipboard was busy and asks you to press the shortcut again. A **Screenshot &
+OCR** still reads the text, because the reading works from the picture Mutation is
+holding and never needed the clipboard for it — you get the text on your clipboard and
+in the **OCR result** box, and a message telling you that only the picture did not make
+it. And if the text is the part that could not be copied, it is still in the **OCR
+result** box for you to copy out yourself.
 
 ## Reading a batch of files at once
 

--- a/Documentation/UserGuide/markdown/troubleshooting.md
+++ b/Documentation/UserGuide/markdown/troubleshooting.md
@@ -163,20 +163,22 @@ different pages.
 **What's happening.** Only one program can have the clipboard open at a time, and the
 moment a picture lands there is exactly when a clipboard manager or your screen reader
 opens it to see what arrived. Mutation waits and tries again a few times, which almost
-always gets in. When it does not, you hear the failure beep and see the message "Another
-program is using the clipboard, so the screenshot was not copied. Press the shortcut
-again."
+always gets in.
 
-Nothing was lost except the picture, and your clipboard still holds whatever it held
-before — Mutation does not wipe it on the way to failing.
+With a plain **Screenshot to clipboard**, when it does not get in you hear the failure
+beep and see the message "Another program is using the clipboard, so the screenshot was
+not copied. Try again in a moment." That picture is gone and you will need to pick the
+region again. Your clipboard still holds whatever it held before — Mutation does not wipe
+it on the way to failing.
 
-If you used **Screenshot & OCR** rather than a plain screenshot, the reading still
-happens. Mutation reads from the picture it is holding, not from the clipboard, so you
-get your text as usual and only a note that the picture itself did not make it.
+With **Screenshot & OCR** it is gentler, because the reading does not need the clipboard.
+Mutation reads from the picture it is holding, so you get your text as usual, you hear
+the ordinary success beep, and the message tells you only that the picture itself did not
+make it.
 
-**What to do.** Press the shortcut again and pick the region again — the second attempt
-almost always gets in. If it happens every time, a clipboard manager or clipboard-history
-tool is the usual culprit; closing it or turning off its monitoring settles it.
+**What to do.** Take the screenshot again — the second attempt almost always gets in. If
+it happens every time, a clipboard manager or clipboard-history tool is the usual
+culprit; closing it or turning off its monitoring settles it.
 
 ### OCR read the text but could not copy it to the clipboard
 

--- a/Documentation/UserGuide/markdown/troubleshooting.md
+++ b/Documentation/UserGuide/markdown/troubleshooting.md
@@ -158,6 +158,26 @@ different pages.
    to right, top to bottom, which is better for a plain block of text that Natural has
    scrambled. Each has its own shortcut, so you can just try the other one.
 
+### The screenshot could not be copied to the clipboard
+
+**What's happening.** Only one program can have the clipboard open at a time, and the
+moment a picture lands there is exactly when a clipboard manager or your screen reader
+opens it to see what arrived. Mutation waits and tries again a few times, which almost
+always gets in. When it does not, you hear the failure beep and see the message "Another
+program is using the clipboard, so the screenshot was not copied. Press the shortcut
+again."
+
+Nothing was lost except the picture, and your clipboard still holds whatever it held
+before — Mutation does not wipe it on the way to failing.
+
+If you used **Screenshot & OCR** rather than a plain screenshot, the reading still
+happens. Mutation reads from the picture it is holding, not from the clipboard, so you
+get your text as usual and only a note that the picture itself did not make it.
+
+**What to do.** Press the shortcut again and pick the region again — the second attempt
+almost always gets in. If it happens every time, a clipboard manager or clipboard-history
+tool is the usual culprit; closing it or turning off its monitoring settles it.
+
 ### OCR read the text but could not copy it to the clipboard
 
 **What's happening.** Only one program can have the clipboard open at a time. Just
@@ -190,9 +210,12 @@ was. There are four reasons it would not.
 - You started the reading with a button in the Mutation window instead of a shortcut.
   The app you were working in is then Mutation, so there is nowhere else to paste. Use
   the shortcut — **Shift+Alt+J** and friends — from the app you want the text in.
-- The reading found no text, or its text never reached the clipboard. Either way the
-  clipboard still holds the picture, and pasting would drop that picture into your
-  document. See the two entries just above this one.
+- The reading found no text, or its text never reached the clipboard. Either way there
+  is no new text to paste, and pasting would put whatever the clipboard does hold — most
+  likely the screenshot — into your document. See
+  [OCR returns nothing useful](#ocr-returns-nothing-useful-or-the-wrong-reading-order)
+  and
+  [OCR read the text but could not copy it](#ocr-read-the-text-but-could-not-copy-it-to-the-clipboard).
 - It was a batch of documents. Those are always started from the Mutation window, so
   the point above applies.
 

--- a/Mutation.Tests/ClipboardCopyMessagesTests.cs
+++ b/Mutation.Tests/ClipboardCopyMessagesTests.cs
@@ -1,0 +1,123 @@
+using Microsoft.UI.Xaml.Controls;
+using Mutation.Ui.Core;
+using Xunit;
+
+namespace Mutation.Tests;
+
+/// <summary>
+/// What the user is told about where a capture ended up. The decisions are small and the cost of
+/// getting one wrong is not: a blind user acts on what they hear, so announcing a copy that did
+/// not happen sends them to paste something that is not there.
+/// </summary>
+public class ClipboardCopyMessagesTests
+{
+	[Fact]
+	public void ACopiedScreenshotIsAnnouncedAsASuccess()
+	{
+		var (message, severity) = ClipboardCopyMessages.ForScreenshot(ScreenshotToClipboardOutcome.Copied);
+
+		Assert.Equal(ClipboardCopyMessages.ScreenshotCopied, message);
+		Assert.Equal(InfoBarSeverity.Success, severity);
+	}
+
+	/// <summary>
+	/// A busy clipboard is an error, not a cancellation and not a success. The severity is not
+	/// decoration: <c>StatusAnnouncement.GetProcessing</c> turns Error into an announcement that
+	/// interrupts whatever the screen reader is saying, which is the only reason the user learns
+	/// of it while working in another application.
+	/// </summary>
+	[Fact]
+	public void ABusyClipboardIsAnnouncedAsAnError()
+	{
+		var (message, severity) = ClipboardCopyMessages.ForScreenshot(ScreenshotToClipboardOutcome.ClipboardUnavailable);
+
+		Assert.Equal(ClipboardCopyMessages.ScreenshotClipboardBusy, message);
+		Assert.Equal(InfoBarSeverity.Error, severity);
+	}
+
+	[Fact]
+	public void ACancelledCaptureIsAnnouncedQuietly()
+	{
+		var (message, severity) = ClipboardCopyMessages.ForScreenshot(ScreenshotToClipboardOutcome.Cancelled);
+
+		Assert.Equal(ClipboardCopyMessages.ScreenshotCancelled, message);
+		Assert.Equal(InfoBarSeverity.Informational, severity);
+	}
+
+	/// <summary>
+	/// The same sentence is said to someone who pressed the shortcut and someone who clicked the
+	/// button, so it must not name either. Telling a screen-reader user to press a shortcut they
+	/// did not use points them at the wrong control.
+	/// </summary>
+	[Fact]
+	public void TheBusyClipboardAdviceNamesNeitherTheButtonNorTheShortcut()
+	{
+		Assert.DoesNotContain("shortcut", ClipboardCopyMessages.ScreenshotClipboardBusy);
+		Assert.DoesNotContain("button", ClipboardCopyMessages.ScreenshotClipboardBusy);
+	}
+
+	/// <summary>
+	/// An unknown outcome is announced as a cancellation — the only one of the three that is safe
+	/// to say by accident, because it claims nothing.
+	/// </summary>
+	[Fact]
+	public void AnUnknownOutcomeNeverClaimsACopy()
+	{
+		var (message, _) = ClipboardCopyMessages.ForScreenshot((ScreenshotToClipboardOutcome)99);
+
+		Assert.Equal(ClipboardCopyMessages.ScreenshotCancelled, message);
+	}
+
+	/// <summary>
+	/// Nothing is said when everything worked. The success line the caller shows afterwards is
+	/// the whole of the story then.
+	/// </summary>
+	[Fact]
+	public void ARunThatCopiedEverythingHasNothingToReport()
+	{
+		Assert.Null(ClipboardCopyMessages.ForOcrRun(success: true, textCopyFailed: false, pictureCopyFailed: false));
+	}
+
+	[Fact]
+	public void TextThatDidNotReachTheClipboardIsReported()
+	{
+		Assert.Equal(
+			ClipboardCopyMessages.OcrTextNotCopied,
+			ClipboardCopyMessages.ForOcrRun(success: true, textCopyFailed: true, pictureCopyFailed: false));
+	}
+
+	[Fact]
+	public void APictureThatDidNotReachTheClipboardIsReported()
+	{
+		Assert.Equal(
+			ClipboardCopyMessages.OcrPictureNotCopied,
+			ClipboardCopyMessages.ForOcrRun(success: true, textCopyFailed: false, pictureCopyFailed: true));
+	}
+
+	/// <summary>
+	/// When both failed, the text is what gets said. It is the thing the user asked for and the
+	/// one they can still lose; the picture they can take again.
+	/// </summary>
+	[Fact]
+	public void AFailedTextCopyOutranksAFailedPictureCopy()
+	{
+		Assert.Equal(
+			ClipboardCopyMessages.OcrTextNotCopied,
+			ClipboardCopyMessages.ForOcrRun(success: true, textCopyFailed: true, pictureCopyFailed: true));
+	}
+
+	/// <summary>
+	/// A reading that produced nothing has its own error to show, and that error is the news. A
+	/// sentence about the clipboard in front of it would bury the reason there is no text — and a
+	/// run that recognised nothing never had text to copy in the first place (issue #341).
+	/// </summary>
+	[Theory]
+	[InlineData(false, false)]
+	[InlineData(true, false)]
+	[InlineData(false, true)]
+	[InlineData(true, true)]
+	public void AFailedReadingSaysNothingAboutTheClipboard(bool textCopyFailed, bool pictureCopyFailed)
+	{
+		Assert.Null(ClipboardCopyMessages.ForOcrRun(success: false, textCopyFailed, pictureCopyFailed));
+	}
+}

--- a/Mutation.Tests/ClipboardManagerUiThreadTests.cs
+++ b/Mutation.Tests/ClipboardManagerUiThreadTests.cs
@@ -155,6 +155,60 @@ public class ClipboardManagerUiThreadTests
 		Assert.All(clipboard.WriteThreadIds, id => Assert.Equal(uiThread.ThreadId, id));
 	}
 
+	/// <summary>
+	/// A ladder that runs out says so somewhere the user cannot, and hands over what actually went
+	/// wrong on the last attempt.
+	/// <para>
+	/// This is what stops a busy clipboard and a permanent failure looking the same. The retry
+	/// swallows exceptions, which is right for retrying, and the caller now turns the resulting
+	/// false into a fixed "another program is using the clipboard". If an encode ran out of memory
+	/// instead — the failure issue #229 was filed about — that sentence is wrong, the advice to
+	/// try again makes it worse, and without this there would be no record of the real cause.
+	/// </para>
+	/// </summary>
+	[Fact]
+	public async Task AnExhaustedLadderReportsWhatWentWrong()
+	{
+		var clipboard = new TestClipboard(uiThread: null) { FailWrites = int.MaxValue };
+		using var image = new SoftwareBitmap(BitmapPixelFormat.Bgra8, 2, 2, BitmapAlphaMode.Premultiplied);
+
+		await clipboard.TrySetImageAsync(image);
+
+		var (operationName, lastFailure) = Assert.Single(clipboard.GaveUp);
+		Assert.Equal(nameof(ClipboardManager.TrySetImageAsync), operationName);
+		Assert.IsType<InvalidOperationException>(lastFailure);
+	}
+
+	/// <summary>
+	/// A ladder that succeeds reports nothing. The log is only worth reading if it is quiet when
+	/// all is well, and a clipboard briefly held is the ordinary case here, not a fault.
+	/// </summary>
+	[Fact]
+	public async Task ALadderThatGetsInReportsNothing()
+	{
+		var clipboard = new TestClipboard(uiThread: null) { FailWrites = 2 };
+		using var image = new SoftwareBitmap(BitmapPixelFormat.Bgra8, 2, 2, BitmapAlphaMode.Premultiplied);
+
+		Assert.True(await clipboard.TrySetImageAsync(image));
+		Assert.Empty(clipboard.GaveUp);
+	}
+
+	/// <summary>
+	/// No bitmap is not a failure, it is nothing to do. It answers false without touching the
+	/// clipboard, the way blank text does — the old method would have thrown.
+	/// </summary>
+	[Fact]
+	public async Task TrySetImageAsync_DoesNotTouchTheClipboard_ForNoImage()
+	{
+		var clipboard = new TestClipboard(uiThread: null);
+
+		bool copied = await clipboard.TrySetImageAsync(null!);
+
+		Assert.False(copied);
+		Assert.Empty(clipboard.WriteThreadIds);
+		Assert.Empty(clipboard.GaveUp);
+	}
+
 	[Fact]
 	public async Task TrySetTextAsync_DoesNotTouchTheClipboard_ForBlankText()
 	{

--- a/Mutation.Tests/ClipboardManagerUiThreadTests.cs
+++ b/Mutation.Tests/ClipboardManagerUiThreadTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using Mutation.Ui.Services;
+using Windows.Graphics.Imaging;
 using Xunit;
 
 namespace Mutation.Tests;
@@ -93,6 +94,65 @@ public class ClipboardManagerUiThreadTests
 		Assert.False(restored);
 		Assert.Null(clipboard.LastRestoredSnapshot);
 		Assert.Equal(ClipboardRetry.DefaultAttempts, clipboard.WriteThreadIds.Count);
+	}
+
+	/// <summary>
+	/// The screenshot write retries too, and does it on the UI thread. This is the write that
+	/// opens the race the two above were fixed for: it is the moment a clipboard manager or a
+	/// screen reader notices something arrived and opens the clipboard to look. It was the one
+	/// asynchronous write here with no retry and no hop, so a clipboard held open for a moment
+	/// reached the user as an error dialog instead of a screenshot (issue #360).
+	/// </summary>
+	[Fact]
+	public async Task TrySetImageAsync_RetriesOnTheUiThread_WhenTheClipboardIsBrieflyBusy()
+	{
+		using var uiThread = new SingleThreadUiDispatcher();
+		var clipboard = new TestClipboard(uiThread) { FailWrites = 2 };
+		using var image = new SoftwareBitmap(BitmapPixelFormat.Bgra8, 2, 2, BitmapAlphaMode.Premultiplied);
+
+		bool copied = await clipboard.TrySetImageAsync(image);
+
+		Assert.True(copied);
+		Assert.Same(image, clipboard.LastImage);
+		Assert.Equal(3, clipboard.WriteThreadIds.Count);
+		Assert.All(clipboard.WriteThreadIds, id => Assert.Equal(uiThread.ThreadId, id));
+	}
+
+	/// <summary>
+	/// Each attempt asks for the UI thread again rather than trusting where the last wait left
+	/// it. Counting the hops is what separates this from a ladder that merely started in the
+	/// right place, which is what issue #352 turned out to be for the other writes.
+	/// </summary>
+	[Fact]
+	public async Task TrySetImageAsync_AsksForTheUiThreadOncePerAttempt()
+	{
+		using var uiThread = new SingleThreadUiDispatcher();
+		var clipboard = new TestClipboard(uiThread) { FailWrites = 2 };
+		using var image = new SoftwareBitmap(BitmapPixelFormat.Bgra8, 2, 2, BitmapAlphaMode.Premultiplied);
+
+		await clipboard.TrySetImageAsync(image);
+
+		Assert.Equal(3, uiThread.DispatchCount);
+	}
+
+	/// <summary>
+	/// A clipboard that never lets go is reported, not thrown. The throw is what reached the
+	/// hotkey handler as an error dialog; a bool is what every sibling on the class answers with,
+	/// and it leaves the caller to decide what to say.
+	/// </summary>
+	[Fact]
+	public async Task TrySetImageAsync_ReportsFailure_WhenTheClipboardNeverLetsGo()
+	{
+		using var uiThread = new SingleThreadUiDispatcher();
+		var clipboard = new TestClipboard(uiThread) { FailWrites = int.MaxValue };
+		using var image = new SoftwareBitmap(BitmapPixelFormat.Bgra8, 2, 2, BitmapAlphaMode.Premultiplied);
+
+		bool copied = await clipboard.TrySetImageAsync(image);
+
+		Assert.False(copied);
+		Assert.Null(clipboard.LastImage);
+		Assert.Equal(ClipboardRetry.DefaultAttempts, clipboard.WriteThreadIds.Count);
+		Assert.All(clipboard.WriteThreadIds, id => Assert.Equal(uiThread.ThreadId, id));
 	}
 
 	[Fact]

--- a/Mutation.Tests/OcrManagerTests.cs
+++ b/Mutation.Tests/OcrManagerTests.cs
@@ -984,6 +984,124 @@ public class OcrManagerTests
 	}
 
 	// ---------------------------------------------------------------------
+	// The screenshot write to the clipboard (issue #360)
+	//
+	// This is the widest clipboard race in the app: the picture arriving is the very thing
+	// that makes a clipboard manager or a screen reader open the clipboard to look. The write
+	// used to get one attempt and report failure by throwing, which reached the hotkey handler
+	// as an error dialog. It now retries like every other clipboard write here, and says which
+	// of the three things happened.
+	// ---------------------------------------------------------------------
+
+	[Fact]
+	public async Task TakeScreenshotToClipboardAsync_CopiesTheImage_WhenTheClipboardIsBrieflyBusy()
+	{
+		using var image = new SoftwareBitmap(BitmapPixelFormat.Bgra8, 2, 2, BitmapAlphaMode.Premultiplied);
+		var clipboard = new TestClipboard { FailWrites = 2 };
+		var manager = new TestableOcrManager(CreateValidSettings(), new StubOcrService(), clipboard)
+		{
+			Screenshot = image,
+		};
+
+		var outcome = await manager.TakeScreenshotToClipboardAsync();
+
+		Assert.Equal(ScreenshotToClipboardOutcome.Copied, outcome);
+		Assert.Same(image, clipboard.LastImage);
+		Assert.Equal(3, clipboard.WriteThreadIds.Count);
+		WaitForBeep(manager, 1);
+		Assert.Equal(new[] { BeepType.Success }, manager.Beeps.ToArray());
+	}
+
+	/// <summary>
+	/// The clipboard never letting go is now an answer rather than an exception, and the answer
+	/// says which of the three it was. Reporting it as a cancellation would tell the user they
+	/// cancelled a capture they did not, and throwing is what put an error dialog in front of
+	/// them.
+	/// </summary>
+	[Fact]
+	public async Task TakeScreenshotToClipboardAsync_ReportsClipboardUnavailable_WhenTheClipboardNeverLetsGo()
+	{
+		using var image = new SoftwareBitmap(BitmapPixelFormat.Bgra8, 2, 2, BitmapAlphaMode.Premultiplied);
+		var clipboard = new TestClipboard { FailWrites = int.MaxValue };
+		var manager = new TestableOcrManager(CreateValidSettings(), new StubOcrService(), clipboard)
+		{
+			Screenshot = image,
+		};
+
+		var outcome = await manager.TakeScreenshotToClipboardAsync();
+
+		Assert.Equal(ScreenshotToClipboardOutcome.ClipboardUnavailable, outcome);
+		Assert.Null(clipboard.LastImage);
+		Assert.Equal(ClipboardRetry.DefaultAttempts, clipboard.WriteThreadIds.Count);
+		WaitForBeep(manager, 1);
+		Assert.Equal(new[] { BeepType.Failure }, manager.Beeps.ToArray());
+	}
+
+	[Fact]
+	public async Task TakeScreenshotToClipboardAsync_ReportsCancelled_WhenNothingWasCaptured()
+	{
+		var clipboard = new TestClipboard();
+		var manager = new TestableOcrManager(CreateValidSettings(), new StubOcrService(), clipboard);
+
+		var outcome = await manager.TakeScreenshotToClipboardAsync();
+
+		Assert.Equal(ScreenshotToClipboardOutcome.Cancelled, outcome);
+		Assert.Empty(clipboard.WriteThreadIds);
+		WaitForBeep(manager, 1);
+		Assert.Equal(new[] { BeepType.Failure }, manager.Beeps.ToArray());
+	}
+
+	/// <summary>
+	/// The reading goes ahead when the picture cannot be copied. It works from the bitmap in
+	/// hand and never needed the clipboard, so throwing here used to lose a capture the user
+	/// cannot take again — whatever was on screen has moved on by then.
+	/// <para>
+	/// The double fails exactly as many writes as one ladder has rungs, so the picture's write
+	/// fails outright and the text's write, which comes after it, succeeds. That is what
+	/// separates the two flags: the text reached the clipboard and the picture did not.
+	/// </para>
+	/// </summary>
+	[Fact]
+	public async Task TakeScreenshotAndExtractTextAsync_StillReadsTheText_WhenTheClipboardWillNotTakeThePicture()
+	{
+		using var image = new SoftwareBitmap(BitmapPixelFormat.Bgra8, 2, 2, BitmapAlphaMode.Premultiplied);
+		var clipboard = new TestClipboard { FailWrites = ClipboardRetry.DefaultAttempts };
+		var manager = new TestableOcrManager(
+			CreateValidSettings(), new StubOcrService("recognised text"), clipboard)
+		{
+			Screenshot = image,
+		};
+
+		var result = await manager.TakeScreenshotAndExtractTextAsync(DefaultOrder);
+
+		Assert.True(result.Success);
+		Assert.Equal("recognised text", result.Message);
+		Assert.True(result.ScreenshotCopyFailed);
+		Assert.False(result.ClipboardCopyFailed);
+		Assert.Equal("recognised text", clipboard.LastText);
+		Assert.Null(clipboard.LastImage);
+	}
+
+	[Fact]
+	public async Task TakeScreenshotAndExtractTextAsync_ReportsNoScreenshotFailure_WhenTheClipboardTakesThePicture()
+	{
+		using var image = new SoftwareBitmap(BitmapPixelFormat.Bgra8, 2, 2, BitmapAlphaMode.Premultiplied);
+		var clipboard = new TestClipboard { FailWrites = 2 };
+		var manager = new TestableOcrManager(
+			CreateValidSettings(), new StubOcrService("recognised text"), clipboard)
+		{
+			Screenshot = image,
+		};
+
+		var result = await manager.TakeScreenshotAndExtractTextAsync(DefaultOrder);
+
+		Assert.True(result.Success);
+		Assert.False(result.ScreenshotCopyFailed);
+		Assert.False(result.ClipboardCopyFailed);
+		Assert.Same(image, clipboard.LastImage);
+	}
+
+	// ---------------------------------------------------------------------
 	// Bitmap lifetime (issue #229)
 	//
 	// A clipboard or screenshot bitmap is unmanaged imaging memory — roughly 30 MB on a
@@ -1074,10 +1192,20 @@ public class OcrManagerTests
 		public int BeepCount => _beeps.Count;
 		public IReadOnlyCollection<BeepType> Beeps => _beeps.ToArray();
 
+		/// <summary>
+		/// What the region overlay will hand back. Null means the user dismissed it without
+		/// selecting anything, which is the cancelled path.
+		/// </summary>
+		public SoftwareBitmap? Screenshot { get; set; }
+
 		protected override void PlayBeep(BeepType type)
 		{
 			_beeps.Enqueue(type);
 		}
+
+		// The real one shows a full-screen overlay and reads the desktop, so nothing about the
+		// two screenshot methods could be tested without standing in for it.
+		protected override Task<SoftwareBitmap?> CaptureScreenshotAsync() => Task.FromResult(Screenshot);
 	}
 
 	private sealed class TestClipboard : RecordingClipboardManager

--- a/Mutation.Tests/PendingUiCallsTests.cs
+++ b/Mutation.Tests/PendingUiCallsTests.cs
@@ -11,11 +11,19 @@ namespace Mutation.Tests;
 /// anybody — so whatever was awaiting it never resumes (issue #361). These pin the bookkeeping
 /// that turns that silence into a failure the caller can act on.
 /// <para>
-/// This is the testable half. <c>DispatcherQueueUiThread</c> itself needs a real WinUI dispatcher
-/// queue on a real UI thread, shut down while a call is still in it, and this test assembly can
-/// create none of those. What is checked there is the wiring — register before enqueuing, release
-/// on the way out, sweep on <c>ShutdownCompleted</c> — and it is checked by reading it, not by
-/// running it.
+/// This is the testable half, and it is worth saying exactly how much of the story it is. These
+/// pin the rules of the bookkeeping itself: one answer per call, nothing held onto on the normal
+/// path, and no <em>tracked</em> call left waiting after a shutdown, whichever order the two
+/// arrive in. They say nothing about the dispatcher as a whole. A call that runs in place because
+/// the caller was already on the UI thread is never tracked, and can still be lost if a
+/// continuation of its own is dropped at shutdown — a path that predates this and that nothing
+/// here reaches.
+/// </para>
+/// <para>
+/// <c>DispatcherQueueUiThread</c> itself needs a real WinUI dispatcher queue on a real UI thread,
+/// shut down while a call is still in it, and this test assembly can create none of those. What
+/// is checked there is the wiring — register before enqueuing, release on the way out, sweep on
+/// <c>ShutdownCompleted</c> — and it is checked by reading it, not by running it.
 /// </para>
 /// </summary>
 public class PendingUiCallsTests

--- a/Mutation.Tests/PendingUiCallsTests.cs
+++ b/Mutation.Tests/PendingUiCallsTests.cs
@@ -1,0 +1,156 @@
+using System;
+using System.Threading.Tasks;
+using Mutation.Ui.Services;
+using Xunit;
+
+namespace Mutation.Tests;
+
+/// <summary>
+/// Accepting a piece of work is not the same as running it. A dispatcher queue answers "yes,
+/// queued" and then, if it shuts down before that callback's turn comes, drops it without telling
+/// anybody — so whatever was awaiting it never resumes (issue #361). These pin the bookkeeping
+/// that turns that silence into a failure the caller can act on.
+/// <para>
+/// This is the testable half. <c>DispatcherQueueUiThread</c> itself needs a real WinUI dispatcher
+/// queue on a real UI thread, shut down while a call is still in it, and this test assembly can
+/// create none of those. What is checked there is the wiring — register before enqueuing, release
+/// on the way out, sweep on <c>ShutdownCompleted</c> — and it is checked by reading it, not by
+/// running it.
+/// </para>
+/// </summary>
+public class PendingUiCallsTests
+{
+	[Fact]
+	public void ACallThatAnswersOnItsOwnIsForgotten()
+	{
+		var pending = new PendingUiCalls();
+		Exception? abandonedWith = null;
+
+		long token = pending.Track(reason => abandonedWith = reason);
+		Assert.Equal(1, pending.Count);
+
+		pending.Release(token);
+
+		Assert.Equal(0, pending.Count);
+		Assert.Null(abandonedWith);
+	}
+
+	/// <summary>
+	/// The leak the tracking exists to prevent is not the dropped callback — it is this list
+	/// growing for the whole life of the app. Every clipboard call goes through it.
+	/// </summary>
+	[Fact]
+	public void NothingIsHeldOntoAfterCallsAnswerOutOfOrder()
+	{
+		var pending = new PendingUiCalls();
+
+		long first = pending.Track(_ => { });
+		long second = pending.Track(_ => { });
+		long third = pending.Track(_ => { });
+
+		pending.Release(second);
+		pending.Release(third);
+		pending.Release(first);
+
+		Assert.Equal(0, pending.Count);
+	}
+
+	[Fact]
+	public void ACallStillWaitingWhenTheUiThreadStopsIsFailed()
+	{
+		var pending = new PendingUiCalls();
+		Exception? abandonedWith = null;
+		var reason = new InvalidOperationException("the UI thread is gone");
+
+		pending.Track(r => abandonedWith = r);
+		pending.AbandonAll(reason);
+
+		Assert.Same(reason, abandonedWith);
+		Assert.Equal(0, pending.Count);
+	}
+
+	/// <summary>
+	/// A call registered after the sweep is failed as it arrives rather than tracked. Without
+	/// this, a call that slipped into the gap between the sweep and the queue starting to refuse
+	/// work would be the one thing nothing could reach — which is the same hang, moved.
+	/// </summary>
+	[Fact]
+	public void ACallRegisteredAfterTheUiThreadStoppedIsFailedImmediately()
+	{
+		var pending = new PendingUiCalls();
+		Exception? abandonedWith = null;
+		var reason = new InvalidOperationException("the UI thread is gone");
+
+		pending.AbandonAll(reason);
+		long token = pending.Track(r => abandonedWith = r);
+
+		Assert.Same(reason, abandonedWith);
+		Assert.Equal(PendingUiCalls.NotTracked, token);
+		Assert.Equal(0, pending.Count);
+	}
+
+	/// <summary>
+	/// Releasing after a sweep has already failed the call is harmless. It is the ordinary race:
+	/// the sweep fails the call, and the dropped callback's own cleanup — or the queue refusing
+	/// it outright — arrives afterwards.
+	/// </summary>
+	[Fact]
+	public void ReleasingACallThatWasAlreadyFailedDoesNothing()
+	{
+		var pending = new PendingUiCalls();
+		int abandonCount = 0;
+
+		long token = pending.Track(_ => abandonCount++);
+		pending.AbandonAll(new InvalidOperationException("the UI thread is gone"));
+		pending.Release(token);
+
+		Assert.Equal(1, abandonCount);
+		Assert.Equal(0, pending.Count);
+	}
+
+	[Fact]
+	public void ReleasingACallThatWasNeverTrackedDoesNothing()
+	{
+		var pending = new PendingUiCalls();
+
+		pending.Release(PendingUiCalls.NotTracked);
+
+		Assert.Equal(0, pending.Count);
+	}
+
+	/// <summary>
+	/// The whole point, stated in the terms the caller sees it in: a task that would otherwise
+	/// wait forever completes as a failure instead. The retry above these calls knows what to do
+	/// with a failure and has nothing to do with a wait that never ends.
+	/// </summary>
+	[Fact]
+	public async Task AWaitingCallerIsFaultedRatherThanLeftWaiting()
+	{
+		var pending = new PendingUiCalls();
+		var completion = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+		pending.Track(reason => completion.TrySetException(reason));
+		pending.AbandonAll(new InvalidOperationException("the UI thread is gone"));
+
+		var thrown = await Assert.ThrowsAsync<InvalidOperationException>(() => completion.Task);
+		Assert.Equal("the UI thread is gone", thrown.Message);
+	}
+
+	/// <summary>
+	/// Only the first answer counts. A sweep and a callback that ran anyway can both try, and the
+	/// second must not turn a completed call into a crash.
+	/// </summary>
+	[Fact]
+	public async Task TheFirstAnswerWins_WhenACallAndASweepRace()
+	{
+		var pending = new PendingUiCalls();
+		var completion = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+		long token = pending.Track(reason => completion.TrySetException(reason));
+		completion.TrySetResult(42);
+		pending.AbandonAll(new InvalidOperationException("the UI thread is gone"));
+		pending.Release(token);
+
+		Assert.Equal(42, await completion.Task);
+	}
+}

--- a/Mutation.Tests/RecordingClipboardManager.cs
+++ b/Mutation.Tests/RecordingClipboardManager.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Mutation.Ui.Services;
+using Windows.Graphics.Imaging;
 
 namespace Mutation.Tests;
 
@@ -33,6 +34,9 @@ internal class RecordingClipboardManager : ClipboardManager
 	/// <summary>The last snapshot restored, or null when none was.</summary>
 	public ClipboardSnapshot? LastRestoredSnapshot { get; private set; }
 
+	/// <summary>The last image written, or null when none was.</summary>
+	public SoftwareBitmap? LastImage { get; private set; }
+
 	public int SetTextCalls { get; private set; }
 
 	/// <summary>
@@ -63,6 +67,20 @@ internal class RecordingClipboardManager : ClipboardManager
 			return Task.CompletedTask;
 
 		LastRestoredSnapshot = snapshot;
+		return Task.CompletedTask;
+	}
+
+	/// <summary>
+	/// The screenshot write. Recorded rather than made for the same reason as the two above: the
+	/// real one encodes a PNG and hands it to the Windows clipboard, neither of which a test can
+	/// check the retrying of.
+	/// </summary>
+	protected override Task SetImageAsync(SoftwareBitmap bitmap)
+	{
+		if (RecordWriteAndDecideToFail())
+			return Task.CompletedTask;
+
+		LastImage = bitmap;
 		return Task.CompletedTask;
 	}
 

--- a/Mutation.Tests/RecordingClipboardManager.cs
+++ b/Mutation.Tests/RecordingClipboardManager.cs
@@ -52,6 +52,20 @@ internal class RecordingClipboardManager : ClipboardManager
 	/// </summary>
 	public int FailWrites { get; set; }
 
+	/// <summary>
+	/// The operation name and last failure of every ladder that ran out of attempts, in order.
+	/// Watched here rather than written to the real error log, which other tests in this
+	/// assembly read and rotate.
+	/// </summary>
+	public IReadOnlyList<(string OperationName, Exception? LastFailure)> GaveUp => _gaveUp;
+
+	private readonly List<(string OperationName, Exception? LastFailure)> _gaveUp = new();
+
+	protected override void OnClipboardGaveUp(string operationName, Exception? lastFailure)
+	{
+		_gaveUp.Add((operationName, lastFailure));
+	}
+
 	public override void SetText(string text)
 	{
 		SetTextCalls++;

--- a/Mutation.Ui/Core/ClipboardCopyMessages.cs
+++ b/Mutation.Ui/Core/ClipboardCopyMessages.cs
@@ -1,0 +1,90 @@
+using Microsoft.UI.Xaml.Controls;
+
+namespace Mutation.Ui.Core;
+
+/// <summary>
+/// What to tell the user about where a capture ended up — the picture, the text, or neither.
+/// <para>
+/// Pure, and out here rather than in the window, because the decisions are worth pinning: which
+/// of three outcomes a plain screenshot gets, and which of two clipboard failures is worth saying
+/// when both happened. The window can only be checked by running it.
+/// </para>
+/// </summary>
+public static class ClipboardCopyMessages
+{
+	public const string ScreenshotCopied = "Screenshot copied to the clipboard.";
+
+	public const string ScreenshotCancelled = "Screenshot cancelled. Nothing was copied to the clipboard.";
+
+	/// <summary>
+	/// Said when a screenshot was captured but the clipboard would not take it. It names the
+	/// cause, because the cause is the whole of the advice: something else has the clipboard for
+	/// a moment, and trying again almost always gets in.
+	/// <para>
+	/// "Try again", not "press the shortcut again". The same sentence is said to someone who
+	/// clicked the button, and telling them to press a shortcut they did not use points them at
+	/// the wrong control — which matters most to the user who is listening rather than looking.
+	/// </para>
+	/// </summary>
+	public const string ScreenshotClipboardBusy =
+		"Another program is using the clipboard, so the screenshot was not copied. Try again in a moment.";
+
+	/// <summary>
+	/// Said when the text was read but the clipboard would not take it. Both halves matter: the
+	/// user has to know the copy did not happen, and — because the shortcut that runs next is
+	/// usually a screen-reader command aimed at the result — that the text itself is not lost.
+	/// </summary>
+	public const string OcrTextNotCopied =
+		"The text was recognised, but it could not be copied to the clipboard. It is in the OCR results box.";
+
+	/// <summary>
+	/// Said when a screenshot was read successfully but the picture itself did not reach the
+	/// clipboard. Leads with the good news, because the text is what the user asked for and it
+	/// is safely on the clipboard — only the picture is missing.
+	/// </summary>
+	public const string OcrPictureNotCopied =
+		"The text was recognised and copied, but the screenshot picture could not be put on the clipboard.";
+
+	/// <summary>
+	/// What to say about a plain screenshot capture, and how loudly.
+	/// <para>
+	/// A busy clipboard is an error and a cancellation is not, which is the distinction the
+	/// severity carries to a screen reader: an error interrupts what it is saying, and an
+	/// informational message waits its turn. Every case is named rather than left to a default,
+	/// so a fourth outcome added later is a compiler-visible gap instead of a silent
+	/// "you cancelled it".
+	/// </para>
+	/// </summary>
+	public static (string Message, InfoBarSeverity Severity) ForScreenshot(ScreenshotToClipboardOutcome outcome) =>
+		outcome switch
+		{
+			ScreenshotToClipboardOutcome.Copied => (ScreenshotCopied, InfoBarSeverity.Success),
+			ScreenshotToClipboardOutcome.ClipboardUnavailable => (ScreenshotClipboardBusy, InfoBarSeverity.Error),
+			ScreenshotToClipboardOutcome.Cancelled => (ScreenshotCancelled, InfoBarSeverity.Informational),
+			_ => (ScreenshotCancelled, InfoBarSeverity.Informational),
+		};
+
+	/// <summary>
+	/// What to say about an OCR run's clipboard writes, or null when there is nothing to say.
+	/// </summary>
+	/// <param name="success">Whether the reading itself produced text.</param>
+	/// <param name="textCopyFailed">Whether that text failed to reach the clipboard.</param>
+	/// <param name="pictureCopyFailed">Whether the screenshot it read failed to reach the clipboard.</param>
+	/// <remarks>
+	/// Two rules, both worth stating. A failed text copy outranks a failed picture copy: the text
+	/// is what the user asked for and the one they can still lose, while the picture is a side
+	/// effect they can retake. And neither is said when the reading itself failed — the reason
+	/// there is no text is the news, and a sentence about the clipboard in front of it would bury
+	/// it. The clipboard is then simply unchanged.
+	/// </remarks>
+	public static string? ForOcrRun(bool success, bool textCopyFailed, bool pictureCopyFailed)
+	{
+		if (!success)
+			return null;
+
+		if (textCopyFailed)
+			return OcrTextNotCopied;
+
+		return pictureCopyFailed ? OcrPictureNotCopied : null;
+	}
+}

--- a/Mutation.Ui/Core/ScreenshotToClipboardOutcome.cs
+++ b/Mutation.Ui/Core/ScreenshotToClipboardOutcome.cs
@@ -1,0 +1,29 @@
+namespace Mutation.Ui.Core;
+
+/// <summary>
+/// What became of a plain screenshot capture — the one whose only product is a picture on the
+/// clipboard.
+/// <para>
+/// Three answers, not two, because a busy clipboard is neither of the other two. It used to
+/// reach the caller as a thrown exception and an error dialog, which is the wrong weight for
+/// something that clears on its own within a second (issue #360), and reporting it as a
+/// cancellation instead would tell the user they cancelled something they did not.
+/// </para>
+/// </summary>
+public enum ScreenshotToClipboardOutcome
+{
+	/// <summary>The picture reached the clipboard.</summary>
+	Copied,
+
+	/// <summary>
+	/// The user dismissed the region overlay without selecting anything, or a capture was
+	/// already on screen. Nothing was captured and nothing on the clipboard changed.
+	/// </summary>
+	Cancelled,
+
+	/// <summary>
+	/// A region was captured, but another program held the clipboard open through every retry,
+	/// so the picture never got there. The clipboard still holds whatever it held before.
+	/// </summary>
+	ClipboardUnavailable,
+}

--- a/Mutation.Ui/Core/ScreenshotToClipboardOutcome.cs
+++ b/Mutation.Ui/Core/ScreenshotToClipboardOutcome.cs
@@ -12,14 +12,20 @@ namespace Mutation.Ui.Core;
 /// </summary>
 public enum ScreenshotToClipboardOutcome
 {
-	/// <summary>The picture reached the clipboard.</summary>
-	Copied,
-
 	/// <summary>
 	/// The user dismissed the region overlay without selecting anything, or a capture was
 	/// already on screen. Nothing was captured and nothing on the clipboard changed.
+	/// <para>
+	/// First, so that it is what <c>default</c> gives. Nothing happened is the only one of the
+	/// three that is safe to say by accident: a zero value meaning <see cref="Copied"/> would
+	/// let a value nobody set announce a screenshot that was never taken, which is the exact
+	/// thing this enum exists to prevent.
+	/// </para>
 	/// </summary>
 	Cancelled,
+
+	/// <summary>The picture reached the clipboard.</summary>
+	Copied,
 
 	/// <summary>
 	/// A region was captured, but another program held the clipboard open through every retry,

--- a/Mutation.Ui/MainWindow.xaml.cs
+++ b/Mutation.Ui/MainWindow.xaml.cs
@@ -3531,30 +3531,6 @@ public sealed partial class MainWindow : Window, IDisposable
 	}
 
 	/// <summary>
-	/// Said when the text was read but the clipboard would not take it. Both halves matter: the
-	/// user has to know the copy did not happen, and — because the shortcut that runs next is
-	/// usually a screen-reader command aimed at the result — that the text itself is not lost.
-	/// </summary>
-	private const string OcrClipboardCopyFailedMessage =
-		"The text was recognised, but it could not be copied to the clipboard. It is in the OCR results box.";
-
-	/// <summary>
-	/// Said when a plain screenshot was captured but the clipboard would not take it. It names
-	/// the cause, because the cause is the whole of the advice: something else has the clipboard
-	/// for a moment, and pressing the shortcut again almost always gets in.
-	/// </summary>
-	private const string ScreenshotClipboardBusyMessage =
-		"Another program is using the clipboard, so the screenshot was not copied. Press the shortcut again.";
-
-	/// <summary>
-	/// Said when a screenshot was read successfully but the picture itself did not reach the
-	/// clipboard. Leads with the good news, because the text is what the user asked for and it
-	/// is safely on the clipboard — only the picture is missing.
-	/// </summary>
-	private const string ScreenshotImageCopyFailedMessage =
-		"The text was recognised and copied, but the screenshot picture could not be put on the clipboard.";
-
-	/// <summary>
 	/// Says which of the three things a plain screenshot capture did. Shared by the shortcut and
 	/// the button, so both tell the user the same thing.
 	/// <para>
@@ -3565,18 +3541,8 @@ public sealed partial class MainWindow : Window, IDisposable
 	/// </summary>
 	private void AnnounceScreenshotOutcome(ScreenshotToClipboardOutcome outcome)
 	{
-		switch (outcome)
-		{
-			case ScreenshotToClipboardOutcome.Copied:
-				ShowStatus("Screenshot", "Screenshot copied to the clipboard.", InfoBarSeverity.Success);
-				break;
-			case ScreenshotToClipboardOutcome.ClipboardUnavailable:
-				ShowStatus("Screenshot", ScreenshotClipboardBusyMessage, InfoBarSeverity.Error);
-				break;
-			default:
-				ShowStatus("Screenshot", "Screenshot cancelled. Nothing was copied to the clipboard.", InfoBarSeverity.Informational);
-				break;
-		}
+		var (message, severity) = ClipboardCopyMessages.ForScreenshot(outcome);
+		ShowStatus("Screenshot", message, severity);
 	}
 
 	/// <summary>
@@ -3616,22 +3582,16 @@ public sealed partial class MainWindow : Window, IDisposable
 				PostOperationHotkey.AfterOcr(paste, _settings.AzureComputerVisionSettings?.SendHotkeyAfterOcrOperation),
 				PostOperationHotkey.OcrDelay(result.Success));
 
-		// The clipboard warning outranks the success line, and says so here rather than being
+		// A clipboard warning outranks the success line, and says so here rather than being
 		// followed by it. The four button paths used to announce their own success afterwards,
-		// which would leave the user believing a copy that did not happen.
-		if (result.Success && result.ClipboardCopyFailed)
-		{
-			ShowStatus(statusTitle ?? "OCR", OcrClipboardCopyFailedMessage, InfoBarSeverity.Warning);
-			return;
-		}
+		// which would leave the user believing a copy that did not happen. Which warning, and
+		// whether there is one at all, is decided by ClipboardCopyMessages.
+		string? clipboardWarning = ClipboardCopyMessages.ForOcrRun(
+			result.Success, result.ClipboardCopyFailed, result.ScreenshotCopyFailed);
 
-		// The picture not reaching the clipboard is worth a word, but only when the reading
-		// itself worked. A run that recognised nothing has an error to show instead, and that
-		// error is the news — a second sentence about the clipboard behind it would bury the
-		// reason there is no text, and the clipboard is then simply unchanged.
-		if (result.Success && result.ScreenshotCopyFailed)
+		if (clipboardWarning is not null)
 		{
-			ShowStatus(statusTitle ?? "OCR", ScreenshotImageCopyFailedMessage, InfoBarSeverity.Warning);
+			ShowStatus(statusTitle ?? "OCR", clipboardWarning, InfoBarSeverity.Warning);
 			return;
 		}
 

--- a/Mutation.Ui/MainWindow.xaml.cs
+++ b/Mutation.Ui/MainWindow.xaml.cs
@@ -490,10 +490,7 @@ public sealed partial class MainWindow : Window, IDisposable
 				// distinguish a captured region from a cancelled one.
 				try
 				{
-					if (await _ocrManager.TakeScreenshotToClipboardAsync())
-						ShowStatus("Screenshot", "Screenshot copied to the clipboard.", InfoBarSeverity.Success);
-					else
-						ShowStatus("Screenshot", "Screenshot cancelled. Nothing was copied to the clipboard.", InfoBarSeverity.Informational);
+					AnnounceScreenshotOutcome(await _ocrManager.TakeScreenshotToClipboardAsync());
 				}
 				catch (Exception ex) { await ShowErrorDialog("Screenshot Error", ex); }
 			});
@@ -998,10 +995,7 @@ public sealed partial class MainWindow : Window, IDisposable
 		try
 		{
 			// Cancelling the region overlay used to be announced as a success.
-			if (await _ocrManager.TakeScreenshotToClipboardAsync())
-				ShowStatus("Screenshot", "Screenshot copied to the clipboard.", InfoBarSeverity.Success);
-			else
-				ShowStatus("Screenshot", "Screenshot cancelled. Nothing was copied to the clipboard.", InfoBarSeverity.Informational);
+			AnnounceScreenshotOutcome(await _ocrManager.TakeScreenshotToClipboardAsync());
 		}
 		catch (Exception ex)
 		{
@@ -3545,6 +3539,47 @@ public sealed partial class MainWindow : Window, IDisposable
 		"The text was recognised, but it could not be copied to the clipboard. It is in the OCR results box.";
 
 	/// <summary>
+	/// Said when a plain screenshot was captured but the clipboard would not take it. It names
+	/// the cause, because the cause is the whole of the advice: something else has the clipboard
+	/// for a moment, and pressing the shortcut again almost always gets in.
+	/// </summary>
+	private const string ScreenshotClipboardBusyMessage =
+		"Another program is using the clipboard, so the screenshot was not copied. Press the shortcut again.";
+
+	/// <summary>
+	/// Said when a screenshot was read successfully but the picture itself did not reach the
+	/// clipboard. Leads with the good news, because the text is what the user asked for and it
+	/// is safely on the clipboard — only the picture is missing.
+	/// </summary>
+	private const string ScreenshotImageCopyFailedMessage =
+		"The text was recognised and copied, but the screenshot picture could not be put on the clipboard.";
+
+	/// <summary>
+	/// Says which of the three things a plain screenshot capture did. Shared by the shortcut and
+	/// the button, so both tell the user the same thing.
+	/// <para>
+	/// A busy clipboard is a status line, not an error dialog. It used to be a dialog, because
+	/// the failure arrived here as a thrown exception (issue #360) — and a modal box the user has
+	/// to dismiss is the wrong weight for something that clears on its own in under a second.
+	/// </para>
+	/// </summary>
+	private void AnnounceScreenshotOutcome(ScreenshotToClipboardOutcome outcome)
+	{
+		switch (outcome)
+		{
+			case ScreenshotToClipboardOutcome.Copied:
+				ShowStatus("Screenshot", "Screenshot copied to the clipboard.", InfoBarSeverity.Success);
+				break;
+			case ScreenshotToClipboardOutcome.ClipboardUnavailable:
+				ShowStatus("Screenshot", ScreenshotClipboardBusyMessage, InfoBarSeverity.Error);
+				break;
+			default:
+				ShowStatus("Screenshot", "Screenshot cancelled. Nothing was copied to the clipboard.", InfoBarSeverity.Informational);
+				break;
+		}
+	}
+
+	/// <summary>
 	/// Puts an OCR run's answer in front of the user: the text, or the error, in the OCR box;
 	/// then the shortcut configured to run afterwards; then a word about the clipboard if it
 	/// would not take the text.
@@ -3587,6 +3622,16 @@ public sealed partial class MainWindow : Window, IDisposable
 		if (result.Success && result.ClipboardCopyFailed)
 		{
 			ShowStatus(statusTitle ?? "OCR", OcrClipboardCopyFailedMessage, InfoBarSeverity.Warning);
+			return;
+		}
+
+		// The picture not reaching the clipboard is worth a word, but only when the reading
+		// itself worked. A run that recognised nothing has an error to show instead, and that
+		// error is the news — a second sentence about the clipboard behind it would bury the
+		// reason there is no text, and the clipboard is then simply unchanged.
+		if (result.Success && result.ScreenshotCopyFailed)
+		{
+			ShowStatus(statusTitle ?? "OCR", ScreenshotImageCopyFailedMessage, InfoBarSeverity.Warning);
 			return;
 		}
 

--- a/Mutation.Ui/Services/ClipboardManager.cs
+++ b/Mutation.Ui/Services/ClipboardManager.cs
@@ -24,9 +24,10 @@ public class ClipboardManager
 	/// Where the retrying calls on this class are made. Null means "make them wherever the
 	/// caller is", which is what the tests that do not care about threading get.
 	/// <para>
-	/// It covers the methods that retry, not every method here. <see cref="SetText"/> is
-	/// synchronous and cannot hop, and <see cref="SetImageAsync"/> has neither a retry nor a
-	/// hop — see issue #360. Both predate this and both are called from the UI thread today.
+	/// It covers the methods that retry, not every method here. <see cref="SetText"/> and
+	/// <see cref="SetImageAsync"/> are the single attempts the retrying methods are built from,
+	/// so they are made wherever their caller already is — which, going through
+	/// <see cref="TrySetTextAsync"/> or <see cref="TrySetImageAsync"/>, is the UI thread.
 	/// </para>
 	/// </param>
 	public ClipboardManager(IUiThreadDispatcher? uiThread = null)
@@ -259,7 +260,32 @@ public class ClipboardManager
 		return bytes;
 	}
 
-	public async Task SetImageAsync(SoftwareBitmap bitmap)
+	/// <summary>
+	/// Puts <paramref name="bitmap"/> on the clipboard, retrying while another process holds the
+	/// clipboard open. Returns false when it stayed unavailable after retries.
+	/// <para>
+	/// This is the screenshot write, and it opens the widest race in the app: it is the moment a
+	/// clipboard manager or a screen reader notices something arrived and opens the clipboard to
+	/// look at it. It used to be the one asynchronous write here with neither a retry nor a
+	/// thread hop, and it reported failure by throwing, which reached the hotkey handler as an
+	/// error dialog (issue #360). It now answers with a bool like every sibling, leaving the
+	/// caller to decide what a busy clipboard is worth saying.
+	/// </para>
+	/// </summary>
+	public virtual Task<bool> TrySetImageAsync(SoftwareBitmap bitmap)
+	{
+		if (bitmap is null)
+			return Task.FromResult(false);
+
+		return RetryOnUiThreadAsync(() => SetImageAsync(bitmap));
+	}
+
+	/// <summary>
+	/// One attempt at putting an image on the clipboard. Split out and virtual for the same
+	/// reason <see cref="SetText"/> is: nothing in a test can reach the real Windows clipboard,
+	/// so without a seam here no test could check that a busy clipboard is retried.
+	/// </summary>
+	protected virtual async Task SetImageAsync(SoftwareBitmap bitmap)
 	{
 		var data = new DataPackage();
 		var stream = new InMemoryRandomAccessStream();

--- a/Mutation.Ui/Services/ClipboardManager.cs
+++ b/Mutation.Ui/Services/ClipboardManager.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices.WindowsRuntime;
 using System.Threading.Tasks;
+using CognitiveSupport;
 using Windows.ApplicationModel.DataTransfer;
 using Windows.Graphics.Imaging;
 using Windows.Storage.Streams;
@@ -225,20 +227,57 @@ public class ClipboardManager
 	/// operations wearing a retry ladder (issue #352).
 	/// </para>
 	/// </summary>
-	private async Task<bool> RetryOnUiThreadAsync(Func<Task> operation)
+	private async Task<bool> RetryOnUiThreadAsync(Func<Task> operation, [CallerMemberName] string operationName = "")
 	{
 		var (success, _) = await RetryOnUiThreadAsync<object?>(async () =>
 		{
 			await operation();
 			return null;
-		});
+		}, operationName);
 
 		return success;
 	}
 
-	/// <inheritdoc cref="RetryOnUiThreadAsync(Func{Task})"/>
-	private Task<(bool Success, T? Value)> RetryOnUiThreadAsync<T>(Func<Task<T>> operation) =>
-		ClipboardRetry.TryAsync(() => OnUiThreadAsync(operation));
+	/// <inheritdoc cref="RetryOnUiThreadAsync(Func{Task}, string)"/>
+	private async Task<(bool Success, T? Value)> RetryOnUiThreadAsync<T>(
+		Func<Task<T>> operation, [CallerMemberName] string operationName = "")
+	{
+		// The last thing that went wrong is kept so a ladder that runs out has something to
+		// report. ClipboardRetry swallows the exceptions, which is right for retrying and would
+		// otherwise mean a permanent failure — a full disk, an encode that ran out of memory —
+		// reaches the user as the same "the clipboard is busy" as a passing one, with nothing
+		// written down anywhere.
+		Exception? lastFailure = null;
+
+		var result = await ClipboardRetry.TryAsync(async () =>
+		{
+			try
+			{
+				return await OnUiThreadAsync(operation);
+			}
+			catch (Exception ex)
+			{
+				lastFailure = ex;
+				throw;
+			}
+		});
+
+		if (!result.Success)
+			OnClipboardGaveUp(operationName, lastFailure);
+
+		return result;
+	}
+
+	/// <summary>
+	/// Called once when a clipboard operation has used up its attempts, with whatever went wrong
+	/// on the last of them. Writes it to the error log.
+	/// <para>
+	/// Virtual so the tests that deliberately exhaust a ladder can watch this instead of writing
+	/// to the real log file, which other tests in this assembly are reading.
+	/// </para>
+	/// </summary>
+	protected virtual void OnClipboardGaveUp(string operationName, Exception? lastFailure) =>
+		ErrorLogger.LogError($"ClipboardManager.{operationName}", lastFailure);
 
 	/// <summary>
 	/// Runs one clipboard call on the UI thread. Runs it where it stands when there is no

--- a/Mutation.Ui/Services/DispatcherQueueUiThread.cs
+++ b/Mutation.Ui/Services/DispatcherQueueUiThread.cs
@@ -9,11 +9,26 @@ namespace Mutation.Ui.Services;
 /// </summary>
 internal sealed class DispatcherQueueUiThread : IUiThreadDispatcher
 {
+	/// <summary>
+	/// Said to anything still waiting on the UI thread when there is no longer a UI thread to
+	/// wait for. A failure, deliberately: the retry above these calls knows what to do with a
+	/// failure and has nothing to do with a wait that never ends.
+	/// </summary>
+	private const string ShuttingDownMessage =
+		"The UI thread is shutting down and is no longer accepting work.";
+
 	private readonly DispatcherQueue _queue;
+	private readonly PendingUiCalls _pending = new();
 
 	public DispatcherQueueUiThread(DispatcherQueue queue)
 	{
 		_queue = queue ?? throw new ArgumentNullException(nameof(queue));
+
+		// ShutdownCompleted, not ShutdownStarting. The queue goes on draining what it already
+		// holds after shutdown starts, so failing everything at that point would abandon calls
+		// that were about to succeed. By the time this fires, anything still outstanding never
+		// ran and never will.
+		_queue.ShutdownCompleted += OnShutdownCompleted;
 	}
 
 	public Task<T> RunAsync<T>(Func<Task<T>> operation)
@@ -31,27 +46,47 @@ internal sealed class DispatcherQueueUiThread : IUiThreadDispatcher
 		// itself needs to be there.
 		var completion = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
 
+		// Registered before the callback is handed over, so a shutdown that lands between the
+		// two finds this call rather than missing it. The reverse order leaves exactly the gap
+		// this is here to close.
+		long token = _pending.Track(reason => completion.TrySetException(reason));
+
 		// Deliberately an async void callback: DispatcherQueueHandler returns void. It is safe
 		// because every exception the operation can raise is caught here and handed to the
-		// caller through the task instead of escaping. The completion calls themselves are not
-		// inside that guarantee, but they cannot throw: this source is completed either by the
-		// callback or by the not-queued branch below, never by both.
+		// caller through the task instead of escaping.
+		//
+		// TrySetResult rather than SetResult, and the same for the two exception paths: a
+		// shutdown sweep can reach this call at any moment, so more than one of them may try to
+		// answer and the first answer must simply win. Only one of them can be the winner, and
+		// it is always the one that ran first.
 		bool queued = _queue.TryEnqueue(async () =>
 		{
 			try
 			{
-				completion.SetResult(await operation());
+				completion.TrySetResult(await operation());
 			}
 			catch (Exception ex)
 			{
-				completion.SetException(ex);
+				completion.TrySetException(ex);
+			}
+			finally
+			{
+				_pending.Release(token);
 			}
 		});
 
+		// A queue that refuses the callback outright is the honest case, and it always was
+		// handled. The one that needed the bookkeeping above is the queue that accepts a
+		// callback and then shuts down before running it (issue #361): accepted is not run.
 		if (!queued)
-			completion.SetException(new InvalidOperationException(
-				"The UI thread is shutting down and is no longer accepting work."));
+		{
+			_pending.Release(token);
+			completion.TrySetException(new InvalidOperationException(ShuttingDownMessage));
+		}
 
 		return completion.Task;
 	}
+
+	private void OnShutdownCompleted(DispatcherQueue sender, object args) =>
+		_pending.AbandonAll(new InvalidOperationException(ShuttingDownMessage));
 }

--- a/Mutation.Ui/Services/DispatcherQueueUiThread.cs
+++ b/Mutation.Ui/Services/DispatcherQueueUiThread.cs
@@ -36,6 +36,15 @@ internal sealed class DispatcherQueueUiThread : IUiThreadDispatcher
 		if (operation is null)
 			throw new ArgumentNullException(nameof(operation));
 
+		// A caller already on the UI thread is left there rather than queued behind itself. This
+		// path is deliberately not tracked: it enqueues nothing, so there is no accepted-but-
+		// dropped callback for a shutdown sweep to find.
+		//
+		// It is not immune to a shutdown, though, and it is worth being straight about that. An
+		// operation running here can await something whose continuation is posted back through
+		// this thread's synchronization context, and that post can be dropped at shutdown just
+		// as an enqueued callback can. Nothing below reaches it. That path predates the tracking
+		// and is not made wider by it (issue #361).
 		if (_queue.HasThreadAccess)
 			return operation();
 

--- a/Mutation.Ui/Services/OcrManager.cs
+++ b/Mutation.Ui/Services/OcrManager.cs
@@ -37,11 +37,19 @@ namespace Mutation.Ui.Services;
 /// only alongside <c>Success</c>: a run that recognised nothing had nothing to copy, and does
 /// not report a copy that never happened as having failed (issue #341).
 /// </param>
+/// <param name="ScreenshotCopyFailed">
+/// True when the screenshot this run read from did not itself reach the clipboard. Separate from
+/// <paramref name="ClipboardCopyFailed"/> because the two are independent: the reading works from
+/// the captured bitmap in hand, so a picture that never got to the clipboard says nothing about
+/// whether the text that followed it did (issue #360). Always false for the paths that never put
+/// a picture on the clipboard.
+/// </param>
 public record OcrResult(
 	bool Success,
 	string Message,
 	OcrRunOutcome Outcome = OcrRunOutcome.Answered,
-	bool ClipboardCopyFailed = false);
+	bool ClipboardCopyFailed = false,
+	bool ScreenshotCopyFailed = false);
 
 /// <param name="ClipboardCopyFailed">
 /// As on <see cref="OcrResult"/>: the combined text was recognised but could not be put on the
@@ -88,17 +96,17 @@ public class OcrManager
     }
 
     /// <summary>
-    /// Returns true when an image reached the clipboard; false when the user cancelled
-    /// the region overlay or no region was selected. Callers must not announce success
-    /// unconditionally — for a blind user, "Screenshot copied to the clipboard" after a
-    /// cancelled capture is worse than silence.
+    /// Captures a region and puts it on the clipboard, saying which of the three things
+    /// happened. Callers must not announce success unconditionally — for a blind user,
+    /// "Screenshot copied to the clipboard" after a cancelled capture is worse than silence,
+    /// and so is it after a capture the clipboard would not take.
     /// </summary>
-    public async Task<bool> TakeScreenshotToClipboardAsync()
+    public async Task<ScreenshotToClipboardOutcome> TakeScreenshotToClipboardAsync()
     {
         if (Interlocked.CompareExchange(ref _captureInFlight, 1, 0) != 0)
         {
             try { _activeOverlay?.BringToFront(); } catch { }
-            return false;
+            return ScreenshotToClipboardOutcome.Cancelled;
         }
         try
         {
@@ -106,15 +114,17 @@ public class OcrManager
             // imaging memory, and waiting for a finalizer pass lets repeated hotkey
             // presses grow the working set until an encode fails outright (issue #229).
             using var bitmap = await CaptureScreenshotAsync();
-            if (bitmap != null)
+            if (bitmap == null)
             {
-                await _clipboard.SetImageAsync(bitmap);
-                await PlayBeepSafeAsync(BeepType.Success);
-                return true;
+                await PlayBeepSafeAsync(BeepType.Failure);
+                return ScreenshotToClipboardOutcome.Cancelled;
             }
 
-            await PlayBeepSafeAsync(BeepType.Failure);
-            return false;
+            bool copied = await _clipboard.TrySetImageAsync(bitmap);
+            await PlayBeepSafeAsync(copied ? BeepType.Success : BeepType.Failure);
+            return copied
+                ? ScreenshotToClipboardOutcome.Copied
+                : ScreenshotToClipboardOutcome.ClipboardUnavailable;
         }
         finally
         {
@@ -156,10 +166,14 @@ public class OcrManager
                 return new(false, "Screenshot cancelled.");
             }
 
-            await _clipboard.SetImageAsync(bitmap);
+            // The reading goes ahead whatever the clipboard says, because it works from the
+            // bitmap in hand and never needed the clipboard copy. This used to throw out of
+            // here when the clipboard was busy, losing a capture the user cannot repeat —
+            // whatever was on screen has moved on (issue #360).
+            bool imageCopied = await _clipboard.TrySetImageAsync(bitmap);
             var result = await ExtractTextViaOcrAsync(order, bitmap);
             await PlayBeepSafeAsync(result.Success ? BeepType.Success : BeepType.Failure);
-            return result;
+            return imageCopied ? result : result with { ScreenshotCopyFailed = true };
         }
         finally
         {
@@ -760,7 +774,18 @@ public class OcrManager
         private const int SM_CXVIRTUALSCREEN = 78;
         private const int SM_CYVIRTUALSCREEN = 79;
 
-        private async Task<SoftwareBitmap?> CaptureScreenshotAsync()
+        /// <summary>
+        /// Puts a region-selection overlay on screen and returns what the user selected, or
+        /// null when they dismissed it.
+        /// <para>
+        /// Virtual so a test can stand in for it. Everything below this line reads the real
+        /// desktop and shows a real window, so without a seam here nothing about the two
+        /// screenshot methods could be tested at all — including what they now do when the
+        /// clipboard will not take the picture (issue #360). Issue #304 wants the same seam
+        /// for the same reason.
+        /// </para>
+        /// </summary>
+        protected virtual async Task<SoftwareBitmap?> CaptureScreenshotAsync()
         {
             // Use GetSystemMetrics to retrieve the physical pixel bounds of the virtual screen.
             // This avoids the scaling issues associated with System.Windows.Forms.SystemInformation.VirtualScreen on high-DPI displays.

--- a/Mutation.Ui/Services/OcrManager.cs
+++ b/Mutation.Ui/Services/OcrManager.cs
@@ -172,6 +172,13 @@ public class OcrManager
             // whatever was on screen has moved on (issue #360).
             bool imageCopied = await _clipboard.TrySetImageAsync(bitmap);
             var result = await ExtractTextViaOcrAsync(order, bitmap);
+
+            // The beep follows the reading, not the picture — deliberately, and unlike the plain
+            // screenshot above, which has nothing but the picture to report. Here the text is
+            // what the user asked for. Beeping failure over a picture that did not copy would
+            // tell them the reading failed, and send them off to take the whole capture again
+            // when the text they wanted is already on their clipboard. The picture gets a spoken
+            // warning instead, which is the right weight for it.
             await PlayBeepSafeAsync(result.Success ? BeepType.Success : BeepType.Failure);
             return imageCopied ? result : result with { ScreenshotCopyFailed = true };
         }

--- a/Mutation.Ui/Services/PendingUiCalls.cs
+++ b/Mutation.Ui/Services/PendingUiCalls.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Collections.Generic;
+
+namespace Mutation.Ui.Services;
+
+/// <summary>
+/// Keeps track of work handed to the UI thread that has not come back yet, so that when the UI
+/// thread stops running for good, everything still waiting can be told rather than left waiting
+/// forever.
+/// <para>
+/// This exists because accepting a piece of work is not the same as running it. A dispatcher
+/// queue takes a callback and answers "yes, queued"; if the queue shuts down before that
+/// callback's turn comes, the callback is dropped and nobody is told. Whatever was awaiting it
+/// never resumes (issue #361). This is the bookkeeping that lets the shutdown say so.
+/// </para>
+/// <para>
+/// Split from the dispatcher itself because it is the only part that can be tested. A test
+/// assembly has no UI thread and cannot create a real dispatcher queue, let alone shut one down
+/// mid-flight, so the wiring in <see cref="DispatcherQueueUiThread"/> is checked by reading it.
+/// The rules that matter — one answer per call, no leak on the normal path, and no call left
+/// waiting after a shutdown, whichever order the two arrive in — live here and are tested.
+/// </para>
+/// </summary>
+internal sealed class PendingUiCalls
+{
+	private readonly object _gate = new();
+	private readonly Dictionary<long, Action<Exception>> _pending = new();
+	private long _nextToken;
+	private Exception? _abandonReason;
+
+	/// <summary>How many calls are outstanding. For tests and diagnostics.</summary>
+	public int Count
+	{
+		get { lock (_gate) return _pending.Count; }
+	}
+
+	/// <summary>
+	/// Registers a call that is about to be handed to the UI thread, returning the token used to
+	/// release it again. <paramref name="abandon"/> is how this call is failed if the UI thread
+	/// stops before it runs; it is invoked at most once, and never while the lock is held.
+	/// <para>
+	/// Registering after the UI thread has already stopped abandons the call immediately and
+	/// returns <see cref="NotTracked"/>. Without that, a call registered in the gap between the
+	/// shutdown sweep and the queue starting to refuse work would be the one thing the sweep
+	/// could not reach.
+	/// </para>
+	/// </summary>
+	public long Track(Action<Exception> abandon)
+	{
+		if (abandon is null)
+			throw new ArgumentNullException(nameof(abandon));
+
+		Exception? alreadyOver;
+
+		lock (_gate)
+		{
+			alreadyOver = _abandonReason;
+			if (alreadyOver is null)
+			{
+				long token = ++_nextToken;
+				_pending.Add(token, abandon);
+				return token;
+			}
+		}
+
+		abandon(alreadyOver);
+		return NotTracked;
+	}
+
+	/// <summary>
+	/// The token for a call that was never tracked, because the UI thread had already stopped.
+	/// Releasing it does nothing, so callers do not have to check.
+	/// </summary>
+	public const long NotTracked = 0;
+
+	/// <summary>
+	/// Forgets a call that answered on its own. Safe to call for a token that was already
+	/// abandoned or never tracked.
+	/// </summary>
+	public void Release(long token)
+	{
+		if (token == NotTracked)
+			return;
+
+		lock (_gate)
+			_pending.Remove(token);
+	}
+
+	/// <summary>
+	/// Fails every outstanding call with <paramref name="reason"/>, and every call registered
+	/// afterwards as it arrives. There is no way back from this: once the UI thread has stopped,
+	/// it does not start again.
+	/// </summary>
+	public void AbandonAll(Exception reason)
+	{
+		if (reason is null)
+			throw new ArgumentNullException(nameof(reason));
+
+		Action<Exception>[] abandoning;
+
+		lock (_gate)
+		{
+			_abandonReason ??= reason;
+			abandoning = new Action<Exception>[_pending.Count];
+			_pending.Values.CopyTo(abandoning, 0);
+			_pending.Clear();
+		}
+
+		// Outside the lock: each of these completes a task, which can run a continuation inline,
+		// and a continuation that came back here for anything would deadlock against a lock held
+		// across the callback.
+		foreach (var abandon in abandoning)
+			abandon(reason);
+	}
+}


### PR DESCRIPTION
Closes #360. Closes #361.

## The screenshot image write had no retry (#360)

Press the screenshot shortcut while a clipboard manager or a screen reader has the clipboard open for a moment, and you got an error dialog instead of a screenshot.

`ClipboardManager.SetImageAsync` was the one asynchronous clipboard call on the class that went through neither the retry ladder nor the UI-thread hop, and it reported failure by throwing. The `CLIPBRD_E_CANT_OPEN` propagated all the way to the hotkey handler in `MainWindow`, which showed a modal dialog. This is the widest race window in the app — the picture landing on the clipboard is the very event that makes a clipboard manager or a screen reader open the clipboard to look — so the failure the fixes for the OCR clipboard copy (#341) and the one-attempt retry ladder (#352) set out to remove was still reachable one step earlier in the same operation.

It is now split the way `SetText` and `RestoreSnapshotAsync` already are: a `protected virtual SetImageAsync` that makes one attempt, and a public `TrySetImageAsync` that runs it through `RetryOnUiThreadAsync`. The issue asked whether it should keep throwing or join its siblings in returning a bool. It joins them — every other write on the class answers with a bool, and a caller that knows what it was doing can say something better than a stack trace.

That is a caller-visible change, and it reaches two places.

**`TakeScreenshotToClipboardAsync`** returned `bool`, where false meant cancelled. Three things can now happen, so it returns `ScreenshotToClipboardOutcome` — `Copied`, `Cancelled`, or `ClipboardUnavailable`. Reporting a busy clipboard as a cancellation would tell the user they cancelled a capture they did not. `MainWindow` announces all three through one shared helper, so the shortcut and the button say the same thing, and a busy clipboard is a status line rather than a modal box the user has to dismiss.

**`TakeScreenshotAndExtractTextAsync`** used to throw the whole capture away when the image write failed. That was the worst case of the lot: the reading works from the bitmap already in hand and never needed the clipboard copy, and by the time the user presses the shortcut again whatever was on screen has moved on. It now goes on and reads the text, reporting the picture's failure separately as `OcrResult.ScreenshotCopyFailed`. The two flags are independent on purpose — the text can reach the clipboard perfectly well when the picture did not, and in that case pasting is still the right thing to do.

`CaptureScreenshotAsync` becomes `protected virtual`. Everything in it reads the real desktop and shows a real window, so without a seam there nothing about either screenshot method was reachable from a test at all. Issue #304 wants the same seam for the same reason.

## A clipboard call started just before the window closes (#361)

`DispatcherQueue.TryEnqueue` returning true means the callback was accepted, not that it will ever run. A callback still sitting in the queue when the dispatcher shuts down is dropped without a word, its `TaskCompletionSource` is never completed, and whatever awaits it never resumes.

`PendingUiCalls` now tracks what is outstanding and fails all of it when the queue shuts down. Two details are deliberate and would be easy to get wrong:

- It sweeps on `ShutdownCompleted`, not `ShutdownStarting`. The queue goes on draining what it already holds after shutdown starts, so failing everything at that point would abandon calls that were about to succeed.
- A call registered *after* the sweep is failed as it arrives rather than tracked, and registration happens before the callback is handed over. Between them those close the race in both directions; the obvious ordering leaves a gap that is the same hang, moved.

Completing is `TrySetResult`/`TrySetException` throughout now, because a sweep and a callback that ran anyway can both try to answer and the first must simply win.

The issue offered a timeout as the one-line alternative. It was not taken: a timeout also fires on a UI thread that is merely busy for a while, which would turn a working clipboard write into a reported failure.

## What a user notices

For the screenshot shortcut with a free clipboard, nothing at all. With a busy one: the capture usually just works now instead of failing, and when it genuinely cannot get in, a status message says the clipboard is busy and to press the shortcut again, instead of a dialog. A screenshot-and-OCR run whose picture cannot be copied still gives you the text and says only the picture was lost. Nothing about #361 is visible to anyone — it is a leaked task at shutdown in a process that is exiting anyway, filed so the next person reading `DispatcherQueueUiThread` does not have to work it out again.

## Tests

Sixteen new tests, all passing; 2258 in the suite, none failing.

The image write is pinned as retried, with every attempt made on the UI thread, one hop requested per attempt, and a failure reported rather than thrown. The screenshot paths are pinned end to end now that the capture has a seam: copied after a brief hold, `ClipboardUnavailable` when the clipboard never lets go, `Cancelled` when nothing was captured, and the OCR path still returning its text with `ScreenshotCopyFailed` set while `ClipboardCopyFailed` stays clear.

**What is not tested, and cannot be.** `DispatcherQueueUiThread` itself needs a real WinUI dispatcher queue on a real UI thread, shut down while a call is still in it. `Mutation.Tests` can create none of those. That is why the bookkeeping is a separate class — `PendingUiCallsTests` covers one answer per call, no leak on the normal path, no call left waiting after a shutdown whichever order the two arrive in, and the first answer winning a race. The wiring in `DispatcherQueueUiThread` — register before enqueuing, release on the way out, sweep on `ShutdownCompleted` — is checked by reading it, and that limitation is written into both files rather than left to be inferred.

I also could not verify any of this against a real busy clipboard or a real closing window. Both need the app running on a desktop with a clipboard manager in the way, which an agent session cannot do.

## Documentation

New troubleshooting entry, "The screenshot could not be copied to the clipboard". The capture chapter's clipboard paragraph rewritten to cover the picture as well as the text. One existing cross-reference said "the two entries just above this one" and a third entry now sits between them, so it is named links instead. HTML rebuilt and committed alongside the Markdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
