### PR TITLE
Test the guard that refuses an OCR press, not a helper that never sees it (#365)

### DIFF
--- a/Mutation.Tests/OcrManagerTests.cs
+++ b/Mutation.Tests/OcrManagerTests.cs
@@ -185,7 +185,12 @@ public class OcrManagerTests
 	/// so the second press meets a genuinely busy manager.
 	/// </para>
 	/// </summary>
-	[Fact]
+	// The timeout is the safety net for the regression this test exists to catch. Weakening the
+	// guard fails the assertion below, but removing it altogether sends the second press into
+	// the held capture, where it waits on a release that only the end of this test performs —
+	// so without a bound the suite hangs instead of going red, which is far worse in a build
+	// that nobody is watching.
+	[Fact(Timeout = 20000)]
 	public async Task A_second_capture_while_one_is_open_is_refused_rather_than_failed()
 	{
 		using var image = new SoftwareBitmap(BitmapPixelFormat.Bgra8, 2, 2, BitmapAlphaMode.Premultiplied);
@@ -1094,7 +1099,9 @@ public class OcrManagerTests
 	/// the only thing telling the user anything.
 	/// </para>
 	/// </summary>
-	[Fact]
+	// Bounded for the same reason as the OCR-side refusal test above: remove the guard and this
+	// one waits forever on a release it can no longer reach.
+	[Fact(Timeout = 20000)]
 	public async Task TakeScreenshotToClipboardAsync_ReportsRefused_WhenACaptureIsAlreadyOnScreen()
 	{
 		using var image = new SoftwareBitmap(BitmapPixelFormat.Bgra8, 2, 2, BitmapAlphaMode.Premultiplied);

--- a/Mutation.Tests/OcrManagerTests.cs
+++ b/Mutation.Tests/OcrManagerTests.cs
@@ -177,15 +177,48 @@ public class OcrManagerTests
 	/// failed. The distinction is the whole fix: the caller reads it to decide whether to send
 	/// the configured shortcut, and used to have nothing to read but the message text
 	/// (issue #342).
+	/// <para>
+	/// Driven through the real method. It used to assert on a helper that returned the refusal,
+	/// which proved the helper's contents and nothing about the guard that is supposed to use
+	/// it — the branch could have been changed with the test still green (issue #365). Holding
+	/// the first press inside the capture is what having an overlay on screen amounts to here,
+	/// so the second press meets a genuinely busy manager.
+	/// </para>
 	/// </summary>
 	[Fact]
-	public void A_second_capture_while_one_is_open_is_refused_rather_than_failed()
+	public async Task A_second_capture_while_one_is_open_is_refused_rather_than_failed()
 	{
-		var result = OcrManager.CaptureAlreadyInProgress();
+		using var image = new SoftwareBitmap(BitmapPixelFormat.Bgra8, 2, 2, BitmapAlphaMode.Premultiplied);
+		var ocrService = new StubOcrService("recognised text");
+		var clipboard = new TestClipboard();
+		var manager = new TestableOcrManager(CreateValidSettings(), ocrService, clipboard)
+		{
+			Screenshot = image,
+			HoldCapture = true,
+		};
+
+		var firstPress = manager.TakeScreenshotAndExtractTextAsync(DefaultOrder);
+		await manager.CaptureStarted.Task;
+
+		var result = await manager.TakeScreenshotAndExtractTextAsync(DefaultOrder);
 
 		Assert.False(result.Success);
 		Assert.Equal(OcrRunOutcome.Refused, result.Outcome);
 		Assert.False(PostOperationHotkey.ShouldSendAfterOcr(result.Outcome));
+
+		// Refused means nothing ran, not that something ran and failed: no reading was asked
+		// for, nothing was written to the clipboard, and no beep claimed an outcome. The
+		// sentence in the OCR box is all the user gets, which is why it says what it says.
+		Assert.Equal("Screenshot already in progress", result.Message);
+		Assert.Equal(0, ocrService.CallCount);
+		Assert.Empty(clipboard.WriteThreadIds);
+		Assert.Equal(0, manager.BeepCount);
+
+		// And the run the user already had is unharmed by the press that was refused.
+		manager.ReleaseCapture.SetResult();
+		var firstResult = await firstPress;
+		Assert.True(firstResult.Success);
+		Assert.Equal(1, ocrService.CallCount);
 	}
 
 	/// <summary>

--- a/Mutation.Ui/Services/OcrManager.cs
+++ b/Mutation.Ui/Services/OcrManager.cs
@@ -138,30 +138,18 @@ public class OcrManager
         }
     }
 
-    /// <summary>
-    /// The answer to an OCR capture press that arrives while one is already on screen.
-    /// <para>
-    /// Refused, not failed. Nothing happened, the OCR box still holds the last run's answer,
-    /// and the thing in front of the user is the capture overlay — so the shortcut configured
-    /// to run after an OCR must not be sent, or it is typed into that overlay (issue #342).
-    /// The outcome carries that; the message used to be the only way to tell, which meant
-    /// rewording it would have quietly broken the decision.
-    /// </para>
-    /// <para>
-    /// Its own method so the outcome can be pinned by a test. Reaching this branch through
-    /// <see cref="TakeScreenshotAndExtractTextAsync"/> would need a real capture already on a
-    /// real screen (issue #304 is the same missing seam).
-    /// </para>
-    /// </summary>
-    internal static OcrResult CaptureAlreadyInProgress() =>
-        new(false, "Screenshot already in progress", OcrRunOutcome.Refused);
-
     public async Task<OcrResult> TakeScreenshotAndExtractTextAsync(OcrReadingOrder order)
     {
         if (Interlocked.CompareExchange(ref _captureInFlight, 1, 0) != 0)
         {
+            // Refused, not failed. Nothing happened, the OCR box still holds the last run's
+            // answer, and the thing in front of the user is the capture overlay — so the
+            // shortcut configured to run after an OCR must not be sent, or it is typed into
+            // that overlay (issue #342). The outcome carries that; the message used to be the
+            // only way to tell, which meant rewording it would have quietly broken the
+            // decision.
             try { _activeOverlay?.BringToFront(); } catch { }
-            return CaptureAlreadyInProgress();
+            return new(false, "Screenshot already in progress", OcrRunOutcome.Refused);
         }
         try
         {


### PR DESCRIPTION
Closes #365

## What was wrong

`OcrManager.CaptureAlreadyInProgress()` existed for one reason: so that the refusal returned when an OCR shortcut is pressed while a capture overlay is already up could be pinned by a test. Its own comment stated the justification — reaching that branch through the real method "would need a real capture already on a real screen".

That stopped being true once the region overlay got a seam. `CaptureScreenshotAsync` is `protected virtual`, `TestableOcrManager` stands in for it, and the fix for a refused screenshot press being announced as a cancellation (#363) added a hold to that double: with `HoldCapture` set the capture parks until the test releases it, which is exactly what an overlay sitting on screen amounts to here.

So the test proved less than it appeared to. Asserting on `CaptureAlreadyInProgress()` showed only that a helper returns `Refused`; nothing tied that to the guard inside `TakeScreenshotAndExtractTextAsync` that is supposed to return it. I checked rather than assumed: dropping `OcrRunOutcome.Refused` from that branch left the old test green.

That gap matters more here than on the screenshot path. `PostOperationHotkey.ShouldSendAfterOcr` reads this outcome to decide whether to send the shortcut configured to run after an OCR. An `Answered` outcome sends it, and the window with the keyboard at that moment is the capture overlay — which is the bug that made the outcome necessary in the first place (#342).

## What changed

The helper is gone and the refusal is returned inline in the guard, with the reasoning kept as a comment where the decision is made. The test now drives `TakeScreenshotAndExtractTextAsync` itself: hold the first press inside the capture, press a second time, and assert on what the real method gives back.

It also pins what "refused" means, rather than only which enum member comes out. No reading was asked for (`StubOcrService.CallCount` is zero), nothing was written to the clipboard, and no beep claimed an outcome — the sentence in the **OCR result** box is the whole of what the user gets. Finally it releases the hold and checks the run the user already had still succeeds, so a refused press is shown to leave it alone.

## Verification

Full suite: 2280 passed, 0 failed, Release, no build warnings. Same count as before — one test was rewritten, not added.

The mutation was checked in both directions. With the branch returning `new(false, "Screenshot already in progress")` — no outcome, so it defaults to `Answered` — the old test passed and the new one fails with "Expected: Refused, Actual: Answered". The test is now pinning the guard rather than restating a constant.

## Nothing changes for the user

The message, the outcome, and the suppressed after-OCR shortcut are all exactly as before. This is test quality only; there is no user-visible behaviour to document, so the guide is untouched.

## Note on the neighbouring comment

The deleted comment also said "issue #304 is the same missing seam". The seam it referred to is `CaptureScreenshotAsync`, which exists and is documented at its own definition, so nothing is lost by the deletion. The broader WinUI-test-seam issue (#304) is closed and is not affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
