### PR TITLE
Say which refusal it is, so the advice fits what is actually on screen (#367)

### DIFF
--- a/Documentation/UserGuide/html/screen-capture-and-ocr.html
+++ b/Documentation/UserGuide/html/screen-capture-and-ocr.html
@@ -170,9 +170,14 @@ depends on how far the first one had got.</p>
 is already in progress. Select a region, or press Escape to cancel it.&quot; So carry on and
 pick your rectangle, or press <strong>Esc</strong> if you would rather start over.</p>
 <p>If you had already picked your rectangle, the overlay has gone and Mutation is busy
-copying the picture, or reading it if you used <strong>Screenshot &amp; OCR</strong>. There is nothing
-for you to do, so it says &quot;A screenshot is already in progress. Wait for it to finish,
-then try again.&quot; Give it a moment and press the shortcut again.</p>
+copying the picture — or, if the capture running was a <strong>Screenshot &amp; OCR</strong>, reading it,
+which takes a few seconds. There is nothing for you to do, so it says &quot;A screenshot is
+already in progress. Wait for it to finish, then try again.&quot; Give it a moment and press
+the shortcut again.</p>
+<p>Those two sentences are what the <strong>Screenshot to clipboard</strong> shortcut says. Press a
+<strong>Screenshot &amp; OCR</strong> shortcut while a capture is running and you get a shorter answer,
+&quot;Screenshot already in progress&quot;, in the <strong>OCR result</strong> box rather than in the status
+area.</p>
 <h3 id="picking-the-rectangle-with-the-mouse">Picking the rectangle with the mouse</h3>
 <p>Hold the left mouse button down at one corner of the area you want, drag to the
 opposite corner, and let go. That is it. A right-click cancels instead.</p>

--- a/Documentation/UserGuide/html/screen-capture-and-ocr.html
+++ b/Documentation/UserGuide/html/screen-capture-and-ocr.html
@@ -163,11 +163,16 @@ overlay appears over everything. You then pick a rectangle. As soon as you finis
 picking, that rectangle is copied to your clipboard as an image, and you are back where
 you were.</p>
 <p>Press <strong>Esc</strong> at any point to cancel. Nothing is copied, and Mutation tells you so.</p>
-<p>If you press the shortcut again while the overlay is still up — easy to do if you did
-not hear the first press land — nothing new starts. Mutation brings the overlay you
-already have back to the front and says &quot;A screenshot is already in progress. Select a
-region, or press Escape to cancel it.&quot; So carry on and pick your rectangle, or press
-<strong>Esc</strong> if you would rather start over.</p>
+<p>If you press the shortcut again while a capture is already running — easy to do if you
+did not hear the first press land — nothing new starts, and what Mutation tells you
+depends on how far the first one had got.</p>
+<p>If the overlay is still up, Mutation brings it back to the front and says &quot;A screenshot
+is already in progress. Select a region, or press Escape to cancel it.&quot; So carry on and
+pick your rectangle, or press <strong>Esc</strong> if you would rather start over.</p>
+<p>If you had already picked your rectangle, the overlay has gone and Mutation is busy
+copying the picture, or reading it if you used <strong>Screenshot &amp; OCR</strong>. There is nothing
+for you to do, so it says &quot;A screenshot is already in progress. Wait for it to finish,
+then try again.&quot; Give it a moment and press the shortcut again.</p>
 <h3 id="picking-the-rectangle-with-the-mouse">Picking the rectangle with the mouse</h3>
 <p>Hold the left mouse button down at one corner of the area you want, drag to the
 opposite corner, and let go. That is it. A right-click cancels instead.</p>

--- a/Documentation/UserGuide/html/troubleshooting.html
+++ b/Documentation/UserGuide/html/troubleshooting.html
@@ -297,19 +297,27 @@ make it.</p>
 it happens every time, a clipboard manager or clipboard-history tool is the usual
 culprit; closing it or turning off its monitoring settles it.</p>
 <h3 id="mutation-says-a-screenshot-is-already-in-progress">Mutation says a screenshot is already in progress</h3>
-<p><strong>What's happening.</strong> You pressed a capture shortcut while a capture overlay was already
-on screen. Only one capture can run at a time, so the second press starts nothing.
-Mutation brings the overlay you already have back to the front and tells you so.</p>
-<p>With <strong>Screenshot to clipboard</strong> you get the message &quot;A screenshot is already in
-progress. Select a region, or press Escape to cancel it.&quot; With <strong>Screenshot &amp; OCR</strong> the
-words &quot;Screenshot already in progress&quot; appear in the <strong>OCR result</strong> box instead, and
-nothing else happens — in particular, any shortcut you set to run after an OCR is held
-back, so it cannot land in the capture overlay.</p>
-<p>Either way, the overlay has not gone anywhere. It is still there, still waiting for you
-to pick a rectangle. This is not a cancellation, and nothing has been copied or lost.</p>
-<p><strong>What to do.</strong> Carry on with the capture: pick your rectangle with the mouse or the
-keyboard as usual. If you would rather start again, press <strong>Esc</strong> to close the overlay
-first, then press the shortcut once more.</p>
+<p><strong>What's happening.</strong> You pressed a capture shortcut while a capture was already
+running. Only one can run at a time, so the second press starts nothing. This is not a
+cancellation, and nothing has been copied or lost.</p>
+<p>A capture lasts longer than the overlay does. The overlay disappears the moment you pick
+your rectangle, but Mutation is still busy after that — copying the picture to your
+clipboard, and with <strong>Screenshot &amp; OCR</strong> sending it away to be read, which can take a few
+seconds. A press that lands in that later stretch is refused too, and there is nothing on
+screen at the time.</p>
+<p>With <strong>Screenshot to clipboard</strong>, Mutation says which of the two you are in. &quot;A
+screenshot is already in progress. Select a region, or press Escape to cancel it.&quot; means
+the overlay is still up and waiting for you. &quot;A screenshot is already in progress. Wait
+for it to finish, then try again.&quot; means it has gone and the capture is finishing off.</p>
+<p>With <strong>Screenshot &amp; OCR</strong>, the words &quot;Screenshot already in progress&quot; appear in the
+<strong>OCR result</strong> box. Any shortcut you set to run after an OCR is held back, so it cannot
+land in the capture overlay. If you started the run from the <strong>Screenshot &amp; OCR</strong> button
+rather than the shortcut, the same words also appear in the status area at the top of
+the window.</p>
+<p><strong>What to do.</strong> If the overlay is still up, carry on with the capture: pick your
+rectangle with the mouse or the keyboard as usual. If you would rather start again, press
+<strong>Esc</strong> to close the overlay first, then press the shortcut once more. If you were told
+to wait, give it a moment and press the shortcut again.</p>
 <h3 id="ocr-read-the-text-but-could-not-copy-it-to-the-clipboard">OCR read the text but could not copy it to the clipboard</h3>
 <p><strong>What's happening.</strong> Only one program can have the clipboard open at a time. Just
 after a screenshot, a clipboard manager or your screen reader often opens it to look at

--- a/Documentation/UserGuide/markdown/screen-capture-and-ocr.md
+++ b/Documentation/UserGuide/markdown/screen-capture-and-ocr.md
@@ -32,9 +32,15 @@ is already in progress. Select a region, or press Escape to cancel it." So carry
 pick your rectangle, or press **Esc** if you would rather start over.
 
 If you had already picked your rectangle, the overlay has gone and Mutation is busy
-copying the picture, or reading it if you used **Screenshot & OCR**. There is nothing
-for you to do, so it says "A screenshot is already in progress. Wait for it to finish,
-then try again." Give it a moment and press the shortcut again.
+copying the picture — or, if the capture running was a **Screenshot & OCR**, reading it,
+which takes a few seconds. There is nothing for you to do, so it says "A screenshot is
+already in progress. Wait for it to finish, then try again." Give it a moment and press
+the shortcut again.
+
+Those two sentences are what the **Screenshot to clipboard** shortcut says. Press a
+**Screenshot & OCR** shortcut while a capture is running and you get a shorter answer,
+"Screenshot already in progress", in the **OCR result** box rather than in the status
+area.
 
 ### Picking the rectangle with the mouse
 

--- a/Documentation/UserGuide/markdown/screen-capture-and-ocr.md
+++ b/Documentation/UserGuide/markdown/screen-capture-and-ocr.md
@@ -23,11 +23,18 @@ you were.
 
 Press **Esc** at any point to cancel. Nothing is copied, and Mutation tells you so.
 
-If you press the shortcut again while the overlay is still up — easy to do if you did
-not hear the first press land — nothing new starts. Mutation brings the overlay you
-already have back to the front and says "A screenshot is already in progress. Select a
-region, or press Escape to cancel it." So carry on and pick your rectangle, or press
-**Esc** if you would rather start over.
+If you press the shortcut again while a capture is already running — easy to do if you
+did not hear the first press land — nothing new starts, and what Mutation tells you
+depends on how far the first one had got.
+
+If the overlay is still up, Mutation brings it back to the front and says "A screenshot
+is already in progress. Select a region, or press Escape to cancel it." So carry on and
+pick your rectangle, or press **Esc** if you would rather start over.
+
+If you had already picked your rectangle, the overlay has gone and Mutation is busy
+copying the picture, or reading it if you used **Screenshot & OCR**. There is nothing
+for you to do, so it says "A screenshot is already in progress. Wait for it to finish,
+then try again." Give it a moment and press the shortcut again.
 
 ### Picking the rectangle with the mouse
 

--- a/Documentation/UserGuide/markdown/troubleshooting.md
+++ b/Documentation/UserGuide/markdown/troubleshooting.md
@@ -182,22 +182,31 @@ culprit; closing it or turning off its monitoring settles it.
 
 ### Mutation says a screenshot is already in progress
 
-**What's happening.** You pressed a capture shortcut while a capture overlay was already
-on screen. Only one capture can run at a time, so the second press starts nothing.
-Mutation brings the overlay you already have back to the front and tells you so.
+**What's happening.** You pressed a capture shortcut while a capture was already
+running. Only one can run at a time, so the second press starts nothing. This is not a
+cancellation, and nothing has been copied or lost.
 
-With **Screenshot to clipboard** you get the message "A screenshot is already in
-progress. Select a region, or press Escape to cancel it." With **Screenshot & OCR** the
-words "Screenshot already in progress" appear in the **OCR result** box instead, and
-nothing else happens — in particular, any shortcut you set to run after an OCR is held
-back, so it cannot land in the capture overlay.
+A capture lasts longer than the overlay does. The overlay disappears the moment you pick
+your rectangle, but Mutation is still busy after that — copying the picture to your
+clipboard, and with **Screenshot & OCR** sending it away to be read, which can take a few
+seconds. A press that lands in that later stretch is refused too, and there is nothing on
+screen at the time.
 
-Either way, the overlay has not gone anywhere. It is still there, still waiting for you
-to pick a rectangle. This is not a cancellation, and nothing has been copied or lost.
+With **Screenshot to clipboard**, Mutation says which of the two you are in. "A
+screenshot is already in progress. Select a region, or press Escape to cancel it." means
+the overlay is still up and waiting for you. "A screenshot is already in progress. Wait
+for it to finish, then try again." means it has gone and the capture is finishing off.
 
-**What to do.** Carry on with the capture: pick your rectangle with the mouse or the
-keyboard as usual. If you would rather start again, press **Esc** to close the overlay
-first, then press the shortcut once more.
+With **Screenshot & OCR**, the words "Screenshot already in progress" appear in the
+**OCR result** box. Any shortcut you set to run after an OCR is held back, so it cannot
+land in the capture overlay. If you started the run from the **Screenshot & OCR** button
+rather than the shortcut, the same words also appear in the status area at the top of
+the window.
+
+**What to do.** If the overlay is still up, carry on with the capture: pick your
+rectangle with the mouse or the keyboard as usual. If you would rather start again, press
+**Esc** to close the overlay first, then press the shortcut once more. If you were told
+to wait, give it a moment and press the shortcut again.
 
 ### OCR read the text but could not copy it to the clipboard
 

--- a/Mutation.Tests/ClipboardCopyMessagesTests.cs
+++ b/Mutation.Tests/ClipboardCopyMessagesTests.cs
@@ -132,6 +132,48 @@ public class ClipboardCopyMessagesTests
 	}
 
 	/// <summary>
+	/// A refused OCR press is not announced as a failure. It used to carry the caller's failure
+	/// severity, which a screen reader turns into an aborted-action notification — said of a
+	/// press where nothing was attempted and nothing broke (issue #367).
+	/// </summary>
+	[Fact]
+	public void ARefusedOcrRunIsAnnouncedAsAWarningRatherThanAnError()
+	{
+		Assert.Equal(
+			InfoBarSeverity.Warning,
+			ClipboardCopyMessages.ForOcrRunSeverity(OcrRunOutcome.Refused, InfoBarSeverity.Error));
+	}
+
+	/// <summary>
+	/// It still interrupts, though. The user pressed a key and got no visible change, so a
+	/// polite announcement would arrive after the moment it was wanted.
+	/// </summary>
+	[Fact]
+	public void ARefusedOcrRunStillInterruptsTheScreenReader()
+	{
+		var severity = ClipboardCopyMessages.ForOcrRunSeverity(OcrRunOutcome.Refused, InfoBarSeverity.Error);
+
+		Assert.Equal(
+			AutomationNotificationProcessing.ImportantMostRecent,
+			StatusAnnouncement.GetProcessing(severity));
+	}
+
+	/// <summary>
+	/// A run that reached an answer keeps the severity its caller chose, whatever that is. Only
+	/// the refusal is quietened; quietening a real failure with the same rule would hide it.
+	/// </summary>
+	[Theory]
+	[InlineData(InfoBarSeverity.Error)]
+	[InlineData(InfoBarSeverity.Warning)]
+	[InlineData(InfoBarSeverity.Informational)]
+	public void AnOcrRunThatReachedAnAnswerKeepsTheCallersSeverity(InfoBarSeverity whenFailed)
+	{
+		Assert.Equal(
+			whenFailed,
+			ClipboardCopyMessages.ForOcrRunSeverity(OcrRunOutcome.Answered, whenFailed));
+	}
+
+	/// <summary>
 	/// Nothing is said when everything worked. The success line the caller shows afterwards is
 	/// the whole of the story then.
 	/// </summary>

--- a/Mutation.Tests/ClipboardCopyMessagesTests.cs
+++ b/Mutation.Tests/ClipboardCopyMessagesTests.cs
@@ -54,21 +54,40 @@ public class ClipboardCopyMessagesTests
 	[Fact]
 	public void ARefusedPressSaysACaptureIsAlreadyWaitingRatherThanCancelled()
 	{
-		var (message, _) = ClipboardCopyMessages.ForScreenshot(ScreenshotToClipboardOutcome.Refused);
+		var (message, _) = ClipboardCopyMessages.ForScreenshot(ScreenshotToClipboardOutcome.RefusedOverlayWaiting);
 
-		Assert.Equal(ClipboardCopyMessages.ScreenshotAlreadyInProgress, message);
+		Assert.Equal(ClipboardCopyMessages.ScreenshotOverlayWaiting, message);
 		Assert.NotEqual(ClipboardCopyMessages.ScreenshotCancelled, message);
 	}
 
 	/// <summary>
-	/// And it interrupts. The user pressed a key and saw nothing change; a polite announcement
-	/// queues behind whatever the overlay is saying and lands after the moment it was wanted.
-	/// <c>StatusAnnouncement.GetProcessing</c> promotes Warning alongside Error.
+	/// A press refused while a capture is running with no overlay gets a different sentence, and
+	/// the difference is the point. The one written for the overlay case says to select a region
+	/// and offers Escape; said here it asks for something the user cannot do, and the Escape
+	/// goes to whichever application actually has the keyboard (issue #367).
 	/// </summary>
 	[Fact]
-	public void ARefusedPressInterruptsTheScreenReader()
+	public void ARefusalWithNoOverlayNeverAsksForARegionOrOffersEscape()
 	{
-		var (_, severity) = ClipboardCopyMessages.ForScreenshot(ScreenshotToClipboardOutcome.Refused);
+		var (message, _) = ClipboardCopyMessages.ForScreenshot(ScreenshotToClipboardOutcome.RefusedCaptureRunning);
+
+		Assert.Equal(ClipboardCopyMessages.ScreenshotCaptureRunning, message);
+		Assert.NotEqual(ClipboardCopyMessages.ScreenshotOverlayWaiting, message);
+		Assert.DoesNotContain("Escape", message);
+		Assert.DoesNotContain("Select a region", message);
+	}
+
+	/// <summary>
+	/// And both interrupt. The user pressed a key and saw nothing change; a polite announcement
+	/// queues behind whatever else is being said and lands after the moment it was wanted.
+	/// <c>StatusAnnouncement.GetProcessing</c> promotes Warning alongside Error.
+	/// </summary>
+	[Theory]
+	[InlineData(ScreenshotToClipboardOutcome.RefusedOverlayWaiting)]
+	[InlineData(ScreenshotToClipboardOutcome.RefusedCaptureRunning)]
+	public void ARefusedPressInterruptsTheScreenReader(ScreenshotToClipboardOutcome outcome)
+	{
+		var (_, severity) = ClipboardCopyMessages.ForScreenshot(outcome);
 
 		Assert.Equal(InfoBarSeverity.Warning, severity);
 		Assert.Equal(
@@ -77,15 +96,15 @@ public class ClipboardCopyMessagesTests
 	}
 
 	/// <summary>
-	/// The refusal has to tell the user the overlay is still there and how to get out of it.
-	/// A sentence that only said "already in progress" would leave someone who cannot see the
-	/// screen with no idea what is now in front of them.
+	/// The overlay refusal has to tell the user the overlay is still there and how to get out of
+	/// it. A sentence that only said "already in progress" would leave someone who cannot see
+	/// the screen with no idea what is now in front of them.
 	/// </summary>
 	[Fact]
 	public void TheRefusalSaysWhatIsOnScreenAndHowToLeaveIt()
 	{
-		Assert.Contains("already in progress", ClipboardCopyMessages.ScreenshotAlreadyInProgress);
-		Assert.Contains("Escape", ClipboardCopyMessages.ScreenshotAlreadyInProgress);
+		Assert.Contains("already in progress", ClipboardCopyMessages.ScreenshotOverlayWaiting);
+		Assert.Contains("Escape", ClipboardCopyMessages.ScreenshotOverlayWaiting);
 	}
 
 	/// <summary>
@@ -101,7 +120,7 @@ public class ClipboardCopyMessagesTests
 	}
 
 	/// <summary>
-	/// An unknown outcome is announced as a cancellation — the only one of the four that is safe
+	/// An unknown outcome is announced as a cancellation — the only one of the five that is safe
 	/// to say by accident, because it claims nothing.
 	/// </summary>
 	[Fact]

--- a/Mutation.Tests/OcrManagerTests.cs
+++ b/Mutation.Tests/OcrManagerTests.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using CognitiveSupport;
+using Microsoft.UI.Xaml.Controls;
 using Mutation.Ui.Core;
 using Mutation.Ui.Services;
 using PdfSharp.Pdf;
@@ -1087,22 +1088,31 @@ public class OcrManagerTests
 	}
 
 	/// <summary>
-	/// A press that arrives while an overlay is already on screen is refused, not cancelled.
-	/// The two used to be the same value, so the user was told "Screenshot cancelled. Nothing
-	/// was copied to the clipboard." about an overlay that was still there waiting for a region
-	/// (issue #363) — the opposite of the truth for someone who cannot see it.
+	/// A press that arrives while a capture is already running is refused, not cancelled. The
+	/// two used to be the same value, so the user was told "Screenshot cancelled. Nothing was
+	/// copied to the clipboard." about a capture that was still going (issue #363) — the
+	/// opposite of the truth for someone who cannot see it.
+	/// <para>
+	/// Which refusal depends on whether an overlay is on screen, and both are exercised here
+	/// because getting that wrong is what issue #367 was: the one sentence fitted to both told
+	/// a user with no overlay to select a region that did not exist. The guard is held for far
+	/// longer than the overlay lives, so the no-overlay case is the common one, not the corner.
+	/// </para>
 	/// <para>
 	/// Driven through the real method rather than a seam: the first press is held inside the
-	/// capture, which is what having an overlay on screen amounts to here, so the second press
-	/// meets a genuinely busy manager. That also pins what the refused press does *not* do —
-	/// it writes nothing to the clipboard and plays no beep, which is why the announcement is
-	/// the only thing telling the user anything.
+	/// capture, so the second meets a genuinely busy manager. That also pins what the refused
+	/// press does *not* do — it writes nothing to the clipboard and plays no beep, which is why
+	/// the announcement is the only thing telling the user anything.
 	/// </para>
 	/// </summary>
 	// Bounded for the same reason as the OCR-side refusal test above: remove the guard and this
 	// one waits forever on a release it can no longer reach.
-	[Fact(Timeout = 20000)]
-	public async Task TakeScreenshotToClipboardAsync_ReportsRefused_WhenACaptureIsAlreadyOnScreen()
+	[Theory(Timeout = 20000)]
+	[InlineData(true, ScreenshotToClipboardOutcome.RefusedOverlayWaiting)]
+	[InlineData(false, ScreenshotToClipboardOutcome.RefusedCaptureRunning)]
+	public async Task TakeScreenshotToClipboardAsync_ReportsRefused_WhenACaptureIsAlreadyRunning(
+		bool overlayOnScreen,
+		ScreenshotToClipboardOutcome expected)
 	{
 		using var image = new SoftwareBitmap(BitmapPixelFormat.Bgra8, 2, 2, BitmapAlphaMode.Premultiplied);
 		var clipboard = new TestClipboard();
@@ -1110,6 +1120,7 @@ public class OcrManagerTests
 		{
 			Screenshot = image,
 			HoldCapture = true,
+			OverlayOnScreen = overlayOnScreen,
 		};
 
 		var firstPress = manager.TakeScreenshotToClipboardAsync();
@@ -1117,7 +1128,7 @@ public class OcrManagerTests
 
 		var secondPress = await manager.TakeScreenshotToClipboardAsync();
 
-		Assert.Equal(ScreenshotToClipboardOutcome.Refused, secondPress);
+		Assert.Equal(expected, secondPress);
 		Assert.NotEqual(ScreenshotToClipboardOutcome.Cancelled, secondPress);
 		Assert.Empty(clipboard.WriteThreadIds);
 		Assert.Equal(0, manager.BeepCount);
@@ -1128,16 +1139,34 @@ public class OcrManagerTests
 	}
 
 	/// <summary>
-	/// What the refused press is announced as. The outcome only matters because of the sentence
-	/// it produces, and that sentence must not be the cancellation one.
+	/// The refusal a user meets while a capture is running past its overlay must not offer them
+	/// a control that is not there. This is the whole of issue #367: the sentence written for
+	/// the overlay case asks for a region that does not exist, and the Escape it offers goes to
+	/// whichever application actually holds the keyboard.
 	/// </summary>
-	[Fact]
-	public void ARefusedScreenshotIsAnnouncedAsACaptureAlreadyWaiting()
+	[Fact(Timeout = 20000)]
+	public async Task ARefusalWithNoOverlayIsAnnouncedWithoutAskingForARegion()
 	{
-		var (message, _) = ClipboardCopyMessages.ForScreenshot(ScreenshotToClipboardOutcome.Refused);
+		using var image = new SoftwareBitmap(BitmapPixelFormat.Bgra8, 2, 2, BitmapAlphaMode.Premultiplied);
+		var manager = new TestableOcrManager(CreateValidSettings(), new StubOcrService(), new TestClipboard())
+		{
+			Screenshot = image,
+			HoldCapture = true,
+			OverlayOnScreen = false,
+		};
 
-		Assert.Equal(ClipboardCopyMessages.ScreenshotAlreadyInProgress, message);
-		Assert.NotEqual(ClipboardCopyMessages.ScreenshotCancelled, message);
+		var firstPress = manager.TakeScreenshotToClipboardAsync();
+		await manager.CaptureStarted.Task;
+
+		var (message, severity) = ClipboardCopyMessages.ForScreenshot(await manager.TakeScreenshotToClipboardAsync());
+
+		Assert.Equal(ClipboardCopyMessages.ScreenshotCaptureRunning, message);
+		Assert.DoesNotContain("Escape", message);
+		Assert.DoesNotContain("Select a region", message);
+		Assert.Equal(InfoBarSeverity.Warning, severity);
+
+		manager.ReleaseCapture.SetResult();
+		await firstPress;
 	}
 
 	[Fact]
@@ -1312,6 +1341,16 @@ public class OcrManagerTests
 		public TaskCompletionSource CaptureStarted { get; } = new();
 
 		public TaskCompletionSource ReleaseCapture { get; } = new();
+
+		/// <summary>
+		/// What the held capture claims is on screen. The real overlay is created and cleared
+		/// inside <c>CaptureScreenshotAsync</c>, which this class replaces wholesale, so without
+		/// standing in for the answer too a held capture always looks like one past the overlay
+		/// — and the overlay-waiting refusal could not be reached in a test at all.
+		/// </summary>
+		public bool OverlayOnScreen { get; set; }
+
+		protected override bool IsCaptureOverlayOnScreen => OverlayOnScreen;
 
 		protected override void PlayBeep(BeepType type)
 		{

--- a/Mutation.Ui/Core/ClipboardCopyMessages.cs
+++ b/Mutation.Ui/Core/ClipboardCopyMessages.cs
@@ -6,8 +6,9 @@ namespace Mutation.Ui.Core;
 /// What to tell the user about where a capture ended up — the picture, the text, or neither.
 /// <para>
 /// Pure, and out here rather than in the window, because the decisions are worth pinning: which
-/// of three outcomes a plain screenshot gets, and which of two clipboard failures is worth saying
-/// when both happened. The window can only be checked by running it.
+/// of five outcomes a plain screenshot gets, how loudly each is said, and which of two clipboard
+/// failures is worth saying when both happened. The window can only be checked by running it, so
+/// a decision left in it is a decision nothing holds in place.
 /// </para>
 /// </summary>
 public static class ClipboardCopyMessages
@@ -103,6 +104,27 @@ public static class ClipboardCopyMessages
 			ScreenshotToClipboardOutcome.Cancelled => (ScreenshotCancelled, InfoBarSeverity.Informational),
 			_ => (ScreenshotCancelled, InfoBarSeverity.Informational),
 		};
+
+	/// <summary>
+	/// How loudly to say what an unsuccessful OCR run came back with.
+	/// <para>
+	/// A refused run is not a failure, so it does not get the failure severity. It was shown as
+	/// an error, which a screen reader announces as an aborted action — for a press where
+	/// nothing was attempted and nothing went wrong. Warning still interrupts, which this needs,
+	/// without claiming the run broke, and it matches what the plain screenshot path says about
+	/// the same press (issue #367).
+	/// </para>
+	/// <para>
+	/// Out here rather than inline in the window for the reason this whole class exists: the
+	/// window cannot be checked without running it, so a decision made there is a decision that
+	/// can be undone without anything going red. That is how the wrong sentence this fix
+	/// replaced survived a green suite in the first place.
+	/// </para>
+	/// </summary>
+	/// <param name="outcome">What the run came back as.</param>
+	/// <param name="whenFailed">The severity for a run that genuinely failed.</param>
+	public static InfoBarSeverity ForOcrRunSeverity(OcrRunOutcome outcome, InfoBarSeverity whenFailed) =>
+		outcome == OcrRunOutcome.Refused ? InfoBarSeverity.Warning : whenFailed;
 
 	/// <summary>
 	/// What to say about an OCR run's clipboard writes, or null when there is nothing to say.

--- a/Mutation.Ui/Core/ClipboardCopyMessages.cs
+++ b/Mutation.Ui/Core/ClipboardCopyMessages.cs
@@ -39,8 +39,22 @@ public static class ClipboardCopyMessages
 	/// go on with the capture they started, not throw it away.
 	/// </para>
 	/// </summary>
-	public const string ScreenshotAlreadyInProgress =
+	public const string ScreenshotOverlayWaiting =
 		"A screenshot is already in progress. Select a region, or press Escape to cancel it.";
+
+	/// <summary>
+	/// Said when a screenshot press arrives while a capture is running with no overlay on screen
+	/// — during the clipboard write, or the whole reading when a screenshot-and-OCR run holds
+	/// the guard.
+	/// <para>
+	/// Both sentences used to be <see cref="ScreenshotOverlayWaiting"/>, which told the user to
+	/// select a region that did not exist and offered an Escape that would have gone to whatever
+	/// application actually had the keyboard (issue #367). It names no control at all now,
+	/// because there is none: waiting is genuinely the whole of the advice.
+	/// </para>
+	/// </summary>
+	public const string ScreenshotCaptureRunning =
+		"A screenshot is already in progress. Wait for it to finish, then try again.";
 
 	/// <summary>
 	/// Said when the text was read but the clipboard would not take it. Both halves matter: the
@@ -64,15 +78,19 @@ public static class ClipboardCopyMessages
 	/// A busy clipboard is an error and a cancellation is not, which is the distinction the
 	/// severity carries to a screen reader: an error interrupts what it is saying, and an
 	/// informational message waits its turn. Every case is named rather than left to a default,
-	/// so a fifth outcome added later is a compiler-visible gap instead of a silent
+	/// so a sixth outcome added later is a compiler-visible gap instead of a silent
 	/// "you cancelled it".
 	/// </para>
 	/// <para>
-	/// A refused press is a warning, which interrupts as an error does. Nothing failed, so it is
-	/// not an error — but the user pressed a key and got no visible change, and the sentence
-	/// telling them why is the only thing that explains the overlay still sitting in front of
-	/// them. Left polite it would queue behind whatever the overlay is saying, and arrive after
-	/// the moment it was needed.
+	/// Both refusals are warnings, which interrupt as an error does. Nothing failed, so neither
+	/// is an error — but the user pressed a key and got no visible change, and the sentence
+	/// telling them why is the only thing that explains what is or is not in front of them. Left
+	/// polite it would queue behind whatever the overlay is saying, and arrive after the moment
+	/// it was needed.
+	/// </para>
+	/// <para>
+	/// The two refusals differ only in their advice, and that is exactly why they are separate.
+	/// One sentence fitted to both told a user with no overlay to select a region (issue #367).
 	/// </para>
 	/// </summary>
 	public static (string Message, InfoBarSeverity Severity) ForScreenshot(ScreenshotToClipboardOutcome outcome) =>
@@ -80,7 +98,8 @@ public static class ClipboardCopyMessages
 		{
 			ScreenshotToClipboardOutcome.Copied => (ScreenshotCopied, InfoBarSeverity.Success),
 			ScreenshotToClipboardOutcome.ClipboardUnavailable => (ScreenshotClipboardBusy, InfoBarSeverity.Error),
-			ScreenshotToClipboardOutcome.Refused => (ScreenshotAlreadyInProgress, InfoBarSeverity.Warning),
+			ScreenshotToClipboardOutcome.RefusedOverlayWaiting => (ScreenshotOverlayWaiting, InfoBarSeverity.Warning),
+			ScreenshotToClipboardOutcome.RefusedCaptureRunning => (ScreenshotCaptureRunning, InfoBarSeverity.Warning),
 			ScreenshotToClipboardOutcome.Cancelled => (ScreenshotCancelled, InfoBarSeverity.Informational),
 			_ => (ScreenshotCancelled, InfoBarSeverity.Informational),
 		};

--- a/Mutation.Ui/Core/OcrRunOutcome.cs
+++ b/Mutation.Ui/Core/OcrRunOutcome.cs
@@ -13,10 +13,16 @@ public enum OcrRunOutcome
 	Answered,
 
 	/// <summary>
-	/// The run never started, because a capture was already on screen. Nothing changed, there
-	/// is no new answer in the OCR box, and the full-screen capture overlay still has the
-	/// keyboard — so a shortcut sent now would land in the overlay rather than anywhere it was
-	/// aimed (issue #342).
+	/// The run never started, because a capture was already under way. Nothing changed and
+	/// there is no new answer in the OCR box, so the shortcut has nothing to act on — and when
+	/// the capture is still at its overlay, that overlay has the keyboard, so a shortcut sent
+	/// now would land in it rather than anywhere it was aimed (issue #342).
+	/// <para>
+	/// Withheld either way. A capture past its overlay has no keyboard to steal, but it also has
+	/// no new answer to read, so sending the shortcut would aim a screen-reader command at the
+	/// previous run's text. One value covers both because the answer is the same; the plain
+	/// screenshot path splits its refusal in two because there the advice differs (issue #367).
+	/// </para>
 	/// </summary>
 	Refused,
 }

--- a/Mutation.Ui/Core/ScreenshotToClipboardOutcome.cs
+++ b/Mutation.Ui/Core/ScreenshotToClipboardOutcome.cs
@@ -4,11 +4,17 @@ namespace Mutation.Ui.Core;
 /// What became of a plain screenshot capture — the one whose only product is a picture on the
 /// clipboard.
 /// <para>
-/// Four answers, not two, because neither a busy clipboard nor a refused press is a
+/// Five answers, not two, because neither a busy clipboard nor a refused press is a
 /// cancellation. A busy clipboard used to reach the caller as a thrown exception and an error
 /// dialog, which is the wrong weight for something that clears on its own within a second
 /// (issue #360), and reporting either of them as a cancellation tells the user they cancelled
 /// something they did not.
+/// </para>
+/// <para>
+/// A refused press splits in two because the user's situation splits in two. A capture holds
+/// the guard from the moment it starts until the picture is on the clipboard, but the overlay
+/// is on screen for only the first part of that. Telling someone with no overlay in front of
+/// them to select a region is an instruction they cannot follow (issue #367).
 /// </para>
 /// </summary>
 public enum ScreenshotToClipboardOutcome
@@ -41,10 +47,22 @@ public enum ScreenshotToClipboardOutcome
 	/// <para>
 	/// Its own value rather than <see cref="Cancelled"/>, because the two are opposite news for
 	/// someone who cannot see the screen: cancelled says the overlay has gone, refused says it
-	/// is still in front of them and wants a selection. Named to match
-	/// <c>OcrRunOutcome.Refused</c>, which the screenshot-and-OCR path has told apart from a
-	/// real cancellation since issue #342.
+	/// is still in front of them and wants a selection.
 	/// </para>
 	/// </summary>
-	Refused,
+	RefusedOverlayWaiting,
+
+	/// <summary>
+	/// The press arrived while a capture was running but past the point of showing an overlay —
+	/// during the crop, the clipboard write and its retries, or the whole reading when the
+	/// capture that holds the guard is a screenshot-and-OCR run. It started nothing, and there
+	/// is nothing on screen for the user to do anything with.
+	/// <para>
+	/// Split from <see cref="RefusedOverlayWaiting"/> because the advice differs and the wrong
+	/// half is actively harmful. "Select a region, or press Escape to cancel it" cannot be
+	/// followed when no overlay exists, and the Escape it invites goes to whatever application
+	/// actually holds the keyboard (issue #367). All the user can usefully do is wait.
+	/// </para>
+	/// </summary>
+	RefusedCaptureRunning,
 }

--- a/Mutation.Ui/Core/ScreenshotToClipboardOutcome.cs
+++ b/Mutation.Ui/Core/ScreenshotToClipboardOutcome.cs
@@ -24,7 +24,7 @@ public enum ScreenshotToClipboardOutcome
 	/// and nothing on the clipboard changed.
 	/// <para>
 	/// First, so that it is what <c>default</c> gives. Nothing happened is the only one of the
-	/// four that is safe to say by accident: a zero value meaning <see cref="Copied"/> would
+	/// five that is safe to say by accident: a zero value meaning <see cref="Copied"/> would
 	/// let a value nobody set announce a screenshot that was never taken, which is the exact
 	/// thing this enum exists to prevent. Nothing may be inserted in front of it.
 	/// </para>

--- a/Mutation.Ui/MainWindow.xaml.cs
+++ b/Mutation.Ui/MainWindow.xaml.cs
@@ -3604,15 +3604,13 @@ public sealed partial class MainWindow : Window, IDisposable
 			return;
 		}
 
-		// A refused run is not a failure, so it does not get the failure severity. It was shown
-		// as an error, which a screen reader announces as an aborted action — for something
-		// where nothing was attempted and nothing went wrong. Warning still interrupts, which
-		// this needs, without claiming the run broke. It also matches what the plain screenshot
-		// path says about the same press (issue #367).
+		// Which severity, and why, is decided by ClipboardCopyMessages — a refused run is not a
+		// failure and must not be announced as one (issue #367). Kept out here so it is pinned
+		// by a test rather than by whoever next reads this line.
 		ShowStatus(
 			statusTitle,
 			result.Message,
-			result.Outcome == OcrRunOutcome.Refused ? InfoBarSeverity.Warning : failureSeverity);
+			ClipboardCopyMessages.ForOcrRunSeverity(result.Outcome, failureSeverity));
 	}
 
 	/// <summary>

--- a/Mutation.Ui/MainWindow.xaml.cs
+++ b/Mutation.Ui/MainWindow.xaml.cs
@@ -3531,7 +3531,7 @@ public sealed partial class MainWindow : Window, IDisposable
 	}
 
 	/// <summary>
-	/// Says which of the three things a plain screenshot capture did. Shared by the shortcut and
+	/// Says which of the five things a plain screenshot capture did. Shared by the shortcut and
 	/// the button, so both tell the user the same thing.
 	/// <para>
 	/// A busy clipboard is a status line, not an error dialog. It used to be a dialog, because
@@ -3599,9 +3599,20 @@ public sealed partial class MainWindow : Window, IDisposable
 			return;
 
 		if (result.Success)
+		{
 			ShowStatus(statusTitle, successMessage ?? string.Empty, InfoBarSeverity.Success);
-		else
-			ShowStatus(statusTitle, result.Message, failureSeverity);
+			return;
+		}
+
+		// A refused run is not a failure, so it does not get the failure severity. It was shown
+		// as an error, which a screen reader announces as an aborted action — for something
+		// where nothing was attempted and nothing went wrong. Warning still interrupts, which
+		// this needs, without claiming the run broke. It also matches what the plain screenshot
+		// path says about the same press (issue #367).
+		ShowStatus(
+			statusTitle,
+			result.Message,
+			result.Outcome == OcrRunOutcome.Refused ? InfoBarSeverity.Warning : failureSeverity);
 	}
 
 	/// <summary>

--- a/Mutation.Ui/Services/OcrManager.cs
+++ b/Mutation.Ui/Services/OcrManager.cs
@@ -98,18 +98,22 @@ public class OcrManager
     /// <summary>
     /// Whether a region-selection overlay is on screen right now.
     /// <para>
-    /// A snapshot, and deliberately so. The field is set and cleared by the capture running on
-    /// the UI thread, so a refused press can only ever read where that capture had got to a
-    /// moment ago. That is as good as this can be: the honest question is what the user is
-    /// looking at when they are told, and the answer moves whatever we do. What matters is that
-    /// the window in which it can be wrong is now microseconds rather than the whole clipboard
-    /// write and reading (issue #367).
+    /// Exact rather than approximate, though only because of where it is read from. The field is
+    /// written by the capture running on the UI thread, and both callers of the guard that reads
+    /// it are UI-thread hotkey and click handlers, so reader and writer never run at once and
+    /// the answer cannot be stale. Nothing enforces that beyond the callers themselves — take
+    /// this guard off the UI thread and the read becomes a genuine race.
     /// </para>
     /// <para>
     /// Virtual because <see cref="CaptureScreenshotAsync"/> is the only thing that sets the
     /// field, and a test stands in for that wholesale — so without this seam the overlay-waiting
     /// case could not be reached in a test at all, which is how the wrong sentence went out
     /// covered by a green suite.
+    /// </para>
+    /// <para>
+    /// The cost of the seam is that this line is the one thing here no test covers: every test
+    /// overrides it, so inverting the condition breaks nothing. What the tests hold is that the
+    /// guard asks this question and says the right thing about each answer.
     /// </para>
     /// </summary>
     protected virtual bool IsCaptureOverlayOnScreen => _activeOverlay is not null;
@@ -138,6 +142,16 @@ public class OcrManager
             // someone with nothing on screen to select a region is an instruction they cannot
             // follow, and the Escape it offers would go to whatever application actually has
             // the keyboard (issue #367).
+            //
+            // The guard also runs ahead of the overlay, between taking the flag and putting the
+            // overlay up, and that stretch must stay unreachable — a press answered there would
+            // say "wait" moments before an overlay appeared asking for a rectangle, which is
+            // this same bug inverted and lands on the commonest mistiming of all, the quick
+            // double press. It is unreachable today only because that stretch never yields:
+            // CaptureScreenshotAsync grabs the screen and prepares the window synchronously,
+            // and RegionSelectionWindow.InitializeAsync returns an already-completed task, so
+            // the message pump cannot deliver a second press until the overlay is up. Give that
+            // method a real await and this opens with nothing going red.
             bool overlayWaiting = IsCaptureOverlayOnScreen;
             try { _activeOverlay?.BringToFront(); } catch { }
             return overlayWaiting

--- a/Mutation.Ui/Services/OcrManager.cs
+++ b/Mutation.Ui/Services/OcrManager.cs
@@ -96,12 +96,32 @@ public class OcrManager
     }
 
     /// <summary>
-    /// Captures a region and puts it on the clipboard, saying which of the four things
+    /// Whether a region-selection overlay is on screen right now.
+    /// <para>
+    /// A snapshot, and deliberately so. The field is set and cleared by the capture running on
+    /// the UI thread, so a refused press can only ever read where that capture had got to a
+    /// moment ago. That is as good as this can be: the honest question is what the user is
+    /// looking at when they are told, and the answer moves whatever we do. What matters is that
+    /// the window in which it can be wrong is now microseconds rather than the whole clipboard
+    /// write and reading (issue #367).
+    /// </para>
+    /// <para>
+    /// Virtual because <see cref="CaptureScreenshotAsync"/> is the only thing that sets the
+    /// field, and a test stands in for that wholesale — so without this seam the overlay-waiting
+    /// case could not be reached in a test at all, which is how the wrong sentence went out
+    /// covered by a green suite.
+    /// </para>
+    /// </summary>
+    protected virtual bool IsCaptureOverlayOnScreen => _activeOverlay is not null;
+
+    /// <summary>
+    /// Captures a region and puts it on the clipboard, saying which of the five things
     /// happened. Callers must not announce success unconditionally — for a blind user,
     /// "Screenshot copied to the clipboard" after a cancelled capture is worse than silence,
-    /// and so is it after a capture the clipboard would not take. Nor may they treat a press
-    /// refused because an overlay is already up as a cancellation: that one tells the user the
-    /// overlay has gone when it is still in front of them (issue #363).
+    /// and so is it after a capture the clipboard would not take. Nor may they treat a refused
+    /// press as a cancellation, which tells the user a capture has gone when it has not
+    /// (issue #363), or run the two refusals together, which offers a control that is only
+    /// there for one of them (issue #367).
     /// </summary>
     public async Task<ScreenshotToClipboardOutcome> TakeScreenshotToClipboardAsync()
     {
@@ -111,8 +131,18 @@ public class OcrManager
             // "Screenshot cancelled. Nothing was copied to the clipboard." about an overlay
             // that was still on screen waiting for them (issue #363) — the opposite of the
             // truth for someone who cannot see it.
+            //
+            // Which refusal depends on whether there is an overlay, because the guard outlives
+            // it: it is held through the crop, the clipboard write and its retries, and — when
+            // the capture holding it is a screenshot-and-OCR run — the entire reading. Telling
+            // someone with nothing on screen to select a region is an instruction they cannot
+            // follow, and the Escape it offers would go to whatever application actually has
+            // the keyboard (issue #367).
+            bool overlayWaiting = IsCaptureOverlayOnScreen;
             try { _activeOverlay?.BringToFront(); } catch { }
-            return ScreenshotToClipboardOutcome.Refused;
+            return overlayWaiting
+                ? ScreenshotToClipboardOutcome.RefusedOverlayWaiting
+                : ScreenshotToClipboardOutcome.RefusedCaptureRunning;
         }
         try
         {


### PR DESCRIPTION
Closes #367

## What was wrong

A press refused because a capture was already running always got the same sentence: "A screenshot is already in progress. Select a region, or press Escape to cancel it."

That is true only while the overlay is up, and the overlay is up for a small part of a capture. `_captureInFlight` is held from the first press until the picture is on the clipboard; `_activeOverlay` is cleared the moment a region is picked. Everything after that — the crop, the clipboard write with its retry ladder, and on the screenshot-and-OCR path the entire Azure reading, which takes seconds — still counts as in progress with nothing on screen.

So the common case was the false one. A user who cannot see the screen was told to select a region that did not exist, and offered an Escape that would have gone to whichever application actually held the keyboard. The wording it replaced ("Screenshot cancelled") was also wrong, but passive; this one is an instruction you can act on and be misled by.

## What changed

The refusal splits in two, because the user's situation splits in two.

`RefusedOverlayWaiting` keeps the existing sentence, which is right when there is an overlay to act on. `RefusedCaptureRunning` gets its own: "A screenshot is already in progress. Wait for it to finish, then try again." It names no control, because there is none — waiting genuinely is the whole of the advice. Both stay `Warning`, so both still interrupt the screen reader; nothing failed in either case.

The guard picks between them through `IsCaptureOverlayOnScreen`, a `protected virtual` property rather than a bare field read. That is not ceremony. `CaptureScreenshotAsync` is the only thing that sets `_activeOverlay`, and the test double replaces it wholesale, so without a seam the overlay-waiting case cannot be reached in a test at all — which is exactly how the wrong sentence shipped under a green suite. The double now supplies the answer and both branches are driven through the real method.

The read is a snapshot and cannot be otherwise, since the capture moves on while the refused press is being answered. The point is that the window in which the sentence can be stale shrinks from an entire clipboard write and reading down to microseconds.

## Two related fixes the issue asked for

A refused OCR run was shown at `Error` severity, which a screen reader announces as an aborted action — for something where nothing was attempted and nothing broke. `PublishOcrResult` now picks `Warning` for a refused outcome, matching the screenshot path and still interrupting.

The guide said the overlay "has not gone anywhere" and that on the OCR path "nothing else happens". Neither held. It now explains that a capture outlives its overlay, gives both sentences and when each appears, and says that the **Screenshot & OCR** *button* also raises a status line where the shortcut does not.

## Tests

The refusal test became a theory covering both overlay states, driven through `TakeScreenshotToClipboardAsync` itself, and a further test asserts that the no-overlay sentence never asks for a region and never offers Escape — the two specific falsehoods this fixes. On the message side, both refusals are pinned to their own sentence and both to `Warning`.

Verified by mutation: forcing the guard to always report an overlay fails both the outcome assertion ("Expected: RefusedCaptureRunning, Actual: RefusedOverlayWaiting") and the sentence assertion, so it is the user-visible text that is pinned and not just an enum member.

Full suite: 2283 passed, 0 failed, Release, zero build warnings.

## Also swept

A test in `OcrManagerTests` that duplicated a `ClipboardCopyMessagesTests` test assertion for assertion while exercising no `OcrManager` code has gone; both were rewritten by this change anyway. A doc comment in `MainWindow` still counting three outcomes now says five. Both were listed in the follow-up debt item (#368), which keeps the rest.

## Not verified

Nothing here exercises the real overlay. `IsCaptureOverlayOnScreen` is now the seam, so what a test proves is that the guard asks the right question and says the right thing about each answer — not that `_activeOverlay` tracks the real window faithfully. That, and whether the announcement actually interrupts ZoomText, need a human at the keyboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
