### PR TITLE
Put the mouse pointer back where the capture found it (#371)

### DIFF
--- a/Documentation/UserGuide/html/screen-capture-and-ocr.html
+++ b/Documentation/UserGuide/html/screen-capture-and-ocr.html
@@ -178,14 +178,13 @@ the shortcut again.</p>
 <strong>Screenshot &amp; OCR</strong> shortcut while a capture is running and you get a shorter answer,
 &quot;Screenshot already in progress&quot;, in the <strong>OCR result</strong> box rather than in the status
 area.</p>
+<p>Your mouse pointer stays put through all of this. Whatever it was resting on when you
+pressed the shortcut, it is still there when the overlay opens and still there when the
+overlay goes away. So you can pick the rectangle with the mouse or the keyboard, either
+way, without the pointer wandering off first.</p>
 <h3 id="picking-the-rectangle-with-the-mouse">Picking the rectangle with the mouse</h3>
 <p>Hold the left mouse button down at one corner of the area you want, drag to the
 opposite corner, and let go. That is it. A right-click cancels instead.</p>
-<p>The mouse pointer stays put throughout. Whatever you were pointing at when you pressed
-the shortcut is still under the pointer when the overlay comes up, so you can start
-dragging straight away. When you let go, the pointer stays exactly where you released
-it as the overlay disappears. Some magnifiers and screen readers move the pointer
-whenever a new window takes over, and Mutation puts it back.</p>
 <h3 id="picking-the-rectangle-with-the-keyboard">Picking the rectangle with the keyboard</h3>
 <p>You never need to see the screen to do this. The overlay talks you through it. When it
 opens it says what it wants from you, then as you move it announces the position you

--- a/Documentation/UserGuide/html/screen-capture-and-ocr.html
+++ b/Documentation/UserGuide/html/screen-capture-and-ocr.html
@@ -181,6 +181,11 @@ area.</p>
 <h3 id="picking-the-rectangle-with-the-mouse">Picking the rectangle with the mouse</h3>
 <p>Hold the left mouse button down at one corner of the area you want, drag to the
 opposite corner, and let go. That is it. A right-click cancels instead.</p>
+<p>The mouse pointer stays put throughout. Whatever you were pointing at when you pressed
+the shortcut is still under the pointer when the overlay comes up, so you can start
+dragging straight away. When you let go, the pointer stays exactly where you released
+it as the overlay disappears. Some magnifiers and screen readers move the pointer
+whenever a new window takes over, and Mutation puts it back.</p>
 <h3 id="picking-the-rectangle-with-the-keyboard">Picking the rectangle with the keyboard</h3>
 <p>You never need to see the screen to do this. The overlay talks you through it. When it
 opens it says what it wants from you, then as you move it announces the position you

--- a/Documentation/UserGuide/markdown/screen-capture-and-ocr.md
+++ b/Documentation/UserGuide/markdown/screen-capture-and-ocr.md
@@ -47,6 +47,12 @@ area.
 Hold the left mouse button down at one corner of the area you want, drag to the
 opposite corner, and let go. That is it. A right-click cancels instead.
 
+The mouse pointer stays put throughout. Whatever you were pointing at when you pressed
+the shortcut is still under the pointer when the overlay comes up, so you can start
+dragging straight away. When you let go, the pointer stays exactly where you released
+it as the overlay disappears. Some magnifiers and screen readers move the pointer
+whenever a new window takes over, and Mutation puts it back.
+
 ### Picking the rectangle with the keyboard
 
 You never need to see the screen to do this. The overlay talks you through it. When it

--- a/Documentation/UserGuide/markdown/screen-capture-and-ocr.md
+++ b/Documentation/UserGuide/markdown/screen-capture-and-ocr.md
@@ -42,16 +42,15 @@ Those two sentences are what the **Screenshot to clipboard** shortcut says. Pres
 "Screenshot already in progress", in the **OCR result** box rather than in the status
 area.
 
+Your mouse pointer stays put through all of this. Whatever it was resting on when you
+pressed the shortcut, it is still there when the overlay opens and still there when the
+overlay goes away. So you can pick the rectangle with the mouse or the keyboard, either
+way, without the pointer wandering off first.
+
 ### Picking the rectangle with the mouse
 
 Hold the left mouse button down at one corner of the area you want, drag to the
 opposite corner, and let go. That is it. A right-click cancels instead.
-
-The mouse pointer stays put throughout. Whatever you were pointing at when you pressed
-the shortcut is still under the pointer when the overlay comes up, so you can start
-dragging straight away. When you let go, the pointer stays exactly where you released
-it as the overlay disappears. Some magnifiers and screen readers move the pointer
-whenever a new window takes over, and Mutation puts it back.
 
 ### Picking the rectangle with the keyboard
 

--- a/Mutation.Tests/CursorAnchorTests.cs
+++ b/Mutation.Tests/CursorAnchorTests.cs
@@ -200,6 +200,87 @@ public class CursorAnchorTests
 	}
 
 	[Fact]
+	public void LateRestoreFromAFinishedCapture_CannotMoveTheNextCapturesPointer()
+	{
+		// The overlay window is created once and reused, so one anchor serves every capture the
+		// app makes. A restore deferred by one capture — onto a dispatcher turn, or onto the
+		// continuation that waits for the foreground to be handed back — could still be pending
+		// when the next capture starts. Without the stamp it would haul the pointer back to the
+		// previous capture's position, which is the very jump this feature exists to prevent.
+		var cursor = new FakeCursor(400, 300);
+		var anchor = new CursorAnchor(cursor);
+
+		anchor.Capture();
+		int firstCapture = anchor.Generation;
+
+		// The next capture begins, from somewhere else entirely.
+		cursor.Position = new CursorPoint(1200, 800);
+		anchor.Capture();
+
+		cursor.Position = new CursorPoint(1210, 805);
+		Assert.False(anchor.RestoreIfCurrent(firstCapture));
+		Assert.Empty(cursor.Writes);
+
+		// The live anchor still works.
+		Assert.True(anchor.RestoreIfCurrent(anchor.Generation));
+		Assert.Equal(new CursorPoint(1200, 800), cursor.Position);
+	}
+
+	[Fact]
+	public void LateTidyUpFromAFinishedCapture_DoesNotThrowAwayTheNextCapturesAnchor()
+	{
+		var cursor = new FakeCursor(400, 300);
+		var anchor = new CursorAnchor(cursor);
+
+		anchor.Capture();
+		int firstCapture = anchor.Generation;
+
+		cursor.Position = new CursorPoint(1200, 800);
+		anchor.Capture();
+
+		anchor.ClearIfCurrent(firstCapture);
+
+		Assert.True(anchor.HasAnchor);
+		Assert.Equal(new CursorPoint(1200, 800), anchor.Anchor);
+	}
+
+	[Fact]
+	public void ClearEndsTheGeneration_SoNothingStillPendingCanRestore()
+	{
+		var cursor = new FakeCursor(400, 300);
+		var anchor = new CursorAnchor(cursor);
+
+		anchor.Capture();
+		int generation = anchor.Generation;
+		anchor.Clear();
+
+		cursor.Position = new CursorPoint(10, 10);
+		Assert.False(anchor.RestoreIfCurrent(generation));
+		Assert.Empty(cursor.Writes);
+	}
+
+	[Fact]
+	public void FailedCaptureStillEndsTheGeneration()
+	{
+		// A capture that could not read the pointer replaces the anchor with nothing. Work
+		// deferred by the previous capture must not carry on defending the old position through
+		// the gap.
+		var cursor = new FakeCursor(400, 300);
+		var anchor = new CursorAnchor(cursor);
+
+		anchor.Capture();
+		int firstCapture = anchor.Generation;
+
+		cursor.CanRead = false;
+		Assert.False(anchor.Capture());
+
+		cursor.CanRead = true;
+		cursor.Position = new CursorPoint(10, 10);
+		Assert.False(anchor.RestoreIfCurrent(firstCapture));
+		Assert.Empty(cursor.Writes);
+	}
+
+	[Fact]
 	public void CapturedAnchorIsReadable()
 	{
 		var cursor = new FakeCursor(-1920, 40);

--- a/Mutation.Tests/CursorAnchorTests.cs
+++ b/Mutation.Tests/CursorAnchorTests.cs
@@ -1,0 +1,213 @@
+using Mutation.Ui.Core;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Mutation.Tests;
+
+/// <summary>
+/// The rules that keep the mouse pointer where the user left it while a screen capture opens
+/// and closes its full-screen overlay (issue #371). Two of them carry the whole feature: put
+/// the pointer back when something else has moved it, and leave it completely alone when
+/// nothing has.
+/// </summary>
+public class CursorAnchorTests
+{
+	/// <summary>
+	/// A pointer that only exists in the test. Records every write, so a test can assert not
+	/// just where the pointer ended up but whether it was written to at all — which is the
+	/// difference between "put back" and "left alone".
+	/// </summary>
+	private sealed class FakeCursor : ICursorPosition
+	{
+		public CursorPoint Position;
+		public bool CanRead = true;
+		public bool WriteSucceeds = true;
+		public List<CursorPoint> Writes { get; } = new();
+		public int Reads { get; private set; }
+
+		public FakeCursor(int x = 0, int y = 0) => Position = new CursorPoint(x, y);
+
+		public bool TryGet(out CursorPoint position)
+		{
+			Reads++;
+			if (!CanRead)
+			{
+				position = default;
+				return false;
+			}
+
+			position = Position;
+			return true;
+		}
+
+		public bool TrySet(CursorPoint position)
+		{
+			Writes.Add(position);
+			if (!WriteSucceeds)
+				return false;
+
+			Position = position;
+			return true;
+		}
+	}
+
+	[Fact]
+	public void NullCursor_IsRejectedAtConstruction()
+	{
+		Assert.Throws<ArgumentNullException>(() => new CursorAnchor(null!));
+	}
+
+	[Fact]
+	public void PointerMovedWhileTheOverlayOpened_IsPutBackWhereItWas()
+	{
+		var cursor = new FakeCursor(400, 300);
+		var anchor = new CursorAnchor(cursor);
+
+		anchor.Capture();
+		// Something following focus drags the pointer to the middle of the new window.
+		cursor.Position = new CursorPoint(960, 540);
+
+		Assert.True(anchor.Restore());
+		Assert.Equal(new CursorPoint(400, 300), cursor.Position);
+	}
+
+	[Fact]
+	public void PointerThatNeverMoved_IsNotWrittenToAtAll()
+	{
+		var cursor = new FakeCursor(400, 300);
+		var anchor = new CursorAnchor(cursor);
+
+		anchor.Capture();
+
+		// Writing the same coordinates back would still raise a mouse-move message, which is
+		// enough to cancel a hover or disturb a drag. Doing nothing has to mean doing nothing.
+		Assert.False(anchor.Restore());
+		Assert.Empty(cursor.Writes);
+	}
+
+	[Fact]
+	public void RestoreWithoutACapture_DoesNothing()
+	{
+		var cursor = new FakeCursor(400, 300);
+		var anchor = new CursorAnchor(cursor);
+
+		Assert.False(anchor.HasAnchor);
+		Assert.False(anchor.Restore());
+		Assert.Empty(cursor.Writes);
+	}
+
+	[Fact]
+	public void AnchorSurvivesRestore_SoASecondJumpIsAlsoUndone()
+	{
+		// The capture restores twice on the way in — inline, then on the next dispatcher turn,
+		// because whatever follows focus reacts after the activation call has returned.
+		var cursor = new FakeCursor(400, 300);
+		var anchor = new CursorAnchor(cursor);
+
+		anchor.Capture();
+		cursor.Position = new CursorPoint(10, 10);
+		Assert.True(anchor.Restore());
+
+		cursor.Position = new CursorPoint(20, 20);
+		Assert.True(anchor.Restore());
+
+		Assert.Equal(new CursorPoint(400, 300), cursor.Position);
+		Assert.Equal(2, cursor.Writes.Count);
+	}
+
+	[Fact]
+	public void SecondCaptureReplacesTheFirst()
+	{
+		// One anchor serves the whole capture: opened at the hotkey press, re-read when the
+		// selection ends so the pointer goes back to where the drag was released, not to where
+		// it started.
+		var cursor = new FakeCursor(400, 300);
+		var anchor = new CursorAnchor(cursor);
+
+		anchor.Capture();
+		cursor.Position = new CursorPoint(800, 600);
+		anchor.Capture();
+
+		cursor.Position = new CursorPoint(0, 0);
+		Assert.True(anchor.Restore());
+		Assert.Equal(new CursorPoint(800, 600), cursor.Position);
+	}
+
+	[Fact]
+	public void PositionThatCannotBeRead_LeavesNothingToRestoreTo()
+	{
+		var cursor = new FakeCursor(400, 300) { CanRead = false };
+		var anchor = new CursorAnchor(cursor);
+
+		Assert.False(anchor.Capture());
+		Assert.False(anchor.HasAnchor);
+
+		cursor.CanRead = true;
+		cursor.Position = new CursorPoint(10, 10);
+
+		// A capture that read nothing must not send the pointer to a stale or default place.
+		Assert.False(anchor.Restore());
+		Assert.Empty(cursor.Writes);
+	}
+
+	[Fact]
+	public void PositionThatCannotBeReadAtRestoreTime_IsNotOverwrittenBlindly()
+	{
+		var cursor = new FakeCursor(400, 300);
+		var anchor = new CursorAnchor(cursor);
+
+		anchor.Capture();
+		cursor.CanRead = false;
+
+		// Not knowing where the pointer is, is not a reason to move it.
+		Assert.False(anchor.Restore());
+		Assert.Empty(cursor.Writes);
+	}
+
+	[Fact]
+	public void RefusedWrite_IsReportedAsNoMove()
+	{
+		// The caller redraws the crosshair only when the pointer really moved, so a refused
+		// write has to read as "nothing happened".
+		var cursor = new FakeCursor(400, 300) { WriteSucceeds = false };
+		var anchor = new CursorAnchor(cursor);
+
+		anchor.Capture();
+		cursor.Position = new CursorPoint(10, 10);
+
+		Assert.False(anchor.Restore());
+		Assert.Single(cursor.Writes);
+		Assert.Equal(new CursorPoint(10, 10), cursor.Position);
+	}
+
+	[Fact]
+	public void ClearedAnchor_IsNoLongerDefended()
+	{
+		// Once the capture is over the pointer belongs to the user, and a later stray restore
+		// must not haul it back.
+		var cursor = new FakeCursor(400, 300);
+		var anchor = new CursorAnchor(cursor);
+
+		anchor.Capture();
+		anchor.Clear();
+		Assert.False(anchor.HasAnchor);
+
+		cursor.Position = new CursorPoint(10, 10);
+		Assert.False(anchor.Restore());
+		Assert.Empty(cursor.Writes);
+		Assert.Equal(new CursorPoint(10, 10), cursor.Position);
+	}
+
+	[Fact]
+	public void CapturedAnchorIsReadable()
+	{
+		var cursor = new FakeCursor(-1920, 40);
+		var anchor = new CursorAnchor(cursor);
+
+		Assert.True(anchor.Capture());
+		Assert.True(anchor.HasAnchor);
+		// Negative coordinates are ordinary: a monitor left of the primary one has them.
+		Assert.Equal(new CursorPoint(-1920, 40), anchor.Anchor);
+	}
+}

--- a/Mutation.Tests/CursorRestorePolicyTests.cs
+++ b/Mutation.Tests/CursorRestorePolicyTests.cs
@@ -1,0 +1,54 @@
+using Mutation.Ui.Core;
+using Xunit;
+
+namespace Mutation.Tests;
+
+/// <summary>
+/// How far a deferred pointer restore may go once the user has started choosing a region
+/// (issue #371). The rule these pin is that putting the pointer back and restarting the
+/// selection are two different things, and only the first is safe mid-selection.
+/// </summary>
+public class CursorRestorePolicyTests
+{
+	[Fact]
+	public void NothingStartedYet_PointerGoesBackAndTheCrosshairFollowsIt()
+	{
+		// The ordinary case: the overlay has just opened, so there is no selection to protect
+		// and the crosshair should be redrawn wherever the pointer really ended up.
+		Assert.Equal(
+			DeferredCursorRestore.MoveAndReseed,
+			CursorRestorePolicy.Decide(dragInFlight: false, keyboardCornerPinned: false));
+	}
+
+	[Fact]
+	public void DragInFlight_NothingIsTouched()
+	{
+		// A button is down and a rectangle is being dragged out. Moving the pointer would
+		// redraw the user's rectangle from under them.
+		Assert.Equal(
+			DeferredCursorRestore.StandDown,
+			CursorRestorePolicy.Decide(dragInFlight: true, keyboardCornerPinned: false));
+	}
+
+	[Fact]
+	public void KeyboardCornerPinned_PointerGoesBackButTheSelectionSurvives()
+	{
+		// The case that made this rule worth naming. A second hotkey press on a capture that is
+		// already running brings the overlay forward, which runs a restore — and re-seeding
+		// there would clear the pinned corner without saying so, leaving someone who cannot see
+		// the overlay to press Enter and pin a fresh corner instead of capturing.
+		Assert.Equal(
+			DeferredCursorRestore.MoveOnly,
+			CursorRestorePolicy.Decide(dragInFlight: false, keyboardCornerPinned: true));
+	}
+
+	[Fact]
+	public void DragWins_EvenWithAKeyboardCornerPinned()
+	{
+		// A mouse drag supersedes a half-finished keyboard selection, and the pointer is then
+		// the user's drawing hand, so standing down beats moving it back.
+		Assert.Equal(
+			DeferredCursorRestore.StandDown,
+			CursorRestorePolicy.Decide(dragInFlight: true, keyboardCornerPinned: true));
+	}
+}

--- a/Mutation.Ui/Core/CursorAnchor.cs
+++ b/Mutation.Ui/Core/CursorAnchor.cs
@@ -55,12 +55,27 @@ public sealed class CursorAnchor
 	public CursorPoint Anchor => _anchor;
 
 	/// <summary>
+	/// Which anchor this is. Changes on every <see cref="Capture"/> and every
+	/// <see cref="Clear"/>, so work that was scheduled against one anchor can tell that a newer
+	/// one has replaced it.
+	/// <para>
+	/// The capture overlay is created once and reused, so one anchor serves every capture the
+	/// app ever makes. Some of the restores are deferred — onto a dispatcher turn, or onto a
+	/// continuation that waits for the foreground to be handed back — and a slow one could
+	/// otherwise still be pending when the next capture starts, and clear or restore against an
+	/// anchor that belongs to a capture that finished.
+	/// </para>
+	/// </summary>
+	public int Generation { get; private set; }
+
+	/// <summary>
 	/// Remembers where the pointer is now, replacing any position remembered before. Returns
 	/// whether a position was read; a failure leaves nothing remembered, so a later
 	/// <see cref="Restore"/> does nothing rather than send the pointer to a stale place.
 	/// </summary>
 	public bool Capture()
 	{
+		Generation++;
 		if (_cursor.TryGet(out var position))
 		{
 			_anchor = position;
@@ -103,12 +118,31 @@ public sealed class CursorAnchor
 	}
 
 	/// <summary>
+	/// As <see cref="Restore"/>, but does nothing unless <paramref name="generation"/> is still
+	/// the current one. Deferred work uses this so a restore scheduled by a capture that has
+	/// since finished cannot move the pointer during the next one.
+	/// </summary>
+	public bool RestoreIfCurrent(int generation) => generation == Generation && Restore();
+
+	/// <summary>
 	/// Forgets the remembered position, so nothing can be restored to it later. Called once a
 	/// capture is over and the pointer belongs to the user again.
 	/// </summary>
 	public void Clear()
 	{
+		Generation++;
 		_anchor = default;
 		HasAnchor = false;
+	}
+
+	/// <summary>
+	/// As <see cref="Clear"/>, but does nothing unless <paramref name="generation"/> is still
+	/// the current one — so a late tidy-up from a finished capture cannot throw away the anchor
+	/// the next capture has just taken.
+	/// </summary>
+	public void ClearIfCurrent(int generation)
+	{
+		if (generation == Generation)
+			Clear();
 	}
 }

--- a/Mutation.Ui/Core/CursorAnchor.cs
+++ b/Mutation.Ui/Core/CursorAnchor.cs
@@ -1,0 +1,114 @@
+using System;
+
+namespace Mutation.Ui.Core;
+
+/// <summary>
+/// Remembers where the mouse pointer was, and puts it back if something moved it.
+///
+/// <para>
+/// A screen capture opens a full-screen topmost overlay, takes the foreground, and moves
+/// keyboard focus onto the overlay; when the selection ends it hides the overlay and hands the
+/// foreground back. Every one of those is a focus change, and a magnifier or screen reader that
+/// follows focus answers a focus change by moving the pointer. To the person capturing, the
+/// pointer jumps: they aimed at a paragraph, pressed the hotkey, and the crosshair came up
+/// somewhere else. Mutation's own code never moves the pointer, so without this there is nothing
+/// standing between the user and that jump.
+/// </para>
+///
+/// <para>
+/// The screenshot is taken before the overlay appears, so the overlay shows the screen exactly
+/// as it was. This does the same for the pointer: capture the position before the focus change,
+/// restore it after, and the whole capture looks like one still frame.
+/// </para>
+///
+/// <para>
+/// The one rule worth stating out loud is that an unmoved pointer is left alone.
+/// <see cref="Restore"/> reads the live position first and writes only on a genuine difference,
+/// because writing the coordinates the pointer is already at still generates a mouse-move
+/// message — enough to cancel a hover, disturb a drag, or wake a window that was quietly idle.
+/// Doing nothing has to actually mean doing nothing.
+/// </para>
+///
+/// <para>
+/// Not thread-safe, and not meant to be: each capture drives one anchor from its own window.
+/// </para>
+/// </summary>
+public sealed class CursorAnchor
+{
+	private readonly ICursorPosition _cursor;
+	private CursorPoint _anchor;
+
+	public CursorAnchor(ICursorPosition cursor)
+	{
+		_cursor = cursor ?? throw new ArgumentNullException(nameof(cursor));
+	}
+
+	/// <summary>
+	/// Whether there is a remembered position to go back to. False before the first successful
+	/// <see cref="Capture"/>, and again after <see cref="Clear"/>.
+	/// </summary>
+	public bool HasAnchor { get; private set; }
+
+	/// <summary>
+	/// The remembered position. Meaningless while <see cref="HasAnchor"/> is false.
+	/// </summary>
+	public CursorPoint Anchor => _anchor;
+
+	/// <summary>
+	/// Remembers where the pointer is now, replacing any position remembered before. Returns
+	/// whether a position was read; a failure leaves nothing remembered, so a later
+	/// <see cref="Restore"/> does nothing rather than send the pointer to a stale place.
+	/// </summary>
+	public bool Capture()
+	{
+		if (_cursor.TryGet(out var position))
+		{
+			_anchor = position;
+			HasAnchor = true;
+			return true;
+		}
+
+		_anchor = default;
+		HasAnchor = false;
+		return false;
+	}
+
+	/// <summary>
+	/// Puts the pointer back where <see cref="Capture"/> found it, if it has drifted since.
+	/// Returns true only when the pointer was actually moved — the caller uses that to decide
+	/// whether anything drawn from the old position, such as the crosshair, has to be redrawn.
+	/// <para>
+	/// Keeps the anchor afterwards, so the same position can be defended across more than one
+	/// focus change: a capture restores once when the overlay appears and again on the following
+	/// dispatcher turn, because a tool that follows focus reacts after the activation call has
+	/// already returned.
+	/// </para>
+	/// <para>
+	/// A position that cannot be read is treated as no drift rather than as a reason to write
+	/// blindly. Not knowing where the pointer is, is not a good enough reason to move it.
+	/// </para>
+	/// </summary>
+	public bool Restore()
+	{
+		if (!HasAnchor)
+			return false;
+
+		if (!_cursor.TryGet(out var current))
+			return false;
+
+		if (current == _anchor)
+			return false;
+
+		return _cursor.TrySet(_anchor);
+	}
+
+	/// <summary>
+	/// Forgets the remembered position, so nothing can be restored to it later. Called once a
+	/// capture is over and the pointer belongs to the user again.
+	/// </summary>
+	public void Clear()
+	{
+		_anchor = default;
+		HasAnchor = false;
+	}
+}

--- a/Mutation.Ui/Core/CursorPoint.cs
+++ b/Mutation.Ui/Core/CursorPoint.cs
@@ -1,0 +1,13 @@
+namespace Mutation.Ui.Core;
+
+/// <summary>
+/// A mouse pointer position in virtual-screen pixels — the coordinate space Windows itself
+/// reports and accepts for the pointer, spanning every monitor.
+/// <para>
+/// Deliberately not in device-independent pixels. A value of this type is only ever produced
+/// by reading the live pointer position and only ever consumed by writing that same position
+/// back, so no DPI scale is applied on the way through and none can be got wrong. The overlay
+/// converts to its own coordinates separately, for drawing.
+/// </para>
+/// </summary>
+public readonly record struct CursorPoint(int X, int Y);

--- a/Mutation.Ui/Core/CursorRestorePolicy.cs
+++ b/Mutation.Ui/Core/CursorRestorePolicy.cs
@@ -1,0 +1,67 @@
+namespace Mutation.Ui.Core;
+
+/// <summary>
+/// What a deferred pointer restore is allowed to do, given what the user has already started.
+/// </summary>
+public enum DeferredCursorRestore
+{
+	/// <summary>
+	/// Do nothing at all. The pointer is the user's drawing hand and moving it would redraw
+	/// their rectangle from under them.
+	/// </summary>
+	StandDown,
+
+	/// <summary>
+	/// Put the pointer back, but leave the half-built selection exactly as it is.
+	/// </summary>
+	MoveOnly,
+
+	/// <summary>
+	/// Put the pointer back, and seed the crosshair and the keyboard caret from where it now
+	/// is. Safe only when no selection has been started, because seeding restarts one.
+	/// </summary>
+	MoveAndReseed
+}
+
+/// <summary>
+/// Decides how far a deferred pointer restore may go.
+///
+/// <para>
+/// The capture overlay puts the pointer back on the dispatcher turn after it opens, because a
+/// magnifier or reader that follows focus moves the pointer from its own message loop, after
+/// the activation call has already returned. By the time that turn runs, though, the user may
+/// have started choosing a region — and the same restore also re-seeds the crosshair and the
+/// keyboard caret, which means restarting the selection from scratch.
+/// </para>
+///
+/// <para>
+/// The distinction this makes is between moving the pointer and restarting the selection. Those
+/// were once the same step, and a second hotkey press on a capture already in progress — which
+/// brings the overlay forward again, and so runs a restore again — silently threw away a pinned
+/// keyboard corner and said nothing about it. Someone who cannot see the overlay then pressed
+/// Enter expecting a capture and pinned a fresh corner instead.
+/// </para>
+///
+/// <para>
+/// Putting the pointer back is still right while a keyboard selection is under way: a pointer
+/// move syncs the caret but never touches the pinned corner, so restoring the pointer restores
+/// the caret with it. It is only the re-seed that has to stand down.
+/// </para>
+/// </summary>
+public static class CursorRestorePolicy
+{
+	/// <param name="dragInFlight">Whether a mouse button is down and a rectangle is being
+	/// dragged out.</param>
+	/// <param name="keyboardCornerPinned">Whether the keyboard path has pinned one corner and
+	/// is waiting for the second.</param>
+	public static DeferredCursorRestore Decide(bool dragInFlight, bool keyboardCornerPinned)
+	{
+		if (dragInFlight)
+			return DeferredCursorRestore.StandDown;
+
+		if (keyboardCornerPinned)
+			return DeferredCursorRestore.MoveOnly;
+
+		return DeferredCursorRestore.MoveAndReseed;
+	}
+}

--- a/Mutation.Ui/Core/ICursorPosition.cs
+++ b/Mutation.Ui/Core/ICursorPosition.cs
@@ -1,0 +1,27 @@
+namespace Mutation.Ui.Core;
+
+/// <summary>
+/// Reads and writes where the mouse pointer is on screen.
+/// <para>
+/// The seam exists so that <see cref="CursorAnchor"/> — which holds all the rules about when
+/// the pointer may be moved — can be tested without a real mouse, and so that a test run does
+/// not fling the developer's pointer across the screen.
+/// </para>
+/// <para>
+/// Neither method throws. The pointer is a nicety; a capture that cannot read or write it
+/// still has to complete.
+/// </para>
+/// </summary>
+public interface ICursorPosition
+{
+	/// <summary>
+	/// Where the pointer is now. Returns false, with <paramref name="position"/> left at its
+	/// default, when the position could not be read.
+	/// </summary>
+	bool TryGet(out CursorPoint position);
+
+	/// <summary>
+	/// Puts the pointer at <paramref name="position"/>. Returns whether the move was accepted.
+	/// </summary>
+	bool TrySet(CursorPoint position);
+}

--- a/Mutation.Ui/Services/Win32CursorPosition.cs
+++ b/Mutation.Ui/Services/Win32CursorPosition.cs
@@ -1,0 +1,64 @@
+using Mutation.Ui.Core;
+using System;
+using System.Runtime.InteropServices;
+
+namespace Mutation.Ui.Services;
+
+/// <summary>
+/// Reads and writes the mouse pointer position through <c>user32</c>. All P/Invoke and no
+/// rules — the rules about when the pointer may be moved live in <see cref="CursorAnchor"/>,
+/// which can be tested without a real mouse.
+/// <para>
+/// Both calls work in virtual-screen pixels across every monitor, so a position read here can be
+/// written back here unchanged. Neither is tied to a particular thread, which is what lets the
+/// capture restore the pointer from the continuation that runs after the foreground has been
+/// handed back rather than having to get back onto the UI thread first.
+/// </para>
+/// </summary>
+internal sealed class Win32CursorPosition : ICursorPosition
+{
+	[StructLayout(LayoutKind.Sequential)]
+	private struct POINT
+	{
+		public int X;
+		public int Y;
+	}
+
+	[DllImport("user32.dll", SetLastError = false)]
+	private static extern bool GetCursorPos(out POINT lpPoint);
+
+	[DllImport("user32.dll", SetLastError = false)]
+	private static extern bool SetCursorPos(int X, int Y);
+
+	public bool TryGet(out CursorPoint position)
+	{
+		try
+		{
+			if (GetCursorPos(out POINT p))
+			{
+				position = new CursorPoint(p.X, p.Y);
+				return true;
+			}
+		}
+		catch
+		{
+			// Falls through to the failure below. A pointer position that cannot be read must
+			// never be the thing that breaks a capture.
+		}
+
+		position = default;
+		return false;
+	}
+
+	public bool TrySet(CursorPoint position)
+	{
+		try
+		{
+			return SetCursorPos(position.X, position.Y);
+		}
+		catch
+		{
+			return false;
+		}
+	}
+}

--- a/Mutation.Ui/Views/RegionSelectionWindow.xaml.cs
+++ b/Mutation.Ui/Views/RegionSelectionWindow.xaml.cs
@@ -6,6 +6,7 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media.Imaging;
 using Mutation.Ui.Core;
+using Mutation.Ui.Services;
 using System;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
@@ -39,6 +40,17 @@ public sealed partial class RegionSelectionWindow : Window
 	// Keyboard path for the overlay, so the four screenshot/OCR hotkeys are completable
 	// without sight of the crosshair (issue #215).
 	private readonly KeyboardRegionSelector _keyboard = new();
+
+	/// <summary>The one way this window reads or writes the mouse pointer position.</summary>
+	private readonly ICursorPosition _cursor = new Win32CursorPosition();
+
+	/// <summary>
+	/// Holds the mouse pointer still across the focus changes a capture causes. Opening this
+	/// overlay and closing it again both move the foreground, and a magnifier or reader that
+	/// follows focus answers that by moving the pointer — so the pointer is read before each
+	/// change and put back after it (issue #371).
+	/// </summary>
+	private readonly CursorAnchor _cursorAnchor;
 	private const string AnnouncementActivityId = "RegionSelection";
 	private const string CancelledAnnouncement = "Region selection cancelled.";
 
@@ -66,10 +78,6 @@ public sealed partial class RegionSelectionWindow : Window
 	private static readonly IntPtr CURSOR_CROSS = LoadCursor(IntPtr.Zero, IDC_CROSS);
 	private static readonly IntPtr CURSOR_ARROW = LoadCursor(IntPtr.Zero, IDC_ARROW);
 
-	[StructLayout(LayoutKind.Sequential)]
-	private struct POINT { public int X; public int Y; }
-	[DllImport("user32.dll", SetLastError = false)]
-	private static extern bool GetCursorPos(out POINT lpPoint);
 	[DllImport("user32.dll", SetLastError = false)]
 	private static extern uint GetDpiForWindow(IntPtr hWnd);
 
@@ -149,6 +157,7 @@ public sealed partial class RegionSelectionWindow : Window
 	public RegionSelectionWindow()
 	{
 		this.InitializeComponent();
+		_cursorAnchor = new CursorAnchor(_cursor);
 		_hwnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
 		_dispatcherQueue = DispatcherQueue.GetForCurrentThread();
 		EnsureElementRefs();
@@ -158,6 +167,12 @@ public sealed partial class RegionSelectionWindow : Window
 	{
 		try
 		{
+			// A second hotkey press on a capture that is already waiting drags the overlay back
+			// to the front, which is one more focus change and one more chance for the pointer
+			// to be moved out from under the user. Skipped entirely mid-drag: the pointer is
+			// then the user's drawing hand, and the position to defend is wherever they have
+			// got to, not wherever they started.
+			bool anchored = !_dragging && _cursorAnchor.Capture();
 			this.Activate();
 			SetForegroundWindow(_hwnd);
 			int left = GetSystemMetrics(SM_XVIRTUALSCREEN);
@@ -166,6 +181,8 @@ public sealed partial class RegionSelectionWindow : Window
 			int height = GetSystemMetrics(SM_CYVIRTUALSCREEN);
 			SetWindowPos(_hwnd, HWND_TOPMOST, left, top, width, height, SWP_NOMOVE | SWP_NOSIZE);
 			TryFocusOverlay();
+			if (anchored)
+				RestoreCursorNowAndAfterFocusSettles();
 		}
 		catch { }
 	}
@@ -241,6 +258,10 @@ public sealed partial class RegionSelectionWindow : Window
 		_tcs = new TaskCompletionSource<Rect?>();
 		_dragging = false;
 		_lastPointerPos = null;
+		// Read the pointer before anything below can move it. Showing the overlay, taking the
+		// foreground and moving focus onto the canvas are three focus changes in a row, and a
+		// tool that follows focus answers each of them by moving the pointer (issue #371).
+		_cursorAnchor.Capture();
 		ResetSelection();
 		RememberForegroundWindow();
 		InstallKeyboardHook();
@@ -254,6 +275,9 @@ public sealed partial class RegionSelectionWindow : Window
 		int width = GetSystemMetrics(SM_CXVIRTUALSCREEN);
 		int height = GetSystemMetrics(SM_CYVIRTUALSCREEN);
 		SetWindowPos(_hwnd, HWND_TOPMOST, left, top, width, height, SWP_NOMOVE | SWP_NOSIZE);
+		// Before ResetKeyboardSelection, which seeds the keyboard caret from wherever the
+		// pointer is: put the pointer back first and the caret is seeded from the truth.
+		RestoreCursorNowAndAfterFocusSettles();
 		ResetKeyboardSelection();
 		// The overlay is full-screen and topmost, so it has to say what it wants (issue
 		// #215) — but the Canvas's AutomationProperties.HelpText already says it, and a
@@ -418,12 +442,21 @@ public sealed partial class RegionSelectionWindow : Window
 	private void CompleteSelection(Rect? result, string announcement, AutomationNotificationKind kind)
 	{
 		_dragging = false;
+		// Where the pointer is at the instant the selection ends — for a mouse drag, exactly
+		// where the button came up. Read here, while the overlay is still up, because hiding it
+		// and handing the foreground back are the next two focus changes that can move the
+		// pointer (issue #371).
+		_cursorAnchor.Capture();
 		Announce(announcement, kind);
 		ResetSelection();
 
 		void Finish()
 		{
 			HideAndRestore();
+			// The overlay is gone; put the pointer back on the screen the user is looking at
+			// again. HideAndRestore has already installed the handback this waits on.
+			_cursorAnchor.Restore();
+			RestoreCursorAfterForegroundHandback();
 			_tcs?.TrySetResult(result);
 		}
 
@@ -447,7 +480,7 @@ public sealed partial class RegionSelectionWindow : Window
 		_crosshairH.Width = overlayW;
 		// Map current cursor (screen px) to overlay DIPs
 		double cx, cy;
-		if (GetCursorPos(out POINT p))
+		if (_cursor.TryGet(out var p))
 		{
 			cx = (p.X - bounds.Left) / scale;
 			cy = (p.Y - bounds.Top) / scale;
@@ -582,7 +615,7 @@ public sealed partial class RegionSelectionWindow : Window
 			if (dpi > 0)
 				scale = dpi / 96.0;
 
-			if (!GetCursorPos(out POINT p))
+			if (!_cursor.TryGet(out var p))
 				return fallback;
 
 			int left = GetSystemMetrics(SM_XVIRTUALSCREEN);
@@ -593,6 +626,82 @@ public sealed partial class RegionSelectionWindow : Window
 		{
 			return fallback;
 		}
+	}
+
+	/// <summary>
+	/// Puts the pointer back where the anchor says it was, twice: once now, and once on the next
+	/// low-priority dispatcher turn.
+	/// <para>
+	/// The second attempt is the one that usually matters. Activating a window and moving focus
+	/// return long before anyone else has reacted to them, and a magnifier or reader that follows
+	/// focus moves the pointer from its own message loop a moment later. Restoring only inline
+	/// would put the pointer back before the thing that moves it had even run.
+	/// </para>
+	/// <para>
+	/// Two attempts and no more, on purpose. A settle window that kept re-checking for a while
+	/// would also drag back a pointer the user had moved deliberately, and there is no way to
+	/// tell those two movements apart from here — the overlay sees an identical pointer event
+	/// either way. Losing the odd very late jump is the better failure.
+	/// </para>
+	/// </summary>
+	private void RestoreCursorNowAndAfterFocusSettles()
+	{
+		_cursorAnchor.Restore();
+
+		if (_dispatcherQueue is null)
+			return;
+
+		_dispatcherQueue.TryEnqueue(DispatcherQueuePriority.Low, () =>
+		{
+			// The user got in first. A drag in flight owns the pointer, and moving it now would
+			// redraw someone's rectangle from under them.
+			if (_dragging)
+				return;
+
+			if (!_cursorAnchor.Restore())
+				return;
+
+			// The pointer really had been moved, so the crosshair and the keyboard caret were
+			// seeded from a position it is no longer at. Seed them again, from the live pointer
+			// rather than from _lastPointerPos, which may itself be the jumped position that
+			// arrived as a pointer-move event.
+			_lastPointerPos = null;
+			ResetKeyboardSelection();
+			RenderKeyboardSelection();
+		});
+	}
+
+	/// <summary>
+	/// Puts the pointer back once more after the window that was in front before the overlay
+	/// opened has the keyboard again, then stops defending the position.
+	/// <para>
+	/// Handing the foreground back is itself a focus change, and the restore ladder that does it
+	/// can run tens of milliseconds after the overlay hides — well after the inline restore in
+	/// <see cref="CompleteSelection"/>. The continuation runs on the thread pool, which is fine:
+	/// setting the pointer position is not tied to a thread.
+	/// </para>
+	/// </summary>
+	private void RestoreCursorAfterForegroundHandback()
+	{
+		var handback = ForegroundHandedBack;
+		if (handback.IsCompleted)
+		{
+			// The foreground went back synchronously, so the restore just done in
+			// CompleteSelection already covered it.
+			_cursorAnchor.Clear();
+			return;
+		}
+
+		_ = handback.ContinueWith(
+			_ =>
+			{
+				_cursorAnchor.Restore();
+				// The capture is over and the pointer belongs to the user again.
+				_cursorAnchor.Clear();
+			},
+			System.Threading.CancellationToken.None,
+			TaskContinuationOptions.None,
+			TaskScheduler.Default);
 	}
 
 	private void Announce(string message, AutomationNotificationKind kind)

--- a/Mutation.Ui/Views/RegionSelectionWindow.xaml.cs
+++ b/Mutation.Ui/Views/RegionSelectionWindow.xaml.cs
@@ -651,14 +651,20 @@ public sealed partial class RegionSelectionWindow : Window
 		if (_dispatcherQueue is null)
 			return;
 
+		// Read now, not inside the callback: this identifies the anchor being defended, so a
+		// turn that runs late cannot act on behalf of a capture that has already finished.
+		int generation = _cursorAnchor.Generation;
+
 		_dispatcherQueue.TryEnqueue(DispatcherQueuePriority.Low, () =>
 		{
-			// The user got in first. A drag in flight owns the pointer, and moving it now would
-			// redraw someone's rectangle from under them.
-			if (_dragging)
+			var allowed = CursorRestorePolicy.Decide(_dragging, _keyboard.HasAnchor);
+			if (allowed == DeferredCursorRestore.StandDown)
 				return;
 
-			if (!_cursorAnchor.Restore())
+			if (!_cursorAnchor.RestoreIfCurrent(generation))
+				return;
+
+			if (allowed != DeferredCursorRestore.MoveAndReseed)
 				return;
 
 			// The pointer really had been moved, so the crosshair and the keyboard caret were
@@ -675,29 +681,38 @@ public sealed partial class RegionSelectionWindow : Window
 	/// Puts the pointer back once more after the window that was in front before the overlay
 	/// opened has the keyboard again, then stops defending the position.
 	/// <para>
-	/// Handing the foreground back is itself a focus change, and the restore ladder that does it
-	/// can run tens of milliseconds after the overlay hides — well after the inline restore in
-	/// <see cref="CompleteSelection"/>. The continuation runs on the thread pool, which is fine:
-	/// setting the pointer position is not tied to a thread.
+	/// Handing the foreground back is itself a focus change, and it is not instant: the ladder in
+	/// <see cref="HideAndRestore"/> retries on a later dispatcher turn and then, if that fails
+	/// too, waits <see cref="FocusRetryDelayMilliseconds"/> before a last attempt. So this can
+	/// land a good hundred milliseconds after the button came up, and someone who released the
+	/// drag and immediately moved the mouse elsewhere will feel it tug back. That is the trade
+	/// the story asks for — a pointer that does not jump is worth more here than one that never
+	/// argues — but it is a real cost, not a free win.
+	/// </para>
+	/// <para>
+	/// The continuation runs on the thread pool, which is fine: setting the pointer position is
+	/// not tied to a thread. It is stamped with the anchor it was registered against, so a
+	/// handback that somehow outlives its own capture cannot touch the next one's pointer.
 	/// </para>
 	/// </summary>
 	private void RestoreCursorAfterForegroundHandback()
 	{
+		int generation = _cursorAnchor.Generation;
 		var handback = ForegroundHandedBack;
 		if (handback.IsCompleted)
 		{
 			// The foreground went back synchronously, so the restore just done in
 			// CompleteSelection already covered it.
-			_cursorAnchor.Clear();
+			_cursorAnchor.ClearIfCurrent(generation);
 			return;
 		}
 
 		_ = handback.ContinueWith(
 			_ =>
 			{
-				_cursorAnchor.Restore();
+				_cursorAnchor.RestoreIfCurrent(generation);
 				// The capture is over and the pointer belongs to the user again.
-				_cursorAnchor.Clear();
+				_cursorAnchor.ClearIfCurrent(generation);
 			},
 			System.Threading.CancellationToken.None,
 			TaskContinuationOptions.None,


### PR DESCRIPTION
Closes #371

## What was wrong

Pressing a screenshot or OCR hotkey opens a full-screen topmost overlay, takes
the foreground, and moves keyboard focus onto the overlay canvas. Finishing the
selection hides the overlay and hands the foreground back to whatever was in
front before. Each of those is a focus change, and a magnifier or screen reader
that follows focus answers a focus change by moving the mouse pointer.

Mutation's own code never moved the pointer — and never put it back. So the
pointer jumped: you aimed at a paragraph, pressed the hotkey, and the crosshair
came up somewhere else. It jumped a second time after you released the drag and
the overlay disappeared. The screenshot itself is taken before the overlay
appears, so the picture is of the screen exactly as it was; the pointer was the
one thing that did not behave like a still frame.

## What it does now

`CursorAnchor` (new, in `Core`) remembers a pointer position and puts it back.
The rule worth stating is that an unmoved pointer is left completely alone: it
reads the live position first and writes only on a genuine difference, because
writing back the coordinates the pointer already has still raises a mouse-move
message — enough to cancel a hover or disturb a drag.

`ICursorPosition` is the seam so those rules are unit-testable without a real
mouse, and so a test run cannot fling the developer's pointer across the screen.
`Win32CursorPosition` (in `Services`) is the `GetCursorPos` / `SetCursorPos`
interop and nothing else, mirroring how `ForegroundIntegrityProbe` sits under
`ForegroundInjectionGuard`.

`RegionSelectionWindow` captures the position before showing the overlay and
again before hiding it, and restores twice on each side — inline, then once more
after the focus change has been seen by everything else. On the way in that
second attempt is a low-priority dispatcher turn; on the way out it is a
continuation on the foreground handback, whose retry ladder can run tens of
milliseconds after the overlay is gone.

Two attempts and no more, deliberately. A settle window that kept re-checking
would also drag back a pointer the user had moved on purpose, and the overlay
sees an identical pointer event either way, so it cannot tell the two apart. A
very late jump is the accepted cost.

Two follow-on details. When a restore really did move the pointer, the crosshair
and keyboard caret are re-seeded, because they had been placed from the position
it had jumped to — including from `_lastPointerPos`, which may itself be the
jump arriving as a pointer-move event. And a drag in flight suppresses the
deferred restore entirely; at that point the pointer is the user's drawing hand.

A second hotkey press on a capture that is already waiting brings the overlay
back to the front, which is one more focus change, so it gets the same treatment
— skipped mid-drag, where the position to defend is wherever the user has got
to rather than where they started.

The window's own `GetCursorPos` interop is gone. The two places that map the
cursor into overlay coordinates now read through the same seam, so there is one
way to ask where the pointer is.

## What a user notices

Whatever you were pointing at when you pressed the shortcut is still under the
pointer when the overlay comes up. When you let go of the drag, the pointer
stays exactly where you released it as the overlay disappears. Nothing else
changes — same shortcuts, same announcements, same pictures.

## Tests

`CursorAnchorTests` — 11 cases covering: a pointer moved during the focus change
is put back; a pointer that never moved is not written to at all; restore
without a capture does nothing; the anchor survives a restore so a second jump
is also undone; a second capture replaces the first; a position that cannot be
read leaves nothing to restore to; a read failure at restore time does not
trigger a blind write; a refused write reports as "no move" so the crosshair is
not needlessly redrawn; a cleared anchor is no longer defended.

Full suite: 2299 passed, 0 failed, `dotnet test --configuration Release`.

## Not verified

The visible behaviour cannot be checked in an agent session — it needs a human
running a magnifier or screen reader that follows focus, pressing the hotkey and
watching the pointer. What is verified here is the build, the full test suite,
and the rules in isolation.

## Documentation

`screen-capture-and-ocr.md` gains a short paragraph under "Picking the rectangle
with the mouse" saying the pointer stays put, and the generated HTML is rebuilt
and committed alongside it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
