### PR TITLE
Optionally wiggle the pointer after a capture, so the magnifier follows it back (#373)

### DIFF
--- a/CognitiveSupport/Settings.cs
+++ b/CognitiveSupport/Settings.cs
@@ -133,6 +133,27 @@ public class AzureComputerVisionSettings
 	// no such key, and keeping the initializer is what turns it on for those files too.
 	public bool PasteOcrTextIntoActiveApplication { get; set; } = true;
 
+	// Moves the mouse pointer one pixel back and forth once the capture is over and the previous
+	// application has the keyboard again. ZoomText follows the keyboard caret as well as the
+	// mouse, so a flashing caret in the application underneath pulls the magnified view away
+	// from the pointer the moment focus returns; the view comes back to the mouse as soon as the
+	// mouse moves. Off unless asked for — it is a workaround for one magnifier's behaviour, and
+	// it moves the pointer on purpose.
+	public bool NudgePointerAfterCapture { get; set; } = false;
+
+	// How long between one one-pixel move and the next, and how long to keep going for. Both are
+	// clamped on load; see PointerNudgeIntervalRange and PointerNudgeDurationRange.
+	public int PointerNudgeIntervalMilliseconds { get; set; } = DefaultPointerNudgeIntervalMilliseconds;
+	public int PointerNudgeDurationMilliseconds { get; set; } = DefaultPointerNudgeDurationMilliseconds;
+
+	public const int DefaultPointerNudgeIntervalMilliseconds = 50;
+	public const int MinPointerNudgeIntervalMilliseconds = 10;
+	public const int MaxPointerNudgeIntervalMilliseconds = 500;
+
+	public const int DefaultPointerNudgeDurationMilliseconds = 500;
+	public const int MinPointerNudgeDurationMilliseconds = 50;
+	public const int MaxPointerNudgeDurationMilliseconds = 5000;
+
 	public string? ApiKey { get; set; }
 	public string? Endpoint { get; set; }
 	public int TimeoutSeconds { get; set; } = 10;

--- a/Documentation/UserGuide/html/index.html
+++ b/Documentation/UserGuide/html/index.html
@@ -283,7 +283,7 @@ authoritative version. To rebuild the web pages after an edit, run
 <code>Build-UserGuide.cmd</code> in the <code>Documentation</code> folder.</p>
 
 <footer>
-<p>Generated from the Markdown source on 11 August 2026. The Markdown files are the source of truth &ndash; do not edit these HTML pages by hand.</p>
+<p>Generated from the Markdown source on 12 August 2026. The Markdown files are the source of truth &ndash; do not edit these HTML pages by hand.</p>
 </footer>
 </main>
 </div>

--- a/Documentation/UserGuide/html/screen-capture-and-ocr.html
+++ b/Documentation/UserGuide/html/screen-capture-and-ocr.html
@@ -182,6 +182,17 @@ area.</p>
 pressed the shortcut, it is still there when the overlay opens and still there when the
 overlay goes away. So you can pick the rectangle with the mouse or the keyboard, either
 way, without the pointer wandering off first.</p>
+<h3 id="if-your-magnifier-loses-the-pointer-afterwards">If your magnifier loses the pointer afterwards</h3>
+<p>Some magnifiers follow the flashing text cursor as well as the mouse. When the capture
+ends, the app you were in gets the keyboard back, and if it has a text box waiting the
+magnifier can swing across to that instead. Your pointer has not moved, but what you are
+looking at has.</p>
+<p>Most magnifiers come back to the mouse as soon as the mouse moves. So Mutation can give
+it a little shake for you: one pixel back and forth for half a second, ending exactly
+where it started. Turn on <strong>Wiggle the mouse pointer after a capture</strong> in <strong>Settings</strong>,
+under <strong>Screen capture &amp; OCR</strong>. It is off unless you switch it on, and you can change how
+fast it shakes and how long it goes on for. Mutation stops shaking the moment you take
+hold of the mouse yourself.</p>
 <h3 id="picking-the-rectangle-with-the-mouse">Picking the rectangle with the mouse</h3>
 <p>Hold the left mouse button down at one corner of the area you want, drag to the
 opposite corner, and let go. That is it. A right-click cancels instead.</p>

--- a/Documentation/UserGuide/html/settings.html
+++ b/Documentation/UserGuide/html/settings.html
@@ -241,6 +241,18 @@ Leaving Advanced off simply hides that button.</p>
 <td>Send hotkey after OCR</td>
 <td>Optional keystrokes sent to the app you are in once the text has been delivered — a screen reader command that reads it back, for example. It comes after the paste above.</td>
 </tr>
+<tr>
+<td>Wiggle the mouse pointer after a capture</td>
+<td>Off by default. Shakes the pointer one pixel back and forth when a capture finishes, then leaves it exactly where it started. Only useful if your magnifier keeps losing the pointer after a capture — see below.</td>
+</tr>
+<tr>
+<td>Wiggle every (milliseconds)</td>
+<td>How long between one shake and the next. 50 by default, and anything from 10 to 500.</td>
+</tr>
+<tr>
+<td>Keep wiggling for (milliseconds)</td>
+<td>How long the shaking goes on for. 500 by default, and anything from 50 to 5000.</td>
+</tr>
 </tbody>
 </table>
 </div>

--- a/Documentation/UserGuide/html/settings.html
+++ b/Documentation/UserGuide/html/settings.html
@@ -243,7 +243,7 @@ Leaving Advanced off simply hides that button.</p>
 </tr>
 <tr>
 <td>Wiggle the mouse pointer after a capture</td>
-<td>Off by default. Shakes the pointer one pixel back and forth when a capture finishes, then leaves it exactly where it started. Only useful if your magnifier keeps losing the pointer after a capture — see below.</td>
+<td>Off by default. Shakes the pointer one pixel back and forth when a capture finishes, then leaves it exactly where it started. Only useful if your magnifier keeps losing the pointer after a capture — see <a href="screen-capture-and-ocr.html">Screen capture and OCR</a> for what that looks like.</td>
 </tr>
 <tr>
 <td>Wiggle every (milliseconds)</td>
@@ -251,7 +251,7 @@ Leaving Advanced off simply hides that button.</p>
 </tr>
 <tr>
 <td>Keep wiggling for (milliseconds)</td>
-<td>How long the shaking goes on for. 500 by default, and anything from 50 to 5000.</td>
+<td>How long the shaking goes on for. 500 by default, and anything from 50 to 5000. You always get at least one shake, so setting this shorter than the interval above still gives you one.</td>
 </tr>
 </tbody>
 </table>

--- a/Documentation/UserGuide/markdown/screen-capture-and-ocr.md
+++ b/Documentation/UserGuide/markdown/screen-capture-and-ocr.md
@@ -47,6 +47,20 @@ pressed the shortcut, it is still there when the overlay opens and still there w
 overlay goes away. So you can pick the rectangle with the mouse or the keyboard, either
 way, without the pointer wandering off first.
 
+### If your magnifier loses the pointer afterwards
+
+Some magnifiers follow the flashing text cursor as well as the mouse. When the capture
+ends, the app you were in gets the keyboard back, and if it has a text box waiting the
+magnifier can swing across to that instead. Your pointer has not moved, but what you are
+looking at has.
+
+Most magnifiers come back to the mouse as soon as the mouse moves. So Mutation can give
+it a little shake for you: one pixel back and forth for half a second, ending exactly
+where it started. Turn on **Wiggle the mouse pointer after a capture** in **Settings**,
+under **Screen capture & OCR**. It is off unless you switch it on, and you can change how
+fast it shakes and how long it goes on for. Mutation stops shaking the moment you take
+hold of the mouse yourself.
+
 ### Picking the rectangle with the mouse
 
 Hold the left mouse button down at one corner of the area you want, drag to the

--- a/Documentation/UserGuide/markdown/settings.md
+++ b/Documentation/UserGuide/markdown/settings.md
@@ -65,6 +65,9 @@ Reading text out of pictures. OCR just means "pulling the words out of an image"
 | Max document size (MB) | Biggest file or page Mutation will send. Anything larger is skipped before upload, so you never accidentally send something huge. Set it to 0 for no limit. |
 | Paste OCR text into the active app | On by default. Puts the recognised text straight into whatever you were working in. Turn it off and the text still reaches your clipboard and the **OCR result** box. |
 | Send hotkey after OCR | Optional keystrokes sent to the app you are in once the text has been delivered — a screen reader command that reads it back, for example. It comes after the paste above. |
+| Wiggle the mouse pointer after a capture | Off by default. Shakes the pointer one pixel back and forth when a capture finishes, then leaves it exactly where it started. Only useful if your magnifier keeps losing the pointer after a capture — see below. |
+| Wiggle every (milliseconds) | How long between one shake and the next. 50 by default, and anything from 10 to 500. |
+| Keep wiggling for (milliseconds) | How long the shaking goes on for. 500 by default, and anything from 50 to 5000. |
 
 The timeout and the "how many at a time" numbers have sensible defaults and hover
 help. Leave them alone unless something is timing out on you.

--- a/Documentation/UserGuide/markdown/settings.md
+++ b/Documentation/UserGuide/markdown/settings.md
@@ -65,9 +65,9 @@ Reading text out of pictures. OCR just means "pulling the words out of an image"
 | Max document size (MB) | Biggest file or page Mutation will send. Anything larger is skipped before upload, so you never accidentally send something huge. Set it to 0 for no limit. |
 | Paste OCR text into the active app | On by default. Puts the recognised text straight into whatever you were working in. Turn it off and the text still reaches your clipboard and the **OCR result** box. |
 | Send hotkey after OCR | Optional keystrokes sent to the app you are in once the text has been delivered — a screen reader command that reads it back, for example. It comes after the paste above. |
-| Wiggle the mouse pointer after a capture | Off by default. Shakes the pointer one pixel back and forth when a capture finishes, then leaves it exactly where it started. Only useful if your magnifier keeps losing the pointer after a capture — see below. |
+| Wiggle the mouse pointer after a capture | Off by default. Shakes the pointer one pixel back and forth when a capture finishes, then leaves it exactly where it started. Only useful if your magnifier keeps losing the pointer after a capture — see [Screen capture and OCR](screen-capture-and-ocr.md) for what that looks like. |
 | Wiggle every (milliseconds) | How long between one shake and the next. 50 by default, and anything from 10 to 500. |
-| Keep wiggling for (milliseconds) | How long the shaking goes on for. 500 by default, and anything from 50 to 5000. |
+| Keep wiggling for (milliseconds) | How long the shaking goes on for. 500 by default, and anything from 50 to 5000. You always get at least one shake, so setting this shorter than the interval above still gives you one. |
 
 The timeout and the "how many at a time" numbers have sensible defaults and hover
 help. Leave them alone unless something is timing out on you.

--- a/Mutation.Tests/PointerNudgePlannerTests.cs
+++ b/Mutation.Tests/PointerNudgePlannerTests.cs
@@ -11,7 +11,6 @@ namespace Mutation.Tests;
 public class PointerNudgePlannerTests
 {
 	private static readonly CursorPoint Anchor = new(400, 300);
-	private const int FarFromTheEdge = 1919;
 
 	private static PointerNudgeOptions On(int intervalMs = 50, int durationMs = 500) =>
 		new(true, intervalMs, durationMs);
@@ -19,7 +18,7 @@ public class PointerNudgePlannerTests
 	[Fact]
 	public void SwitchedOff_ThePointerIsNeverTouched()
 	{
-		Assert.Empty(PointerNudgePlanner.Plan(Anchor, FarFromTheEdge, PointerNudgeOptions.Off));
+		Assert.Empty(PointerNudgePlanner.Plan(Anchor, PointerNudgeOptions.Off));
 	}
 
 	[Fact]
@@ -27,7 +26,7 @@ public class PointerNudgePlannerTests
 	{
 		// Half a second at one move every 50 ms is ten moves, and ten is even, so the last of
 		// them is already the way home — no eleventh move is needed.
-		var plan = PointerNudgePlanner.Plan(Anchor, FarFromTheEdge, On());
+		var plan = PointerNudgePlanner.Plan(Anchor, On());
 
 		Assert.Equal(10, plan.Count);
 		Assert.Equal(Anchor, plan[plan.Count - 1]);
@@ -40,7 +39,7 @@ public class PointerNudgePlannerTests
 		// finished a pixel out would quietly undo that on every capture.
 		for (int durationMs = 50; durationMs <= 1000; durationMs += 50)
 		{
-			var plan = PointerNudgePlanner.Plan(Anchor, FarFromTheEdge, On(durationMs: durationMs));
+			var plan = PointerNudgePlanner.Plan(Anchor, On(durationMs: durationMs));
 			Assert.NotEmpty(plan);
 			Assert.Equal(Anchor, plan[plan.Count - 1]);
 		}
@@ -50,7 +49,7 @@ public class PointerNudgePlannerTests
 	public void OddNumberOfMoves_GetsOneExtraMoveHome()
 	{
 		// Three intervals' worth would end on the offset pixel, so a fourth move is added.
-		var plan = PointerNudgePlanner.Plan(Anchor, FarFromTheEdge, On(intervalMs: 50, durationMs: 150));
+		var plan = PointerNudgePlanner.Plan(Anchor, On(intervalMs: 50, durationMs: 150));
 
 		Assert.Equal(4, plan.Count);
 		Assert.Equal(Anchor, plan[plan.Count - 1]);
@@ -59,7 +58,7 @@ public class PointerNudgePlannerTests
 	[Fact]
 	public void ThePointerActuallyAlternates()
 	{
-		var plan = PointerNudgePlanner.Plan(Anchor, FarFromTheEdge, On());
+		var plan = PointerNudgePlanner.Plan(Anchor, On());
 
 		for (int i = 0; i < plan.Count; i++)
 			Assert.Equal(i % 2 == 0 ? new CursorPoint(Anchor.X + 1, Anchor.Y) : Anchor, plan[i]);
@@ -68,23 +67,9 @@ public class PointerNudgePlannerTests
 	[Fact]
 	public void MovementIsHorizontalOnly()
 	{
-		var plan = PointerNudgePlanner.Plan(Anchor, FarFromTheEdge, On());
+		var plan = PointerNudgePlanner.Plan(Anchor, On());
 
 		Assert.All(plan, p => Assert.Equal(Anchor.Y, p.Y));
-	}
-
-	[Fact]
-	public void AtTheRightEdgeOfTheScreen_ItWigglesLeftInstead()
-	{
-		// Windows clamps the pointer to the virtual screen, so a move one pixel further right
-		// would be accepted and do nothing at all — and the magnifier would never see any
-		// movement. Exactly the case for someone who parks the pointer against the edge.
-		var atEdge = new CursorPoint(FarFromTheEdge, 300);
-
-		var plan = PointerNudgePlanner.Plan(atEdge, FarFromTheEdge, On());
-
-		Assert.Equal(new CursorPoint(FarFromTheEdge - 1, 300), plan[0]);
-		Assert.Equal(atEdge, plan[plan.Count - 1]);
 	}
 
 	[Fact]
@@ -92,7 +77,7 @@ public class PointerNudgePlannerTests
 	{
 		// A setting that is switched on but silently does nothing is the worst answer available,
 		// and worst of all for someone who cannot see that nothing happened.
-		var plan = PointerNudgePlanner.Plan(Anchor, FarFromTheEdge, On(intervalMs: 500, durationMs: 50));
+		var plan = PointerNudgePlanner.Plan(Anchor, On(intervalMs: 500, durationMs: 50));
 
 		Assert.Equal(2, plan.Count);
 		Assert.Equal(new CursorPoint(Anchor.X + 1, Anchor.Y), plan[0]);
@@ -106,6 +91,6 @@ public class PointerNudgePlannerTests
 	[InlineData(50, -500)]
 	public void UnusableTimings_LeaveThePointerAlone(int intervalMs, int durationMs)
 	{
-		Assert.Empty(PointerNudgePlanner.Plan(Anchor, FarFromTheEdge, On(intervalMs, durationMs)));
+		Assert.Empty(PointerNudgePlanner.Plan(Anchor, On(intervalMs, durationMs)));
 	}
 }

--- a/Mutation.Tests/PointerNudgePlannerTests.cs
+++ b/Mutation.Tests/PointerNudgePlannerTests.cs
@@ -1,0 +1,111 @@
+using Mutation.Ui.Core;
+using Xunit;
+
+namespace Mutation.Tests;
+
+/// <summary>
+/// The shape of the pointer wiggle that pulls a magnifier's view back to the mouse after a
+/// capture (issue #373). Two properties carry the whole feature: the pointer moves at all, and
+/// the pointer finishes on exactly the pixel it started from.
+/// </summary>
+public class PointerNudgePlannerTests
+{
+	private static readonly CursorPoint Anchor = new(400, 300);
+	private const int FarFromTheEdge = 1919;
+
+	private static PointerNudgeOptions On(int intervalMs = 50, int durationMs = 500) =>
+		new(true, intervalMs, durationMs);
+
+	[Fact]
+	public void SwitchedOff_ThePointerIsNeverTouched()
+	{
+		Assert.Empty(PointerNudgePlanner.Plan(Anchor, FarFromTheEdge, PointerNudgeOptions.Off));
+	}
+
+	[Fact]
+	public void DefaultTimings_GiveOneMovePerIntervalForTheWholeDuration()
+	{
+		// Half a second at one move every 50 ms is ten moves, and ten is even, so the last of
+		// them is already the way home — no eleventh move is needed.
+		var plan = PointerNudgePlanner.Plan(Anchor, FarFromTheEdge, On());
+
+		Assert.Equal(10, plan.Count);
+		Assert.Equal(Anchor, plan[plan.Count - 1]);
+	}
+
+	[Fact]
+	public void EveryPlanEndsOnTheAnchor()
+	{
+		// The capture works hard to put the pointer back where the user left it. A wiggle that
+		// finished a pixel out would quietly undo that on every capture.
+		for (int durationMs = 50; durationMs <= 1000; durationMs += 50)
+		{
+			var plan = PointerNudgePlanner.Plan(Anchor, FarFromTheEdge, On(durationMs: durationMs));
+			Assert.NotEmpty(plan);
+			Assert.Equal(Anchor, plan[plan.Count - 1]);
+		}
+	}
+
+	[Fact]
+	public void OddNumberOfMoves_GetsOneExtraMoveHome()
+	{
+		// Three intervals' worth would end on the offset pixel, so a fourth move is added.
+		var plan = PointerNudgePlanner.Plan(Anchor, FarFromTheEdge, On(intervalMs: 50, durationMs: 150));
+
+		Assert.Equal(4, plan.Count);
+		Assert.Equal(Anchor, plan[plan.Count - 1]);
+	}
+
+	[Fact]
+	public void ThePointerActuallyAlternates()
+	{
+		var plan = PointerNudgePlanner.Plan(Anchor, FarFromTheEdge, On());
+
+		for (int i = 0; i < plan.Count; i++)
+			Assert.Equal(i % 2 == 0 ? new CursorPoint(Anchor.X + 1, Anchor.Y) : Anchor, plan[i]);
+	}
+
+	[Fact]
+	public void MovementIsHorizontalOnly()
+	{
+		var plan = PointerNudgePlanner.Plan(Anchor, FarFromTheEdge, On());
+
+		Assert.All(plan, p => Assert.Equal(Anchor.Y, p.Y));
+	}
+
+	[Fact]
+	public void AtTheRightEdgeOfTheScreen_ItWigglesLeftInstead()
+	{
+		// Windows clamps the pointer to the virtual screen, so a move one pixel further right
+		// would be accepted and do nothing at all — and the magnifier would never see any
+		// movement. Exactly the case for someone who parks the pointer against the edge.
+		var atEdge = new CursorPoint(FarFromTheEdge, 300);
+
+		var plan = PointerNudgePlanner.Plan(atEdge, FarFromTheEdge, On());
+
+		Assert.Equal(new CursorPoint(FarFromTheEdge - 1, 300), plan[0]);
+		Assert.Equal(atEdge, plan[plan.Count - 1]);
+	}
+
+	[Fact]
+	public void DurationShorterThanOneInterval_StillMovesOnce()
+	{
+		// A setting that is switched on but silently does nothing is the worst answer available,
+		// and worst of all for someone who cannot see that nothing happened.
+		var plan = PointerNudgePlanner.Plan(Anchor, FarFromTheEdge, On(intervalMs: 500, durationMs: 50));
+
+		Assert.Equal(2, plan.Count);
+		Assert.Equal(new CursorPoint(Anchor.X + 1, Anchor.Y), plan[0]);
+		Assert.Equal(Anchor, plan[1]);
+	}
+
+	[Theory]
+	[InlineData(0, 500)]
+	[InlineData(-50, 500)]
+	[InlineData(50, 0)]
+	[InlineData(50, -500)]
+	public void UnusableTimings_LeaveThePointerAlone(int intervalMs, int durationMs)
+	{
+		Assert.Empty(PointerNudgePlanner.Plan(Anchor, FarFromTheEdge, On(intervalMs, durationMs)));
+	}
+}

--- a/Mutation.Tests/PointerNudgeRunnerTests.cs
+++ b/Mutation.Tests/PointerNudgeRunnerTests.cs
@@ -1,0 +1,193 @@
+using Mutation.Ui.Core;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Mutation.Tests;
+
+/// <summary>
+/// How the pointer wiggle behaves while it runs, and — the part that matters — when it gives up
+/// (issue #373). A wiggle that carried on regardless would spend half a second dragging the
+/// pointer back out from under a user who had picked up the mouse.
+/// </summary>
+public class PointerNudgeRunnerTests
+{
+	private static readonly CursorPoint Anchor = new(400, 300);
+	private static readonly CursorPoint Away = new(401, 300);
+	private static readonly TimeSpan Interval = TimeSpan.FromMilliseconds(50);
+
+	/// <summary>
+	/// A pointer that only exists in the test. Writing to <see cref="Position"/> from the
+	/// clock's callback is how a test plays whatever else might grab the pointer part-way
+	/// through the run.
+	/// </summary>
+	private sealed class FakeCursor : ICursorPosition
+	{
+		public CursorPoint Position = Anchor;
+		public bool CanRead = true;
+		public bool WriteSucceeds = true;
+		public List<CursorPoint> Writes { get; } = new();
+
+		public bool TryGet(out CursorPoint position)
+		{
+			if (!CanRead)
+			{
+				position = default;
+				return false;
+			}
+
+			position = Position;
+			return true;
+		}
+
+		public bool TrySet(CursorPoint position)
+		{
+			Writes.Add(position);
+			if (!WriteSucceeds)
+				return false;
+
+			Position = position;
+			return true;
+		}
+	}
+
+	// Runs the whole sequence with no waiting at all, and records what was asked for so a test
+	// can check the pacing without spending the half second it takes on a real screen.
+	private sealed class FakeClock
+	{
+		public List<TimeSpan> Waits { get; } = new();
+		public Action? OnWait;
+
+		public Func<TimeSpan, Task> Delay => interval =>
+		{
+			Waits.Add(interval);
+			OnWait?.Invoke();
+			return Task.CompletedTask;
+		};
+	}
+
+	private static IReadOnlyList<CursorPoint> PlanOf(int moves)
+	{
+		var plan = new List<CursorPoint>(moves);
+		for (int i = 0; i < moves; i++)
+			plan.Add(i % 2 == 0 ? Away : Anchor);
+		return plan;
+	}
+
+	[Fact]
+	public async Task UninterruptedRun_AppliesEveryMoveAndWaitsBeforeEachOne()
+	{
+		var cursor = new FakeCursor();
+		var clock = new FakeClock();
+
+		int applied = await PointerNudgeRunner.RunAsync(cursor, clock.Delay, Anchor, PlanOf(4), Interval);
+
+		Assert.Equal(4, applied);
+		Assert.Equal(new[] { Away, Anchor, Away, Anchor }, cursor.Writes);
+		Assert.Equal(4, clock.Waits.Count);
+		Assert.All(clock.Waits, w => Assert.Equal(Interval, w));
+		Assert.Equal(Anchor, cursor.Position);
+	}
+
+	[Fact]
+	public async Task SomethingElseMovesThePointer_TheWiggleGetsOutOfTheWay()
+	{
+		// The user has picked up the mouse. Half a second of an application hauling the pointer
+		// back would be far worse than the magnifier looking at the wrong place.
+		var cursor = new FakeCursor();
+		var clock = new FakeClock();
+		int waits = 0;
+		clock.OnWait = () =>
+		{
+			if (++waits == 3)
+				cursor.Position = new CursorPoint(900, 700);
+		};
+
+		int applied = await PointerNudgeRunner.RunAsync(cursor, clock.Delay, Anchor, PlanOf(6), Interval);
+
+		Assert.Equal(2, applied);
+		Assert.Equal(new CursorPoint(900, 700), cursor.Position);
+	}
+
+	[Fact]
+	public async Task PointerAlreadyElsewhereBeforeTheFirstMove_NothingHappens()
+	{
+		// The run expects to find the pointer where the capture left it. Finding it somewhere
+		// else means somebody got there first, and wiggling the plan's positions would haul the
+		// pointer back to a place it had already left — the very jump this all exists to stop.
+		var cursor = new FakeCursor { Position = new CursorPoint(900, 700) };
+		var clock = new FakeClock();
+
+		int applied = await PointerNudgeRunner.RunAsync(cursor, clock.Delay, Anchor, PlanOf(4), Interval);
+
+		Assert.Equal(0, applied);
+		Assert.Empty(cursor.Writes);
+	}
+
+	[Fact]
+	public async Task NoLongerWanted_StopsBeforeTheNextMove()
+	{
+		// What drops the wiggle when the next capture has already claimed the pointer.
+		var cursor = new FakeCursor();
+		var clock = new FakeClock();
+		int checks = 0;
+
+		int applied = await PointerNudgeRunner.RunAsync(
+			cursor, clock.Delay, Anchor, PlanOf(6), Interval, stillWanted: () => ++checks <= 2);
+
+		Assert.Equal(2, applied);
+	}
+
+	[Fact]
+	public async Task EmptyPlan_DoesNotEvenReadThePointer()
+	{
+		var cursor = new FakeCursor { CanRead = false };
+		var clock = new FakeClock();
+
+		int applied = await PointerNudgeRunner.RunAsync(cursor, clock.Delay, Anchor, Array.Empty<CursorPoint>(), Interval);
+
+		Assert.Equal(0, applied);
+		Assert.Empty(clock.Waits);
+	}
+
+	[Fact]
+	public async Task PointerThatCannotBeRead_IsNotWiggledBlindly()
+	{
+		var cursor = new FakeCursor { CanRead = false };
+		var clock = new FakeClock();
+
+		int applied = await PointerNudgeRunner.RunAsync(cursor, clock.Delay, Anchor, PlanOf(4), Interval);
+
+		Assert.Equal(0, applied);
+		Assert.Empty(cursor.Writes);
+	}
+
+	[Fact]
+	public async Task RefusedMove_EndsTheWiggleRatherThanCarryingOnBlind()
+	{
+		// After a refused write the pointer is no longer where the run believes it is, so every
+		// later check would compare against a lie.
+		var cursor = new FakeCursor { WriteSucceeds = false };
+		var clock = new FakeClock();
+
+		int applied = await PointerNudgeRunner.RunAsync(cursor, clock.Delay, Anchor, PlanOf(6), Interval);
+
+		Assert.Equal(0, applied);
+		Assert.Single(cursor.Writes);
+	}
+
+	[Fact]
+	public async Task NullArguments_AreRejected()
+	{
+		var cursor = new FakeCursor();
+		var clock = new FakeClock();
+
+		await Assert.ThrowsAsync<ArgumentNullException>(() =>
+			PointerNudgeRunner.RunAsync(null!, clock.Delay, Anchor, PlanOf(2), Interval));
+		await Assert.ThrowsAsync<ArgumentNullException>(() =>
+			PointerNudgeRunner.RunAsync(cursor, null!, Anchor, PlanOf(2), Interval));
+		await Assert.ThrowsAsync<ArgumentNullException>(() =>
+			PointerNudgeRunner.RunAsync(cursor, clock.Delay, Anchor, null!, Interval));
+	}
+}

--- a/Mutation.Tests/PointerNudgeRunnerTests.cs
+++ b/Mutation.Tests/PointerNudgeRunnerTests.cs
@@ -27,6 +27,17 @@ public class PointerNudgeRunnerTests
 		public CursorPoint Position = Anchor;
 		public bool CanRead = true;
 		public bool WriteSucceeds = true;
+		public int? FailWriteAtIndex;
+
+		/// <summary>
+		/// Columns the pointer is allowed to occupy. A write outside them is accepted and then
+		/// quietly ignored, which is what Windows does with a move into the empty space beside a
+		/// monitor: the pointer is confined to the union of the monitors, not to the rectangle
+		/// drawn around them.
+		/// </summary>
+		public int? ClampMinX;
+		public int? ClampMaxX;
+
 		public List<CursorPoint> Writes { get; } = new();
 
 		public bool TryGet(out CursorPoint position)
@@ -43,11 +54,16 @@ public class PointerNudgeRunnerTests
 
 		public bool TrySet(CursorPoint position)
 		{
+			int index = Writes.Count;
 			Writes.Add(position);
-			if (!WriteSucceeds)
+			if (!WriteSucceeds || FailWriteAtIndex == index)
 				return false;
 
-			Position = position;
+			bool clamped = (ClampMaxX is int max && position.X > max)
+				|| (ClampMinX is int min && position.X < min);
+			if (!clamped)
+				Position = position;
+
 			return true;
 		}
 	}
@@ -175,6 +191,86 @@ public class PointerNudgeRunnerTests
 
 		Assert.Equal(0, applied);
 		Assert.Single(cursor.Writes);
+	}
+
+	[Fact]
+	public async Task MoveClampedAtAMonitorEdge_TheWiggleGoesTheOtherWayInstead()
+	{
+		// The pointer is at the right edge of a monitor with empty space beside it. Windows
+		// accepts the move and clamps it away, so the magnifier sees nothing at all — the same
+		// silent failure the planner's old right-edge rule missed, one monitor edge inwards.
+		var cursor = new FakeCursor { ClampMaxX = Anchor.X };
+		var clock = new FakeClock();
+
+		int applied = await PointerNudgeRunner.RunAsync(cursor, clock.Delay, Anchor, PlanOf(4), Interval);
+
+		Assert.Equal(4, applied);
+		Assert.Equal(new CursorPoint(Anchor.X + 1, Anchor.Y), cursor.Writes[0]);
+		Assert.Equal(new CursorPoint(Anchor.X - 1, Anchor.Y), cursor.Writes[1]);
+		Assert.Equal(Anchor, cursor.Position);
+	}
+
+	[Fact]
+	public async Task PointerBoxedInOnBothSides_TheRunGivesUpAndLeavesItOnTheAnchor()
+	{
+		var cursor = new FakeCursor { ClampMinX = Anchor.X, ClampMaxX = Anchor.X };
+		var clock = new FakeClock();
+
+		int applied = await PointerNudgeRunner.RunAsync(cursor, clock.Delay, Anchor, PlanOf(4), Interval);
+
+		Assert.Equal(0, applied);
+		Assert.Equal(Anchor, cursor.Position);
+	}
+
+	[Fact]
+	public async Task StoppedOnAnOddStep_ThePointerIsPutBackOnTheAnchor()
+	{
+		// The next capture claims the pointer part-way through. Stopping where it stood would
+		// leave the pointer a pixel out, and the next capture would anchor on that drift and keep
+		// it — undoing the whole point of putting the pointer back at all.
+		var cursor = new FakeCursor();
+		var clock = new FakeClock();
+		int checks = 0;
+
+		int applied = await PointerNudgeRunner.RunAsync(
+			cursor, clock.Delay, Anchor, PlanOf(6), Interval, stillWanted: () => ++checks <= 1);
+
+		Assert.Equal(1, applied);
+		Assert.Equal(Anchor, cursor.Position);
+	}
+
+	[Fact]
+	public async Task RefusedMoveOnAnOddStep_StillPutsThePointerBack()
+	{
+		var cursor = new FakeCursor { FailWriteAtIndex = 1 };
+		var clock = new FakeClock();
+
+		int applied = await PointerNudgeRunner.RunAsync(cursor, clock.Delay, Anchor, PlanOf(6), Interval);
+
+		Assert.Equal(1, applied);
+		Assert.Equal(Anchor, cursor.Position);
+	}
+
+	[Fact]
+	public async Task UserTookTheMouse_ThePointerIsLeftExactlyWhereTheyPutIt()
+	{
+		// The one exit that must not tidy up after itself. The pointer is theirs now, drift and
+		// all, and hauling it to the anchor would be the jump this feature exists to avoid.
+		var elsewhere = new CursorPoint(900, 700);
+		var cursor = new FakeCursor();
+		var clock = new FakeClock();
+		int waits = 0;
+		clock.OnWait = () =>
+		{
+			// After one move, so the run believes the pointer is on the offset pixel.
+			if (++waits == 2)
+				cursor.Position = elsewhere;
+		};
+
+		await PointerNudgeRunner.RunAsync(cursor, clock.Delay, Anchor, PlanOf(6), Interval);
+
+		Assert.Equal(elsewhere, cursor.Position);
+		Assert.DoesNotContain(Anchor, cursor.Writes);
 	}
 
 	[Fact]

--- a/Mutation.Tests/PointerNudgeSettingsTests.cs
+++ b/Mutation.Tests/PointerNudgeSettingsTests.cs
@@ -1,0 +1,94 @@
+using CognitiveSupport;
+using Mutation.Ui.Services;
+using Newtonsoft.Json;
+
+namespace Mutation.Tests;
+
+// The pointer-nudge settings contract (issue #373): off by default with sensible timings,
+// backward compatible with a settings file written before the feature existed, and clamped on
+// load to the same range the Settings dialog offers — so a hand-edited file cannot produce a
+// nudge nobody can stop.
+public class PointerNudgeSettingsTests
+{
+	[Fact]
+	public void OffByDefault_WithFiftyAndFiveHundred()
+	{
+		// It moves the pointer on purpose. Nobody gets that uninvited.
+		var ocr = new AzureComputerVisionSettings();
+
+		Assert.False(ocr.NudgePointerAfterCapture);
+		Assert.Equal(50, ocr.PointerNudgeIntervalMilliseconds);
+		Assert.Equal(500, ocr.PointerNudgeDurationMilliseconds);
+	}
+
+	[Fact]
+	public void SettingsFileWrittenBeforeTheFeature_KeepsTheDefaults()
+	{
+		// No keys in the file, so the deserialiser leaves the property initializers alone.
+		var ocr = JsonConvert.DeserializeObject<AzureComputerVisionSettings>("{\"TimeoutSeconds\":10}");
+
+		Assert.NotNull(ocr);
+		Assert.False(ocr!.NudgePointerAfterCapture);
+		Assert.Equal(50, ocr.PointerNudgeIntervalMilliseconds);
+		Assert.Equal(500, ocr.PointerNudgeDurationMilliseconds);
+	}
+
+	[Theory]
+	[InlineData(0, 50)]      // never configured, or hand-edited to nothing
+	[InlineData(-10, 50)]
+	[InlineData(1, 10)]      // below the floor
+	[InlineData(10, 10)]
+	[InlineData(50, 50)]
+	[InlineData(500, 500)]
+	[InlineData(9999, 500)]  // above the ceiling
+	public void IntervalIsClampedOnLoad(int stored, int expected)
+	{
+		Assert.Equal(expected, Load(intervalMs: stored).PointerNudgeIntervalMilliseconds);
+	}
+
+	[Theory]
+	[InlineData(0, 500)]
+	[InlineData(-10, 500)]
+	[InlineData(10, 50)]
+	[InlineData(50, 50)]
+	[InlineData(500, 500)]
+	[InlineData(5000, 5000)]
+	[InlineData(60000, 5000)]
+	public void DurationIsClampedOnLoad(int stored, int expected)
+	{
+		Assert.Equal(expected, Load(durationMs: stored).PointerNudgeDurationMilliseconds);
+	}
+
+	[Fact]
+	public void ValuesAlreadyInRange_AreLeftExactlyAsTheyAre()
+	{
+		// Whatever the user picked in the dialog has to survive a reload untouched.
+		var ocr = Load(intervalMs: 120, durationMs: 3000);
+
+		Assert.Equal(120, ocr.PointerNudgeIntervalMilliseconds);
+		Assert.Equal(3000, ocr.PointerNudgeDurationMilliseconds);
+	}
+
+	[Fact]
+	public void TheToggleIsNeverTurnedOnForAnybody()
+	{
+		Assert.False(Load().NudgePointerAfterCapture);
+	}
+
+	private static AzureComputerVisionSettings Load(int intervalMs = 50, int durationMs = 500)
+	{
+		using var settingsFile = new TempSettingsFile("nudge", "{}");
+
+		var manager = new SettingsManager(settingsFile.FilePath);
+		var settings = new Settings
+		{
+			AzureComputerVisionSettings = new AzureComputerVisionSettings
+			{
+				PointerNudgeIntervalMilliseconds = intervalMs,
+				PointerNudgeDurationMilliseconds = durationMs,
+			},
+		};
+		manager.EnsureSettings(settings, isNewFile: false);
+		return settings.AzureComputerVisionSettings!;
+	}
+}

--- a/Mutation.Tests/SettingsDefaultsParityTests.cs
+++ b/Mutation.Tests/SettingsDefaultsParityTests.cs
@@ -53,6 +53,9 @@ public class SettingsDefaultsParityTests : IDisposable
 		Assert.Equal(SettingsDefaults.Ocr.MaxParallelRequests, ocr.MaxParallelRequests);
 		Assert.Equal(SettingsDefaults.Ocr.MaxDocumentBytes, ocr.MaxDocumentBytes!.Value);
 		Assert.Equal(SettingsDefaults.Ocr.PasteOcrTextIntoActiveApplication, ocr.PasteOcrTextIntoActiveApplication);
+		Assert.Equal(SettingsDefaults.Ocr.NudgePointerAfterCapture, ocr.NudgePointerAfterCapture);
+		Assert.Equal(SettingsDefaults.Ocr.PointerNudgeIntervalMilliseconds, ocr.PointerNudgeIntervalMilliseconds);
+		Assert.Equal(SettingsDefaults.Ocr.PointerNudgeDurationMilliseconds, ocr.PointerNudgeDurationMilliseconds);
 	}
 
 	[Fact]

--- a/Mutation.Ui/Core/CursorAnchor.cs
+++ b/Mutation.Ui/Core/CursorAnchor.cs
@@ -30,13 +30,22 @@ namespace Mutation.Ui.Core;
 /// </para>
 ///
 /// <para>
-/// Not thread-safe, and not meant to be: each capture drives one anchor from its own window.
+/// Thread-safe, because it has to be. The capture's own steps run on the UI thread, but the last
+/// one — putting the pointer back after the foreground has been handed over, and the optional
+/// wiggle that may follow it for seconds afterwards — runs off it. Without the lock,
+/// <see cref="ClearIfCurrent"/> could read a matching generation, be overtaken by the next
+/// capture's <see cref="Capture"/> on the UI thread, and then wipe the anchor that capture had
+/// just taken, leaving it with no pointer defence at all. The lock is uncontended in practice:
+/// one capture at a time, a handful of calls each.
 /// </para>
 /// </summary>
 public sealed class CursorAnchor
 {
 	private readonly ICursorPosition _cursor;
+	private readonly object _gate = new();
 	private CursorPoint _anchor;
+	private bool _hasAnchor;
+	private int _generation;
 
 	public CursorAnchor(ICursorPosition cursor)
 	{
@@ -47,12 +56,18 @@ public sealed class CursorAnchor
 	/// Whether there is a remembered position to go back to. False before the first successful
 	/// <see cref="Capture"/>, and again after <see cref="Clear"/>.
 	/// </summary>
-	public bool HasAnchor { get; private set; }
+	public bool HasAnchor
+	{
+		get { lock (_gate) return _hasAnchor; }
+	}
 
 	/// <summary>
 	/// The remembered position. Meaningless while <see cref="HasAnchor"/> is false.
 	/// </summary>
-	public CursorPoint Anchor => _anchor;
+	public CursorPoint Anchor
+	{
+		get { lock (_gate) return _anchor; }
+	}
 
 	/// <summary>
 	/// Which anchor this is. Changes on every <see cref="Capture"/> and every
@@ -66,7 +81,10 @@ public sealed class CursorAnchor
 	/// anchor that belongs to a capture that finished.
 	/// </para>
 	/// </summary>
-	public int Generation { get; private set; }
+	public int Generation
+	{
+		get { lock (_gate) return _generation; }
+	}
 
 	/// <summary>
 	/// Remembers where the pointer is now, replacing any position remembered before. Returns
@@ -75,17 +93,14 @@ public sealed class CursorAnchor
 	/// </summary>
 	public bool Capture()
 	{
-		Generation++;
-		if (_cursor.TryGet(out var position))
+		bool read = _cursor.TryGet(out var position);
+		lock (_gate)
 		{
-			_anchor = position;
-			HasAnchor = true;
-			return true;
+			_generation++;
+			_anchor = read ? position : default;
+			_hasAnchor = read;
 		}
-
-		_anchor = default;
-		HasAnchor = false;
-		return false;
+		return read;
 	}
 
 	/// <summary>
@@ -103,26 +118,39 @@ public sealed class CursorAnchor
 	/// blindly. Not knowing where the pointer is, is not a good enough reason to move it.
 	/// </para>
 	/// </summary>
-	public bool Restore()
-	{
-		if (!HasAnchor)
-			return false;
-
-		if (!_cursor.TryGet(out var current))
-			return false;
-
-		if (current == _anchor)
-			return false;
-
-		return _cursor.TrySet(_anchor);
-	}
+	public bool Restore() => Restore(null);
 
 	/// <summary>
 	/// As <see cref="Restore"/>, but does nothing unless <paramref name="generation"/> is still
 	/// the current one. Deferred work uses this so a restore scheduled by a capture that has
 	/// since finished cannot move the pointer during the next one.
 	/// </summary>
-	public bool RestoreIfCurrent(int generation) => generation == Generation && Restore();
+	public bool RestoreIfCurrent(int generation) => Restore(generation);
+
+	// The generation is checked under the same lock that reads the anchor, so a caller can never
+	// act on a generation that agreed a moment ago and an anchor that has since been replaced.
+	private bool Restore(int? requiredGeneration)
+	{
+		CursorPoint target;
+		lock (_gate)
+		{
+			if (!_hasAnchor)
+				return false;
+
+			if (requiredGeneration is int required && required != _generation)
+				return false;
+
+			target = _anchor;
+		}
+
+		if (!_cursor.TryGet(out var current))
+			return false;
+
+		if (current == target)
+			return false;
+
+		return _cursor.TrySet(target);
+	}
 
 	/// <summary>
 	/// Forgets the remembered position, so nothing can be restored to it later. Called once a
@@ -130,9 +158,8 @@ public sealed class CursorAnchor
 	/// </summary>
 	public void Clear()
 	{
-		Generation++;
-		_anchor = default;
-		HasAnchor = false;
+		lock (_gate)
+			ClearLocked();
 	}
 
 	/// <summary>
@@ -142,7 +169,17 @@ public sealed class CursorAnchor
 	/// </summary>
 	public void ClearIfCurrent(int generation)
 	{
-		if (generation == Generation)
-			Clear();
+		lock (_gate)
+		{
+			if (generation == _generation)
+				ClearLocked();
+		}
+	}
+
+	private void ClearLocked()
+	{
+		_generation++;
+		_anchor = default;
+		_hasAnchor = false;
 	}
 }

--- a/Mutation.Ui/Core/PointerNudgeOptions.cs
+++ b/Mutation.Ui/Core/PointerNudgeOptions.cs
@@ -1,0 +1,24 @@
+namespace Mutation.Ui.Core;
+
+/// <summary>
+/// Whether to nudge the mouse pointer when a capture ends, and how.
+/// <para>
+/// A workaround for one magnifier behaviour, which is why it is off unless asked for. ZoomText
+/// follows the keyboard caret as well as the mouse. When the capture overlay disappears and the
+/// application underneath gets the keyboard back, a flashing caret in a text box pulls the
+/// magnified view away from the pointer — the pointer is in the right place, but the user cannot
+/// see it. ZoomText switches back to the mouse the moment the mouse moves, and a stationary
+/// pointer gives it no reason to.
+/// </para>
+/// </summary>
+/// <param name="Enabled">Whether to nudge at all.</param>
+/// <param name="IntervalMilliseconds">How long between one one-pixel move and the next.</param>
+/// <param name="DurationMilliseconds">How long to keep nudging for, in total.</param>
+public readonly record struct PointerNudgeOptions(
+	bool Enabled,
+	int IntervalMilliseconds,
+	int DurationMilliseconds)
+{
+	/// <summary>What every capture gets unless the user has turned the nudge on.</summary>
+	public static PointerNudgeOptions Off => new(false, 0, 0);
+}

--- a/Mutation.Ui/Core/PointerNudgePlanner.cs
+++ b/Mutation.Ui/Core/PointerNudgePlanner.cs
@@ -13,6 +13,12 @@ namespace Mutation.Ui.Core;
 /// a nicety. The capture goes to some length to put the pointer back where the user left it, and
 /// a nudge that finished one pixel off would quietly undo that every single time.
 /// </para>
+///
+/// <para>
+/// The plan always moves right first. Which way the pointer can actually go is not knowable from
+/// here — it depends on where the monitors are — so <see cref="PointerNudgeRunner"/> settles that
+/// by watching whether the first move took effect.
+/// </para>
 /// </summary>
 public static class PointerNudgePlanner
 {
@@ -25,11 +31,7 @@ public static class PointerNudgePlanner
 	/// </para>
 	/// </summary>
 	/// <param name="anchor">Where the pointer is, and where it must finish.</param>
-	/// <param name="rightmostX">The last usable pixel column on the virtual screen. A pointer
-	/// already there cannot move further right — Windows clamps to the virtual screen, so the
-	/// move would be accepted and do nothing, and the magnifier would never see any movement.
-	/// The nudge goes left instead.</param>
-	public static IReadOnlyList<CursorPoint> Plan(CursorPoint anchor, int rightmostX, PointerNudgeOptions options)
+	public static IReadOnlyList<CursorPoint> Plan(CursorPoint anchor, PointerNudgeOptions options)
 	{
 		if (!options.Enabled)
 			return Array.Empty<CursorPoint>();
@@ -40,11 +42,11 @@ public static class PointerNudgePlanner
 		// At least one move whenever the nudge is switched on. A duration shorter than a single
 		// interval would otherwise divide down to nothing, and a setting that is on but silently
 		// does nothing is the worst answer available — worst of all for someone who cannot see
-		// that nothing happened.
+		// that nothing happened. The cost is that such a pairing runs past its stated duration,
+		// which the help text says.
 		int moves = Math.Max(1, options.DurationMilliseconds / options.IntervalMilliseconds);
 
-		int step = anchor.X >= rightmostX ? -1 : 1;
-		var away = new CursorPoint(anchor.X + step, anchor.Y);
+		var away = new CursorPoint(anchor.X + 1, anchor.Y);
 
 		var plan = new List<CursorPoint>(moves + 1);
 		for (int i = 0; i < moves; i++)

--- a/Mutation.Ui/Core/PointerNudgePlanner.cs
+++ b/Mutation.Ui/Core/PointerNudgePlanner.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+
+namespace Mutation.Ui.Core;
+
+/// <summary>
+/// Works out the exact sequence of positions a pointer nudge will visit.
+///
+/// <para>
+/// Kept apart from the running of it so the shape of the movement can be checked without
+/// waiting half a second per test, and so the two properties that matter are stated in one
+/// place: the pointer moves, and the pointer ends up exactly where it started. The second is not
+/// a nicety. The capture goes to some length to put the pointer back where the user left it, and
+/// a nudge that finished one pixel off would quietly undo that every single time.
+/// </para>
+/// </summary>
+public static class PointerNudgePlanner
+{
+	/// <summary>
+	/// The positions to move through, in order, one per interval. The last one is always the
+	/// anchor itself.
+	/// <para>
+	/// Empty only when the nudge is off, or when the numbers are not usable at all — a
+	/// non-positive interval or duration. An empty plan means the pointer is never touched.
+	/// </para>
+	/// </summary>
+	/// <param name="anchor">Where the pointer is, and where it must finish.</param>
+	/// <param name="rightmostX">The last usable pixel column on the virtual screen. A pointer
+	/// already there cannot move further right — Windows clamps to the virtual screen, so the
+	/// move would be accepted and do nothing, and the magnifier would never see any movement.
+	/// The nudge goes left instead.</param>
+	public static IReadOnlyList<CursorPoint> Plan(CursorPoint anchor, int rightmostX, PointerNudgeOptions options)
+	{
+		if (!options.Enabled)
+			return Array.Empty<CursorPoint>();
+
+		if (options.IntervalMilliseconds <= 0 || options.DurationMilliseconds <= 0)
+			return Array.Empty<CursorPoint>();
+
+		// At least one move whenever the nudge is switched on. A duration shorter than a single
+		// interval would otherwise divide down to nothing, and a setting that is on but silently
+		// does nothing is the worst answer available — worst of all for someone who cannot see
+		// that nothing happened.
+		int moves = Math.Max(1, options.DurationMilliseconds / options.IntervalMilliseconds);
+
+		int step = anchor.X >= rightmostX ? -1 : 1;
+		var away = new CursorPoint(anchor.X + step, anchor.Y);
+
+		var plan = new List<CursorPoint>(moves + 1);
+		for (int i = 0; i < moves; i++)
+			plan.Add(i % 2 == 0 ? away : anchor);
+
+		// An odd number of moves ends on the offset position, so the pointer needs one more move
+		// home. That extra move costs one more interval and is worth it: finishing a pixel out
+		// is exactly the drift the capture spends its effort preventing.
+		if (plan[plan.Count - 1] != anchor)
+			plan.Add(anchor);
+
+		return plan;
+	}
+}

--- a/Mutation.Ui/Core/PointerNudgeRunner.cs
+++ b/Mutation.Ui/Core/PointerNudgeRunner.cs
@@ -18,9 +18,14 @@ namespace Mutation.Ui.Core;
 /// </para>
 ///
 /// <para>
-/// That check is exact rather than approximate because every position it compares against was
-/// written by this loop through the same interface it reads back, so the value returned is the
-/// value written. Nothing here has to reason about pixels or tolerances.
+/// Two things the loop has to get right, and both are about not leaving a mess behind. It checks
+/// that the first move really happened, because Windows confines the pointer to the union of the
+/// monitors rather than to the rectangle around them: a move into empty space beside a monitor is
+/// accepted, quietly clamped away, and shows a magnifier no movement at all. When that happens
+/// the run mirrors the rest of the plan and goes the other way instead. And when the run gives up
+/// part-way through, on any path other than the user taking the mouse, it puts the pointer back
+/// on the anchor before it leaves — a nudge that stopped on an odd step would otherwise leave the
+/// pointer a pixel out, and the next capture would anchor on the drift and keep it.
 /// </para>
 ///
 /// <para>
@@ -39,9 +44,9 @@ public static class PointerNudgeRunner
 	/// <param name="cursor">Where the pointer is read and written.</param>
 	/// <param name="delay">How to wait one interval.</param>
 	/// <param name="anchor">Where the pointer is expected to be found when the run starts — the
-	/// position the capture put it back on. Seeding the expectation from here rather than from a
-	/// live read is what stops a pointer somebody else has already taken over from being hauled
-	/// back to a place it left.</param>
+	/// position the capture put it back on, and the position it must be left on. Seeding the
+	/// expectation from here rather than from a live read is what stops a pointer somebody else
+	/// has already taken over from being hauled back to a place it left.</param>
 	/// <param name="plan">Positions to move through, from <see cref="PointerNudgePlanner"/>.</param>
 	/// <param name="interval">How long to wait before each move.</param>
 	/// <param name="stillWanted">Asked before each move. False stops the nudge — used to drop it
@@ -64,24 +69,75 @@ public static class PointerNudgeRunner
 		// Where the pointer has to be found before each move, starting from where the capture
 		// left it.
 		var expected = anchor;
+		bool mirrored = false;
+		bool directionSettled = false;
 		int applied = 0;
+
 		foreach (var position in plan)
 		{
 			await delay(interval).ConfigureAwait(false);
 
 			if (stillWanted is not null && !stillWanted())
-				return applied;
+				return Settle(cursor, anchor, expected, applied);
 
+			// The user has the mouse. Leave the pointer exactly as they left it, drift and all —
+			// the one exit that must not tidy up after itself.
 			if (!cursor.TryGet(out var current) || current != expected)
 				return applied;
 
-			if (!cursor.TrySet(position))
-				return applied;
+			var target = mirrored ? Mirror(anchor, position) : position;
 
-			expected = position;
+			if (!cursor.TrySet(target))
+				return Settle(cursor, anchor, expected, applied);
+
+			if (!directionSettled && target != anchor)
+			{
+				directionSettled = true;
+				if (!TookEffect(cursor, target))
+				{
+					// Nothing that way — the pointer is against a monitor edge with empty space
+					// beyond it, so the move was accepted and clamped away. Go the other way for
+					// the rest of the run.
+					mirrored = true;
+					target = Mirror(anchor, position);
+					if (!cursor.TrySet(target) || !TookEffect(cursor, target))
+						return Settle(cursor, anchor, expected, applied);
+				}
+			}
+
+			expected = target;
 			applied++;
 		}
 
+		return applied;
+	}
+
+	private static CursorPoint Mirror(CursorPoint anchor, CursorPoint position) =>
+		new(anchor.X - (position.X - anchor.X), position.Y);
+
+	/// <summary>
+	/// Whether the pointer actually arrived where it was sent. A position that cannot be read
+	/// counts as arrived: refusing to believe an accepted move on the strength of a failed read
+	/// would abandon the nudge on every machine where reading the pointer is the flaky part.
+	/// </summary>
+	private static bool TookEffect(ICursorPosition cursor, CursorPoint target) =>
+		!cursor.TryGet(out var landed) || landed == target;
+
+	/// <summary>
+	/// Leaves the pointer on the anchor when the run gives up part-way through and the pointer is
+	/// still the one the run has been moving. Without this, stopping on an odd step would leave
+	/// the pointer a pixel off, the next capture would anchor on that, and the drift would stay —
+	/// which is the whole thing the plan's extra move home exists to prevent.
+	/// </summary>
+	private static int Settle(ICursorPosition cursor, CursorPoint anchor, CursorPoint expected, int applied)
+	{
+		if (expected == anchor)
+			return applied;
+
+		if (cursor.TryGet(out var current) && current != expected)
+			return applied;
+
+		cursor.TrySet(anchor);
 		return applied;
 	}
 }

--- a/Mutation.Ui/Core/PointerNudgeRunner.cs
+++ b/Mutation.Ui/Core/PointerNudgeRunner.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Mutation.Ui.Core;
+
+/// <summary>
+/// Walks a nudge plan, one position per interval, and gets out of the way the moment the pointer
+/// stops being ours to move.
+///
+/// <para>
+/// The stand-down rule is the whole reason this is not a plain loop. Before each move it checks
+/// that the pointer is still exactly where the previous move left it. If it is not, something
+/// else has taken hold of it — the user has picked up the mouse, or the next capture has already
+/// started and put the pointer somewhere of its own — and the nudge stops immediately. Half a
+/// second of an application dragging the pointer back under the user's hand would be far worse
+/// than the problem being solved.
+/// </para>
+///
+/// <para>
+/// That check is exact rather than approximate because every position it compares against was
+/// written by this loop through the same interface it reads back, so the value returned is the
+/// value written. Nothing here has to reason about pixels or tolerances.
+/// </para>
+///
+/// <para>
+/// The delay is injected, so the whole sequence can be tested in no time at all rather than in
+/// the half second it takes on a real screen — the same arrangement <see cref="ContentReadyGate"/>
+/// uses.
+/// </para>
+/// </summary>
+public static class PointerNudgeRunner
+{
+	/// <summary>
+	/// Applies each position in <paramref name="plan"/>, waiting <paramref name="interval"/>
+	/// before each one. Returns how many were applied, which is the length of the plan on an
+	/// uninterrupted run.
+	/// </summary>
+	/// <param name="cursor">Where the pointer is read and written.</param>
+	/// <param name="delay">How to wait one interval.</param>
+	/// <param name="anchor">Where the pointer is expected to be found when the run starts — the
+	/// position the capture put it back on. Seeding the expectation from here rather than from a
+	/// live read is what stops a pointer somebody else has already taken over from being hauled
+	/// back to a place it left.</param>
+	/// <param name="plan">Positions to move through, from <see cref="PointerNudgePlanner"/>.</param>
+	/// <param name="interval">How long to wait before each move.</param>
+	/// <param name="stillWanted">Asked before each move. False stops the nudge — used to drop it
+	/// when the capture that started it is over. Null means never asked.</param>
+	public static async Task<int> RunAsync(
+		ICursorPosition cursor,
+		Func<TimeSpan, Task> delay,
+		CursorPoint anchor,
+		IReadOnlyList<CursorPoint> plan,
+		TimeSpan interval,
+		Func<bool>? stillWanted = null)
+	{
+		if (cursor is null) throw new ArgumentNullException(nameof(cursor));
+		if (delay is null) throw new ArgumentNullException(nameof(delay));
+		if (plan is null) throw new ArgumentNullException(nameof(plan));
+
+		if (plan.Count == 0)
+			return 0;
+
+		// Where the pointer has to be found before each move, starting from where the capture
+		// left it.
+		var expected = anchor;
+		int applied = 0;
+		foreach (var position in plan)
+		{
+			await delay(interval).ConfigureAwait(false);
+
+			if (stillWanted is not null && !stillWanted())
+				return applied;
+
+			if (!cursor.TryGet(out var current) || current != expected)
+				return applied;
+
+			if (!cursor.TrySet(position))
+				return applied;
+
+			expected = position;
+			applied++;
+		}
+
+		return applied;
+	}
+}

--- a/Mutation.Ui/Resources/HelpText.xaml
+++ b/Mutation.Ui/Resources/HelpText.xaml
@@ -21,7 +21,7 @@
 	<x:String x:Key="Help.Ocr.SendHotkeyAfter">Optional keystrokes sent to the active app once the OCR text has been delivered, for example a screen reader command that reads it back.</x:String>
 	<x:String x:Key="Help.Ocr.NudgePointer">Wiggles the mouse pointer one pixel back and forth after a capture, then leaves it exactly where it started. Some magnifiers follow a flashing text cursor instead of the mouse, so when the app underneath gets focus back the magnified view jumps away from your pointer. A little movement brings the view back to the mouse. Leave this off unless you see that happen.</x:String>
 	<x:String x:Key="Help.Ocr.NudgeInterval">How long to wait between one wiggle and the next. Shorter is more insistent.</x:String>
-	<x:String x:Key="Help.Ocr.NudgeDuration">How long to keep wiggling for in total. Long enough for the magnifier to notice, short enough to be out of your way.</x:String>
+	<x:String x:Key="Help.Ocr.NudgeDuration">How long to keep wiggling for in total. Long enough for the magnifier to notice, short enough to be out of your way. You always get at least one wiggle, so a duration shorter than the interval above still gives you one.</x:String>
 
 	<!-- Interface -->
 	<x:String x:Key="Help.Interface.MaxVisibleLines">Caps the height of the transcript and OCR text boxes on the main window.</x:String>

--- a/Mutation.Ui/Resources/HelpText.xaml
+++ b/Mutation.Ui/Resources/HelpText.xaml
@@ -19,6 +19,9 @@
 	<x:String x:Key="Help.Ocr.MaxDocumentSize">Maximum size of a file or page sent for OCR. Larger files are skipped before upload to avoid unexpectedly large uploads. Set to 0 for no limit.</x:String>
 	<x:String x:Key="Help.Ocr.PasteIntoActiveApp">Paste the recognised text into whatever app you were working in, as soon as OCR finishes. The text is always copied to the clipboard; this decides whether Mutation also pastes it for you.</x:String>
 	<x:String x:Key="Help.Ocr.SendHotkeyAfter">Optional keystrokes sent to the active app once the OCR text has been delivered, for example a screen reader command that reads it back.</x:String>
+	<x:String x:Key="Help.Ocr.NudgePointer">Wiggles the mouse pointer one pixel back and forth after a capture, then leaves it exactly where it started. Some magnifiers follow a flashing text cursor instead of the mouse, so when the app underneath gets focus back the magnified view jumps away from your pointer. A little movement brings the view back to the mouse. Leave this off unless you see that happen.</x:String>
+	<x:String x:Key="Help.Ocr.NudgeInterval">How long to wait between one wiggle and the next. Shorter is more insistent.</x:String>
+	<x:String x:Key="Help.Ocr.NudgeDuration">How long to keep wiggling for in total. Long enough for the magnifier to notice, short enough to be out of your way.</x:String>
 
 	<!-- Interface -->
 	<x:String x:Key="Help.Interface.MaxVisibleLines">Caps the height of the transcript and OCR text boxes on the main window.</x:String>

--- a/Mutation.Ui/Services/OcrManager.cs
+++ b/Mutation.Ui/Services/OcrManager.cs
@@ -887,6 +887,9 @@ public class OcrManager
         try
         {
             var overlay = _cachedOverlay ?? new RegionSelectionWindow();
+            // Read per capture, not once at startup: the overlay is cached and reused, so a
+            // change made in the Settings dialog has to reach the next capture (issue #373).
+            overlay.PointerNudge = ReadPointerNudgeOptions();
             // InitializeAsync already calls UpdateBitmap; calling it again converted and
             // copied the whole virtual screen a second time for nothing (issue #229).
             await overlay.InitializeAsync(bmp);
@@ -926,6 +929,22 @@ public class OcrManager
         {
             bmp.Dispose();
         }
+    }
+
+    /// <summary>
+    /// The pointer-nudge settings, as the overlay wants them. Off whenever the OCR settings are
+    /// missing altogether, which is the same answer a fresh settings file gives.
+    /// </summary>
+    private PointerNudgeOptions ReadPointerNudgeOptions()
+    {
+        var ocr = _settings.AzureComputerVisionSettings;
+        if (ocr is null || !ocr.NudgePointerAfterCapture)
+            return PointerNudgeOptions.Off;
+
+        return new PointerNudgeOptions(
+            true,
+            ocr.PointerNudgeIntervalMilliseconds,
+            ocr.PointerNudgeDurationMilliseconds);
     }
 
     private static async Task<SoftwareBitmap> CropBitmapAsync(SoftwareBitmap src, Rect rect)

--- a/Mutation.Ui/Services/SettingsManager.cs
+++ b/Mutation.Ui/Services/SettingsManager.cs
@@ -196,6 +196,34 @@ internal class SettingsManager : ISettingsManager
                         somethingWasMissing = true;
                 }
 
+		// Pointer-nudge timings. A settings file written before the nudge existed has neither
+		// key, so both land on 0 rather than on the property initializer, and 0 would mean a
+		// nudge that is switched on but never moves. Clamping into the same range the dialog
+		// offers is what keeps a hand-edited file from producing a nudge nobody can stop.
+		int nudgeInterval = azureComputerVisionSettings.PointerNudgeIntervalMilliseconds <= 0
+			? AzureComputerVisionSettings.DefaultPointerNudgeIntervalMilliseconds
+			: Math.Clamp(
+				azureComputerVisionSettings.PointerNudgeIntervalMilliseconds,
+				AzureComputerVisionSettings.MinPointerNudgeIntervalMilliseconds,
+				AzureComputerVisionSettings.MaxPointerNudgeIntervalMilliseconds);
+		if (nudgeInterval != azureComputerVisionSettings.PointerNudgeIntervalMilliseconds)
+		{
+			azureComputerVisionSettings.PointerNudgeIntervalMilliseconds = nudgeInterval;
+			somethingWasMissing = true;
+		}
+
+		int nudgeDuration = azureComputerVisionSettings.PointerNudgeDurationMilliseconds <= 0
+			? AzureComputerVisionSettings.DefaultPointerNudgeDurationMilliseconds
+			: Math.Clamp(
+				azureComputerVisionSettings.PointerNudgeDurationMilliseconds,
+				AzureComputerVisionSettings.MinPointerNudgeDurationMilliseconds,
+				AzureComputerVisionSettings.MaxPointerNudgeDurationMilliseconds);
+		if (nudgeDuration != azureComputerVisionSettings.PointerNudgeDurationMilliseconds)
+		{
+			azureComputerVisionSettings.PointerNudgeDurationMilliseconds = nudgeDuration;
+			somethingWasMissing = true;
+		}
+
 
 		if (settings.AudioSettings is null)
 		{

--- a/Mutation.Ui/Services/SettingsManager.cs
+++ b/Mutation.Ui/Services/SettingsManager.cs
@@ -196,10 +196,12 @@ internal class SettingsManager : ISettingsManager
                         somethingWasMissing = true;
                 }
 
-		// Pointer-nudge timings. A settings file written before the nudge existed has neither
-		// key, so both land on 0 rather than on the property initializer, and 0 would mean a
-		// nudge that is switched on but never moves. Clamping into the same range the dialog
-		// offers is what keeps a hand-edited file from producing a nudge nobody can stop.
+		// Pointer-nudge timings. A file written before the nudge existed keeps the property
+		// initializers, because the deserialiser constructs the object and then overwrites only
+		// the keys the file actually has — so this is a no-op there. It is for a hand-edited
+		// file, which can carry a zero, a negative, or a number far outside what the dialog
+		// offers. Clamping to the same range the dialog offers is what stops one of those
+		// producing a nudge nobody can stop.
 		int nudgeInterval = azureComputerVisionSettings.PointerNudgeIntervalMilliseconds <= 0
 			? AzureComputerVisionSettings.DefaultPointerNudgeIntervalMilliseconds
 			: Math.Clamp(

--- a/Mutation.Ui/Views/RegionSelectionWindow.xaml.cs
+++ b/Mutation.Ui/Views/RegionSelectionWindow.xaml.cs
@@ -51,6 +51,13 @@ public sealed partial class RegionSelectionWindow : Window
 	/// change and put back after it (issue #371).
 	/// </summary>
 	private readonly CursorAnchor _cursorAnchor;
+
+	/// <summary>
+	/// Whether to nudge the pointer when this capture ends, and how. Set by the caller before
+	/// each capture rather than read from settings here, so the overlay stays free of settings
+	/// and a change made in the dialog takes effect on the next capture.
+	/// </summary>
+	public PointerNudgeOptions PointerNudge { get; set; } = PointerNudgeOptions.Off;
 	private const string AnnouncementActivityId = "RegionSelection";
 	private const string CancelledAnnouncement = "Region selection cancelled.";
 
@@ -690,33 +697,69 @@ public sealed partial class RegionSelectionWindow : Window
 	/// argues — but it is a real cost, not a free win.
 	/// </para>
 	/// <para>
-	/// The continuation runs on the thread pool, which is fine: setting the pointer position is
-	/// not tied to a thread. It is stamped with the anchor it was registered against, so a
-	/// handback that somehow outlives its own capture cannot touch the next one's pointer.
+	/// The work runs off the UI thread, which is fine: setting the pointer position is not tied
+	/// to a thread. It is stamped with the anchor it was registered against, so a handback that
+	/// somehow outlives its own capture cannot touch the next one's pointer.
+	/// </para>
+	/// <para>
+	/// Nothing waits for this. Deliberately: a cancelled capture waits for
+	/// <see cref="ForegroundHandedBack"/> before it says anything, and the nudge that may follow
+	/// runs for up to five seconds. Adding that to the wait would leave the user in silence for
+	/// the whole of it.
 	/// </para>
 	/// </summary>
 	private void RestoreCursorAfterForegroundHandback()
 	{
-		int generation = _cursorAnchor.Generation;
-		var handback = ForegroundHandedBack;
-		if (handback.IsCompleted)
-		{
-			// The foreground went back synchronously, so the restore just done in
-			// CompleteSelection already covered it.
-			_cursorAnchor.ClearIfCurrent(generation);
-			return;
-		}
+		_ = HandPointerBackAsync(_cursorAnchor.Generation, PointerNudge);
+	}
 
-		_ = handback.ContinueWith(
-			_ =>
-			{
-				_cursorAnchor.RestoreIfCurrent(generation);
-				// The capture is over and the pointer belongs to the user again.
-				_cursorAnchor.ClearIfCurrent(generation);
-			},
-			System.Threading.CancellationToken.None,
-			TaskContinuationOptions.None,
-			TaskScheduler.Default);
+	private async Task HandPointerBackAsync(int generation, PointerNudgeOptions nudge)
+	{
+		try
+		{
+			await ForegroundHandedBack.ConfigureAwait(false);
+			_cursorAnchor.RestoreIfCurrent(generation);
+			await NudgePointerAsync(generation, nudge).ConfigureAwait(false);
+		}
+		catch
+		{
+			// The pointer is a nicety. Nothing here may break a capture that has already
+			// produced its picture.
+		}
+		finally
+		{
+			// The capture is over and the pointer belongs to the user again.
+			_cursorAnchor.ClearIfCurrent(generation);
+		}
+	}
+
+	/// <summary>
+	/// Moves the pointer one pixel back and forth for a while, so a magnifier that has followed
+	/// the keyboard caret somewhere else brings its view back to the mouse (issue #373).
+	/// <para>
+	/// Runs after the restore, not instead of it, and finishes on the very pixel the restore put
+	/// the pointer on. The order matters: nudging around a position that had drifted would
+	/// advertise the wrong place.
+	/// </para>
+	/// </summary>
+	private Task NudgePointerAsync(int generation, PointerNudgeOptions nudge)
+	{
+		if (!nudge.Enabled || _cursorAnchor.Generation != generation || !_cursorAnchor.HasAnchor)
+			return Task.CompletedTask;
+
+		var anchor = _cursorAnchor.Anchor;
+		int rightmostX = GetSystemMetrics(SM_XVIRTUALSCREEN) + GetSystemMetrics(SM_CXVIRTUALSCREEN) - 1;
+		var plan = PointerNudgePlanner.Plan(anchor, rightmostX, nudge);
+
+		return PointerNudgeRunner.RunAsync(
+			_cursor,
+			Task.Delay,
+			anchor,
+			plan,
+			TimeSpan.FromMilliseconds(nudge.IntervalMilliseconds),
+			// Drops the nudge the moment a new capture claims the anchor, so two captures in
+			// quick succession never have one nudging against the other's pointer.
+			() => _cursorAnchor.Generation == generation);
 	}
 
 	private void Announce(string message, AutomationNotificationKind kind)

--- a/Mutation.Ui/Views/RegionSelectionWindow.xaml.cs
+++ b/Mutation.Ui/Views/RegionSelectionWindow.xaml.cs
@@ -748,8 +748,7 @@ public sealed partial class RegionSelectionWindow : Window
 			return Task.CompletedTask;
 
 		var anchor = _cursorAnchor.Anchor;
-		int rightmostX = GetSystemMetrics(SM_XVIRTUALSCREEN) + GetSystemMetrics(SM_CXVIRTUALSCREEN) - 1;
-		var plan = PointerNudgePlanner.Plan(anchor, rightmostX, nudge);
+		var plan = PointerNudgePlanner.Plan(anchor, nudge);
 
 		return PointerNudgeRunner.RunAsync(
 			_cursor,

--- a/Mutation.Ui/Views/Settings/Pages/OcrSettingsPage.xaml
+++ b/Mutation.Ui/Views/Settings/Pages/OcrSettingsPage.xaml
@@ -98,6 +98,39 @@
 			<controls:InfoHint Text="{StaticResource Help.Ocr.PasteIntoActiveApp}" VerticalAlignment="Center" />
 		</StackPanel>
 
+		<StackPanel Spacing="8">
+			<StackPanel Orientation="Horizontal" Spacing="6">
+				<ToggleSwitch x:Name="ToggleNudgePointer" Header="Wiggle the mouse pointer after a capture" AutomationProperties.HelpText="{StaticResource Help.Ocr.NudgePointer}" Toggled="ToggleNudgePointer_Toggled" />
+				<controls:InfoHint Text="{StaticResource Help.Ocr.NudgePointer}" VerticalAlignment="Center" />
+			</StackPanel>
+			<StackPanel Orientation="Horizontal" Spacing="16">
+				<StackPanel>
+					<StackPanel Orientation="Horizontal" Spacing="6">
+						<TextBlock Text="Wiggle every (milliseconds)" VerticalAlignment="Center" Style="{StaticResource BodyStrongTextBlockStyle}" />
+						<controls:InfoHint Text="{StaticResource Help.Ocr.NudgeInterval}" VerticalAlignment="Center" />
+					</StackPanel>
+					<StackPanel Orientation="Horizontal" Spacing="6">
+						<NumberBox x:Name="NbNudgeInterval" AutomationProperties.Name="Wiggle every (milliseconds)" AutomationProperties.HelpText="{StaticResource Help.Ocr.NudgeInterval}" Minimum="10" Maximum="500" SmallChange="10" LargeChange="50" Width="180" SpinButtonPlacementMode="Inline" ValueChanged="NbNudgeInterval_ValueChanged" />
+						<Button Click="BtnResetNudgeInterval_Click" ToolTipService.ToolTip="Reset to default" AutomationProperties.Name="Reset wiggle interval">
+							<FontIcon Glyph="&#xE72C;" FontFamily="Segoe Fluent Icons" FontSize="12" AutomationProperties.AccessibilityView="Raw" />
+						</Button>
+					</StackPanel>
+				</StackPanel>
+				<StackPanel>
+					<StackPanel Orientation="Horizontal" Spacing="6">
+						<TextBlock Text="Keep wiggling for (milliseconds)" VerticalAlignment="Center" Style="{StaticResource BodyStrongTextBlockStyle}" />
+						<controls:InfoHint Text="{StaticResource Help.Ocr.NudgeDuration}" VerticalAlignment="Center" />
+					</StackPanel>
+					<StackPanel Orientation="Horizontal" Spacing="6">
+						<NumberBox x:Name="NbNudgeDuration" AutomationProperties.Name="Keep wiggling for (milliseconds)" AutomationProperties.HelpText="{StaticResource Help.Ocr.NudgeDuration}" Minimum="50" Maximum="5000" SmallChange="50" LargeChange="250" Width="200" SpinButtonPlacementMode="Inline" ValueChanged="NbNudgeDuration_ValueChanged" />
+						<Button Click="BtnResetNudgeDuration_Click" ToolTipService.ToolTip="Reset to default" AutomationProperties.Name="Reset wiggle duration">
+							<FontIcon Glyph="&#xE72C;" FontFamily="Segoe Fluent Icons" FontSize="12" AutomationProperties.AccessibilityView="Raw" />
+						</Button>
+					</StackPanel>
+				</StackPanel>
+			</StackPanel>
+		</StackPanel>
+
 		<controls:HotkeyEditor x:Name="HkSendAfterOcr" Header="Send hotkey after OCR (optional)" HelpText="{StaticResource Help.Ocr.SendHotkeyAfter}" AllowEmpty="True" AllowSendKeysSyntax="True" />
 
 		<TextBlock Text="OCR action hotkeys appear in the Hotkeys tab."

--- a/Mutation.Ui/Views/Settings/Pages/OcrSettingsPage.xaml.cs
+++ b/Mutation.Ui/Views/Settings/Pages/OcrSettingsPage.xaml.cs
@@ -48,6 +48,13 @@ public sealed partial class OcrSettingsPage : UserControl
 			ToggleUseFreeTier.IsOn = ocr.UseFreeTier;
 			ToggleInvert.IsOn = ocr.InvertScreenshot;
 			TogglePasteOcrText.IsOn = ocr.PasteOcrTextIntoActiveApplication;
+			ToggleNudgePointer.IsOn = ocr.NudgePointerAfterCapture;
+			NbNudgeInterval.Value = ocr.PointerNudgeIntervalMilliseconds > 0
+				? ocr.PointerNudgeIntervalMilliseconds
+				: SettingsDefaults.Ocr.PointerNudgeIntervalMilliseconds;
+			NbNudgeDuration.Value = ocr.PointerNudgeDurationMilliseconds > 0
+				? ocr.PointerNudgeDurationMilliseconds
+				: SettingsDefaults.Ocr.PointerNudgeDurationMilliseconds;
 			HkSendAfterOcr.Hotkey = ocr.SendHotkeyAfterOcrOperation ?? string.Empty;
 		}
 		finally { _suppressEvents = false; }
@@ -98,6 +105,18 @@ public sealed partial class OcrSettingsPage : UserControl
 		(_settings.AzureComputerVisionSettings ??= new AzureComputerVisionSettings()).PasteOcrTextIntoActiveApplication = TogglePasteOcrText.IsOn;
 	}
 
+	private void ToggleNudgePointer_Toggled(object sender, RoutedEventArgs e)
+	{
+		if (_suppressEvents) return;
+		(_settings.AzureComputerVisionSettings ??= new AzureComputerVisionSettings()).NudgePointerAfterCapture = ToggleNudgePointer.IsOn;
+	}
+
+	private void NbNudgeInterval_ValueChanged(NumberBox sender, NumberBoxValueChangedEventArgs args) =>
+		WriteInt(args.NewValue, v => (_settings.AzureComputerVisionSettings ??= new AzureComputerVisionSettings()).PointerNudgeIntervalMilliseconds = v);
+
+	private void NbNudgeDuration_ValueChanged(NumberBox sender, NumberBoxValueChangedEventArgs args) =>
+		WriteInt(args.NewValue, v => (_settings.AzureComputerVisionSettings ??= new AzureComputerVisionSettings()).PointerNudgeDurationMilliseconds = v);
+
 	private void WriteInt(double value, System.Action<int> apply)
 	{
 		if (_suppressEvents) return;
@@ -115,4 +134,8 @@ public sealed partial class OcrSettingsPage : UserControl
 		NbMaxParallelRequests.Value = SettingsDefaults.Ocr.MaxParallelRequests;
 	private void BtnResetMaxDocSize_Click(object sender, RoutedEventArgs e) =>
 		NbMaxDocumentSizeMb.Value = SettingsDefaults.Ocr.MaxDocumentBytes / BytesPerMb;
+	private void BtnResetNudgeInterval_Click(object sender, RoutedEventArgs e) =>
+		NbNudgeInterval.Value = SettingsDefaults.Ocr.PointerNudgeIntervalMilliseconds;
+	private void BtnResetNudgeDuration_Click(object sender, RoutedEventArgs e) =>
+		NbNudgeDuration.Value = SettingsDefaults.Ocr.PointerNudgeDurationMilliseconds;
 }

--- a/Mutation.Ui/Views/Settings/SettingsDefaults.cs
+++ b/Mutation.Ui/Views/Settings/SettingsDefaults.cs
@@ -35,6 +35,16 @@ internal static class SettingsDefaults
 		public const long MaxDocumentBytes = 10L * 1024 * 1024;
 		public const int MaxDocumentSizeMbUiMax = 500;
 		public const bool PasteOcrTextIntoActiveApplication = true;
+
+		// Pointer nudge after a capture. Defaults and UI bounds mirror the domain so the
+		// dialog, the load-time clamp and the nudge itself all agree on one source of truth.
+		public const bool NudgePointerAfterCapture = false;
+		public const int PointerNudgeIntervalMilliseconds = AzureComputerVisionSettings.DefaultPointerNudgeIntervalMilliseconds;
+		public const int MinPointerNudgeIntervalMilliseconds = AzureComputerVisionSettings.MinPointerNudgeIntervalMilliseconds;
+		public const int MaxPointerNudgeIntervalMilliseconds = AzureComputerVisionSettings.MaxPointerNudgeIntervalMilliseconds;
+		public const int PointerNudgeDurationMilliseconds = AzureComputerVisionSettings.DefaultPointerNudgeDurationMilliseconds;
+		public const int MinPointerNudgeDurationMilliseconds = AzureComputerVisionSettings.MinPointerNudgeDurationMilliseconds;
+		public const int MaxPointerNudgeDurationMilliseconds = AzureComputerVisionSettings.MaxPointerNudgeDurationMilliseconds;
 	}
 
 	public static class Speech

--- a/README.md
+++ b/README.md
@@ -205,7 +205,10 @@ All hotkeys are global and fully customisable. Below is an example covering ever
     "FreeTierPageLimit": 2,
     "MaxParallelDocuments": 2,
     "MaxParallelRequests": 4,
-    "MaxDocumentBytes": 10485760
+    "MaxDocumentBytes": 10485760,
+    "NudgePointerAfterCapture": false,
+    "PointerNudgeIntervalMilliseconds": 50,
+    "PointerNudgeDurationMilliseconds": 500
   },
 
   "SpeechToTextSettings": {


### PR DESCRIPTION
Closes #373

## What was wrong

Putting the pointer back where the capture found it (the pointer-stays-put story, #371) fixed the pointer. It did not fix what the magnifier is looking at.

ZoomText follows the keyboard caret as well as the mouse. When the overlay disappears and the application underneath gets the keyboard back, a flashing caret in a text box pulls the magnified view away from the pointer. The pointer is exactly where the user left it — they just cannot see it any more. ZoomText switches back to the mouse the moment the mouse moves, and a stationary pointer gives it no reason to.

## What it does now

Optionally, when a capture ends, Mutation moves the pointer one pixel back and forth, once per interval, for a while, finishing on exactly the pixel it started from. Off unless switched on: this is a workaround for one magnifier's focus-tracking behaviour, and it moves the pointer on purpose, which is not something to do to anyone uninvited.

`PointerNudgePlanner` works out which positions to visit; `PointerNudgeRunner` walks them, with the delay injected so the whole sequence is testable in no time rather than in the half second it takes on a real screen.

**Two rules carry the feature.** The plan always ends on the anchor, adding one extra move home when the move count comes out odd — a wiggle that finished a pixel out would quietly undo #371 on every single capture. And the run stands down the instant the pointer is not where the previous move left it, because half a second of an application dragging the pointer back under someone's hand is worse than the problem being solved. The expectation is seeded from the anchor the capture recorded rather than from a live read, so a pointer somebody else has already taken over is never hauled back to a place it left. The run is dropped as well when the anchor generation moves on, so two captures in quick succession never nudge against each other.

**Two smaller decisions.** A pointer already against the right edge of the virtual screen wiggles left instead: Windows clamps to the virtual screen, so moving one pixel further right would be accepted, do nothing, and show the magnifier no movement at all — exactly for someone who parks the pointer at the edge. And a duration shorter than one interval still yields one move rather than dividing down to nothing, because a setting that is switched on and silently does nothing is the worst answer available, most of all for someone who cannot see that nothing happened.

Nothing waits for the nudge. A cancelled capture already waits for the foreground handback before it speaks its error message, and up to five seconds of wiggling must not be added to that silence.

## Settings

On the **Screen capture & OCR** page:

| Setting | Default | Range |
|---|---|---|
| Wiggle the mouse pointer after a capture | Off | — |
| Wiggle every (milliseconds) | 50 | 10–500 |
| Keep wiggling for (milliseconds) | 500 | 50–5000 |

Each has a label, hover help, an automation name and help text for a screen reader, and a reset-to-default button, matching the rest of the page. The timings are clamped on load to the same range the dialog offers, so a hand-edited settings file cannot produce a nudge nobody can stop, and a file written before this existed picks up the defaults rather than a stored 0. The existing defaults-parity test covers all three.

Read per capture rather than once at startup, because the overlay window is cached and reused — a change made in the dialog has to reach the next capture.

## What a user notices

Nothing at all, unless they turn it on. With it on, the pointer gives a small shake when a capture finishes and ends up exactly where it was, and the magnified view comes back to it. Taking hold of the mouse stops the shaking immediately.

## Tests

`PointerNudgePlannerTests` — 12 cases: off means the pointer is never touched; default timings give one move per interval for the whole duration; every plan from 50 ms to 1000 ms ends on the anchor; an odd move count gets one extra move home; the positions really do alternate; movement is horizontal only; at the right edge it wiggles left; a duration shorter than one interval still moves once; and four unusable timing pairs leave the pointer alone.

`PointerNudgeRunnerTests` — 8 cases: an uninterrupted run applies every move and waits before each one; something else moving the pointer stops it mid-run; a pointer already elsewhere before the first move is not touched at all; `stillWanted` returning false stops it; an empty plan does not even read the pointer; a pointer that cannot be read is not wiggled blindly; a refused write ends the run rather than carrying on against a stale expectation; null arguments are rejected.

Full suite: **2327 passed, 0 failed**, `dotnet test --configuration Release`.

## Not verified

Whether the magnified view actually returns to the pointer cannot be checked in an agent session — it needs a human with ZoomText running. What is verified is the build, the full suite, and the movement logic in isolation.

## Out of scope

A **Screenshot & OCR** also pastes text and can send a hotkey after the OCR finishes, which is a second moment the caret can steal the view. This covers the moment the overlay disappears, which is the one reported. Worth a follow-up if it turns out to matter.

## Documentation

`screen-capture-and-ocr.md` gains a short section, "If your magnifier loses the pointer afterwards", explaining the symptom before the setting. `settings.md` gains the three rows with their defaults and ranges. Generated HTML rebuilt and committed alongside.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
