### PR TITLE
Recognise a grab by the teleport itself, so jitter cannot hide it (#384)

### DIFF
--- a/Mutation.Tests/PointerHoldTests.cs
+++ b/Mutation.Tests/PointerHoldTests.cs
@@ -77,7 +77,7 @@ public class PointerHoldTests
 		public long Grabs;
 		public List<CursorPoint> Followed { get; } = new();
 		public int Wiggles;
-		public Func<Task>? OnWiggle;
+		public Func<Task<CursorPoint?>>? OnWiggle;
 		public bool Current = true;
 
 		public Task<PointerHoldOutcome> Run(TimeSpan? hold = null) =>
@@ -89,7 +89,7 @@ public class PointerHoldTests
 				() => Grabs,
 				() => Current,
 				Followed.Add,
-				() => { Wiggles++; return OnWiggle?.Invoke() ?? Task.CompletedTask; },
+				() => { Wiggles++; return OnWiggle?.Invoke() ?? Task.FromResult<CursorPoint?>(null); },
 				Clock.Delay,
 				Clock.Elapsed,
 				Poll,
@@ -255,7 +255,7 @@ public class PointerHoldTests
 		// first.
 		var h = new Harness();
 		h.Clock.OnWait = () => h.Cursor.Position = new CursorPoint(500, 300); // grabbed every tick
-		h.OnWiggle = () => { h.Acts++; return Task.CompletedTask; };
+		h.OnWiggle = () => { h.Acts++; return Task.FromResult<CursorPoint?>(null); };
 
 		var outcome = await h.Run();
 
@@ -265,11 +265,11 @@ public class PointerHoldTests
 	}
 
 	[Fact]
-	public async Task HandStepsDuringTheWiggle_AreFollowedOnTheNextTick_NotYankedBack()
+	public async Task TheWiggleReportsTheHandTookThePointer_TheHoldFollowsItThere()
 	{
-		// The hand moves while the wiggle runs. Those steps must not be swallowed by the wiggle:
-		// the next tick has to read them as the hand and follow, or the movement they left
-		// behind would be undone as though it were a grab.
+		// The hand moves while the wiggle runs; the wiggle stops for it and says where. The hold
+		// follows to the reported position rather than re-judging the wiggle's whole stretch
+		// from the counters, which cannot say who moved the pointer last.
 		var h = new Harness();
 		var handWentTo = new CursorPoint(300, 300);
 		int tick = 0;
@@ -281,9 +281,9 @@ public class PointerHoldTests
 		};
 		h.OnWiggle = () =>
 		{
-			h.Steps++; // the hand moved while the wiggle ran
+			h.Steps++; // the hand moved while the wiggle ran, and the wiggle saw it
 			h.Cursor.Position = handWentTo;
-			return Task.CompletedTask;
+			return Task.FromResult<CursorPoint?>(handWentTo);
 		};
 
 		var outcome = await h.Run();
@@ -291,6 +291,38 @@ public class PointerHoldTests
 		Assert.Equal(PointerHoldOutcome.TimeUp, outcome);
 		Assert.Single(h.Cursor.Writes); // only the one grab was corrected
 		Assert.Equal(new[] { handWentTo }, h.Followed);
+	}
+
+	[Fact]
+	public async Task ASecondGrabDuringTheWiggle_CannotOutvoteTheHandTheWiggleSaw()
+	{
+		// The compounding case (issue #384): the wiggle's stretch contains both a second grab
+		// and genuine hand travel, in that order or any other. The counters alone cannot say
+		// who had the last word — only the wiggle saw the order, and its report wins. Judging
+		// by the counters here restored a stale baseline over the hand's chosen position.
+		var h = new Harness();
+		var handSettledAt = new CursorPoint(320, 240);
+		int tick = 0;
+		h.Clock.OnWait = () =>
+		{
+			tick++;
+			if (tick == 1)
+				h.Cursor.Position = new CursorPoint(500, 300); // the first grab; wiggle follows
+		};
+		h.OnWiggle = () =>
+		{
+			h.Grabs++; // a second grab landed during the wiggle and was reclaimed by it
+			h.Steps++; // then the hand genuinely took the pointer
+			h.Cursor.Position = handSettledAt;
+			return Task.FromResult<CursorPoint?>(handSettledAt);
+		};
+
+		var outcome = await h.Run();
+
+		Assert.Equal(PointerHoldOutcome.TimeUp, outcome);
+		// One write: the first grab's correction. The hand's position was never overwritten.
+		Assert.Equal(new[] { Baseline }, h.Cursor.Writes);
+		Assert.Equal(new[] { handSettledAt }, h.Followed);
 	}
 
 	[Fact]
@@ -374,7 +406,7 @@ public class PointerHoldTests
 		Func<long> zero = () => 0;
 		Func<bool> yes = () => true;
 		Action<CursorPoint> follow = _ => { };
-		Func<Task> nothing = () => Task.CompletedTask;
+		Func<Task<CursorPoint?>> nothing = () => Task.FromResult<CursorPoint?>(null);
 
 		await Assert.ThrowsAsync<ArgumentNullException>(() =>
 			PointerHold.RunAsync(null!, Baseline, zero, zero, zero, yes, follow, nothing, clock.Delay, clock.Elapsed, Poll, Hold));
@@ -402,7 +434,8 @@ public class PointerHoldTests
 
 		await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
 			PointerHold.RunAsync(
-				cursor, Baseline, zero, zero, zero, () => true, _ => { }, () => Task.CompletedTask,
+				cursor, Baseline, zero, zero, zero, () => true, _ => { },
+				() => Task.FromResult<CursorPoint?>(null),
 				clock.Delay, clock.Elapsed, TimeSpan.Zero, Hold));
 	}
 }

--- a/Mutation.Tests/PointerHoldTests.cs
+++ b/Mutation.Tests/PointerHoldTests.cs
@@ -74,6 +74,7 @@ public class PointerHoldTests
 		public FakeCursor Cursor { get; } = new() { Position = Baseline };
 		public long Acts;
 		public long Steps;
+		public long Grabs;
 		public List<CursorPoint> Followed { get; } = new();
 		public int Wiggles;
 		public Func<Task>? OnWiggle;
@@ -85,6 +86,7 @@ public class PointerHoldTests
 				Baseline,
 				() => Acts,
 				() => Steps,
+				() => Grabs,
 				() => Current,
 				Followed.Add,
 				() => { Wiggles++; return OnWiggle?.Invoke() ?? Task.CompletedTask; },
@@ -169,6 +171,64 @@ public class PointerHoldTests
 		Assert.Equal(new[] { handRestedAt }, h.Followed);
 		Assert.All(h.Cursor.Writes, w => Assert.Equal(handRestedAt, w));
 		Assert.Single(h.Cursor.Writes);
+	}
+
+	[Fact]
+	public async Task AGrabInTheSameLookAsRestingJitter_IsUndoneNotFollowed()
+	{
+		// The measured defeat of the first counter design (issue #384): the resting hand's
+		// jitter advances the step count in every look, so the look containing the magnifier's
+		// caret grab also says "the hand moved" — and a follow would adopt the grabbed position.
+		// The teleport count is what says a grab happened in the window, whatever the jitter did.
+		var h = new Harness();
+		int tick = 0;
+		h.Clock.OnWait = () =>
+		{
+			tick++;
+			h.Steps++; // resting jitter, every look
+			if (tick == 3)
+			{
+				h.Grabs++;
+				h.Cursor.Position = new CursorPoint(700, 20); // the caret grab
+			}
+		};
+
+		var outcome = await h.Run();
+
+		Assert.Equal(PointerHoldOutcome.TimeUp, outcome);
+		Assert.Equal(new[] { Baseline }, h.Cursor.Writes);
+		Assert.Empty(h.Followed);
+	}
+
+	[Fact]
+	public async Task GenuineTravelSharingALookWithAGrab_IsRestoredOnceThenFollowedAgain()
+	{
+		// The accepted cost of asking about the grab first: a hand whose real travel lands in
+		// the same look as a teleport is pulled back once, and its very next step is followed.
+		var h = new Harness();
+		var handKeptGoingTo = new CursorPoint(160, 160);
+		int tick = 0;
+		h.Clock.OnWait = () =>
+		{
+			tick++;
+			if (tick == 1)
+			{
+				h.Steps++;
+				h.Grabs++;
+				h.Cursor.Position = new CursorPoint(150, 150);
+			}
+			if (tick == 2)
+			{
+				h.Steps++;
+				h.Cursor.Position = handKeptGoingTo;
+			}
+		};
+
+		var outcome = await h.Run();
+
+		Assert.Equal(PointerHoldOutcome.TimeUp, outcome);
+		Assert.Equal(new[] { Baseline }, h.Cursor.Writes);
+		Assert.Equal(new[] { handKeptGoingTo }, h.Followed);
 	}
 
 	[Fact]
@@ -317,17 +377,19 @@ public class PointerHoldTests
 		Func<Task> nothing = () => Task.CompletedTask;
 
 		await Assert.ThrowsAsync<ArgumentNullException>(() =>
-			PointerHold.RunAsync(null!, Baseline, zero, zero, yes, follow, nothing, clock.Delay, clock.Elapsed, Poll, Hold));
+			PointerHold.RunAsync(null!, Baseline, zero, zero, zero, yes, follow, nothing, clock.Delay, clock.Elapsed, Poll, Hold));
 		await Assert.ThrowsAsync<ArgumentNullException>(() =>
-			PointerHold.RunAsync(cursor, Baseline, null!, zero, yes, follow, nothing, clock.Delay, clock.Elapsed, Poll, Hold));
+			PointerHold.RunAsync(cursor, Baseline, null!, zero, zero, yes, follow, nothing, clock.Delay, clock.Elapsed, Poll, Hold));
 		await Assert.ThrowsAsync<ArgumentNullException>(() =>
-			PointerHold.RunAsync(cursor, Baseline, zero, null!, yes, follow, nothing, clock.Delay, clock.Elapsed, Poll, Hold));
+			PointerHold.RunAsync(cursor, Baseline, zero, null!, zero, yes, follow, nothing, clock.Delay, clock.Elapsed, Poll, Hold));
 		await Assert.ThrowsAsync<ArgumentNullException>(() =>
-			PointerHold.RunAsync(cursor, Baseline, zero, zero, null!, follow, nothing, clock.Delay, clock.Elapsed, Poll, Hold));
+			PointerHold.RunAsync(cursor, Baseline, zero, zero, null!, yes, follow, nothing, clock.Delay, clock.Elapsed, Poll, Hold));
 		await Assert.ThrowsAsync<ArgumentNullException>(() =>
-			PointerHold.RunAsync(cursor, Baseline, zero, zero, yes, null!, nothing, clock.Delay, clock.Elapsed, Poll, Hold));
+			PointerHold.RunAsync(cursor, Baseline, zero, zero, zero, null!, follow, nothing, clock.Delay, clock.Elapsed, Poll, Hold));
 		await Assert.ThrowsAsync<ArgumentNullException>(() =>
-			PointerHold.RunAsync(cursor, Baseline, zero, zero, yes, follow, null!, clock.Delay, clock.Elapsed, Poll, Hold));
+			PointerHold.RunAsync(cursor, Baseline, zero, zero, zero, yes, null!, nothing, clock.Delay, clock.Elapsed, Poll, Hold));
+		await Assert.ThrowsAsync<ArgumentNullException>(() =>
+			PointerHold.RunAsync(cursor, Baseline, zero, zero, zero, yes, follow, null!, clock.Delay, clock.Elapsed, Poll, Hold));
 	}
 
 	[Fact]
@@ -340,7 +402,7 @@ public class PointerHoldTests
 
 		await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
 			PointerHold.RunAsync(
-				cursor, Baseline, zero, zero, () => true, _ => { }, () => Task.CompletedTask,
+				cursor, Baseline, zero, zero, zero, () => true, _ => { }, () => Task.CompletedTask,
 				clock.Delay, clock.Elapsed, TimeSpan.Zero, Hold));
 	}
 }

--- a/Mutation.Tests/PointerNudgeRunnerTests.cs
+++ b/Mutation.Tests/PointerNudgeRunnerTests.cs
@@ -97,7 +97,7 @@ public class PointerNudgeRunnerTests
 		var cursor = new FakeCursor();
 		var clock = new FakeClock();
 
-		int applied = await PointerNudgeRunner.RunAsync(cursor, clock.Delay, Anchor, PlanOf(4), Interval);
+		var (applied, _) = await PointerNudgeRunner.RunAsync(cursor, clock.Delay, Anchor, PlanOf(4), Interval);
 
 		Assert.Equal(4, applied);
 		Assert.Equal(new[] { Away, Anchor, Away, Anchor }, cursor.Writes);
@@ -120,7 +120,7 @@ public class PointerNudgeRunnerTests
 				cursor.Position = new CursorPoint(900, 700);
 		};
 
-		int applied = await PointerNudgeRunner.RunAsync(cursor, clock.Delay, Anchor, PlanOf(6), Interval);
+		var (applied, _) = await PointerNudgeRunner.RunAsync(cursor, clock.Delay, Anchor, PlanOf(6), Interval);
 
 		Assert.Equal(2, applied);
 		Assert.Equal(new CursorPoint(900, 700), cursor.Position);
@@ -135,7 +135,7 @@ public class PointerNudgeRunnerTests
 		var cursor = new FakeCursor { Position = new CursorPoint(900, 700) };
 		var clock = new FakeClock();
 
-		int applied = await PointerNudgeRunner.RunAsync(cursor, clock.Delay, Anchor, PlanOf(4), Interval);
+		var (applied, _) = await PointerNudgeRunner.RunAsync(cursor, clock.Delay, Anchor, PlanOf(4), Interval);
 
 		Assert.Equal(0, applied);
 		Assert.Empty(cursor.Writes);
@@ -149,7 +149,7 @@ public class PointerNudgeRunnerTests
 		var clock = new FakeClock();
 		int checks = 0;
 
-		int applied = await PointerNudgeRunner.RunAsync(
+		var (applied, _) = await PointerNudgeRunner.RunAsync(
 			cursor, clock.Delay, Anchor, PlanOf(6), Interval, verdict: () => ++checks <= 2 ? PointerNudgeVerdict.Continue : PointerNudgeVerdict.StopAndSettle);
 
 		Assert.Equal(2, applied);
@@ -161,7 +161,7 @@ public class PointerNudgeRunnerTests
 		var cursor = new FakeCursor { CanRead = false };
 		var clock = new FakeClock();
 
-		int applied = await PointerNudgeRunner.RunAsync(cursor, clock.Delay, Anchor, Array.Empty<CursorPoint>(), Interval);
+		var (applied, _) = await PointerNudgeRunner.RunAsync(cursor, clock.Delay, Anchor, Array.Empty<CursorPoint>(), Interval);
 
 		Assert.Equal(0, applied);
 		Assert.Empty(clock.Waits);
@@ -173,7 +173,7 @@ public class PointerNudgeRunnerTests
 		var cursor = new FakeCursor { CanRead = false };
 		var clock = new FakeClock();
 
-		int applied = await PointerNudgeRunner.RunAsync(cursor, clock.Delay, Anchor, PlanOf(4), Interval);
+		var (applied, _) = await PointerNudgeRunner.RunAsync(cursor, clock.Delay, Anchor, PlanOf(4), Interval);
 
 		Assert.Equal(0, applied);
 		Assert.Empty(cursor.Writes);
@@ -187,7 +187,7 @@ public class PointerNudgeRunnerTests
 		var cursor = new FakeCursor { WriteSucceeds = false };
 		var clock = new FakeClock();
 
-		int applied = await PointerNudgeRunner.RunAsync(cursor, clock.Delay, Anchor, PlanOf(6), Interval);
+		var (applied, _) = await PointerNudgeRunner.RunAsync(cursor, clock.Delay, Anchor, PlanOf(6), Interval);
 
 		Assert.Equal(0, applied);
 		Assert.Single(cursor.Writes);
@@ -202,7 +202,7 @@ public class PointerNudgeRunnerTests
 		var cursor = new FakeCursor { ClampMaxX = Anchor.X };
 		var clock = new FakeClock();
 
-		int applied = await PointerNudgeRunner.RunAsync(cursor, clock.Delay, Anchor, PlanOf(4), Interval);
+		var (applied, _) = await PointerNudgeRunner.RunAsync(cursor, clock.Delay, Anchor, PlanOf(4), Interval);
 
 		Assert.Equal(4, applied);
 		Assert.Equal(new CursorPoint(Anchor.X + 1, Anchor.Y), cursor.Writes[0]);
@@ -216,7 +216,7 @@ public class PointerNudgeRunnerTests
 		var cursor = new FakeCursor { ClampMinX = Anchor.X, ClampMaxX = Anchor.X };
 		var clock = new FakeClock();
 
-		int applied = await PointerNudgeRunner.RunAsync(cursor, clock.Delay, Anchor, PlanOf(4), Interval);
+		var (applied, _) = await PointerNudgeRunner.RunAsync(cursor, clock.Delay, Anchor, PlanOf(4), Interval);
 
 		Assert.Equal(0, applied);
 		Assert.Equal(Anchor, cursor.Position);
@@ -232,7 +232,7 @@ public class PointerNudgeRunnerTests
 		var clock = new FakeClock();
 		int checks = 0;
 
-		int applied = await PointerNudgeRunner.RunAsync(
+		var (applied, _) = await PointerNudgeRunner.RunAsync(
 			cursor, clock.Delay, Anchor, PlanOf(6), Interval, verdict: () => ++checks <= 1 ? PointerNudgeVerdict.Continue : PointerNudgeVerdict.StopAndSettle);
 
 		Assert.Equal(1, applied);
@@ -245,7 +245,7 @@ public class PointerNudgeRunnerTests
 		var cursor = new FakeCursor { FailWriteAtIndex = 1 };
 		var clock = new FakeClock();
 
-		int applied = await PointerNudgeRunner.RunAsync(cursor, clock.Delay, Anchor, PlanOf(6), Interval);
+		var (applied, _) = await PointerNudgeRunner.RunAsync(cursor, clock.Delay, Anchor, PlanOf(6), Interval);
 
 		Assert.Equal(1, applied);
 		Assert.Equal(Anchor, cursor.Position);
@@ -283,7 +283,7 @@ public class PointerNudgeRunnerTests
 		var clock = new FakeClock();
 		int checks = 0;
 
-		int applied = await PointerNudgeRunner.RunAsync(
+		var (applied, _) = await PointerNudgeRunner.RunAsync(
 			cursor, clock.Delay, Anchor, PlanOf(6), Interval,
 			verdict: () => ++checks <= 1 ? PointerNudgeVerdict.Continue : PointerNudgeVerdict.StopAndLeave);
 
@@ -308,7 +308,7 @@ public class PointerNudgeRunnerTests
 				cursor.Position = new CursorPoint(900, 700); // the grab; no hand steps follow
 		};
 
-		int applied = await PointerNudgeRunner.RunAsync(
+		var (applied, _) = await PointerNudgeRunner.RunAsync(
 			cursor, clock.Delay, Anchor, PlanOf(6), Interval, handSteps: () => 0);
 
 		Assert.Equal(6, applied);
@@ -333,7 +333,7 @@ public class PointerNudgeRunnerTests
 			}
 		};
 
-		int applied = await PointerNudgeRunner.RunAsync(
+		var (applied, handTookItAt) = await PointerNudgeRunner.RunAsync(
 			cursor, clock.Delay, Anchor, PlanOf(6), Interval, handSteps: () => steps);
 
 		Assert.Equal(2, applied);
@@ -341,6 +341,9 @@ public class PointerNudgeRunnerTests
 		// the pointer stays exactly where the hand put it, with no tidy-up haul to the anchor.
 		Assert.Equal(2, cursor.Writes.Count);
 		Assert.Equal(elsewhere, cursor.Position);
+		// And the run says so, with the position it saw — the report a caller whose window
+		// spans the whole run needs, since its own counters cannot tell who moved last.
+		Assert.Equal(elsewhere, handTookItAt);
 	}
 
 	[Fact]
@@ -359,7 +362,7 @@ public class PointerNudgeRunnerTests
 			steps++;
 		};
 
-		int applied = await PointerNudgeRunner.RunAsync(
+		var (applied, _) = await PointerNudgeRunner.RunAsync(
 			cursor, clock.Delay, Anchor, PlanOf(4), Interval, handSteps: () => steps, teleports: () => 0);
 
 		Assert.Equal(4, applied);
@@ -388,7 +391,7 @@ public class PointerNudgeRunnerTests
 			}
 		};
 
-		int applied = await PointerNudgeRunner.RunAsync(
+		var (applied, _) = await PointerNudgeRunner.RunAsync(
 			cursor, clock.Delay, Anchor, PlanOf(6), Interval, handSteps: () => steps, teleports: () => grabs);
 
 		Assert.Equal(6, applied);

--- a/Mutation.Tests/PointerNudgeRunnerTests.cs
+++ b/Mutation.Tests/PointerNudgeRunnerTests.cs
@@ -344,10 +344,12 @@ public class PointerNudgeRunnerTests
 	}
 
 	[Fact]
-	public async Task RestingHandJitterBeforeTheFirstMove_EndsTheRunWithoutAWrite()
+	public async Task RestingHandJitter_IsToleratedAndTheRunCarriesOn()
 	{
-		// The hand is on the mouse, merely resting; the pointer drifted a pixel before the first
-		// look and the watch counted the step. The pointer is the hand's, not the wiggle's.
+		// The hand is on the mouse, merely resting: real steps arrive every look and the pointer
+		// sits a pixel off where the last move left it. That is not the hand going anywhere, and
+		// a run that stopped for it never ran at all — measured, not imagined (issue #384). The
+		// run recentres and carries on.
 		var cursor = new FakeCursor();
 		var clock = new FakeClock();
 		long steps = 0;
@@ -358,10 +360,39 @@ public class PointerNudgeRunnerTests
 		};
 
 		int applied = await PointerNudgeRunner.RunAsync(
-			cursor, clock.Delay, Anchor, PlanOf(4), Interval, handSteps: () => steps);
+			cursor, clock.Delay, Anchor, PlanOf(4), Interval, handSteps: () => steps, teleports: () => 0);
 
-		Assert.Equal(0, applied);
-		Assert.Empty(cursor.Writes);
+		Assert.Equal(4, applied);
+		Assert.Equal(Anchor, cursor.Position);
+	}
+
+	[Fact]
+	public async Task AGrabInTheSameLookAsRestingJitter_IsStillReclaimed()
+	{
+		// The closing scenario that beat the first version of this rule (issue #384): the
+		// resting hand's jitter makes "did the hand move?" true in every look, and the
+		// magnifier's caret grab lands inside one of them. The teleport count says a grab
+		// happened in the window, whatever the jitter did, so the run reclaims and carries on.
+		var cursor = new FakeCursor();
+		var clock = new FakeClock();
+		long steps = 0;
+		long grabs = 0;
+		int waits = 0;
+		clock.OnWait = () =>
+		{
+			steps++; // jitter, every look
+			if (++waits == 3)
+			{
+				grabs++;
+				cursor.Position = new CursorPoint(900, 700); // the caret grab
+			}
+		};
+
+		int applied = await PointerNudgeRunner.RunAsync(
+			cursor, clock.Delay, Anchor, PlanOf(6), Interval, handSteps: () => steps, teleports: () => grabs);
+
+		Assert.Equal(6, applied);
+		Assert.Equal(Anchor, cursor.Position);
 	}
 
 	[Fact]

--- a/Mutation.Ui/Core/PointerHold.cs
+++ b/Mutation.Ui/Core/PointerHold.cs
@@ -68,7 +68,10 @@ public static class PointerHold
 	/// else aims at the defended position — the wiggle — aims at the new one.</param>
 	/// <param name="afterRestore">Run when a grab was undone — the wiggle, which brings a
 	/// magnified view back to the pointer, since whatever grabbed the pointer probably took the
-	/// view with it.</param>
+	/// view with it. Its answer is where the hand was seen taking the pointer during the run, or
+	/// null when it was not. The answer is trusted over the counters, because the wiggle can last
+	/// for seconds: a teleport early in it and genuine hand travel late in it can both have
+	/// happened, and only the run itself saw the order (issue #384).</param>
 	/// <param name="delay">How to wait one poll interval.</param>
 	/// <param name="elapsed">Time since the hold started. Measured rather than counted, because a
 	/// busy machine makes a count of intervals mean nothing.</param>
@@ -80,7 +83,7 @@ public static class PointerHold
 		Func<long> teleports,
 		Func<bool> stillCurrent,
 		Action<CursorPoint> followedTo,
-		Func<Task> afterRestore,
+		Func<Task<CursorPoint?>> afterRestore,
 		Func<TimeSpan, Task> delay,
 		Func<TimeSpan> elapsed,
 		TimeSpan pollInterval,
@@ -151,15 +154,29 @@ public static class PointerHold
 			if (elapsed() >= hold)
 				return PointerHoldOutcome.TimeUp;
 
-			await afterRestore().ConfigureAwait(false);
+			var handTookItAt = await afterRestore().ConfigureAwait(false);
 
 			// The wiggle takes a while, so the user may have clicked during it. Asked again here
 			// rather than only at the top of the loop, so the hold stands down at the first
-			// opportunity. Hand steps during the wiggle are left to the next tick on purpose:
-			// refreshing the snapshot here would swallow them, and the movement they left behind
-			// would then read as a grab and be yanked back.
+			// opportunity.
 			if (handActs() != acts)
 				return PointerHoldOutcome.UserTookTheMouse;
+
+			// The wiggle saw the hand take the pointer: follow it to the position it reported.
+			// Trusted over the counters, which for a window as long as a wiggle cannot say
+			// whether the hand or a teleport had the last word.
+			if (handTookItAt is CursorPoint handAt)
+			{
+				baseline = handAt;
+				followedTo(handAt);
+			}
+
+			// Everything the counters saw during the wiggle has now been accounted for — grabs
+			// were reclaimed by the run, hand travel came back in its report — so the snapshots
+			// are brought up to date rather than left to be re-judged by the next tick, where a
+			// wiggle-old teleport could outvote a fresh hand step.
+			steps = handSteps();
+			grabs = teleports();
 		}
 
 		return PointerHoldOutcome.TimeUp;

--- a/Mutation.Ui/Core/PointerHold.cs
+++ b/Mutation.Ui/Core/PointerHold.cs
@@ -58,6 +58,11 @@ public static class PointerHold
 	/// Monotonic; only changes matter, so a snapshot taken before a wait is compared after it.</param>
 	/// <param name="handSteps">Count of hand-sized real movement events seen so far, from the
 	/// watch. Monotonic, compared the same way. This is what tells a followed hand from a grab.</param>
+	/// <param name="teleports">Count of single-event moves too large for a hand — a driver
+	/// grabbing the pointer. Checked before the hand steps, because a resting hand's jitter
+	/// advances the step count in every look: a grab that lands in the same look as jitter would
+	/// otherwise be followed as though the hand had made it, which is how the magnifier's caret
+	/// grab beat the first version of this hold on every capture (issue #384).</param>
 	/// <param name="stillCurrent">Whether the capture this hold belongs to is still the live one.</param>
 	/// <param name="followedTo">Told each time the baseline moves to follow the hand, so whatever
 	/// else aims at the defended position — the wiggle — aims at the new one.</param>
@@ -72,6 +77,7 @@ public static class PointerHold
 		CursorPoint baseline,
 		Func<long> handActs,
 		Func<long> handSteps,
+		Func<long> teleports,
 		Func<bool> stillCurrent,
 		Action<CursorPoint> followedTo,
 		Func<Task> afterRestore,
@@ -83,6 +89,7 @@ public static class PointerHold
 		if (cursor is null) throw new ArgumentNullException(nameof(cursor));
 		if (handActs is null) throw new ArgumentNullException(nameof(handActs));
 		if (handSteps is null) throw new ArgumentNullException(nameof(handSteps));
+		if (teleports is null) throw new ArgumentNullException(nameof(teleports));
 		if (stillCurrent is null) throw new ArgumentNullException(nameof(stillCurrent));
 		if (followedTo is null) throw new ArgumentNullException(nameof(followedTo));
 		if (afterRestore is null) throw new ArgumentNullException(nameof(afterRestore));
@@ -92,6 +99,7 @@ public static class PointerHold
 
 		long acts = handActs();
 		long steps = handSteps();
+		long grabs = teleports();
 
 		while (elapsed() < hold)
 		{
@@ -107,22 +115,31 @@ public static class PointerHold
 			bool handMoved = stepsNow != steps;
 			steps = stepsNow;
 
+			long grabsNow = teleports();
+			bool grabbed = grabsNow != grabs;
+			grabs = grabsNow;
+
 			if (!cursor.TryGet(out var current) || current == baseline)
 				continue;
 
-			if (handMoved)
+			// Asked before the hand steps, on purpose. A resting hand's jitter advances the step
+			// count in every look, so on the tick the magnifier grabs the pointer, "did the hand
+			// move?" is true as well — and a follow here would adopt the grabbed position as
+			// though the hand had walked there. The teleport says a grab happened in this look,
+			// whatever else did; the position the hand actually holds is the baseline, which the
+			// jitter has been walking along a pixel at a time. The one thing given up is a hand
+			// whose genuine travel shares a look with a grab — it is restored once and followed
+			// again on its next step, a cost of one tick.
+			if (handMoved && !grabbed)
 			{
-				// The hand went there. The defense follows it — deliberately not asking whether
-				// something else moved the pointer in the same interval, because when a hand and
-				// a grab land together, deferring to the hand is the mistake that costs one lost
-				// correction, and fighting the hand is the mistake this whole class exists to
-				// never make.
 				baseline = current;
 				followedTo(current);
 				continue;
 			}
 
-			// A grab: the pointer moved and no hand moved it.
+			// A grab: a teleport landed in this look, or the pointer moved with no hand behind
+			// it at all (a silent cursor placement). Either way the pointer goes back to where
+			// the hand holds it.
 			if (!cursor.TrySet(baseline))
 				continue;
 

--- a/Mutation.Ui/Core/PointerNudgeRunner.cs
+++ b/Mutation.Ui/Core/PointerNudgeRunner.cs
@@ -33,16 +33,16 @@ public enum PointerNudgeVerdict
 ///
 /// <para>
 /// The stand-down rule is the whole reason this is not a plain loop. Before each move it checks
-/// that the pointer is still exactly where the previous move left it. If it is not, something
-/// else has taken hold of it, and what happens next depends on who. When the watch reports hand
-/// movement since the last look, the run stops immediately and leaves the pointer exactly where
-/// the hand put it — half a second of an application dragging the pointer back under the user's
-/// hand would be far worse than the problem being solved. When the watch reports no hand behind
-/// the move, the pointer was grabbed by a program — the very thing the wiggle exists to defend
-/// against — and the run reclaims it by carrying on: the next planned move puts the pointer back
-/// within a pixel of the anchor. Without the distinction the wiggle died on its first tick every
-/// time, because a hand merely resting on a high-polling-rate mouse drifts the pointer a pixel
-/// between any two looks (issue #382).
+/// that the pointer is still where the previous move left it. If it is not, something else has
+/// taken hold of it, and what happens next depends on who. A driver teleport — a single move no
+/// hand could make — is a grab, and the run reclaims: the next planned move puts the pointer
+/// back within a pixel of the anchor. A drift within the resting hand's jitter radius is a hand
+/// breathing on the mouse, and the run recentres and carries on. Genuine hand travel beyond
+/// that radius stops the run immediately, leaving the pointer exactly where the hand put it —
+/// half a second of an application dragging the pointer back under the user's hand would be far
+/// worse than the problem being solved. The order matters: the grab is asked about first,
+/// because the resting hand's jitter makes "did the hand move?" true in every look, and a grab
+/// judged second would end the run at the very moment it is needed (issues #382 and #384).
 /// </para>
 ///
 /// <para>
@@ -87,6 +87,10 @@ public static class PointerNudgeRunner
 	/// <param name="handSteps">Count of hand-sized real movement events, from the watch.
 	/// Monotonic; the run compares it across each look to decide whether a foreign move was the
 	/// hand or a grab. Null means there is no watch, and every foreign move then ends the run.</param>
+	/// <param name="teleports">Count of single-event moves too large for a hand — a driver
+	/// grabbing the pointer. Checked before the hand steps, because a resting hand's jitter
+	/// advances the step count in every look, and a grab landing in the same look would
+	/// otherwise read as the hand and end the run exactly when it is needed (issue #384).</param>
 	public static async Task<int> RunAsync(
 		ICursorPosition cursor,
 		Func<TimeSpan, Task> delay,
@@ -94,7 +98,8 @@ public static class PointerNudgeRunner
 		IReadOnlyList<CursorPoint> plan,
 		TimeSpan interval,
 		Func<PointerNudgeVerdict>? verdict = null,
-		Func<long>? handSteps = null)
+		Func<long>? handSteps = null,
+		Func<long>? teleports = null)
 	{
 		if (cursor is null) throw new ArgumentNullException(nameof(cursor));
 		if (delay is null) throw new ArgumentNullException(nameof(delay));
@@ -110,6 +115,7 @@ public static class PointerNudgeRunner
 		bool directionSettled = false;
 		int applied = 0;
 		long steps = handSteps?.Invoke() ?? 0;
+		long grabs = teleports?.Invoke() ?? 0;
 
 		foreach (var position in plan)
 		{
@@ -127,19 +133,39 @@ public static class PointerNudgeRunner
 			bool handMoved = stepsNow != steps;
 			steps = stepsNow;
 
+			long grabsNow = teleports?.Invoke() ?? 0;
+			bool grabbed = grabsNow != grabs;
+			grabs = grabsNow;
+
 			if (!cursor.TryGet(out var current))
 				return applied;
 
 			if (current != expected)
 			{
-				// The hand moved since the last look — or there is no watch to say otherwise.
-				// Leave the pointer exactly where it was found, drift and all — the one exit
-				// that must not tidy up after itself.
-				if (handSteps is null || handMoved)
+				// No watch: no way to tell a hand from a grab, so any foreign move ends the run
+				// — the only safe answer.
+				if (handSteps is null)
 					return applied;
 
-				// A grab with no hand behind it. Fall through: the write below reclaims the
-				// pointer onto this move's planned position, a pixel from the anchor.
+				// A grab landed in this look. Whatever the jitter also did, reclaim: the write
+				// below puts the pointer back on this move's planned position, a pixel from the
+				// anchor. Without this the magnifier's caret grab ended the run every time,
+				// because the resting hand's jitter made "did the hand move?" true in the same
+				// look (issue #384).
+				if (!grabbed)
+				{
+					// The hand walked the pointer somewhere. Leave it exactly where it was
+					// found, drift and all — the one exit that must not tidy up after itself.
+					bool genuineTravel = handMoved
+						&& (Math.Abs(current.X - expected.X) > RealMouseInput.RestingHandJitterRadiusPixels
+							|| Math.Abs(current.Y - expected.Y) > RealMouseInput.RestingHandJitterRadiusPixels);
+					if (genuineTravel)
+						return applied;
+
+					// Within the jitter radius: a resting hand breathing on the mouse. The write
+					// below recentres, and the run carries on. A moved pointer with no hand steps
+					// at all is a silent grab and falls through to be reclaimed too.
+				}
 			}
 
 			var target = mirrored ? Mirror(anchor, position) : position;

--- a/Mutation.Ui/Core/PointerNudgeRunner.cs
+++ b/Mutation.Ui/Core/PointerNudgeRunner.cs
@@ -28,6 +28,23 @@ public enum PointerNudgeVerdict
 }
 
 /// <summary>
+/// What a wiggle run did, and — the part its callers cannot infer — why it ended.
+///
+/// <para>
+/// The report exists because the run can last for seconds, and "did a teleport happen somewhere
+/// in it?" tells a caller nothing about who owns the pointer at the end: a grab early in the run
+/// and a deliberate hand movement late in it can both be true. The run is the only party that
+/// saw the order, so it says the one thing that matters — whether the hand took the pointer,
+/// and where it was seen holding it (issue #384).
+/// </para>
+/// </summary>
+/// <param name="Applied">How many planned moves were made.</param>
+/// <param name="HandTookItAt">Where the hand was seen holding the pointer when the run stood
+/// down for it, or null when the run ended any other way — completed, called off, or unable to
+/// read or write the pointer.</param>
+public readonly record struct PointerNudgeResult(int Applied, CursorPoint? HandTookItAt);
+
+/// <summary>
 /// Walks a nudge plan, one position per interval, and gets out of the way the moment the pointer
 /// stops being ours to move.
 ///
@@ -71,8 +88,9 @@ public static class PointerNudgeRunner
 {
 	/// <summary>
 	/// Applies each position in <paramref name="plan"/>, waiting <paramref name="interval"/>
-	/// before each one. Returns how many were applied, which is the length of the plan on an
-	/// uninterrupted run.
+	/// before each one. Reports how many were applied — the length of the plan on an
+	/// uninterrupted run — and whether the run ended because the hand took the pointer, which is
+	/// the one fact about a run's ending its callers cannot reconstruct afterwards.
 	/// </summary>
 	/// <param name="cursor">Where the pointer is read and written.</param>
 	/// <param name="delay">How to wait one interval.</param>
@@ -91,7 +109,7 @@ public static class PointerNudgeRunner
 	/// grabbing the pointer. Checked before the hand steps, because a resting hand's jitter
 	/// advances the step count in every look, and a grab landing in the same look would
 	/// otherwise read as the hand and end the run exactly when it is needed (issue #384).</param>
-	public static async Task<int> RunAsync(
+	public static async Task<PointerNudgeResult> RunAsync(
 		ICursorPosition cursor,
 		Func<TimeSpan, Task> delay,
 		CursorPoint anchor,
@@ -106,7 +124,7 @@ public static class PointerNudgeRunner
 		if (plan is null) throw new ArgumentNullException(nameof(plan));
 
 		if (plan.Count == 0)
-			return 0;
+			return new PointerNudgeResult(0, null);
 
 		// Where the pointer has to be found before each move, starting from where the capture
 		// left it.
@@ -124,9 +142,9 @@ public static class PointerNudgeRunner
 			switch (verdict?.Invoke() ?? PointerNudgeVerdict.Continue)
 			{
 				case PointerNudgeVerdict.StopAndSettle:
-					return Settle(cursor, anchor, expected, applied);
+					return new PointerNudgeResult(Settle(cursor, anchor, expected, applied), null);
 				case PointerNudgeVerdict.StopAndLeave:
-					return applied;
+					return new PointerNudgeResult(applied, null);
 			}
 
 			long stepsNow = handSteps?.Invoke() ?? 0;
@@ -138,14 +156,14 @@ public static class PointerNudgeRunner
 			grabs = grabsNow;
 
 			if (!cursor.TryGet(out var current))
-				return applied;
+				return new PointerNudgeResult(applied, null);
 
 			if (current != expected)
 			{
 				// No watch: no way to tell a hand from a grab, so any foreign move ends the run
-				// — the only safe answer.
+				// — the only safe answer. Reported as nobody's, because nobody can say.
 				if (handSteps is null)
-					return applied;
+					return new PointerNudgeResult(applied, null);
 
 				// A grab landed in this look. Whatever the jitter also did, reclaim: the write
 				// below puts the pointer back on this move's planned position, a pixel from the
@@ -155,12 +173,15 @@ public static class PointerNudgeRunner
 				if (!grabbed)
 				{
 					// The hand walked the pointer somewhere. Leave it exactly where it was
-					// found, drift and all — the one exit that must not tidy up after itself.
+					// found, drift and all — the one exit that must not tidy up after itself —
+					// and say so in the report, with the position the hand was seen holding.
+					// The report is what lets a caller whose window spans this whole run trust
+					// the hand over a teleport that landed earlier in it (issue #384).
 					bool genuineTravel = handMoved
 						&& (Math.Abs(current.X - expected.X) > RealMouseInput.RestingHandJitterRadiusPixels
 							|| Math.Abs(current.Y - expected.Y) > RealMouseInput.RestingHandJitterRadiusPixels);
 					if (genuineTravel)
-						return applied;
+						return new PointerNudgeResult(applied, current);
 
 					// Within the jitter radius: a resting hand breathing on the mouse. The write
 					// below recentres, and the run carries on. A moved pointer with no hand steps
@@ -171,7 +192,7 @@ public static class PointerNudgeRunner
 			var target = mirrored ? Mirror(anchor, position) : position;
 
 			if (!cursor.TrySet(target))
-				return Settle(cursor, anchor, expected, applied);
+				return new PointerNudgeResult(Settle(cursor, anchor, expected, applied), null);
 
 			if (!directionSettled && target != anchor)
 			{
@@ -184,7 +205,7 @@ public static class PointerNudgeRunner
 					mirrored = true;
 					target = Mirror(anchor, position);
 					if (!cursor.TrySet(target) || !TookEffect(cursor, target))
-						return Settle(cursor, anchor, expected, applied);
+						return new PointerNudgeResult(Settle(cursor, anchor, expected, applied), null);
 				}
 			}
 
@@ -192,7 +213,7 @@ public static class PointerNudgeRunner
 			applied++;
 		}
 
-		return applied;
+		return new PointerNudgeResult(applied, null);
 	}
 
 	private static CursorPoint Mirror(CursorPoint anchor, CursorPoint position) =>

--- a/Mutation.Ui/Core/RealMouseInput.cs
+++ b/Mutation.Ui/Core/RealMouseInput.cs
@@ -92,6 +92,16 @@ public static class RealMouseInput
 	public const int HandStepLimitPixels = 12;
 
 	/// <summary>
+	/// How far a resting hand's jitter can put the pointer from where a wiggle expected it,
+	/// in pixels on either axis, without meaning anything. Measured jitter is one to two pixels
+	/// between two 50 ms looks; genuine travel crosses this in a single look. A hand crawling
+	/// slower than this per look during an active wiggle is re-centred for the wiggle's duration
+	/// — a real cost, accepted because the alternative was a wiggle that died on the first
+	/// jitter pixel and so never ran at all (issue #384).
+	/// </summary>
+	public const int RestingHandJitterRadiusPixels = 3;
+
+	/// <summary>
 	/// Says what <paramref name="message"/> was, given its hook flags and how far it moved the
 	/// pointer from the previous event, in pixels on the larger axis.
 	/// </summary>

--- a/Mutation.Ui/Services/RealMouseInputWatch.cs
+++ b/Mutation.Ui/Services/RealMouseInputWatch.cs
@@ -89,6 +89,7 @@ internal sealed class RealMouseInputWatch : IDisposable
 
 	private long _handActs;
 	private long _handSteps;
+	private long _teleports;
 
 	// Where the previous move event put the pointer, whoever made it. Touched only on the hook
 	// thread. The first move after installation has no previous event to measure a step against,
@@ -113,6 +114,15 @@ internal sealed class RealMouseInputWatch : IDisposable
 	/// hand movement is the caller's rule.
 	/// </summary>
 	public long HandSteps => Interlocked.Read(ref _handSteps);
+
+	/// <summary>
+	/// How many single-event moves too large for a hand have been seen — a driver grabbing the
+	/// pointer. This is the count that lets a grab be recognised even when it lands in the same
+	/// look as the resting hand's jitter (issue #384): the jitter advances
+	/// <see cref="HandSteps"/> every look, so "did the hand move?" says yes in every window, and
+	/// only the teleport itself says what else happened in it.
+	/// </summary>
+	public long Teleports => Interlocked.Read(ref _teleports);
 
 	/// <summary>
 	/// Whether the hook is actually installed. False means there is no signal at all, and a
@@ -191,6 +201,9 @@ internal sealed class RealMouseInputWatch : IDisposable
 						break;
 					case RealMouseEventKind.HandStep when measurable:
 						Interlocked.Increment(ref _handSteps);
+						break;
+					case RealMouseEventKind.Teleport when measurable:
+						Interlocked.Increment(ref _teleports);
 						break;
 				}
 			}

--- a/Mutation.Ui/Views/RegionSelectionWindow.xaml.cs
+++ b/Mutation.Ui/Views/RegionSelectionWindow.xaml.cs
@@ -812,9 +812,10 @@ public sealed partial class RegionSelectionWindow : Window
 			await ForegroundHandedBack.ConfigureAwait(false);
 			_cursorAnchor.RestoreIfCurrent(generation);
 
-			// Snapshot taken before the wiggle so the reconciliation below can tell whether the
-			// hand moved while it ran.
+			// Snapshots taken before the wiggle so the reconciliation below can tell what
+			// happened while it ran.
 			long stepsBeforeNudge = watch?.HandSteps ?? 0;
+			long grabsBeforeNudge = watch?.Teleports ?? 0;
 			await NudgePointerAsync(generation, nudge, watch).ConfigureAwait(false);
 
 			// If the hand moved during the wiggle, the run left the pointer exactly where the
@@ -822,9 +823,14 @@ public sealed partial class RegionSelectionWindow : Window
 			// next would read that difference as a grab and snap the pointer back out from under
 			// the resting hand, because its own counter snapshot is taken after the movement
 			// already happened. So the anchor is brought to the pointer first: the hold then
-			// defends where the hand actually is. When no hand moved, the anchor is left alone —
-			// any divergence is a genuine grab, and the hold's first tick undoes it.
-			if (watch is { IsWatching: true } && watch.HandSteps != stepsBeforeNudge
+			// defends where the hand actually is. Not when a teleport also landed in that
+			// stretch, though — the pointer may then be standing where a grab put it, and
+			// rebasing would defend the grab; the anchor is left alone and the hold's first tick
+			// undoes it. And when nothing moved at all, the anchor is left alone for the same
+			// reason (issues #382 and #384).
+			if (watch is { IsWatching: true }
+				&& watch.HandSteps != stepsBeforeNudge
+				&& watch.Teleports == grabsBeforeNudge
 				&& _cursor.TryGet(out var handLeftItAt))
 			{
 				_cursorAnchor.RebaseIfCurrent(generation, handLeftItAt);
@@ -887,6 +893,7 @@ public sealed partial class RegionSelectionWindow : Window
 			baseline: _cursorAnchor.Anchor,
 			handActs: () => watch.HandActs,
 			handSteps: () => watch.HandSteps,
+			teleports: () => watch.Teleports,
 			stillCurrent: () => _cursorAnchor.Generation == generation,
 			// Keep the anchor with the hand, so the wiggle below — and the settle, if anything
 			// interrupts it — aim at where the hand actually is, not where the capture ended.
@@ -972,10 +979,11 @@ public sealed partial class RegionSelectionWindow : Window
 				TimeSpan.FromMilliseconds(nudge.IntervalMilliseconds),
 				() => NudgeVerdict(generation),
 				// The watch is what lets the run tell a grab from the hand and reclaim the
-				// pointer instead of dying on a one-pixel drift (issue #382). Without one — not
-				// asked for, or the hook refused to install — the run keeps the old rule and
-				// stops on any foreign move.
-				watch is { IsWatching: true } ? () => watch.HandSteps : null).ConfigureAwait(false);
+				// pointer instead of dying on a one-pixel drift (issues #382 and #384). Without
+				// one — not asked for, or the hook refused to install — the run keeps the old
+				// rule and stops on any foreign move.
+				watch is { IsWatching: true } ? () => watch.HandSteps : null,
+				watch is { IsWatching: true } ? () => watch.Teleports : null).ConfigureAwait(false);
 		}
 		finally
 		{

--- a/Mutation.Ui/Views/RegionSelectionWindow.xaml.cs
+++ b/Mutation.Ui/Views/RegionSelectionWindow.xaml.cs
@@ -812,29 +812,17 @@ public sealed partial class RegionSelectionWindow : Window
 			await ForegroundHandedBack.ConfigureAwait(false);
 			_cursorAnchor.RestoreIfCurrent(generation);
 
-			// Snapshots taken before the wiggle so the reconciliation below can tell what
-			// happened while it ran.
-			long stepsBeforeNudge = watch?.HandSteps ?? 0;
-			long grabsBeforeNudge = watch?.Teleports ?? 0;
-			await NudgePointerAsync(generation, nudge, watch).ConfigureAwait(false);
-
-			// If the hand moved during the wiggle, the run left the pointer exactly where the
-			// hand put it — and the anchor still points at the old place. The hold that starts
-			// next would read that difference as a grab and snap the pointer back out from under
-			// the resting hand, because its own counter snapshot is taken after the movement
-			// already happened. So the anchor is brought to the pointer first: the hold then
-			// defends where the hand actually is. Not when a teleport also landed in that
-			// stretch, though — the pointer may then be standing where a grab put it, and
-			// rebasing would defend the grab; the anchor is left alone and the hold's first tick
-			// undoes it. And when nothing moved at all, the anchor is left alone for the same
-			// reason (issues #382 and #384).
-			if (watch is { IsWatching: true }
-				&& watch.HandSteps != stepsBeforeNudge
-				&& watch.Teleports == grabsBeforeNudge
-				&& _cursor.TryGet(out var handLeftItAt))
-			{
+			// If the wiggle saw the hand take the pointer, it left it exactly where the hand put
+			// it — and the anchor still points at the old place. The hold that starts next would
+			// read that difference as a grab and snap the pointer back out from under the
+			// resting hand. So the anchor is brought to the position the wiggle reported first,
+			// and the hold defends where the hand actually is. The run's own report is the only
+			// trustworthy account: the wiggle can last for seconds, and asking the counters "did
+			// a teleport happen anywhere in it?" cannot say whether the hand or a grab had the
+			// last word (issues #382 and #384).
+			var nudgeReport = await NudgePointerAsync(generation, nudge, watch).ConfigureAwait(false);
+			if (nudgeReport is CursorPoint handLeftItAt)
 				_cursorAnchor.RebaseIfCurrent(generation, handLeftItAt);
-			}
 
 			await HoldPointerAsync(generation, nudge, hold, watch).ConfigureAwait(false);
 		}
@@ -960,10 +948,10 @@ public sealed partial class RegionSelectionWindow : Window
 	/// advertise the wrong place.
 	/// </para>
 	/// </summary>
-	private async Task NudgePointerAsync(int generation, PointerNudgeOptions nudge, RealMouseInputWatch? watch)
+	private async Task<CursorPoint?> NudgePointerAsync(int generation, PointerNudgeOptions nudge, RealMouseInputWatch? watch)
 	{
 		if (!nudge.Enabled || _cursorAnchor.Generation != generation || !_cursorAnchor.HasAnchor)
-			return;
+			return null;
 
 		var anchor = _cursorAnchor.Anchor;
 		var plan = PointerNudgePlanner.Plan(anchor, nudge);
@@ -971,7 +959,7 @@ public sealed partial class RegionSelectionWindow : Window
 		_nudgeOwnsPointer = true;
 		try
 		{
-			await PointerNudgeRunner.RunAsync(
+			var run = await PointerNudgeRunner.RunAsync(
 				_nudgeCursor,
 				Task.Delay,
 				anchor,
@@ -984,6 +972,7 @@ public sealed partial class RegionSelectionWindow : Window
 				// rule and stops on any foreign move.
 				watch is { IsWatching: true } ? () => watch.HandSteps : null,
 				watch is { IsWatching: true } ? () => watch.Teleports : null).ConfigureAwait(false);
+			return run.HandTookItAt;
 		}
 		finally
 		{


### PR DESCRIPTION
Closes #384.

## The failure

After the follow-the-hand fix (#382, PR #383), the opening of a capture recovers, which also proves the magnifier follows program-made pointer movement. The closing end still failed: the view (and pointer) went to the reactivated app's caret and stayed.

The hold judged each 40 ms look by "did hand steps arrive in this window?" — and a resting hand streams real micro-step events (~1/ms, measured). ZoomText's caret grab, a single unflagged ~27 px driver teleport, always lands in a window that also contains jitter, so the hold **followed the grab** as though the hand had walked there. The closing wiggle died the same way: any hand step plus any mismatch ended the run, and jitter supplies both every look.

## The rule change

The watch already classifies teleports; it now counts them, and both defenses ask about the grab **first**:

- **Hold:** a look containing a teleport is a grab and is undone to the baseline, whatever the jitter did. Hand steps without a teleport follow as before; buttons still end the hold. A hand whose genuine travel shares a look with a grab is restored once and followed again on its next step — the accepted one-tick cost.
- **Wiggle:** three-way rule per look. Teleport → reclaim and carry on. Drift within a three-pixel jitter radius → recentre and carry on. Genuine travel beyond it → stop dead, leaving the pointer exactly where the hand put it.
- **The reconcile between wiggle and hold** no longer rebases the anchor onto a position a teleport produced.

Documented residual holes: a silent SetCursorPos grab during jitter is still followed (ZoomText grabs via driver teleports, not silently), and a hand crawling under three pixels per look during an active wiggle is re-centred for the wiggle's duration.

## Verified

2430 tests, 0 failures, including new cases: grab-inside-jitter undone not followed (hold and wiggle), genuine-travel-plus-grab restored once then followed, jitter tolerated by the wiggle. Not verifiable here: the real ZoomText closing sequence — the user's acceptance test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)