### PR TITLE
Hold the speakers open, so a beep arrives with the thing it confirms

### DIFF
--- a/CognitiveSupport/BeepAudioOutput.cs
+++ b/CognitiveSupport/BeepAudioOutput.cs
@@ -1,0 +1,320 @@
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Threading;
+using NAudio.Wave;
+using NAudio.Wave.SampleProviders;
+
+namespace CognitiveSupport;
+
+/// <summary>
+/// The speaker every beep goes out of: one audio device, opened once and held open, fed by a
+/// mixer that beeps are dropped into.
+///
+/// <para>
+/// This replaces <c>System.Media.SoundPlayer</c>, and it exists because of what that API does
+/// between being asked for a sound and the sound being heard. It owns no device, so for every
+/// beep Windows opens the default output, reads the file, plays, and closes again — on an
+/// internal thread, with no bound on how long the open takes. A dictation run is the worst case
+/// for it: the recording has just released the microphone, and on hardware that shares a
+/// capture and a playback endpoint (a headset above all) Windows reconfigures the endpoint when
+/// the microphone is let go. A beep asked for during that window waits it out. Measured on the
+/// user's machine, the app was asking for the success beep 40 to 110 ms after the transcript was
+/// pasted, every time, and the sound was still arriving five to ten seconds later (issue #386).
+/// </para>
+///
+/// <para>
+/// Holding the device open moves that cost to startup, where nobody is waiting on it, and leaves
+/// a beep needing nothing but an array handed to a mixer. It also ends the one-sound-at-a-time
+/// rule that came with the old API: sounds are added together now, so a retry beep still
+/// counting cannot swallow the success beep that follows it.
+/// </para>
+///
+/// <para>
+/// The trade is worth stating plainly. Mutation now shows as an active playback session in the
+/// Windows volume mixer for as long as it runs, and on a Bluetooth headset it keeps the audio
+/// link awake. That is the price of a confirmation sound that arrives with the thing it is
+/// confirming.
+/// </para>
+///
+/// <para>
+/// Every request is handed to one background thread rather than played on the caller's. Opening
+/// a device is the slow step and it can fail, and the callers here are the UI thread finishing a
+/// dictation and a Polly retry lambda mid-transcription — neither can afford to wait on an audio
+/// device or to be thrown out of by one.
+/// </para>
+/// </summary>
+public sealed class BeepAudioOutput : IDisposable
+{
+	/// <summary>The one format the mixer runs at; every clip is converted to it when loaded.</summary>
+	public const int SampleRate = 48000;
+
+	public const int Channels = 2;
+
+	/// <summary>
+	/// How much audio the device buffers, and in how many pieces. A beep starts at the next
+	/// buffer boundary, so this is the app's own share of the delay between asking for a sound
+	/// and hearing it: about 33 ms here. NAudio's default is 300 ms in two buffers, which would
+	/// have put a tenth of a second between the paste and its confirmation for no reason.
+	/// </summary>
+	public const int DesiredLatencyMs = 100;
+
+	public const int BufferCount = 3;
+
+	/// <summary>
+	/// Anything slower than this is worth a line in the log. The point is that the next time a
+	/// beep is late, whether the app was the cause is a matter of record rather than argument
+	/// (issue #386).
+	/// </summary>
+	public const int SlowReportThresholdMs = 250;
+
+	/// <summary>
+	/// How long to leave a device that would not open alone before trying again. Without it, a
+	/// machine with no working audio output logs a failure for every beep of the session.
+	/// </summary>
+	public static readonly TimeSpan ReopenBackoff = TimeSpan.FromSeconds(30);
+
+	private readonly Func<IAudioOutputDevice> _deviceFactory;
+	private readonly Action<string, string> _log;
+	private readonly Func<DateTimeOffset> _now;
+	private readonly BlockingCollection<PlayRequest> _requests = new();
+	private readonly Thread _pump;
+
+	// Raised whenever the queue empties. The pump is asynchronous by design, so a test needs a
+	// way to say "and now everything asked for has been handed over" without sleeping. The count
+	// and the event are moved together under one lock, or a beep queued in the instant the pump
+	// finished the one before it would leave the event saying there was nothing left to do.
+	private readonly ManualResetEventSlim _idle = new(initialState: true);
+	private readonly object _idleLock = new();
+	private int _pending;
+
+	private IAudioOutputDevice? _device;
+	private MixingSampleProvider? _mixer;
+	private DateTimeOffset _nextOpenAttempt = DateTimeOffset.MinValue;
+	private volatile bool _deviceFaulted;
+	private bool _disposed;
+
+	public BeepAudioOutput()
+		: this(() => new WaveOutAudioOutputDevice(DesiredLatencyMs, BufferCount))
+	{
+	}
+
+	/// <param name="deviceFactory">Makes the output device. Injected so the rules here can be tested without audio hardware.</param>
+	/// <param name="log">Where slow opens and failures are reported. Defaults to the app's error log.</param>
+	/// <param name="now">The clock, so the reopen backoff can be tested without waiting on it.</param>
+	public BeepAudioOutput(
+		Func<IAudioOutputDevice> deviceFactory,
+		Action<string, string>? log = null,
+		Func<DateTimeOffset>? now = null)
+	{
+		_deviceFactory = deviceFactory ?? throw new ArgumentNullException(nameof(deviceFactory));
+		_log = log ?? ErrorLogger.LogInfo;
+		_now = now ?? (() => DateTimeOffset.UtcNow);
+
+		_pump = new Thread(Pump)
+		{
+			IsBackground = true,
+			Name = "Mutation beep output",
+		};
+		_pump.Start();
+	}
+
+	/// <summary>How many times a device has actually been opened. Zero until the first beep, or the first <see cref="Warm"/>.</summary>
+	public int DeviceOpenCount { get; private set; }
+
+	/// <summary>
+	/// Opens the device ahead of the first beep, so the one slow open of the session happens at
+	/// startup instead of under a user who is waiting to hear something. Returns immediately.
+	/// </summary>
+	public void Warm() => Enqueue(new PlayRequest(Clip: null, RepeatCount: 1, QueuedAt: Stopwatch.GetTimestamp()));
+
+	/// <summary>
+	/// Asks for <paramref name="clip"/> to be played <paramref name="repeatCount"/> times over.
+	/// Returns straight away and never throws: a beep that cannot be played must never take down
+	/// the operation it was reporting on.
+	/// </summary>
+	public void Play(BeepClip clip, int repeatCount = 1)
+	{
+		ArgumentNullException.ThrowIfNull(clip);
+		if (repeatCount <= 0)
+			return;
+
+		Enqueue(new PlayRequest(clip, repeatCount, Stopwatch.GetTimestamp()));
+	}
+
+	private void Enqueue(PlayRequest request)
+	{
+		if (_disposed)
+			return;
+
+		try
+		{
+			lock (_idleLock)
+			{
+				_pending++;
+				_idle.Reset();
+			}
+
+			_requests.Add(request);
+		}
+		catch (Exception)
+		{
+			// The window closed underneath a beep that was on its way in. There is nothing left
+			// to play it on, and a shutdown race must not become an exception at a call site
+			// that was only trying to make a noise.
+			try { MarkServed(); } catch { }
+		}
+	}
+
+	private void MarkServed()
+	{
+		lock (_idleLock)
+		{
+			if (--_pending <= 0)
+			{
+				_pending = 0;
+				_idle.Set();
+			}
+		}
+	}
+
+	/// <summary>
+	/// Waits until every request queued so far has been handed to the mixer. A test seam; nothing
+	/// in the app waits for a beep.
+	/// </summary>
+	internal bool WaitForIdle(TimeSpan timeout) => _idle.Wait(timeout);
+
+	private void Pump()
+	{
+		try
+		{
+			foreach (var request in _requests.GetConsumingEnumerable())
+			{
+				try
+				{
+					Serve(request);
+				}
+				catch (Exception ex)
+				{
+					// The device has gone — pulled out, reconfigured, or refused. Drop it and let
+					// the next beep open a fresh one rather than failing for the rest of the run.
+					CloseDevice();
+					_nextOpenAttempt = _now() + ReopenBackoff;
+					_log("Beep", $"Could not play a beep: {ex.Message}. The audio device will be reopened on a later beep.");
+				}
+
+				MarkServed();
+			}
+		}
+		catch (ObjectDisposedException)
+		{
+			// Disposed underneath the enumerator. Shutting down is the whole point.
+		}
+		finally
+		{
+			lock (_idleLock)
+			{
+				_pending = 0;
+				_idle.Set();
+			}
+			CloseDevice();
+		}
+	}
+
+	private void Serve(PlayRequest request)
+	{
+		if (_deviceFaulted)
+			CloseDevice();
+
+		if (_device is null && _now() < _nextOpenAttempt)
+			return;
+
+		OpenDeviceIfNeeded();
+
+		if (request.Clip is null || _mixer is null)
+			return;
+
+		_mixer.AddMixerInput((ISampleProvider)new BeepClipSampleProvider(request.Clip, request.RepeatCount));
+
+		var waited = Stopwatch.GetElapsedTime(request.QueuedAt);
+		if (waited.TotalMilliseconds > SlowReportThresholdMs)
+			_log("Beep", $"A beep waited {waited.TotalMilliseconds:F0} ms to reach the speaker.");
+	}
+
+	private void OpenDeviceIfNeeded()
+	{
+		if (_device is not null)
+			return;
+
+		var mixer = new MixingSampleProvider(WaveFormat.CreateIeeeFloatWaveFormat(SampleRate, Channels))
+		{
+			// Silence rather than nothing when no beep is playing. Without it the mixer reports
+			// that the audio ran out the moment the first beep ends, the device stops, and every
+			// beep after that pays the open cost this class exists to avoid.
+			ReadFully = true,
+		};
+
+		var started = Stopwatch.GetTimestamp();
+		var device = _deviceFactory();
+		try
+		{
+			device.PlaybackStopped += OnPlaybackStopped;
+			device.Init(mixer.ToWaveProvider16());
+			device.Play();
+		}
+		catch
+		{
+			device.PlaybackStopped -= OnPlaybackStopped;
+			try { device.Dispose(); } catch { }
+			throw;
+		}
+
+		_device = device;
+		_mixer = mixer;
+		_deviceFaulted = false;
+		_nextOpenAttempt = DateTimeOffset.MinValue;
+		DeviceOpenCount++;
+
+		var elapsed = Stopwatch.GetElapsedTime(started);
+		if (elapsed.TotalMilliseconds > SlowReportThresholdMs)
+			_log("Beep", $"Opening the audio output took {elapsed.TotalMilliseconds:F0} ms.");
+	}
+
+	// Raised on the device's own thread when playback ends. With ReadFully the audio never runs
+	// out, so this only happens when the device fails or is stopped — either way the handle is no
+	// longer worth beeping into.
+	private void OnPlaybackStopped(object? sender, StoppedEventArgs e) => _deviceFaulted = true;
+
+	private void CloseDevice()
+	{
+		var device = _device;
+		_device = null;
+		_mixer = null;
+		_deviceFaulted = false;
+
+		if (device is null)
+			return;
+
+		device.PlaybackStopped -= OnPlaybackStopped;
+		try { device.Stop(); } catch { }
+		try { device.Dispose(); } catch { }
+	}
+
+	public void Dispose()
+	{
+		if (_disposed)
+			return;
+		_disposed = true;
+
+		try { _requests.CompleteAdding(); } catch { }
+		// Bounded, because shutdown must not hang on an audio driver. The device is closed by the
+		// pump's finally either way, and by the process if the driver never lets go.
+		_pump.Join(TimeSpan.FromSeconds(2));
+		_requests.Dispose();
+		_idle.Dispose();
+	}
+
+	/// <param name="Clip">Null asks only that the device be opened — see <see cref="Warm"/>.</param>
+	/// <param name="QueuedAt">A <see cref="Stopwatch"/> timestamp, so the wait can be measured.</param>
+	private readonly record struct PlayRequest(BeepClip? Clip, int RepeatCount, long QueuedAt);
+}

--- a/CognitiveSupport/BeepAudioOutput.cs
+++ b/CognitiveSupport/BeepAudioOutput.cs
@@ -139,6 +139,17 @@ public sealed class BeepAudioOutput : IDisposable
 		if (repeatCount <= 0)
 			return;
 
+		// Checked here rather than left to the mixer. NAudio's mixer adds the input to its list
+		// first and validates the format afterwards, so a clip in the wrong format is already in
+		// the mix by the time it throws — and would then be played, at the wrong rate, over
+		// everything else. Every clip the app builds goes through BeepClipReader in this format,
+		// so this only ever catches a mistake made outside it.
+		if (clip.SampleRate != SampleRate || clip.Channels != Channels)
+		{
+			_log("Beep", $"A beep in {clip.SampleRate} Hz / {clip.Channels} channel form was not played; the mixer runs at {SampleRate} Hz / {Channels} channels.");
+			return;
+		}
+
 		Enqueue(new PlayRequest(clip, repeatCount, Stopwatch.GetTimestamp()));
 	}
 
@@ -212,12 +223,21 @@ public sealed class BeepAudioOutput : IDisposable
 		}
 		finally
 		{
-			lock (_idleLock)
+			// Both of these can throw if shutdown gave up waiting for this thread and disposed
+			// the queue and the event underneath it — see Dispose. An exception escaping a
+			// background thread's finally takes the process down with it, which is a poor way
+			// for an app to close because a beep was still in the air.
+			try
 			{
-				_pending = 0;
-				_idle.Set();
+				lock (_idleLock)
+				{
+					_pending = 0;
+					_idle.Set();
+				}
 			}
-			CloseDevice();
+			catch (ObjectDisposedException) { }
+
+			try { CloseDevice(); } catch { }
 		}
 	}
 
@@ -307,11 +327,17 @@ public sealed class BeepAudioOutput : IDisposable
 		_disposed = true;
 
 		try { _requests.CompleteAdding(); } catch { }
-		// Bounded, because shutdown must not hang on an audio driver. The device is closed by the
-		// pump's finally either way, and by the process if the driver never lets go.
-		_pump.Join(TimeSpan.FromSeconds(2));
-		_requests.Dispose();
-		_idle.Dispose();
+
+		// Bounded, because closing the window must not hang on an audio driver. The device is
+		// closed by the pump's finally either way, and by the process if the driver never lets
+		// go. Only tidy up behind the pump if it actually finished: pulling the queue and the
+		// event out from under a thread that is still running them is how a slow driver would
+		// turn a clean exit into a crash.
+		if (_pump.Join(TimeSpan.FromSeconds(2)))
+		{
+			try { _requests.Dispose(); } catch { }
+			try { _idle.Dispose(); } catch { }
+		}
 	}
 
 	/// <param name="Clip">Null asks only that the device be opened — see <see cref="Warm"/>.</param>

--- a/CognitiveSupport/BeepClip.cs
+++ b/CognitiveSupport/BeepClip.cs
@@ -1,0 +1,44 @@
+using System;
+
+namespace CognitiveSupport;
+
+/// <summary>
+/// One beep's audio, decoded into memory and already in the format the beep mixer runs at.
+/// <para>
+/// Beeps used to be played straight off disk by <c>System.Media.SoundPlayer</c>, which asks
+/// Windows to open an audio device, read the file and close the device again for every single
+/// sound. All of that happened after the app had asked for the beep and before anything was
+/// audible, and none of it was bounded — which is how a success sound came to arrive five to
+/// ten seconds after the text it was confirming (issue #386). Holding the samples here means
+/// the only work left at the moment a beep is wanted is handing an array to a device that is
+/// already open.
+/// </para>
+/// </summary>
+public sealed class BeepClip
+{
+	public BeepClip(float[] samples, int sampleRate, int channels)
+	{
+		ArgumentNullException.ThrowIfNull(samples);
+		if (sampleRate <= 0)
+			throw new ArgumentOutOfRangeException(nameof(sampleRate));
+		if (channels <= 0)
+			throw new ArgumentOutOfRangeException(nameof(channels));
+
+		Samples = samples;
+		SampleRate = sampleRate;
+		Channels = channels;
+	}
+
+	/// <summary>
+	/// Interleaved samples, one float per channel per frame. Read-only by contract: a clip is
+	/// shared by every playback of that beep and several can be mixing at once.
+	/// </summary>
+	public ReadOnlyMemory<float> Samples { get; }
+
+	public int SampleRate { get; }
+
+	public int Channels { get; }
+
+	public TimeSpan Duration =>
+		TimeSpan.FromSeconds((double)Samples.Length / Channels / SampleRate);
+}

--- a/CognitiveSupport/BeepClipReader.cs
+++ b/CognitiveSupport/BeepClipReader.cs
@@ -48,7 +48,8 @@ public static class BeepClipReader
 			throw new ArgumentOutOfRangeException(nameof(channels), "Only mono and stereo are supported.");
 
 		using var reader = new WaveFileReader(wav);
-		ISampleProvider source = reader.ToSampleProvider();
+		using var decoded = Decode(reader);
+		ISampleProvider source = decoded.Provider;
 
 		// Channels first, then rate. The resampler keeps whatever channel count it is handed, so
 		// doing it in this order means only one of them ever has to think about the other.
@@ -57,6 +58,82 @@ public static class BeepClipReader
 			source = new WdlResamplingSampleProvider(source, sampleRate);
 
 		return new BeepClip(ReadToEnd(source, sampleRate, channels), sampleRate, channels);
+	}
+
+	/// <summary>
+	/// Gets samples out of whatever kind of <c>.wav</c> the user pointed the setting at.
+	/// <para>
+	/// NAudio reads plain PCM and 32-bit float directly, and that covers nearly every beep file
+	/// anyone has. It refuses two shapes that the old <c>PlaySound</c> path played without
+	/// complaint, and both are common enough to matter: a file written in the "extensible"
+	/// layout, which many tools use for float audio and which Windows requires above two
+	/// channels; and a compressed one such as ADPCM or mu-law. Losing those would mean a sound
+	/// the user has been hearing for months going quiet the day this shipped, which is not a
+	/// trade worth making for a beep that arrives on time.
+	/// </para>
+	/// <para>
+	/// Extensible files are relabelled: the layout only wraps ordinary PCM or float samples, and
+	/// the sub-format written into the header says which. A compressed file is handed to
+	/// Windows' own audio codecs — the same ones the old path relied on.
+	/// </para>
+	/// </summary>
+	private static DecodedWave Decode(WaveFileReader reader)
+	{
+		try
+		{
+			return new DecodedWave(reader.ToSampleProvider(), null);
+		}
+		catch (ArgumentException)
+		{
+			// Not a shape NAudio converts on its own. Fall through.
+		}
+
+		var relabelled = AsStandardFormat(reader.WaveFormat);
+		if (relabelled is not null)
+		{
+			var raw = new RawSourceWaveStream(reader, relabelled);
+			return new DecodedWave(raw.ToSampleProvider(), raw);
+		}
+
+		// Compressed audio. CreatePcmStream goes through Windows' installed codecs, and throws
+		// if none of them knows this format — which is the honest answer, and reaches the user
+		// as a named beep file that could not be loaded.
+		var pcm = WaveFormatConversionStream.CreatePcmStream(reader);
+		return new DecodedWave(pcm.ToSampleProvider(), pcm);
+	}
+
+	// The sub-format GUID of an extensible header, whose first four bytes say PCM (1) or IEEE
+	// float (3). It sits after the two bytes of valid-bits and the four of channel mask.
+	private const int SubFormatOffset = 6;
+	private const byte SubFormatPcm = 1;
+	private const byte SubFormatIeeeFloat = 3;
+
+	private static WaveFormat? AsStandardFormat(WaveFormat format)
+	{
+		if (format.Encoding != WaveFormatEncoding.Extensible || format is not WaveFormatExtraData extra)
+			return null;
+
+		var data = extra.ExtraData;
+		if (data is null || data.Length < SubFormatOffset + 4)
+			return null;
+
+		return data[SubFormatOffset] switch
+		{
+			SubFormatIeeeFloat when format.BitsPerSample == 32 =>
+				WaveFormat.CreateIeeeFloatWaveFormat(format.SampleRate, format.Channels),
+			SubFormatPcm =>
+				new WaveFormat(format.SampleRate, format.BitsPerSample, format.Channels),
+			_ => null,
+		};
+	}
+
+	/// <param name="Owned">
+	/// The stream wrapped around the reader, when one was needed. Held so it is closed with the
+	/// clip rather than left to a finalizer.
+	/// </param>
+	private readonly record struct DecodedWave(ISampleProvider Provider, IDisposable? Owned) : IDisposable
+	{
+		public void Dispose() => Owned?.Dispose();
 	}
 
 	private static ISampleProvider MatchChannels(ISampleProvider source, int channels)

--- a/CognitiveSupport/BeepClipReader.cs
+++ b/CognitiveSupport/BeepClipReader.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using NAudio.Wave;
+using NAudio.Wave.SampleProviders;
+
+namespace CognitiveSupport;
+
+/// <summary>
+/// Turns a <c>.wav</c> — a file the user chose, or the tones the app synthesizes for itself —
+/// into a <see cref="BeepClip"/> in one fixed format, so everything the beep mixer is given can
+/// simply be added together.
+/// <para>
+/// The conversion has to happen somewhere. The user's own beep files are a mix of sample rates
+/// (44.1 kHz and 48 kHz are both common) and the synthesized tones are 22.05 kHz mono, while a
+/// mixer can only add sources that agree. Doing it here, once, when settings are loaded, is what
+/// keeps it out of the moment a beep is actually wanted.
+/// </para>
+/// </summary>
+public static class BeepClipReader
+{
+	/// <summary>
+	/// Longest clip accepted. A beep is a beep; if someone points the setting at an album track
+	/// the tail is dropped rather than held in memory for the life of the process.
+	/// </summary>
+	public static readonly TimeSpan MaxDuration = TimeSpan.FromSeconds(30);
+
+	public static BeepClip ReadFile(string filePath, int sampleRate, int channels)
+	{
+		ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+		using var stream = File.OpenRead(filePath);
+		return Read(stream, sampleRate, channels);
+	}
+
+	public static BeepClip ReadBytes(byte[] wav, int sampleRate, int channels)
+	{
+		ArgumentNullException.ThrowIfNull(wav);
+		using var stream = new MemoryStream(wav, writable: false);
+		return Read(stream, sampleRate, channels);
+	}
+
+	public static BeepClip Read(Stream wav, int sampleRate, int channels)
+	{
+		ArgumentNullException.ThrowIfNull(wav);
+		if (sampleRate <= 0)
+			throw new ArgumentOutOfRangeException(nameof(sampleRate));
+		if (channels is not (1 or 2))
+			throw new ArgumentOutOfRangeException(nameof(channels), "Only mono and stereo are supported.");
+
+		using var reader = new WaveFileReader(wav);
+		ISampleProvider source = reader.ToSampleProvider();
+
+		// Channels first, then rate. The resampler keeps whatever channel count it is handed, so
+		// doing it in this order means only one of them ever has to think about the other.
+		source = MatchChannels(source, channels);
+		if (source.WaveFormat.SampleRate != sampleRate)
+			source = new WdlResamplingSampleProvider(source, sampleRate);
+
+		return new BeepClip(ReadToEnd(source, sampleRate, channels), sampleRate, channels);
+	}
+
+	private static ISampleProvider MatchChannels(ISampleProvider source, int channels)
+	{
+		if (source.WaveFormat.Channels == channels)
+			return source;
+
+		return (source.WaveFormat.Channels, channels) switch
+		{
+			(1, 2) => new MonoToStereoSampleProvider(source),
+			(2, 1) => new StereoToMonoSampleProvider(source),
+			_ => throw new NotSupportedException(
+				$"A {source.WaveFormat.Channels}-channel beep file cannot be played as {channels}-channel audio."),
+		};
+	}
+
+	private static float[] ReadToEnd(ISampleProvider source, int sampleRate, int channels)
+	{
+		long maxSamples = (long)(MaxDuration.TotalSeconds * sampleRate) * channels;
+		var buffer = new float[sampleRate * channels / 4];
+		var samples = new List<float>();
+
+		int read;
+		while (samples.Count < maxSamples && (read = source.Read(buffer, 0, buffer.Length)) > 0)
+		{
+			for (var i = 0; i < read && samples.Count < maxSamples; i++)
+				samples.Add(buffer[i]);
+		}
+
+		// A whole number of frames, always. A clip ending mid-frame would swap the channels of
+		// every sound mixed after it.
+		int remainder = samples.Count % channels;
+		if (remainder != 0)
+			samples.RemoveRange(samples.Count - remainder, remainder);
+
+		return samples.ToArray();
+	}
+}

--- a/CognitiveSupport/BeepClipSampleProvider.cs
+++ b/CognitiveSupport/BeepClipSampleProvider.cs
@@ -1,0 +1,68 @@
+using System;
+using NAudio.Wave;
+
+namespace CognitiveSupport;
+
+/// <summary>
+/// Plays one <see cref="BeepClip"/> through the beep mixer, back-to-back
+/// <c>repeatCount</c> times, and then ends so the mixer drops it.
+/// <para>
+/// The repeat lives here rather than in a loop at the call site because the mixer is what makes
+/// counting possible at all. The old code ran the clip synchronously on a background thread, N
+/// times over, and Windows only lets one sound play per process — so a success beep raised
+/// while a retry beep was still counting stopped it dead, and was stopped in turn by the retry's
+/// next repetition. Mixed instead of interrupted, both are heard (issue #386).
+/// </para>
+/// </summary>
+internal sealed class BeepClipSampleProvider : ISampleProvider
+{
+	private readonly BeepClip _clip;
+	private readonly int _repeatCount;
+	private int _repeatsDone;
+	private int _position;
+
+	public BeepClipSampleProvider(BeepClip clip, int repeatCount)
+	{
+		ArgumentNullException.ThrowIfNull(clip);
+		if (repeatCount <= 0)
+			throw new ArgumentOutOfRangeException(nameof(repeatCount));
+
+		_clip = clip;
+		_repeatCount = repeatCount;
+		WaveFormat = WaveFormat.CreateIeeeFloatWaveFormat(clip.SampleRate, clip.Channels);
+	}
+
+	public WaveFormat WaveFormat { get; }
+
+	public int Read(float[] buffer, int offset, int count)
+	{
+		ArgumentNullException.ThrowIfNull(buffer);
+
+		var samples = _clip.Samples.Span;
+		int written = 0;
+
+		while (written < count && _repeatsDone < _repeatCount)
+		{
+			// An empty clip would otherwise spin here for ever: nothing is copied, the position
+			// never reaches the end, and the repeat is never counted off.
+			if (samples.Length == 0)
+			{
+				_repeatsDone = _repeatCount;
+				break;
+			}
+
+			int available = Math.Min(count - written, samples.Length - _position);
+			samples.Slice(_position, available).CopyTo(buffer.AsSpan(offset + written, available));
+			written += available;
+			_position += available;
+
+			if (_position >= samples.Length)
+			{
+				_position = 0;
+				_repeatsDone++;
+			}
+		}
+
+		return written;
+	}
+}

--- a/CognitiveSupport/BeepClipSampleProvider.cs
+++ b/CognitiveSupport/BeepClipSampleProvider.cs
@@ -7,6 +7,14 @@ namespace CognitiveSupport;
 /// Plays one <see cref="BeepClip"/> through the beep mixer, back-to-back
 /// <c>repeatCount</c> times, and then ends so the mixer drops it.
 /// <para>
+/// It must fill every read completely until it is genuinely finished. NAudio's mixer drops an
+/// input the moment a read comes back short — measured against NAudio 2.3.0, the test is
+/// "fewer samples than asked for", not "no samples at all" — so a beep that returned a partial
+/// buffer for any reason other than reaching its end would be cut off there and never heard
+/// again. The samples in that last short read are mixed before the input is dropped, so ending
+/// this way loses nothing.
+/// </para>
+/// <para>
 /// The repeat lives here rather than in a loop at the call site because the mixer is what makes
 /// counting possible at all. The old code ran the clip synchronously on a background thread, N
 /// times over, and Windows only lets one sound play per process — so a success beep raised

--- a/CognitiveSupport/BeepPlayer.cs
+++ b/CognitiveSupport/BeepPlayer.cs
@@ -72,6 +72,12 @@ public static class BeepPlayer
 			// here — at startup, and again after a settings save — rather than under a user who
 			// is waiting to hear whether their dictation landed (issue #386).
 			Output().Warm();
+
+			// This method reads and converts every beep file while holding the lock, on whichever
+			// thread called it, which in the app is the UI thread. Measured against the six sound
+			// files that ship with Mutation: 29 ms in total, holding 3.2 MB of decoded audio.
+			// BeepClipReaderTests keeps a budget on it, because the whole point of doing the work
+			// here is that none of it is left for the moment a beep is wanted.
 		}
 	}
 

--- a/CognitiveSupport/BeepPlayer.cs
+++ b/CognitiveSupport/BeepPlayer.cs
@@ -1,4 +1,7 @@
-﻿using System.Media;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 
 namespace CognitiveSupport;
 
@@ -32,54 +35,58 @@ public static class BeepPlayer
 	private static readonly object SyncLock = new();
 	private static readonly TimeSpan DuplicateSuppressWindow = TimeSpan.FromMilliseconds(500);
 	private static readonly Dictionary<BeepType, DateTime> _lastPlayed = new();
-	private static SoundPlayer? _playerStart;
-	private static SoundPlayer? _playerSuccess;
-	private static SoundPlayer? _playerFailure;
-	private static SoundPlayer? _playerEnd;
-	private static SoundPlayer? _playerMute;
-	private static SoundPlayer? _playerUnmute;
-	private static SoundPlayer? _previewPlayer;
-	// Bumped whenever the per-type players are torn down, so an in-flight repeat loop
-	// can tell that the SoundPlayer it captured is no longer the live one.
-	private static int _playerGeneration;
-	private static readonly Dictionary<(BeepType Type, int RepeatCount), (SoundPlayer Player, MemoryStream Stream)> _defaultPlayers = new();
+
+	// The user's own sound files, decoded once when settings are loaded. Empty when custom
+	// beeps are switched off, or when a file could not be read — either way the synthesized
+	// tone below is played instead, so the app is never silent about an outcome.
+	private static readonly Dictionary<BeepType, BeepClip> _customClips = new();
+
+	// The synthesized tones, built on first use and kept. Keyed by repeat count as well as
+	// type because a repeat of a default beep is one longer sequence with gaps in it, not the
+	// same sound played twice — that is what lets a listener count the retries (issue #216).
+	private static readonly Dictionary<(BeepType Type, int RepeatCount), BeepClip> _defaultClips = new();
+
+	private static BeepAudioOutput? _output;
+
 	public static IReadOnlyList<string> LastInitializationIssues { get; private set; } = Array.Empty<string>();
 
 	public static void Initialize(Settings settings)
 	{
 		lock (SyncLock)
 		{
-			DisposePlayersCore();
+			_customClips.Clear();
 			var issues = new List<string>();
 			var custom = settings.AudioSettings?.CustomBeepSettings;
 			if (custom?.UseCustomBeeps == true)
 			{
-				_playerStart = LoadPlayer(custom.ResolveAudioFilePath(custom.BeepStartFile ?? string.Empty), fp => issues.Add($"Could not load start beep file: {fp}"));
-				_playerSuccess = LoadPlayer(custom.ResolveAudioFilePath(custom.BeepSuccessFile ?? string.Empty), fp => issues.Add($"Could not load success beep file: {fp}"));
-				_playerFailure = LoadPlayer(custom.ResolveAudioFilePath(custom.BeepFailureFile ?? string.Empty), fp => issues.Add($"Could not load failure beep file: {fp}"));
-				_playerEnd = LoadPlayer(custom.ResolveAudioFilePath(custom.BeepEndFile ?? string.Empty), fp => issues.Add($"Could not load end beep file: {fp}"));
-				_playerMute = LoadPlayer(custom.ResolveAudioFilePath(custom.BeepMuteFile ?? string.Empty), fp => issues.Add($"Could not load mute beep file: {fp}"));
-				_playerUnmute = LoadPlayer(custom.ResolveAudioFilePath(custom.BeepUnmuteFile ?? string.Empty), fp => issues.Add($"Could not load unmute beep file: {fp}"));
+				Load(BeepType.Start, custom.ResolveAudioFilePath(custom.BeepStartFile ?? string.Empty), "start", issues);
+				Load(BeepType.Success, custom.ResolveAudioFilePath(custom.BeepSuccessFile ?? string.Empty), "success", issues);
+				Load(BeepType.Failure, custom.ResolveAudioFilePath(custom.BeepFailureFile ?? string.Empty), "failure", issues);
+				Load(BeepType.End, custom.ResolveAudioFilePath(custom.BeepEndFile ?? string.Empty), "end", issues);
+				Load(BeepType.Mute, custom.ResolveAudioFilePath(custom.BeepMuteFile ?? string.Empty), "mute", issues);
+				Load(BeepType.Unmute, custom.ResolveAudioFilePath(custom.BeepUnmuteFile ?? string.Empty), "unmute", issues);
 			}
 			LastInitializationIssues = issues;
+
+			// Opening an audio device is the one slow step left in the beep path, so it is done
+			// here — at startup, and again after a settings save — rather than under a user who
+			// is waiting to hear whether their dictation landed (issue #386).
+			Output().Warm();
 		}
 	}
 
-	private static SoundPlayer? LoadPlayer(string filePath, Action<string> onError)
+	private static void Load(BeepType type, string filePath, string name, List<string> issues)
 	{
 		if (string.IsNullOrWhiteSpace(filePath) || !File.Exists(filePath))
-			return null;
+			return;
 
 		try
 		{
-			var player = new SoundPlayer(filePath);
-			player.Load();
-			return player;
+			_customClips[type] = BeepClipReader.ReadFile(filePath, BeepAudioOutput.SampleRate, BeepAudioOutput.Channels);
 		}
 		catch
 		{
-			onError(filePath);
-			return null;
+			issues.Add($"Could not load {name} beep file: {filePath}");
 		}
 	}
 
@@ -94,18 +101,20 @@ public static class BeepPlayer
 				return;
 			}
 			_lastPlayed[type] = now;
+
+			PlayCore(type, repeatCount: 1);
 		}
-		if (TryPlayCustom(type))
-			return;
-		PlayDefault(type, repeatCount: 1);
 	}
 
-	// Plays <paramref name="repeatCount"/> copies of a beep as a single sound so the
-	// listener can actually count them. Playing Play() in a loop does not work: the
-	// duplicate-suppression window above swallows every call after the first (issue
-	// #216), and even without it SoundPlayer.Play restarts rather than queues. The
-	// default beeps are therefore synthesized as one N-tone WAV, and custom beep files
-	// are played back-to-back synchronously off the calling thread.
+	/// <summary>
+	/// Plays <paramref name="repeatCount"/> copies of a beep so the listener can count them.
+	/// <para>
+	/// Calling <see cref="Play"/> in a loop does not work: the duplicate-suppression window
+	/// above swallows every call after the first (issue #216). The default beeps are therefore
+	/// synthesized as one sequence with gaps in it, and a custom sound file is played
+	/// back-to-back the requested number of times.
+	/// </para>
+	/// </summary>
 	public static void PlayRepeated(BeepType type, int repeatCount)
 	{
 		repeatCount = ClampRepeatCount(repeatCount);
@@ -116,12 +125,47 @@ public static class BeepPlayer
 			// repeat, so it must never be collapsed. Still stamped so a stray single
 			// Play right behind it stays suppressed.
 			_lastPlayed[type] = DateTime.UtcNow;
-		}
 
-		if (TryPlayCustomRepeated(type, repeatCount))
-			return;
-		PlayDefault(type, repeatCount);
+			PlayCore(type, repeatCount);
+		}
 	}
+
+	// Held under SyncLock by both callers. Everything here is a dictionary lookup or a handover
+	// to the output's own thread, so the lock is never held across anything that waits.
+	private static void PlayCore(BeepType type, int repeatCount)
+	{
+		try
+		{
+			if (_customClips.TryGetValue(type, out var custom))
+			{
+				Output().Play(custom, repeatCount);
+				return;
+			}
+
+			Output().Play(DefaultClip(type, repeatCount));
+		}
+		catch
+		{
+			// A beep that will not play must never take down the operation it is reporting on:
+			// this runs inside Polly retry lambdas, where an escaping exception aborts the
+			// transcription. Playback itself cannot throw here — it is a handover to another
+			// thread — but synthesizing a default tone for the first time can.
+		}
+	}
+
+	private static BeepClip DefaultClip(BeepType type, int repeatCount)
+	{
+		var key = (type, ClampRepeatCount(repeatCount));
+		if (_defaultClips.TryGetValue(key, out var cached))
+			return cached;
+
+		var wav = BeepToneSynthesizer.SynthesizeWav(GetRepeatedSequence(key.Item1, key.Item2));
+		var clip = BeepClipReader.ReadBytes(wav, BeepAudioOutput.SampleRate, BeepAudioOutput.Channels);
+		_defaultClips[key] = clip;
+		return clip;
+	}
+
+	private static BeepAudioOutput Output() => _output ??= new BeepAudioOutput();
 
 	private static int ClampRepeatCount(int repeatCount) => Math.Clamp(repeatCount, 1, MaxRepeatCount);
 
@@ -140,125 +184,6 @@ public static class BeepPlayer
 		return sequence;
 	}
 
-	private static bool TryPlayCustomRepeated(BeepType type, int repeatCount)
-	{
-		SoundPlayer player;
-		int generation;
-
-		// The player field and the generation counter are read together under the lock so
-		// they cannot disagree: DisposePlayers bumps the generation and disposes in one
-		// locked step, so a stale player never pairs with a still-current generation.
-		lock (SyncLock)
-		{
-			var candidate = GetCustomPlayer(type);
-			if (candidate is null)
-				return false;
-
-			if (repeatCount == 1)
-			{
-				PlaySafely(candidate);
-				return true;
-			}
-
-			player = candidate;
-			generation = Volatile.Read(ref _playerGeneration);
-		}
-
-		// PlaySync blocks, so the repeat runs off the caller's thread rather than
-		// stalling the transcription retry it is reporting on. That leaves the loop
-		// running while Initialize/DisposePlayers may replace these players (a Settings
-		// save, or shutdown), so it bails out the moment its generation is superseded
-		// instead of hammering a disposed SoundPlayer.
-		Task.Run(() =>
-		{
-			for (var i = 0; i < repeatCount; i++)
-			{
-				if (Volatile.Read(ref _playerGeneration) != generation)
-					return;
-
-				try
-				{
-					player.PlaySync();
-				}
-				catch
-				{
-					// A failed beep must never take down the operation it reports on.
-					return;
-				}
-			}
-		});
-		return true;
-	}
-
-	private static bool TryPlayCustom(BeepType type)
-	{
-		// The lock covers the Play call, not just the field read. SoundPlayer.Play is
-		// asynchronous — it returns as soon as playback is queued — so holding the lock that
-		// long is cheap, and it is what stops DisposePlayers from disposing this player in
-		// the gap between reading the field and using it.
-		lock (SyncLock)
-		{
-			var player = GetCustomPlayer(type);
-			if (player is null)
-				return false;
-
-			PlaySafely(player);
-			return true;
-		}
-	}
-
-	// A beep that will not play must never take down the operation it is reporting on: this
-	// runs inside Polly retry lambdas, where an escaping exception aborts the transcription.
-	private static void PlaySafely(SoundPlayer player)
-	{
-		try
-		{
-			player.Play();
-		}
-		catch
-		{
-			// Nothing useful to do — the user simply does not hear this beep.
-		}
-	}
-
-	private static SoundPlayer? GetCustomPlayer(BeepType type) => type switch
-	{
-		BeepType.Start => _playerStart,
-		BeepType.Success => _playerSuccess,
-		BeepType.Failure => _playerFailure,
-		BeepType.End => _playerEnd,
-		BeepType.Mute => _playerMute,
-		BeepType.Unmute => _playerUnmute,
-		// Waiting has no custom-file slot: the Settings dialog offers a file per beep the
-		// user already knew about, and a null here simply falls through to the synthesized
-		// default rather than going silent.
-		_ => null
-	};
-
-	// Default beeps are synthesized once into in-memory WAVs and played through
-	// SoundPlayer.Play (asynchronous), so they never block the calling thread the
-	// way Console.Beep did (issue #169).
-	private static void PlayDefault(BeepType type, int repeatCount)
-	{
-		var key = (type, ClampRepeatCount(repeatCount));
-
-		// Play stays inside the lock so DisposePlayers cannot dispose the cached player — or
-		// clear the dictionary out from under this lookup — between the two.
-		lock (SyncLock)
-		{
-			if (!_defaultPlayers.TryGetValue(key, out var cached))
-			{
-				var wav = BeepToneSynthesizer.SynthesizeWav(GetRepeatedSequence(key.Item1, key.Item2));
-				var stream = new MemoryStream(wav, writable: false);
-				cached = (new SoundPlayer(stream), stream);
-				cached.Player.Load();
-				_defaultPlayers[key] = cached;
-			}
-
-			PlaySafely(cached.Player);
-		}
-	}
-
 	public static IReadOnlyList<(int Frequency, int Duration)> GetDefaultSequence(BeepType type) => type switch
 	{
 		BeepType.Start => new[] { (DefaultStartFrequency, DefaultStartDuration) },
@@ -271,10 +196,12 @@ public static class BeepPlayer
 		_ => throw new ArgumentOutOfRangeException(nameof(type))
 	};
 
-	// Plays an arbitrary .wav file for previewing (e.g. from the settings dialog),
-	// independent of the UseCustomBeeps toggle and the cached per-type players.
-	// Expects an already-resolved file path (see CustomBeepSettingsData.ResolveAudioFilePath).
-	// Returns true if playback started; false if the file is missing or could not be loaded.
+	/// <summary>
+	/// Plays an arbitrary .wav file for previewing (e.g. from the settings dialog), independent
+	/// of the UseCustomBeeps toggle and the clips loaded for each beep type. Expects an
+	/// already-resolved file path (see <c>CustomBeepSettingsData.ResolveAudioFilePath</c>).
+	/// Returns true if the file was read and handed over; false if it is missing or unreadable.
+	/// </summary>
 	public static bool PreviewFile(string? resolvedFilePath)
 	{
 		if (string.IsNullOrWhiteSpace(resolvedFilePath) || !File.Exists(resolvedFilePath))
@@ -284,57 +211,30 @@ public static class BeepPlayer
 		{
 			try
 			{
-				_previewPlayer?.Dispose();
-				_previewPlayer = new SoundPlayer(resolvedFilePath);
-				_previewPlayer.Load();
-				_previewPlayer.Play();
+				var clip = BeepClipReader.ReadFile(resolvedFilePath, BeepAudioOutput.SampleRate, BeepAudioOutput.Channels);
+				Output().Play(clip);
 				return true;
 			}
 			catch
 			{
-				_previewPlayer?.Dispose();
-				_previewPlayer = null;
 				return false;
 			}
 		}
 	}
 
 	/// <summary>
-	/// Tears down every cached player. Stays public because the UI project calls it on window
-	/// close; every sibling that touches these statics holds <c>SyncLock</c>, and so does this.
+	/// Releases the audio device and everything loaded for it. Stays public because the UI
+	/// project calls it on window close; every sibling that touches these statics holds
+	/// <c>SyncLock</c>, and so does this. A beep after this point simply opens a new device.
 	/// </summary>
 	public static void DisposePlayers()
 	{
 		lock (SyncLock)
-			DisposePlayersCore();
-	}
-
-	// Callers already holding SyncLock use this, so Initialize does not re-enter the public
-	// entry point. Monitor is re-entrant, but routing through one core keeps it obvious that
-	// nothing here runs unlocked.
-	private static void DisposePlayersCore()
-	{
-		// Signal before disposing, so a repeat loop stops rather than racing the tear-down.
-		Interlocked.Increment(ref _playerGeneration);
-		_previewPlayer?.Dispose();
-		_previewPlayer = null;
-		_playerStart?.Dispose();
-		_playerSuccess?.Dispose();
-		_playerFailure?.Dispose();
-		_playerEnd?.Dispose();
-		_playerMute?.Dispose();
-		_playerUnmute?.Dispose();
-		_playerStart = null;
-		_playerSuccess = null;
-		_playerFailure = null;
-		_playerEnd = null;
-		_playerMute = null;
-		_playerUnmute = null;
-		foreach (var (player, stream) in _defaultPlayers.Values)
 		{
-			player.Dispose();
-			stream.Dispose();
+			_customClips.Clear();
+			_defaultClips.Clear();
+			_output?.Dispose();
+			_output = null;
 		}
-		_defaultPlayers.Clear();
 	}
 }

--- a/CognitiveSupport/WaveOutAudioOutputDevice.cs
+++ b/CognitiveSupport/WaveOutAudioOutputDevice.cs
@@ -11,7 +11,23 @@ internal sealed class WaveOutAudioOutputDevice : IAudioOutputDevice
 	private readonly WaveOutEvent _waveOut = new();
 
 	public WaveOutAudioOutputDevice()
+		: this(desiredLatencyMs: null, bufferCount: null)
 	{
+	}
+
+	/// <param name="desiredLatencyMs">
+	/// How much audio the device holds ahead of what is being heard, split across
+	/// <paramref name="bufferCount"/> buffers. Null keeps NAudio's own default, which is right
+	/// for playing a recording back and much too generous for a beep — see
+	/// <see cref="BeepAudioOutput.DesiredLatencyMs"/>.
+	/// </param>
+	public WaveOutAudioOutputDevice(int? desiredLatencyMs, int? bufferCount)
+	{
+		if (desiredLatencyMs.HasValue)
+			_waveOut.DesiredLatency = desiredLatencyMs.Value;
+		if (bufferCount.HasValue)
+			_waveOut.NumberOfBuffers = bufferCount.Value;
+
 		_waveOut.PlaybackStopped += (_, e) => PlaybackStopped?.Invoke(this, e);
 	}
 

--- a/Documentation/UserGuide/html/index.html
+++ b/Documentation/UserGuide/html/index.html
@@ -283,7 +283,7 @@ authoritative version. To rebuild the web pages after an edit, run
 <code>Build-UserGuide.cmd</code> in the <code>Documentation</code> folder.</p>
 
 <footer>
-<p>Generated from the Markdown source on 12 August 2026. The Markdown files are the source of truth &ndash; do not edit these HTML pages by hand.</p>
+<p>Generated from the Markdown source on 16 August 2026. The Markdown files are the source of truth &ndash; do not edit these HTML pages by hand.</p>
 </footer>
 </main>
 </div>

--- a/Documentation/UserGuide/html/settings.html
+++ b/Documentation/UserGuide/html/settings.html
@@ -203,6 +203,20 @@ Leaving Advanced off simply hides that button.</p>
 </tbody>
 </table>
 </div>
+<p>Mutation keeps a connection to your speakers open for the whole time it is running, so
+that a sound arrives the moment it is meant to. This is why the success sound now
+follows your dictation straight away instead of turning up several seconds later. Two
+things follow from it, and neither one needs anything from you:</p>
+<ul>
+<li>Windows lists Mutation in its volume mixer for as long as the app is open, even when
+it is not making a sound. You can set Mutation's own level there if the beeps are
+louder or quieter than you would like.</li>
+<li>Sounds that happen close together now play over each other instead of cutting each
+other off. If a slow transcription is beeping to say it is trying again, and the
+transcript arrives mid-count, you hear both.</li>
+</ul>
+<p>If you use a Bluetooth headset, this also keeps it awake rather than letting it doze
+between sounds.</p>
 <h3 id="screen-capture--ocr">Screen capture &amp; OCR</h3>
 <p>Reading text out of pictures. OCR just means &quot;pulling the words out of an image&quot;.</p>
 <div class="table-wrap"><table>

--- a/Documentation/UserGuide/html/troubleshooting.html
+++ b/Documentation/UserGuide/html/troubleshooting.html
@@ -697,6 +697,27 @@ hear it before you commit.</li>
 <li>Save.</li>
 </ol>
 <p>Until you do, everything still works — you just hear Mutation's own beeps.</p>
+<h3 id="a-sound-arrives-long-after-the-thing-it-is-confirming">A sound arrives long after the thing it is confirming</h3>
+<p><strong>What's happening.</strong> Mutation used to hand each beep to Windows one at a time, and
+Windows had to find your speakers, play the sound and let go of them again for every
+single one. Finding the speakers is usually instant, but not always — and the worst
+moment for it is the end of a dictation, because Mutation has just let go of your
+microphone and Windows may still be sorting the device out. That is how a success sound
+came to arrive five or ten seconds after the text had already been pasted.</p>
+<p>Mutation now holds a connection to your speakers open the whole time it is running, so
+there is nothing to find when a sound is wanted. See <strong>Audio</strong> in
+<a href="settings.html">Settings</a> for what else that changes.</p>
+<p><strong>What to do.</strong> If a sound still arrives late, Mutation writes a line to its log saying
+how long it waited, so the delay can be looked at rather than guessed at. Open the log
+(see below) and look for entries marked <code>[Beep]</code>. Two things are worth trying first:</p>
+<ol>
+<li>Check Windows' own sound settings. If your headset or speakers are set to be used for
+calls as well as everything else, Windows quietens or holds up other sounds while an
+app is using the microphone, and it takes a few seconds to undo that afterwards.</li>
+<li>If you are on a Bluetooth headset, try a wired one or your built-in speakers for a
+run or two. Bluetooth headsets switch between a call mode and a music mode when an
+app picks up the microphone, and that switch takes seconds on some models.</li>
+</ol>
 <h2 id="finding-the-log-file">Finding the log file</h2>
 <p>When something goes wrong, Mutation writes a timestamped entry to a log file called
 <code>Mutation_Errors.log</code>. It lives here:</p>

--- a/Documentation/UserGuide/markdown/settings.md
+++ b/Documentation/UserGuide/markdown/settings.md
@@ -52,6 +52,21 @@ Your microphone and the little sounds Mutation makes.
 | Use custom beeps | Play your own sound files instead of the built-in beeps for status cues. |
 | Beep files | One file each for Success, Failure, Start, End, Mute and Unmute. **Browse...** picks a file, and the small play button lets you hear it. The low falling "waiting for the microphone" sound is built in and always plays as-is. |
 
+Mutation keeps a connection to your speakers open for the whole time it is running, so
+that a sound arrives the moment it is meant to. This is why the success sound now
+follows your dictation straight away instead of turning up several seconds later. Two
+things follow from it, and neither one needs anything from you:
+
+- Windows lists Mutation in its volume mixer for as long as the app is open, even when
+  it is not making a sound. You can set Mutation's own level there if the beeps are
+  louder or quieter than you would like.
+- Sounds that happen close together now play over each other instead of cutting each
+  other off. If a slow transcription is beeping to say it is trying again, and the
+  transcript arrives mid-count, you hear both.
+
+If you use a Bluetooth headset, this also keeps it awake rather than letting it doze
+between sounds.
+
 ### Screen capture & OCR
 
 Reading text out of pictures. OCR just means "pulling the words out of an image".

--- a/Documentation/UserGuide/markdown/troubleshooting.md
+++ b/Documentation/UserGuide/markdown/troubleshooting.md
@@ -668,6 +668,30 @@ that depends on the problem:
 
 Until you do, everything still works — you just hear Mutation's own beeps.
 
+### A sound arrives long after the thing it is confirming
+
+**What's happening.** Mutation used to hand each beep to Windows one at a time, and
+Windows had to find your speakers, play the sound and let go of them again for every
+single one. Finding the speakers is usually instant, but not always — and the worst
+moment for it is the end of a dictation, because Mutation has just let go of your
+microphone and Windows may still be sorting the device out. That is how a success sound
+came to arrive five or ten seconds after the text had already been pasted.
+
+Mutation now holds a connection to your speakers open the whole time it is running, so
+there is nothing to find when a sound is wanted. See **Audio** in
+[Settings](settings.md) for what else that changes.
+
+**What to do.** If a sound still arrives late, Mutation writes a line to its log saying
+how long it waited, so the delay can be looked at rather than guessed at. Open the log
+(see below) and look for entries marked `[Beep]`. Two things are worth trying first:
+
+1. Check Windows' own sound settings. If your headset or speakers are set to be used for
+   calls as well as everything else, Windows quietens or holds up other sounds while an
+   app is using the microphone, and it takes a few seconds to undo that afterwards.
+2. If you are on a Bluetooth headset, try a wired one or your built-in speakers for a
+   run or two. Bluetooth headsets switch between a call mode and a music mode when an
+   app picks up the microphone, and that switch takes seconds on some models.
+
 ## Finding the log file
 
 When something goes wrong, Mutation writes a timestamped entry to a log file called

--- a/Mutation.Tests/BeepAudioOutputShutdownTests.cs
+++ b/Mutation.Tests/BeepAudioOutputShutdownTests.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Threading;
+using CognitiveSupport;
+using NAudio.Wave;
+using Xunit;
+
+namespace Mutation.Tests;
+
+/// <summary>
+/// Closing down while a beep is still being handed to a slow audio device.
+///
+/// <para>
+/// This is the case the whole change is about, seen from the other end. The device open is
+/// unbounded — that is why beeps were arriving late in the first place (issue #386) — so the
+/// window can perfectly well close while the beep thread is still inside one. Shutdown waits
+/// two seconds for that thread and then stops waiting, and everything it does afterwards has to
+/// be safe against the thread still running. An exception escaping a background thread's
+/// <c>finally</c> ends the process, which is a poor way for an app to close because a beep was
+/// still in the air.
+/// </para>
+/// </summary>
+public class BeepAudioOutputShutdownTests
+{
+	[Fact]
+	public void Closing_down_while_the_device_is_still_opening_does_not_bring_the_process_down()
+	{
+		var opening = new ManualResetEventSlim(false);
+		var release = new ManualResetEventSlim(false);
+		var escaped = (Exception?)null;
+
+		var previousHandler = new UnhandledExceptionEventHandler((_, e) => escaped = e.ExceptionObject as Exception);
+		AppDomain.CurrentDomain.UnhandledException += previousHandler;
+		try
+		{
+			var output = new BeepAudioOutput(
+				() => new BlockingDevice(opening, release),
+				log: (_, _) => { });
+
+			output.Warm();
+			Assert.True(opening.Wait(TimeSpan.FromSeconds(5)), "The device never started opening.");
+
+			// Shutdown gives up on the pump after two seconds; the device is still held open
+			// past that, so the pump is guaranteed to still be running when Dispose returns.
+			output.Dispose();
+
+			release.Set();
+			// Long enough for the pump to run its finally against whatever Dispose left behind.
+			Thread.Sleep(500);
+
+			Assert.Null(escaped);
+		}
+		finally
+		{
+			AppDomain.CurrentDomain.UnhandledException -= previousHandler;
+			release.Set();
+			opening.Dispose();
+			release.Dispose();
+		}
+	}
+
+	[Fact]
+	public void Asking_for_a_beep_while_the_window_is_closing_is_dropped_rather_than_thrown()
+	{
+		var output = new BeepAudioOutput(() => new FakeAudioOutputDevice(), log: (_, _) => { });
+		var clip = new BeepClip(new float[64], BeepAudioOutput.SampleRate, BeepAudioOutput.Channels);
+
+		output.Dispose();
+
+		Assert.Null(Record.Exception(() =>
+		{
+			output.Play(clip);
+			output.Warm();
+			output.Dispose();
+		}));
+	}
+
+	/// <summary>An audio device that takes as long to open as the test tells it to.</summary>
+	private sealed class BlockingDevice : IAudioOutputDevice
+	{
+		private readonly ManualResetEventSlim _opening;
+		private readonly ManualResetEventSlim _release;
+
+		public BlockingDevice(ManualResetEventSlim opening, ManualResetEventSlim release)
+		{
+			_opening = opening;
+			_release = release;
+		}
+
+		public event EventHandler<StoppedEventArgs>? PlaybackStopped;
+
+		public PlaybackState PlaybackState { get; private set; } = PlaybackState.Stopped;
+
+		public void Init(IWaveProvider waveProvider)
+		{
+			_opening.Set();
+			_release.Wait(TimeSpan.FromSeconds(30));
+		}
+
+		public void Play() => PlaybackState = PlaybackState.Playing;
+
+		public void Stop() => PlaybackState = PlaybackState.Stopped;
+
+		public void Dispose()
+		{
+			PlaybackState = PlaybackState.Stopped;
+			PlaybackStopped?.Invoke(this, new StoppedEventArgs());
+		}
+	}
+}

--- a/Mutation.Tests/BeepAudioOutputTests.cs
+++ b/Mutation.Tests/BeepAudioOutputTests.cs
@@ -1,0 +1,298 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using CognitiveSupport;
+using NAudio.Wave;
+using Xunit;
+
+namespace Mutation.Tests;
+
+/// <summary>
+/// The rules that make a beep arrive when it is asked for (issue #386).
+///
+/// <para>
+/// Measured on the user's machine, the app was asking for the success beep 40 to 110 ms after
+/// the transcript had been pasted, every time, and the sound was still arriving five to ten
+/// seconds later. The old <c>SoundPlayer</c> path owned no device, so Windows opened the default
+/// output, played, and closed it again for every single beep — and a dictation run is exactly
+/// when that open is slow, because the microphone has just been released. This class holds the
+/// device open instead. What is tested here is that it really is held, that a beep never waits
+/// on it, and that a device which fails is replaced rather than beeped into for the rest of the
+/// session.
+/// </para>
+/// </summary>
+public class BeepAudioOutputTests
+{
+	private static readonly TimeSpan Patience = TimeSpan.FromSeconds(5);
+
+	private static BeepClip Clip(float value = 0.25f, int frames = 4800) =>
+		new(Fill(frames * BeepAudioOutput.Channels, value), BeepAudioOutput.SampleRate, BeepAudioOutput.Channels);
+
+	private static float[] Fill(int length, float value)
+	{
+		var samples = new float[length];
+		for (var i = 0; i < length; i++)
+			samples[i] = value;
+		return samples;
+	}
+
+	// Every device this factory hands out, in the order they were made.
+	private sealed class RecordingFactory
+	{
+		public List<FakeAudioOutputDevice> Devices { get; } = new();
+
+		public IAudioOutputDevice Create()
+		{
+			var device = new FakeAudioOutputDevice();
+			lock (Devices)
+				Devices.Add(device);
+			return device;
+		}
+
+		public FakeAudioOutputDevice this[int index]
+		{
+			get { lock (Devices) return Devices[index]; }
+		}
+
+		public int Count
+		{
+			get { lock (Devices) return Devices.Count; }
+		}
+	}
+
+	// Reads 16-bit samples back out of what the device was handed, which is the only way to see
+	// what a listener would actually hear.
+	private static short[] Pull(FakeAudioOutputDevice device, int sampleCount)
+	{
+		Assert.NotNull(device.Provider);
+		var bytes = new byte[sampleCount * 2];
+		int read = device.Provider!.Read(bytes, 0, bytes.Length);
+		var samples = new short[read / 2];
+		for (var i = 0; i < samples.Length; i++)
+			samples[i] = BitConverter.ToInt16(bytes, i * 2);
+		return samples;
+	}
+
+	[Fact]
+	public void The_device_is_opened_once_and_kept_open_however_many_beeps_are_played()
+	{
+		var factory = new RecordingFactory();
+		using var output = new BeepAudioOutput(factory.Create, log: (_, _) => { });
+
+		for (var i = 0; i < 20; i++)
+			output.Play(Clip());
+		Assert.True(output.WaitForIdle(Patience));
+
+		Assert.Equal(1, factory.Count);
+		Assert.Equal(1, output.DeviceOpenCount);
+		Assert.Equal(PlaybackState.Playing, factory[0].PlaybackState);
+	}
+
+	[Fact]
+	public void Warming_opens_the_device_before_any_beep_needs_it()
+	{
+		var factory = new RecordingFactory();
+		using var output = new BeepAudioOutput(factory.Create, log: (_, _) => { });
+
+		output.Warm();
+		Assert.True(output.WaitForIdle(Patience));
+
+		Assert.Equal(1, output.DeviceOpenCount);
+	}
+
+	// The whole point. A device that takes a second to open must not take that second out of the
+	// caller — which on the transcript delivery path is the UI thread, and inside a retry ladder
+	// is the thread the transcription itself is running on.
+	[Fact]
+	public void Asking_for_a_beep_does_not_wait_for_the_audio_device()
+	{
+		var slowDevice = new SlowOpeningDevice(TimeSpan.FromSeconds(1));
+		using var output = new BeepAudioOutput(() => slowDevice, log: (_, _) => { });
+
+		var stopwatch = Stopwatch.StartNew();
+		output.Play(Clip());
+		stopwatch.Stop();
+
+		Assert.True(stopwatch.ElapsedMilliseconds < 250,
+			$"Play blocked the caller for {stopwatch.ElapsedMilliseconds} ms.");
+		Assert.True(output.WaitForIdle(Patience));
+	}
+
+	// Windows only lets one sound play per process through the old API, so a retry beep that was
+	// still counting stopped the success beep that followed it, and was stopped in turn by its
+	// own next repetition. Mixed, both are heard.
+	[Fact]
+	public void Two_beeps_at_once_are_added_together_rather_than_cutting_each_other_off()
+	{
+		var factory = new RecordingFactory();
+		using var output = new BeepAudioOutput(factory.Create, log: (_, _) => { });
+
+		output.Play(Clip(value: 0.25f));
+		output.Play(Clip(value: 0.25f));
+		Assert.True(output.WaitForIdle(Patience));
+
+		var heard = Pull(factory[0], sampleCount: 100);
+
+		Assert.NotEmpty(heard);
+		// Two quarter-scale beeps together are half scale. One on its own would be half that,
+		// and silence would be zero, so this distinguishes mixing from either failure.
+		short expected = (short)(0.5f * short.MaxValue);
+		Assert.All(heard, s => Assert.InRange(s, expected - 200, expected + 200));
+	}
+
+	[Fact]
+	public void A_beep_reaches_the_speaker_as_audio_rather_than_silence()
+	{
+		var factory = new RecordingFactory();
+		using var output = new BeepAudioOutput(factory.Create, log: (_, _) => { });
+
+		output.Play(Clip(value: 0.5f));
+		Assert.True(output.WaitForIdle(Patience));
+
+		Assert.Contains(Pull(factory[0], sampleCount: 100), s => s != 0);
+	}
+
+	// With the mixer reading fully, the audio never runs out — so a stop means the device has
+	// gone: unplugged, reconfigured, or failed. Beeping into it again would be silent for the
+	// rest of the session.
+	[Fact]
+	public void A_device_that_stops_is_replaced_on_the_next_beep()
+	{
+		var factory = new RecordingFactory();
+		using var output = new BeepAudioOutput(factory.Create, log: (_, _) => { });
+
+		output.Play(Clip());
+		Assert.True(output.WaitForIdle(Patience));
+		factory[0].RaisePlaybackStopped(new InvalidOperationException("the headset went away"));
+
+		output.Play(Clip());
+		Assert.True(output.WaitForIdle(Patience));
+
+		Assert.Equal(2, factory.Count);
+		Assert.Equal(2, output.DeviceOpenCount);
+		Assert.Equal(1, factory[0].DisposeCount);
+	}
+
+	[Fact]
+	public void A_device_that_will_not_open_is_reported_once_rather_than_on_every_beep()
+	{
+		var now = new DateTimeOffset(2026, 8, 16, 12, 0, 0, TimeSpan.Zero);
+		var reports = new List<string>();
+		using var output = new BeepAudioOutput(
+			() => new UnopenableDevice(),
+			log: (_, message) => { lock (reports) reports.Add(message); },
+			now: () => now);
+
+		for (var i = 0; i < 5; i++)
+		{
+			output.Play(Clip());
+			Assert.True(output.WaitForIdle(Patience));
+		}
+
+		lock (reports)
+			Assert.Single(reports);
+	}
+
+	[Fact]
+	public void A_device_that_would_not_open_is_tried_again_once_the_backoff_has_passed()
+	{
+		var now = new DateTimeOffset(2026, 8, 16, 12, 0, 0, TimeSpan.Zero);
+		var attempts = 0;
+		using var output = new BeepAudioOutput(
+			() => { Interlocked.Increment(ref attempts); return new UnopenableDevice(); },
+			log: (_, _) => { },
+			now: () => now);
+
+		output.Play(Clip());
+		Assert.True(output.WaitForIdle(Patience));
+		output.Play(Clip());
+		Assert.True(output.WaitForIdle(Patience));
+		Assert.Equal(1, Volatile.Read(ref attempts));
+
+		now += BeepAudioOutput.ReopenBackoff + TimeSpan.FromSeconds(1);
+		output.Play(Clip());
+		Assert.True(output.WaitForIdle(Patience));
+
+		Assert.Equal(2, Volatile.Read(ref attempts));
+	}
+
+	// A beep that will not play must never take down the operation it is reporting on: these
+	// calls sit inside Polly retry lambdas, where an escaping exception aborts the transcription.
+	[Fact]
+	public void A_broken_audio_device_never_throws_at_the_caller()
+	{
+		using var output = new BeepAudioOutput(() => new UnopenableDevice(), log: (_, _) => { });
+
+		var exception = Record.Exception(() =>
+		{
+			output.Play(Clip());
+			output.Warm();
+			output.WaitForIdle(Patience);
+		});
+
+		Assert.Null(exception);
+	}
+
+	[Fact]
+	public void Closing_down_releases_the_device()
+	{
+		var factory = new RecordingFactory();
+		var output = new BeepAudioOutput(factory.Create, log: (_, _) => { });
+		output.Play(Clip());
+		Assert.True(output.WaitForIdle(Patience));
+
+		output.Dispose();
+
+		Assert.Equal(1, factory[0].DisposeCount);
+	}
+
+	[Fact]
+	public void A_beep_asked_for_after_shutdown_is_dropped_rather_than_throwing()
+	{
+		var factory = new RecordingFactory();
+		var output = new BeepAudioOutput(factory.Create, log: (_, _) => { });
+		output.Dispose();
+
+		Assert.Null(Record.Exception(() => output.Play(Clip())));
+	}
+
+	private sealed class SlowOpeningDevice : IAudioOutputDevice
+	{
+		private readonly TimeSpan _openDelay;
+
+		public SlowOpeningDevice(TimeSpan openDelay) => _openDelay = openDelay;
+
+		public event EventHandler<StoppedEventArgs>? PlaybackStopped;
+
+		public PlaybackState PlaybackState { get; private set; } = PlaybackState.Stopped;
+
+		public void Init(IWaveProvider waveProvider) => Thread.Sleep(_openDelay);
+
+		public void Play() => PlaybackState = PlaybackState.Playing;
+
+		public void Stop() => PlaybackState = PlaybackState.Stopped;
+
+		public void Dispose()
+		{
+			PlaybackStopped?.Invoke(this, new StoppedEventArgs());
+			PlaybackState = PlaybackState.Stopped;
+		}
+	}
+
+	/// <summary>A machine with no working audio output, which is what a build agent usually is.</summary>
+	private sealed class UnopenableDevice : IAudioOutputDevice
+	{
+		public event EventHandler<StoppedEventArgs>? PlaybackStopped;
+
+		public PlaybackState PlaybackState => PlaybackState.Stopped;
+
+		public void Init(IWaveProvider waveProvider) => throw new InvalidOperationException("No audio output device.");
+
+		public void Play() { }
+
+		public void Stop() { }
+
+		public void Dispose() => PlaybackStopped?.Invoke(this, new StoppedEventArgs());
+	}
+}

--- a/Mutation.Tests/BeepClipReaderTests.cs
+++ b/Mutation.Tests/BeepClipReaderTests.cs
@@ -102,12 +102,93 @@ public class BeepClipReaderTests
 		Assert.InRange(clip.Duration, TimeSpan.FromSeconds(29.9), BeepClipReader.MaxDuration);
 	}
 
+	// A WAV in the "extensible" layout, which is what many tools write for float audio and what
+	// Windows requires above two channels. NAudio refuses these on its own, and the old
+	// PlaySound path played them without complaint — so a beep file the user has been hearing
+	// for months would have gone quiet the day this shipped.
+	private static byte[] ExtensibleWav(int sampleRate, short channels, int frames, bool ieeeFloat)
+	{
+		short bits = (short)(ieeeFloat ? 32 : 16);
+		short blockAlign = (short)(channels * bits / 8);
+		int dataBytes = frames * blockAlign;
+
+		using var stream = new MemoryStream();
+		using var writer = new BinaryWriter(stream);
+		writer.Write("RIFF"u8);
+		writer.Write(36 + 24 + dataBytes);
+		writer.Write("WAVE"u8);
+		writer.Write("fmt "u8);
+		writer.Write(40);              // fmt chunk size with the extensible tail
+		writer.Write(unchecked((short)0xFFFE));   // WAVE_FORMAT_EXTENSIBLE
+		writer.Write(channels);
+		writer.Write(sampleRate);
+		writer.Write(sampleRate * blockAlign);
+		writer.Write(blockAlign);
+		writer.Write(bits);
+		writer.Write((short)22);       // cbSize
+		writer.Write(bits);            // valid bits per sample
+		writer.Write(channels == 2 ? 3 : 4);  // channel mask
+		// KSDATAFORMAT_SUBTYPE_PCM / _IEEE_FLOAT: the first four bytes are what tells them apart.
+		writer.Write(ieeeFloat ? 3 : 1);
+		writer.Write(new byte[] { 0x00, 0x00, 0x10, 0x00, 0x80, 0x00, 0x00, 0xAA, 0x00, 0x38, 0x9B, 0x71 });
+		writer.Write("data"u8);
+		writer.Write(dataBytes);
+		for (var i = 0; i < frames * channels; i++)
+		{
+			if (ieeeFloat)
+				writer.Write(0.25f);
+			else
+				writer.Write((short)4000);
+		}
+		writer.Flush();
+		return stream.ToArray();
+	}
+
+	[Theory]
+	[InlineData(true)]
+	[InlineData(false)]
+	public void A_wav_written_in_the_extensible_layout_still_plays(bool ieeeFloat)
+	{
+		var wav = ExtensibleWav(sampleRate: 44100, channels: 2, frames: 4410, ieeeFloat);
+
+		var clip = BeepClipReader.ReadBytes(wav, Rate, Channels);
+
+		Assert.Equal(Rate, clip.SampleRate);
+		Assert.Equal(Channels, clip.Channels);
+		Assert.InRange(clip.Duration.TotalSeconds, 0.08, 0.12);
+		Assert.Contains(clip.Samples.ToArray(), s => s != 0f);
+	}
+
 	[Fact]
 	public void Something_that_is_not_a_wav_file_is_refused_rather_than_played_as_noise()
 	{
 		var garbage = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 };
 
 		Assert.ThrowsAny<Exception>(() => BeepClipReader.ReadBytes(garbage, Rate, Channels));
+	}
+
+	/// <summary>
+	/// Loading every beep file has to stay quick, because <c>BeepPlayer.Initialize</c> does it on
+	/// the UI thread while holding its lock — at startup and again after every settings save.
+	/// Doing the work there is the whole point: it is what leaves nothing to do at the moment a
+	/// beep is actually wanted. Measured at 29 ms for all six files, so the budget below is wide
+	/// enough not to fail on a loaded build machine and narrow enough to catch decoding that has
+	/// quietly become expensive — or moved to the wrong place.
+	/// </summary>
+	[Fact]
+	public void Loading_every_beep_file_stays_out_of_the_way_of_the_user_interface()
+	{
+		var files = new[] { "Start.wav", "Success.wav", "Failure.wav", "End.wav", "Mute.wav", "Unmute.wav" };
+		var paths = files.Select(f => Path.Combine(AppContext.BaseDirectory, "CustomAudio", f)).ToArray();
+		Assert.All(paths, p => Assert.True(File.Exists(p), $"The fixture assumes {p} is copied next to the tests."));
+
+		var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+		var clips = paths.Select(p => BeepClipReader.ReadFile(p, Rate, Channels)).ToArray();
+		stopwatch.Stop();
+
+		Assert.True(stopwatch.ElapsedMilliseconds < 1000,
+			$"Loading the six beep files took {stopwatch.ElapsedMilliseconds} ms on the thread that opens the window.");
+		Assert.All(clips, c => Assert.True(c.Duration > TimeSpan.Zero));
 	}
 
 	// The real beep files ship next to the test host, so this is the shape the app actually

--- a/Mutation.Tests/BeepClipReaderTests.cs
+++ b/Mutation.Tests/BeepClipReaderTests.cs
@@ -1,0 +1,132 @@
+using System;
+using System.IO;
+using System.Linq;
+using CognitiveSupport;
+using Xunit;
+
+namespace Mutation.Tests;
+
+/// <summary>
+/// Beeps are mixed together now rather than played one at a time, and a mixer can only add
+/// sources that agree on sample rate and channel count. The user's own sound files do not agree
+/// — the ones shipped with the app are a mix of 44.1 kHz and 48 kHz — so everything is converted
+/// to one format when it is loaded. These tests are about that conversion (issue #386).
+/// </summary>
+public class BeepClipReaderTests
+{
+	private const int Rate = BeepAudioOutput.SampleRate;
+	private const int Channels = BeepAudioOutput.Channels;
+
+	// A PCM 16-bit WAV of the given shape, filled with a value that is easy to recognise again.
+	private static byte[] Wav(int sampleRate, short channels, int frames, short value = 4000)
+	{
+		using var stream = new MemoryStream();
+		using var writer = new BinaryWriter(stream);
+		int dataBytes = frames * channels * 2;
+		writer.Write("RIFF"u8);
+		writer.Write(36 + dataBytes);
+		writer.Write("WAVE"u8);
+		writer.Write("fmt "u8);
+		writer.Write(16);
+		writer.Write((short)1);
+		writer.Write(channels);
+		writer.Write(sampleRate);
+		writer.Write(sampleRate * channels * 2);
+		writer.Write((short)(channels * 2));
+		writer.Write((short)16);
+		writer.Write("data"u8);
+		writer.Write(dataBytes);
+		for (var i = 0; i < frames * channels; i++)
+			writer.Write(value);
+		writer.Flush();
+		return stream.ToArray();
+	}
+
+	[Fact]
+	public void A_clip_always_comes_back_in_the_mixer_format()
+	{
+		var clip = BeepClipReader.ReadBytes(Wav(sampleRate: 22050, channels: 1, frames: 22050), Rate, Channels);
+
+		Assert.Equal(Rate, clip.SampleRate);
+		Assert.Equal(Channels, clip.Channels);
+	}
+
+	// The synthesized tones are 22.05 kHz mono and the device runs at 48 kHz stereo, so this is
+	// the conversion every default beep goes through.
+	[Fact]
+	public void Upsampling_keeps_the_clip_the_same_length_in_time()
+	{
+		var clip = BeepClipReader.ReadBytes(Wav(sampleRate: 22050, channels: 1, frames: 22050), Rate, Channels);
+
+		Assert.InRange(clip.Duration.TotalSeconds, 0.98, 1.02);
+	}
+
+	// 44.1 kHz is the other rate the user's own beep files come in.
+	[Fact]
+	public void Downsampling_from_44100_keeps_the_clip_the_same_length_in_time()
+	{
+		var clip = BeepClipReader.ReadBytes(Wav(sampleRate: 44100, channels: 2, frames: 22050), Rate, Channels);
+
+		Assert.InRange(clip.Duration.TotalSeconds, 0.48, 0.52);
+	}
+
+	[Fact]
+	public void A_mono_file_is_heard_in_both_ears()
+	{
+		var clip = BeepClipReader.ReadBytes(Wav(sampleRate: Rate, channels: 1, frames: 1000), Rate, Channels);
+
+		var samples = clip.Samples.ToArray();
+		Assert.Equal(2000, samples.Length);
+		// Interleaved: left and right of the same frame carry the same value.
+		for (var frame = 0; frame < 1000; frame++)
+			Assert.Equal(samples[frame * 2], samples[frame * 2 + 1]);
+		Assert.Contains(samples, s => s != 0f);
+	}
+
+	// A clip ending mid-frame would swap left and right for every sound mixed after it.
+	[Fact]
+	public void A_clip_holds_whole_frames_only()
+	{
+		var clip = BeepClipReader.ReadBytes(Wav(sampleRate: 44100, channels: 2, frames: 7777), Rate, Channels);
+
+		Assert.Equal(0, clip.Samples.Length % Channels);
+	}
+
+	[Fact]
+	public void A_file_longer_than_a_beep_has_any_business_being_is_cut_short()
+	{
+		var overlong = Wav(sampleRate: Rate, channels: 1, frames: Rate * 45);
+
+		var clip = BeepClipReader.ReadBytes(overlong, Rate, Channels);
+
+		Assert.InRange(clip.Duration, TimeSpan.FromSeconds(29.9), BeepClipReader.MaxDuration);
+	}
+
+	[Fact]
+	public void Something_that_is_not_a_wav_file_is_refused_rather_than_played_as_noise()
+	{
+		var garbage = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 };
+
+		Assert.ThrowsAny<Exception>(() => BeepClipReader.ReadBytes(garbage, Rate, Channels));
+	}
+
+	// The real beep files ship next to the test host, so this is the shape the app actually
+	// loads at startup rather than one invented here.
+	[Theory]
+	[InlineData("Success.wav")]
+	[InlineData("End.wav")]
+	[InlineData("Failure.wav")]
+	[InlineData("Start.wav")]
+	public void The_beep_files_that_ship_with_the_app_load_and_have_audio_in_them(string fileName)
+	{
+		var path = Path.Combine(AppContext.BaseDirectory, "CustomAudio", fileName);
+		Assert.True(File.Exists(path), $"The fixture assumes {fileName} is copied next to the tests.");
+
+		var clip = BeepClipReader.ReadFile(path, Rate, Channels);
+
+		Assert.Equal(Rate, clip.SampleRate);
+		Assert.Equal(Channels, clip.Channels);
+		Assert.True(clip.Duration > TimeSpan.Zero);
+		Assert.Contains(clip.Samples.ToArray(), s => s != 0f);
+	}
+}

--- a/Mutation.Tests/BeepClipSampleProviderTests.cs
+++ b/Mutation.Tests/BeepClipSampleProviderTests.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Linq;
+using CognitiveSupport;
+using Xunit;
+
+namespace Mutation.Tests;
+
+/// <summary>
+/// What the mixer pulls out of one beep. The repeat counts here are the ones the transcription
+/// retry ladders ask for — one beep per attempt, so a listener can tell a third retry from a
+/// first (issue #216) — and they now have to survive being mixed alongside other sounds rather
+/// than played on their own (issue #386).
+/// </summary>
+public class BeepClipSampleProviderTests
+{
+	private static BeepClip Clip(int frames, float value = 0.5f)
+	{
+		var samples = new float[frames * 2];
+		for (var i = 0; i < samples.Length; i++)
+			samples[i] = value;
+		return new BeepClip(samples, BeepAudioOutput.SampleRate, 2);
+	}
+
+	// Reads until the provider says it is finished, in pieces of the given size, and hands back
+	// everything it produced. The buffer size matters: a real device asks in whatever size its
+	// buffers happen to be, never in whole clips.
+	private static float[] DrainInChunks(BeepClipSampleProvider provider, int chunk)
+	{
+		var all = new System.Collections.Generic.List<float>();
+		var buffer = new float[chunk];
+		int read;
+		while ((read = provider.Read(buffer, 0, buffer.Length)) > 0)
+			all.AddRange(buffer.Take(read));
+		return all.ToArray();
+	}
+
+	[Fact]
+	public void One_beep_gives_back_exactly_the_clip()
+	{
+		var provider = new BeepClipSampleProvider(Clip(frames: 100), repeatCount: 1);
+
+		var played = DrainInChunks(provider, chunk: 64);
+
+		Assert.Equal(200, played.Length);
+		Assert.All(played, s => Assert.Equal(0.5f, s));
+	}
+
+	[Theory]
+	[InlineData(2)]
+	[InlineData(3)]
+	[InlineData(10)]
+	public void A_repeat_plays_the_clip_that_many_times_over(int repeatCount)
+	{
+		var provider = new BeepClipSampleProvider(Clip(frames: 100), repeatCount);
+
+		var played = DrainInChunks(provider, chunk: 64);
+
+		Assert.Equal(200 * repeatCount, played.Length);
+	}
+
+	// A device never asks in clip-sized pieces, so the repeat must survive a read landing in the
+	// middle of one. This is the case the old back-to-back synchronous playback never had.
+	[Theory]
+	[InlineData(1)]
+	[InlineData(7)]
+	[InlineData(199)]
+	[InlineData(1024)]
+	public void The_length_is_the_same_however_the_reads_fall(int chunk)
+	{
+		var provider = new BeepClipSampleProvider(Clip(frames: 100), repeatCount: 3);
+
+		var played = DrainInChunks(provider, chunk);
+
+		Assert.Equal(600, played.Length);
+	}
+
+	[Fact]
+	public void A_finished_beep_reports_nothing_left_so_the_mixer_drops_it()
+	{
+		var provider = new BeepClipSampleProvider(Clip(frames: 10), repeatCount: 1);
+		DrainInChunks(provider, chunk: 64);
+
+		Assert.Equal(0, provider.Read(new float[64], 0, 64));
+	}
+
+	// Guards a loop that would otherwise never end: an empty clip copies nothing, so the
+	// position never reaches the end and the repeat is never counted off.
+	[Fact]
+	public void An_empty_clip_ends_instead_of_spinning()
+	{
+		var provider = new BeepClipSampleProvider(new BeepClip(Array.Empty<float>(), BeepAudioOutput.SampleRate, 2), repeatCount: 4);
+
+		Assert.Equal(0, provider.Read(new float[64], 0, 64));
+	}
+
+	[Fact]
+	public void A_beep_is_offered_to_the_mixer_in_the_format_the_mixer_runs_at()
+	{
+		var provider = new BeepClipSampleProvider(Clip(frames: 10), repeatCount: 1);
+
+		Assert.Equal(BeepAudioOutput.SampleRate, provider.WaveFormat.SampleRate);
+		Assert.Equal(BeepAudioOutput.Channels, provider.WaveFormat.Channels);
+	}
+
+	[Fact]
+	public void Writing_starts_where_the_caller_asked_and_leaves_the_rest_alone()
+	{
+		var provider = new BeepClipSampleProvider(Clip(frames: 5), repeatCount: 1);
+		var buffer = new float[20];
+
+		int read = provider.Read(buffer, 4, 10);
+
+		Assert.Equal(10, read);
+		Assert.Equal(0f, buffer[3]);
+		Assert.All(buffer.Skip(4).Take(10), s => Assert.Equal(0.5f, s));
+		Assert.Equal(0f, buffer[14]);
+	}
+}


### PR DESCRIPTION
Fixes #386 — the success sound arriving seconds after the text it is confirming.

## What was wrong

After a dictation the transcript was pasted into the user's application and the success
sound followed five to ten seconds later, sometimes straight away, with no pattern to it.

## Where the delay actually was

Two measurements, before any code was written.

**The app asks for the sound on time.** `Mutation.Hotkey.log` records the paste
(`Sending via SendInput: 'Ctrl+V'`) and the post-operation shortcut scheduled a fixed
100 ms behind it. Across ~25 real dictation runs in the user's own log the gap between
those two lines was 134–211 ms — every time, no outliers. `BeepPlayer.Play(plan.Beep)` is
the statement immediately after that scheduling call, so the beep was requested inside a
quarter of a second of the paste on every run. The UI thread was not stalled.

**The request returns instantly.** Timing `SoundPlayer.Play()` on the user's own
`Success.wav`: 15 ms on the first call, 0.3–0.5 ms afterwards, including while another
thread was inside a `PlaySync()` loop.

Asked on time, returned at once, still not heard for seconds — so the wait was entirely
inside Windows, after the app had handed the sound over.

That is what `System.Media.SoundPlayer` is: Win32 `PlaySound`, which owns no audio device.
For every beep it opens the default output, reads, plays and closes again, on an internal
thread, with no bound on how long the open takes. The end of a dictation is the worst
moment to ask it: the recording has just released the capture device, and hardware that
shares a capture and a playback endpoint — a headset above all — is reconfigured by
Windows when the microphone is let go.

## What changed

`BeepAudioOutput` replaces `SoundPlayer`. It owns one audio device, opens it once and
holds it open, and feeds it from a `MixingSampleProvider` that beeps are dropped into.

- **Nothing is left to do at play time.** Beep audio is decoded and converted to the
  mixer's format (48 kHz stereo) when settings load — `BeepClipReader` handles the 44.1 kHz
  and 48 kHz files the user's own beeps come in, and the 22.05 kHz mono tones the app
  synthesizes for itself. Playing a beep is an array handed to a mixer.
- **No caller ever waits on an audio device.** Every request goes to one background thread.
  The callers are the UI thread finishing a dictation and Polly retry lambdas mid-
  transcription; neither can afford to block on a device or be thrown out of by one.
  `Play` returns immediately and cannot throw.
- **Sounds no longer cut each other off.** `PlaySound` allows one sound per process, so a
  retry beep still counting stopped the success beep that followed it and was stopped in
  turn by its own next repetition. They are added together now. The `PlaySync` loop, its
  `Task.Run`, and the generation counter that guarded it are all gone.
- **Failure is handled rather than assumed away.** A device that stops (unplugged,
  reconfigured, failed) is replaced on the next beep. One that will not open is reported
  once and retried after 30 seconds, instead of logging on every beep for the rest of the
  session.
- **The latency is now on the record.** Opening the device, or a beep waiting to reach the
  speaker, is logged whenever it exceeds 250 ms. If a sound is late again it can be
  measured instead of argued about.
- Device buffering is 100 ms across three buffers rather than NAudio's 300 ms default, so
  the app's own contribution to the delay is about 33 ms.

`BeepPlayer` keeps its whole public surface — `Initialize`, `Play`, `PlayRepeated`,
`PreviewFile`, `DisposePlayers`, `LastInitializationIssues`, the default sequences, the
500 ms duplicate-suppression window and the repeat counts the retry ladders rely on. No
call site changed.

## What the user will notice

The success sound arrives with the paste. Two consequences follow, both documented in the
guide:

- Mutation shows as an active playback session in the Windows volume mixer for as long as
  it runs, even when silent. Its level can be set there.
- On a Bluetooth headset the audio link is kept awake rather than dozing between sounds.

## Tests

`dotnet test --configuration Release` — **2465 passed, 0 failed.**

New: `BeepAudioOutputTests` (device opened once and held; `Play` returns in under 250 ms
against a device that takes a second to open; two beeps mix rather than truncate; a
stopped device is replaced; a broken device is reported once, retried after the backoff,
and never throws at the caller; shutdown releases the device), `BeepClipReaderTests`
(format conversion both ways, mono to stereo, whole frames only, overlong files trimmed,
non-WAV refused, plus the real shipped `.wav` files), `BeepClipSampleProviderTests`
(repeat counts survive reads that land mid-clip, an empty clip ends instead of spinning,
offset writes leave the rest of the buffer alone).

## What has not been verified

The fix removes the only remaining unexplained variable, and the mechanism is measured
rather than inferred — but the delay itself only appears on the user's own machine with
their own audio hardware, and an agent session cannot reproduce it. Confirming that the
success sound now lands with the paste needs a real dictation run on that machine. The
`[Beep]` log entries are there for exactly that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
