### PR TITLE
Give the capture preview the whole screen to draw on, so it stays sharp

### DIFF
--- a/Mutation.Tests/OverlayDrawingAreaTests.cs
+++ b/Mutation.Tests/OverlayDrawingAreaTests.cs
@@ -1,0 +1,169 @@
+using Mutation.Ui.Core;
+
+namespace Mutation.Tests;
+
+// Issue #388: the capture overlay was sized to the screen, but a window's drawing area is
+// smaller than its outer rectangle by the window frame, so the full-size screenshot was
+// stretched into a slightly smaller space and resampled. Measured on a 1920 by 1080 display
+// the drawing area came back as 1914 by 1074, and the preview kept 30.8% of the hard edges
+// the real desktop had.
+public class OverlayDrawingAreaTests
+{
+	private static readonly PixelRect Screen = new(0, 0, 1920, 1080);
+
+	/// <summary>The measurement taken from the affected machine: a symmetric three-pixel frame.</summary>
+	[Fact]
+	public void GrowsTheWindowByTheFrameSoTheDrawingAreaCoversTheScreen()
+	{
+		var fitted = OverlayDrawingArea.Fit(
+			window: new PixelRect(0, 0, 1920, 1080),
+			drawingWidth: 1914,
+			drawingHeight: 1074,
+			drawingOrigin: (3, 3),
+			target: Screen);
+
+		Assert.Equal(new PixelRect(-3, -3, 1926, 1086), fitted);
+	}
+
+	/// <summary>
+	/// The whole point of the exercise: whatever comes back, the drawing area inside it has to
+	/// land on the screen exactly. Checked as the property rather than as a fixed answer, so a
+	/// change to the arithmetic cannot pass by matching a number that was itself wrong.
+	/// </summary>
+	[Theory]
+	[InlineData(3, 3, 3, 3)]      // symmetric, the common case
+	[InlineData(8, 0, 8, 31)]     // a left border and a title bar, nothing on the right
+	[InlineData(0, 0, 6, 6)]      // the whole frame on the right and bottom
+	[InlineData(1, 2, 4, 9)]      // lopsided in both directions
+	public void TheDrawingAreaLandsOnTheScreenWhateverTheFrameLooksLike(int insetLeft, int insetTop, int extraWidth, int extraHeight)
+	{
+		var window = new PixelRect(0, 0, 1920, 1080);
+		int drawingWidth = window.Width - extraWidth;
+		int drawingHeight = window.Height - extraHeight;
+
+		var fitted = OverlayDrawingArea.Fit(
+			window,
+			drawingWidth,
+			drawingHeight,
+			(window.Left + insetLeft, window.Top + insetTop),
+			Screen);
+
+		Assert.NotNull(fitted);
+		// Where the drawing area ends up once the window is placed where Fit asked.
+		Assert.Equal(Screen.Left, fitted!.Value.Left + insetLeft);
+		Assert.Equal(Screen.Top, fitted.Value.Top + insetTop);
+		Assert.Equal(Screen.Width, fitted.Value.Width - extraWidth);
+		Assert.Equal(Screen.Height, fitted.Value.Height - extraHeight);
+	}
+
+	/// <summary>
+	/// A borderless window is already right, so it must be left exactly where it is. Nudging it
+	/// would push its content off the screen to correct a frame that is not there.
+	/// </summary>
+	[Fact]
+	public void LeavesAWindowWithNoFrameAlone()
+	{
+		var fitted = OverlayDrawingArea.Fit(
+			window: new PixelRect(0, 0, 1920, 1080),
+			drawingWidth: 1920,
+			drawingHeight: 1080,
+			drawingOrigin: (0, 0),
+			target: Screen);
+
+		Assert.Null(fitted);
+	}
+
+	/// <summary>A window that has not been laid out reports no drawing area, which is not a frame.</summary>
+	[Theory]
+	[InlineData(0, 0)]
+	[InlineData(0, 1074)]
+	[InlineData(1914, 0)]
+	[InlineData(-1, -1)]
+	public void DeclinesWhenTheDrawingAreaHasNoSize(int drawingWidth, int drawingHeight)
+	{
+		var fitted = OverlayDrawingArea.Fit(
+			window: new PixelRect(0, 0, 1920, 1080),
+			drawingWidth,
+			drawingHeight,
+			drawingOrigin: (3, 3),
+			target: Screen);
+
+		Assert.Null(fitted);
+	}
+
+	/// <summary>
+	/// A drawing area bigger than its own window is a bad reading, not a frame. Acting on it
+	/// would shrink the window and make the blur worse than doing nothing.
+	/// </summary>
+	[Fact]
+	public void DeclinesWhenTheDrawingAreaIsLargerThanTheWindow()
+	{
+		var fitted = OverlayDrawingArea.Fit(
+			window: new PixelRect(0, 0, 1920, 1080),
+			drawingWidth: 1930,
+			drawingHeight: 1090,
+			drawingOrigin: (0, 0),
+			target: Screen);
+
+		Assert.Null(fitted);
+	}
+
+	/// <summary>
+	/// The two rectangles are read one after the other, so a window moving in between can
+	/// produce a pair that do not describe the same window. An origin outside its own frame is
+	/// how that shows up.
+	/// </summary>
+	[Theory]
+	[InlineData(-4, 3)]   // drawing area starts left of the window
+	[InlineData(3, -4)]   // and above it
+	[InlineData(99, 3)]   // inset wider than the whole frame
+	[InlineData(3, 99)]
+	public void DeclinesWhenTheDrawingAreaDoesNotSitInsideItsWindow(int insetLeft, int insetTop)
+	{
+		var fitted = OverlayDrawingArea.Fit(
+			window: new PixelRect(0, 0, 1920, 1080),
+			drawingWidth: 1914,
+			drawingHeight: 1074,
+			drawingOrigin: (insetLeft, insetTop),
+			target: Screen);
+
+		Assert.Null(fitted);
+	}
+
+	/// <summary>
+	/// The virtual screen does not start at the origin once a second monitor sits left of or
+	/// above the primary one, and the target is carried through rather than assumed to be zero.
+	/// </summary>
+	[Fact]
+	public void CarriesAVirtualScreenThatDoesNotStartAtTheOrigin()
+	{
+		var virtualScreen = new PixelRect(-1920, -120, 3840, 1200);
+
+		var fitted = OverlayDrawingArea.Fit(
+			window: new PixelRect(-1920, -120, 3840, 1200),
+			drawingWidth: 3834,
+			drawingHeight: 1194,
+			drawingOrigin: (-1917, -117),
+			target: virtualScreen);
+
+		Assert.Equal(new PixelRect(-1923, -123, 3846, 1206), fitted);
+	}
+
+	/// <summary>
+	/// A thicker frame is what a higher display scale looks like here, since everything is in
+	/// physical pixels. Measuring rather than assuming is what makes that work, so the answer
+	/// has to track the frame it is given.
+	/// </summary>
+	[Fact]
+	public void FollowsAThickerFrameRatherThanAssumingThreePixels()
+	{
+		var fitted = OverlayDrawingArea.Fit(
+			window: new PixelRect(0, 0, 1920, 1080),
+			drawingWidth: 1911,
+			drawingHeight: 1071,
+			drawingOrigin: (4, 4),
+			target: Screen);
+
+		Assert.Equal(new PixelRect(-4, -4, 1929, 1089), fitted);
+	}
+}

--- a/Mutation.Ui/Core/OverlayDrawingArea.cs
+++ b/Mutation.Ui/Core/OverlayDrawingArea.cs
@@ -1,0 +1,84 @@
+namespace Mutation.Ui.Core;
+
+/// <summary>A rectangle in screen pixels.</summary>
+internal readonly record struct PixelRect(int Left, int Top, int Width, int Height);
+
+/// <summary>
+/// Works out how large a window has to be, and where it has to sit, for the area it draws
+/// into to land exactly on a target rectangle.
+///
+/// <para>
+/// The capture overlay needs this because it shows one image stretched to fill its drawing
+/// area, and that image is a picture of the whole screen. The picture only stays sharp when
+/// the area it is stretched across holds exactly as many pixels as the picture does. Sizing
+/// the window to the screen does not achieve that: a window is measured by its outer
+/// rectangle, and the area inside it is smaller by whatever frame the window carries. On a
+/// 1920 by 1080 display the drawing area came back as 1914 by 1074, six pixels short each
+/// way, and the whole screenshot was being squeezed into it. That shrink of a third of a
+/// percent moves nothing anyone can see, but it resamples every pixel, and text loses the
+/// hard one-pixel edges that make it look crisp (issue #388).
+/// </para>
+///
+/// <para>
+/// Kept apart from the window itself, and from the Win32 calls that supply the numbers, so
+/// the arithmetic can be checked without a window. The same split as
+/// <see cref="KeyboardRegionSelector"/> and <see cref="PointerNudgePlanner"/>, and for the
+/// same reason: the interesting part is a decision over four rectangles, and none of it
+/// needs a screen to be true.
+/// </para>
+/// </summary>
+internal static class OverlayDrawingArea
+{
+	/// <summary>
+	/// The outer rectangle a window needs so that its drawing area covers
+	/// <paramref name="target"/> exactly, or null when it already does, or when the numbers
+	/// describe something that cannot be compensated for.
+	/// </summary>
+	/// <param name="window">The window's current outer rectangle, in screen pixels.</param>
+	/// <param name="drawingWidth">Width of the area the window draws into.</param>
+	/// <param name="drawingHeight">Height of the area the window draws into.</param>
+	/// <param name="drawingOrigin">
+	/// Where the drawing area's top-left corner sits on screen. Asked for rather than worked
+	/// out by halving the frame, because a frame is not always shared evenly between the
+	/// edges, and a window whose left border is thicker than its right would end up offset by
+	/// the difference.
+	/// </param>
+	/// <param name="target">Where the drawing area should land. For the overlay, the whole virtual screen.</param>
+	public static PixelRect? Fit(PixelRect window, int drawingWidth, int drawingHeight, (int X, int Y) drawingOrigin, PixelRect target)
+	{
+		// A window that has not been laid out yet reports nothing useful. Leave it alone
+		// rather than acting on a measurement that says the drawing area has no size.
+		if (drawingWidth <= 0 || drawingHeight <= 0)
+			return null;
+
+		int extraWidth = window.Width - drawingWidth;
+		int extraHeight = window.Height - drawingHeight;
+
+		// No frame at all, so the window is already all drawing area and nothing needs moving.
+		// This is the answer a genuinely borderless window gives, and it must stay a no-op:
+		// nudging it would move the content off the screen for no gain.
+		if (extraWidth == 0 && extraHeight == 0)
+			return null;
+
+		// A drawing area larger than the window it lives in is not a frame, it is a bad
+		// measurement. Growing the window by a negative amount would shrink it and make the
+		// blur worse, so decline.
+		if (extraWidth < 0 || extraHeight < 0)
+			return null;
+
+		int insetLeft = drawingOrigin.X - window.Left;
+		int insetTop = drawingOrigin.Y - window.Top;
+
+		// The drawing area starts inside the window and ends inside it. Anything else means
+		// the two rectangles were not read at the same moment, which happens if the window is
+		// being moved while it is measured.
+		if (insetLeft < 0 || insetTop < 0 || insetLeft > extraWidth || insetTop > extraHeight)
+			return null;
+
+		return new PixelRect(
+			target.Left - insetLeft,
+			target.Top - insetTop,
+			target.Width + extraWidth,
+			target.Height + extraHeight);
+	}
+}

--- a/Mutation.Ui/Views/RegionSelectionWindow.xaml
+++ b/Mutation.Ui/Views/RegionSelectionWindow.xaml
@@ -7,13 +7,18 @@
     mc:Ignorable="d"
     Title="Select Region">
     <Grid Background="Transparent" UseLayoutRounding="True">
+        <!--
+            No CacheMode here, deliberately. A BitmapCache was added for speed, and it
+            rasterises this element into an offscreen surface that the compositor then
+            samples to get the pixels on screen. For an image already sized to fill the
+            display that buys nothing: it is one full-screen surface either way. What it
+            costs is a resampling step the source pixels did not need, and the picture
+            comes out soft. Feeding the Image straight to the compositor lets one bitmap
+            pixel land on one screen pixel.
+        -->
         <Image x:Name="Img" Stretch="Fill"
             AutomationProperties.AccessibilityView="Raw"
-            AutomationProperties.Name="Screen capture preview">
-            <Image.CacheMode>
-                <BitmapCache />
-            </Image.CacheMode>
-        </Image>
+            AutomationProperties.Name="Screen capture preview" />
 
         <Canvas x:Name="Overlay" Background="Transparent"
             IsTabStop="True"

--- a/Mutation.Ui/Views/RegionSelectionWindow.xaml.cs
+++ b/Mutation.Ui/Views/RegionSelectionWindow.xaml.cs
@@ -298,17 +298,30 @@ public sealed partial class RegionSelectionWindow : Window
 		}
 		try
 		{
+			// Kept even though MoveAndResize has already placed the window and
+			// MatchDrawingAreaToScreen is about to place it again. This is the only one of
+			// the three that runs outside the try above, so it is what re-asserts topmost
+			// if MoveAndResize threw. All three run synchronously before the message pump
+			// turns, so XAML still lays out once.
 			SetWindowPos(_hwnd, HWND_TOPMOST, left, top, width, height, SWP_NOACTIVATE);
 		}
 		catch { }
-		MatchDrawingAreaToScreen(left, top, width, height);
 		// Expand content into title bar area (hide chrome).
+		//
+		// Ahead of MatchDrawingAreaToScreen, not after it. Every chrome setting has to be in
+		// its final state before the frame is measured, or the measurement describes a window
+		// that no longer exists and the compensation is built on it. Ordering this one last
+		// was safe only by luck: PrepareWindow runs again per capture on the pre-warmed
+		// overlay, so the second run would have measured the settled window. An overlay built
+		// fresh, which happens when the startup pre-warm throws, gets exactly one run and
+		// would have kept the stale measurement for its whole life.
 		if (this.AppWindow?.TitleBar is AppWindowTitleBar tb)
 		{
 			tb.ExtendsContentIntoTitleBar = true;
 			tb.ButtonBackgroundColor = Windows.UI.Color.FromArgb(1, 0, 0, 0);
 			tb.ButtonInactiveBackgroundColor = Windows.UI.Color.FromArgb(1, 0, 0, 0);
 		}
+		MatchDrawingAreaToScreen(left, top, width, height);
 	}
 
 	/// <summary>
@@ -328,52 +341,83 @@ public sealed partial class RegionSelectionWindow : Window
 	/// </para>
 	/// <para>
 	/// So measure the frame rather than assume it. Ask the window where its drawing area
-	/// sits and how big it is, work out the difference from the outer rectangle, and add
-	/// that difference back. The window then hangs very slightly off every edge of the
-	/// screen, which nothing can see because the frame is what hangs off, and the drawing
-	/// area lands exactly on the screen. One bitmap pixel, one screen pixel.
+	/// sits and how big it is, and hand those numbers to <see cref="OverlayDrawingArea"/>,
+	/// which works out the outer rectangle that puts the drawing area on the screen. The
+	/// window then hangs very slightly off every edge, which nothing can see because the
+	/// frame is what hangs off, and the drawing area lands exactly on the screen. One bitmap
+	/// pixel, one screen pixel.
 	/// </para>
 	/// <para>
-	/// A window with no frame at all measures a difference of zero and is left alone.
+	/// A window with no frame at all measures a difference of zero and is left alone. The
+	/// arithmetic lives in <see cref="OverlayDrawingArea"/> rather than here so it can be
+	/// checked without a window; this method is only the Win32 reading and writing around it.
 	/// </para>
 	/// </summary>
 	private void MatchDrawingAreaToScreen(int left, int top, int width, int height)
 	{
+		var target = new PixelRect(left, top, width, height);
+
+		// Twice at most. The first pass compensates for the frame as it stands; the second
+		// exists because moving the window is not always inert. Growing it by a few pixels can
+		// change which monitor owns most of it, and on a mixed-DPI desktop that arrives as a
+		// DPI change, which resizes the window again and undoes the correction. The frame is a
+		// different thickness at the new scale too, so the answer has to be measured again
+		// rather than reapplied. Bounded rather than looped: if two passes have not settled it,
+		// something is moving the window faster than this can follow, and the picture being
+		// slightly soft is a far better outcome than a window that will not stop resizing.
+		for (int attempt = 0; attempt < 2; attempt++)
+		{
+			if (!TryFitDrawingArea(target, out PixelRect fitted))
+				return;
+
+			if (!SetWindowPos(_hwnd, HWND_TOPMOST, fitted.Left, fitted.Top, fitted.Width, fitted.Height, SWP_NOACTIVATE))
+			{
+				System.Diagnostics.Debug.WriteLine("MatchDrawingAreaToScreen: SetWindowPos failed; the capture preview may be resampled.");
+				return;
+			}
+		}
+	}
+
+	/// <summary>
+	/// Measures the window and works out the outer rectangle it needs. False when there is
+	/// nothing to do, or when the window cannot be measured.
+	/// </summary>
+	private bool TryFitDrawingArea(PixelRect target, out PixelRect fitted)
+	{
+		fitted = default;
 		try
 		{
-			if (!GetClientRect(_hwnd, out Win32Rect client) || !GetWindowRect(_hwnd, out Win32Rect window))
-				return;
+			if (!GetWindowRect(_hwnd, out Win32Rect window) || !GetClientRect(_hwnd, out Win32Rect client))
+			{
+				System.Diagnostics.Debug.WriteLine("MatchDrawingAreaToScreen: could not measure the window; the capture preview may be resampled.");
+				return false;
+			}
 
-			int drawingWidth = client.Right - client.Left;
-			int drawingHeight = client.Bottom - client.Top;
-			if (drawingWidth <= 0 || drawingHeight <= 0)
-				return;
-
-			int extraWidth = (window.Right - window.Left) - drawingWidth;
-			int extraHeight = (window.Bottom - window.Top) - drawingHeight;
-			if (extraWidth <= 0 && extraHeight <= 0)
-				return;
-
-			// Where the drawing area starts, relative to the window's own corner. The frame
-			// is not always shared evenly between the edges, so this is asked for rather
-			// than halved.
 			Win32Point origin = default;
 			if (!ClientToScreen(_hwnd, ref origin))
-				return;
+			{
+				System.Diagnostics.Debug.WriteLine("MatchDrawingAreaToScreen: could not locate the drawing area; the capture preview may be resampled.");
+				return false;
+			}
 
-			int insetLeft = origin.X - window.Left;
-			int insetTop = origin.Y - window.Top;
+			PixelRect? answer = OverlayDrawingArea.Fit(
+				new PixelRect(window.Left, window.Top, window.Right - window.Left, window.Bottom - window.Top),
+				client.Right - client.Left,
+				client.Bottom - client.Top,
+				(origin.X, origin.Y),
+				target);
 
-			SetWindowPos(
-				_hwnd,
-				HWND_TOPMOST,
-				left - insetLeft,
-				top - insetTop,
-				width + extraWidth,
-				height + extraHeight,
-				SWP_NOACTIVATE);
+			if (answer is null)
+				return false;
+
+			fitted = answer.Value;
+			return true;
 		}
-		catch { }
+		catch (Exception ex)
+		{
+			System.Diagnostics.Debug.WriteLine($"MatchDrawingAreaToScreen failed: {ex.Message}");
+			return false;
+		}
 	}
 
 	public void UpdateBitmap(SoftwareBitmap bitmap)

--- a/Mutation.Ui/Views/RegionSelectionWindow.xaml.cs
+++ b/Mutation.Ui/Views/RegionSelectionWindow.xaml.cs
@@ -139,6 +139,21 @@ public sealed partial class RegionSelectionWindow : Window
 	private static extern bool SetWindowPos(IntPtr hWnd, IntPtr hWndInsertAfter, int X, int Y, int cx, int cy, uint uFlags);
 
 	[DllImport("user32.dll")]
+	private static extern bool GetClientRect(IntPtr hWnd, out Win32Rect rect);
+
+	[DllImport("user32.dll")]
+	private static extern bool GetWindowRect(IntPtr hWnd, out Win32Rect rect);
+
+	[DllImport("user32.dll")]
+	private static extern bool ClientToScreen(IntPtr hWnd, ref Win32Point point);
+
+	[StructLayout(LayoutKind.Sequential)]
+	private struct Win32Rect { public int Left, Top, Right, Bottom; }
+
+	[StructLayout(LayoutKind.Sequential)]
+	private struct Win32Point { public int X, Y; }
+
+	[DllImport("user32.dll")]
 	private static extern bool SetForegroundWindow(IntPtr hWnd);
 
 	[DllImport("user32.dll")]
@@ -267,7 +282,9 @@ public sealed partial class RegionSelectionWindow : Window
 		{
 			try
 			{
-				appWindow.MoveAndResize(new RectInt32(left, top, width, height));
+				// Chrome off before sizing, so the first layout pass already runs against
+				// the drawing area the window is going to keep. It does not on its own make
+				// that area the right size — see MatchDrawingAreaToScreen below.
 				if (appWindow.Presenter is OverlappedPresenter presenter)
 				{
 					presenter.IsResizable = false;
@@ -275,6 +292,7 @@ public sealed partial class RegionSelectionWindow : Window
 					presenter.IsMinimizable = false;
 					presenter.SetBorderAndTitleBar(false, false);
 				}
+				appWindow.MoveAndResize(new RectInt32(left, top, width, height));
 			}
 			catch { }
 		}
@@ -283,6 +301,7 @@ public sealed partial class RegionSelectionWindow : Window
 			SetWindowPos(_hwnd, HWND_TOPMOST, left, top, width, height, SWP_NOACTIVATE);
 		}
 		catch { }
+		MatchDrawingAreaToScreen(left, top, width, height);
 		// Expand content into title bar area (hide chrome).
 		if (this.AppWindow?.TitleBar is AppWindowTitleBar tb)
 		{
@@ -290,6 +309,71 @@ public sealed partial class RegionSelectionWindow : Window
 			tb.ButtonBackgroundColor = Windows.UI.Color.FromArgb(1, 0, 0, 0);
 			tb.ButtonInactiveBackgroundColor = Windows.UI.Color.FromArgb(1, 0, 0, 0);
 		}
+	}
+
+	/// <summary>
+	/// Grows the window until the area it actually draws into is exactly the virtual
+	/// screen, rather than the window's outer rectangle being that size.
+	/// <para>
+	/// This is what made the capture preview look soft. The preview is one image stretched
+	/// to fill the drawing area, so it is only sharp when that area holds exactly as many
+	/// pixels as the picture does. Sizing the window to the screen does not achieve that:
+	/// a window is measured by its outer rectangle, and the area inside it is smaller by
+	/// whatever frame the window still carries. Measured on a 1920 by 1080 display the
+	/// drawing area came back as 1914 by 1074, six pixels short each way, and the whole
+	/// screenshot was being squeezed into it. A shrink of a third of a percent moves
+	/// nothing you could see, but it resamples every pixel in the picture, and text loses
+	/// the hard one-pixel edges that make it look crisp. Turning the frame off does not
+	/// give those six pixels back.
+	/// </para>
+	/// <para>
+	/// So measure the frame rather than assume it. Ask the window where its drawing area
+	/// sits and how big it is, work out the difference from the outer rectangle, and add
+	/// that difference back. The window then hangs very slightly off every edge of the
+	/// screen, which nothing can see because the frame is what hangs off, and the drawing
+	/// area lands exactly on the screen. One bitmap pixel, one screen pixel.
+	/// </para>
+	/// <para>
+	/// A window with no frame at all measures a difference of zero and is left alone.
+	/// </para>
+	/// </summary>
+	private void MatchDrawingAreaToScreen(int left, int top, int width, int height)
+	{
+		try
+		{
+			if (!GetClientRect(_hwnd, out Win32Rect client) || !GetWindowRect(_hwnd, out Win32Rect window))
+				return;
+
+			int drawingWidth = client.Right - client.Left;
+			int drawingHeight = client.Bottom - client.Top;
+			if (drawingWidth <= 0 || drawingHeight <= 0)
+				return;
+
+			int extraWidth = (window.Right - window.Left) - drawingWidth;
+			int extraHeight = (window.Bottom - window.Top) - drawingHeight;
+			if (extraWidth <= 0 && extraHeight <= 0)
+				return;
+
+			// Where the drawing area starts, relative to the window's own corner. The frame
+			// is not always shared evenly between the edges, so this is asked for rather
+			// than halved.
+			Win32Point origin = default;
+			if (!ClientToScreen(_hwnd, ref origin))
+				return;
+
+			int insetLeft = origin.X - window.Left;
+			int insetTop = origin.Y - window.Top;
+
+			SetWindowPos(
+				_hwnd,
+				HWND_TOPMOST,
+				left - insetLeft,
+				top - insetTop,
+				width + extraWidth,
+				height + extraHeight,
+				SWP_NOACTIVATE);
+		}
+		catch { }
 	}
 
 	public void UpdateBitmap(SoftwareBitmap bitmap)


### PR DESCRIPTION
Fixes #388.

## What was wrong

The region-selection overlay window is sized to the screen, but a window is measured by its outer rectangle and the area it actually draws into is smaller by whatever frame the window carries. The preview is one image stretched to fill that drawing area, so the full-size screenshot was being squeezed into a slightly smaller space and every pixel resampled.

Measured on a 1920x1080 display at 100% scale, the window came back as 1920x1080 and its drawing area as **1914x1074**. Six pixels short each way. That shrink is invisible as a size change but it costs the picture its hard edges. Comparing the same region of the same screen, once through the preview and once directly, the real desktop had 100% of its edges landing as hard one-pixel steps and the preview had 30.8%.

Turning off the border and title bar does not give those six pixels back, which is why the existing `SetBorderAndTitleBar(false, false)` call did not prevent this.

## What changed

**`OverlayDrawingArea.Fit` works out the outer rectangle the window needs.** It takes the window rectangle, the drawing area's size, where that area sits on screen, and the target, and returns the rectangle that puts the drawing area exactly on the target. It lives in `Mutation.Ui/Core` with tests, alongside `KeyboardRegionSelector` and `PointerNudgePlanner`, because it is pure integer arithmetic over four rectangles and needs no screen to be true.

The inset comes from `ClientToScreen` rather than from halving the frame, because a frame is not always shared evenly between the edges and a window with a thicker left border would otherwise end up offset by the difference.

**`MatchDrawingAreaToScreen` does the Win32 reading and writing around it**, and checks its work once. Growing the window can change which monitor owns most of it, and on a mixed-DPI desktop that arrives as a DPI change which resizes the window and undoes the correction. Bounded at two passes rather than looped. On a settled window the second pass measures the same frame and asks for the same rectangle, so it converges rather than drifting.

**All chrome settings are applied before the frame is measured.** `SetBorderAndTitleBar` moved above `MoveAndResize`, and `ExtendsContentIntoTitleBar` above the measurement. On the pre-warmed overlay the old ordering was harmless by luck, because `PrepareWindow` runs again per capture. An overlay built fresh, which happens when the startup pre-warm throws and `OcrManager` falls back to a new window, gets exactly one run and would have kept a stale measurement for its whole life.

**The `BitmapCache` on the preview `Image` is gone.** It was added for performance in `97923e7` and rasterises the element into an offscreen surface which is reused rather than redrawn, so a surface built at the wrong size stays wrong. The overlay is pre-warmed and reused, so that one surface would serve the rest of the session. It bought nothing here, since the element already covers the display.

## Result

| Measurement | Before | After |
| --- | --- | --- |
| Overlay window | 1920 x 1080 | 1926 x 1086 |
| **Overlay drawing area** | **1914 x 1074** | **1920 x 1080** |
| Screen disagreeing with the preview | 6.61% | 2.83% |

The drawing-area figure is content-independent and is the measurement to trust.

## Region selection does move, and it is worth testing

An earlier version of this description said region selection was untouched. That was wrong, and review caught it.

The overlay's drawing area used to start at screen (3,3) while `CursorInOverlayCoordinates` computed the pointer position as `screenX - SM_XVIRTUALSCREEN`, so the crosshair was drawn up to 3 pixels away from the real pointer. `FinishSelection` scaled the crop by `1920 / 1914`, so a selection was reported up to 3 pixels out at the screen edges. The error was zero at the centre of the screen and largest at the edges.

After this change the drawing area starts at (0,0), the scale is exactly 1.0, and both mappings are exact. **This removes a pre-existing error rather than introducing one**, but it is a real behaviour change and should be tested rather than assumed:

- A selection dragged hard into the top-left corner of the screen should crop from bitmap (0,0).
- A selection at the far right or bottom edge should reach the last pixel.
- The crosshair should sit on the pointer, not beside it.
- Ctrl+A should still announce the full screen size and crop exactly that.

Announced sizes and cropped sizes still agree, and the reading disagreement fixed in #265 does not return. `KeyboardRegionSelector` scales spoken numbers by `_bitmapWidth / _width` and `FinishSelection` scales the crop by `_bmpW / _overlay.ActualWidth`. Those are the same ratio from the same two live values, so they agree at any overlay size. Before the fix both used 1920/1914; now both use 1.0.

## Scope

Only the on-screen preview was ever affected by the blur. The capture is a 1:1 block copy, the crop applies no scaling, and the upload is PNG, so the image reaching the OCR service and the clipboard was always correct.

Nothing changes about how the feature is used, so the user guide needs no update.

## Testing

`dotnet test --configuration Release` — 2487 passed, 0 failed. 17 of those are new, covering `OverlayDrawingArea`: a symmetric frame, asymmetric frames in both directions, no frame at all, a drawing area with no size, a drawing area larger than its own window, an origin outside its own frame, a virtual screen that does not start at the origin, and a thicker frame than the one measured here.

Verified on the real app by driving it through the accessibility layer and photographing the screen while the overlay was up, then comparing against the desktop underneath. The numbers above are from those runs.

**Not verified:** multi-monitor, any display scale above 100%, and mixed DPI. The test machine is a single 1920x1080 panel at 96 DPI, so the frame measurement has only been exercised at one DPI. The approach measures rather than assumes and the arithmetic is unit-tested at other frame sizes, so it should hold, but I have not seen it do so on real hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
